### PR TITLE
ci: fix codecov and add ts type checking to ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,10 +38,13 @@ jobs:
       # run tests!
       - run: yarn test --collectCoverage=true
 
+      # Check for TypeScript errors
+      - run: yarn test:ts
+
       - store_artifacts:
           path: coverage
 
       - codecov/upload:
-        file: {{ coverage_report_filepath }}
+          file: "{{ coverage_report_filepath }}"
 
       - run: yarn semantic-release

--- a/package.json
+++ b/package.json
@@ -22,13 +22,14 @@
     "client",
     "library"
   ],
-    "bin": {
+  "bin": {
     "yahoo-finance": "bin/yahoo-finance.js"
   },
   "scripts": {
     "lint": "eslint",
     "test": "jest",
     "coverage": "jest --coverage",
+    "test:ts": "tsc --noEmit",
     "generateSchema": "ts-json-schema-generator -p 'src/**/*.ts' -t '*' | node bin/modify-schema.js > schema.json",
     "prepublishOnly": "tsc && yarn generateSchema"
   },


### PR DESCRIPTION
This PR fixes the indent of the `codecov/upload` part of the CI. It also adds typechecking to the CI. The CI will automatically run `tsc --noEmit` to check for any type errors.