### PR TITLE
fix: remove multiple default exports in modules

### DIFF
--- a/src/modules/autoc.ts
+++ b/src/modules/autoc.ts
@@ -1,7 +1,5 @@
 import type {
   ModuleOptions,
-  ModuleOptionsWithValidateTrue,
-  ModuleOptionsWithValidateFalse,
   ModuleThis,
 } from '../lib/moduleCommon';
 
@@ -33,22 +31,8 @@ export default function autoc(
   this: ModuleThis,
   query: string,
   queryOptionsOverrides?: AutocOptions,
-  moduleOptions?: ModuleOptionsWithValidateFalse
-): Promise<any>;
-
-export default function autoc(
-  this: ModuleThis,
-  query: string,
-  queryOptionsOverrides?: AutocOptions,
-  moduleOptions?: ModuleOptionsWithValidateTrue
-): Promise<AutocResult>;
-
-export default function autoc(
-  this: ModuleThis,
-  query: string,
-  queryOptionsOverrides?: AutocOptions,
   moduleOptions?: ModuleOptions
-): Promise<any> {
+): Promise<AutocResult> {
 
   return this._moduleExec({
     moduleName: "autoc",

--- a/src/modules/historical.ts
+++ b/src/modules/historical.ts
@@ -1,7 +1,5 @@
 import type {
   ModuleOptions,
-  ModuleOptionsWithValidateTrue,
-  ModuleOptionsWithValidateFalse,
   ModuleThis,
 } from '../lib/moduleCommon';
 
@@ -35,22 +33,8 @@ export default function historical(
   this: ModuleThis,
   symbol: string,
   queryOptionsOverrides: HistoricalOptions,
-  moduleOptions?: ModuleOptionsWithValidateFalse
-): Promise<any>;
-
-export default function historical(
-  this: ModuleThis,
-  symbol: string,
-  queryOptionsOverrides: HistoricalOptions,
-  moduleOptions?: ModuleOptionsWithValidateTrue
-): Promise<HistoricalResult>;
-
-export default function historical(
-  this: ModuleThis,
-  symbol: string,
-  queryOptionsOverrides: HistoricalOptions,
   moduleOptions?: ModuleOptions
-): Promise<any> {
+): Promise<HistoricalResult> {
 
   return this._moduleExec({
     moduleName: "historical",

--- a/src/modules/quote.ts
+++ b/src/modules/quote.ts
@@ -1,7 +1,5 @@
 import type {
   ModuleOptions,
-  ModuleOptionsWithValidateTrue,
-  ModuleOptionsWithValidateFalse,
   ModuleThis,
 } from '../lib/moduleCommon';
 
@@ -118,29 +116,8 @@ export default function quote(
   this: ModuleThis,
   query: string | string[],
   queryOptionsOverrides?: QuoteOptions,
-  moduleOptions?: ModuleOptionsWithValidateFalse
-): Promise<any>;
-
-export default function quote(
-  this: ModuleThis,
-  query: string[],
-  queryOptionsOverrides?: QuoteOptions,
-  moduleOptions?: ModuleOptionsWithValidateTrue
-): Promise<QuoteResponse>;
-
-export default function quote(
-  this: ModuleThis,
-  query: string,
-  queryOptionsOverrides?: QuoteOptions,
-  moduleOptions?: ModuleOptionsWithValidateTrue
-): Promise<Quote>;
-
-export default function quote(
-  this: ModuleThis,
-  query: string | string[],
-  queryOptionsOverrides?: QuoteOptions,
   moduleOptions?: ModuleOptions
-): Promise<any> {
+): Promise<QuoteResponse> {
   const symbols = typeof query === 'string' ? query : query.join(',');
 
   return this._moduleExec({

--- a/src/modules/quoteSummary.ts
+++ b/src/modules/quoteSummary.ts
@@ -4,8 +4,6 @@ import { QuoteSummaryResult } from './quoteSummary-iface';
 
 import type {
   ModuleOptions,
-  ModuleOptionsWithValidateTrue,
-  ModuleOptionsWithValidateFalse,
   ModuleThis,
 } from '../lib/moduleCommon';
 
@@ -90,20 +88,6 @@ const queryOptionsDefaults = {
   formatted: false,
   modules: ['price', 'summaryDetail']
 };
-
-export default function quoteSummary(
-  this: ModuleThis,
-  symbol: string,
-  queryOptionsOverrides?: QuoteSummaryOptions,
-  moduleOptions?: ModuleOptionsWithValidateFalse
-): Promise<any>;
-
-export default function quoteSummary(
-  this: ModuleThis,
-  symbol: string,
-  queryOptionsOverrides?: QuoteSummaryOptions,
-  moduleOptions?: ModuleOptionsWithValidateTrue
-): Promise<QuoteSummaryResult>;
 
 export default function quoteSummary(
   this: ModuleThis,

--- a/src/modules/search.spec.ts
+++ b/src/modules/search.spec.ts
@@ -1,5 +1,4 @@
 import search from './search';
-const { InvalidOptionsError } = require('../lib/errors');
 
 import _env from '../env-node';
 import _fetch from '../lib/yahooFinanceFetch';
@@ -31,6 +30,33 @@ describe('search', () => {
       const devel = `search-${search}.json`;
       await yf.search(search, {}, { devel });
     });
+  });
+
+  it('successfully figure out symbol for Evolution Gaming Group', async () => {
+    const response = await yf.search('Apple', {}, { devel: 'search-Evolution Gaming Group.json'});
+
+    const onlyQuotesWithQuoteTypeEquity = response.quotes.filter(
+      (searchQuote) => {
+        if ('quoteType' in searchQuote && searchQuote.quoteType === 'EQUITY') {
+          return true;
+        } else {
+          return false;
+        }
+      },
+    );
+
+    let symbol;
+    if (
+      'quoteType' in onlyQuotesWithQuoteTypeEquity[0] &&
+      'symbol' in onlyQuotesWithQuoteTypeEquity[0]
+    ) {
+      symbol = onlyQuotesWithQuoteTypeEquity[0].symbol;
+    } else {
+      throw new Error(`The quote we found din't have a symbol`);
+    }
+
+    expect(symbol).toBe('AAPL');
+
   });
 
 });

--- a/src/modules/search.ts
+++ b/src/modules/search.ts
@@ -1,7 +1,5 @@
 import type {
   ModuleOptions,
-  ModuleOptionsWithValidateTrue,
-  ModuleOptionsWithValidateFalse,
   ModuleThis,
 } from '../lib/moduleCommon';
 
@@ -92,22 +90,8 @@ export default function search(
   this: ModuleThis,
   query: string,
   queryOptionsOverrides?: SearchOptions,
-  moduleOptions?: ModuleOptionsWithValidateFalse,
-): Promise<any>;
-
-export default function search(
-  this: ModuleThis,
-  query: string,
-  queryOptionsOverrides?: SearchOptions,
-  moduleOptions?: ModuleOptionsWithValidateTrue,
-): Promise<SearchResult>;
-
-export default function search(
-  this: ModuleThis,
-  query: string,
-  queryOptionsOverrides?: SearchOptions,
   moduleOptions?: ModuleOptions
-): Promise<any> {
+): Promise<SearchResult> {
 
   return this._moduleExec({
     moduleName: "search",


### PR DESCRIPTION
This PR removes multiple default exports in modules. See issue https://github.com/gadicc/node-yahoo-finance2/issues/21

## Changes

- fix: remove multiple exports
- chore(search): add another test