### PR TITLE
fix(moduleExec): pass correct object to validation

### DIFF
--- a/src/lib/moduleExec.ts
+++ b/src/lib/moduleExec.ts
@@ -101,16 +101,11 @@ export default async function moduleExec(this: ThisWithFetch, opts: ModuleExecOp
   const moduleName = opts.moduleName;
   const resultOpts = opts.result;
 
-  const objectToValidate = {
-    ...queryOpts.defaults,    // Module defaults e.g. { period: '1wk', lang: 'en' }
-    ...queryOpts.overrides,   // User supplied options that override above
-  };
-
   // Check that query options passed by the user are valid for this module
   validateAndCoerceTypes({
     source: moduleName,
     type: 'options',
-    object: objectToValidate,
+    object: queryOpts.overrides ?? {},
     schemaKey: queryOpts.schemaKey,
     options: this._opts ? this._opts.validation : _opts.validation
   });

--- a/src/lib/moduleExec.ts
+++ b/src/lib/moduleExec.ts
@@ -101,11 +101,16 @@ export default async function moduleExec(this: ThisWithFetch, opts: ModuleExecOp
   const moduleName = opts.moduleName;
   const resultOpts = opts.result;
 
+  const objectToValidate = {
+    ...queryOpts.defaults,    // Module defaults e.g. { period: '1wk', lang: 'en' }
+    ...queryOpts.overrides,   // User supplied options that override above
+  };
+
   // Check that query options passed by the user are valid for this module
   validateAndCoerceTypes({
     source: moduleName,
     type: 'options',
-    object: queryOpts.overrides,
+    object: objectToValidate,
     schemaKey: queryOpts.schemaKey,
     options: this._opts ? this._opts.validation : _opts.validation
   });

--- a/src/modules/quote.ts
+++ b/src/modules/quote.ts
@@ -151,7 +151,7 @@ export default function quote(
       schemaKey: "#/definitions/QuoteOptions",
       defaults: queryOptionsDefaults,
       runtime: { symbols },
-      overrides: queryOptionsOverrides || {},
+      overrides: queryOptionsOverrides,
     },
 
     result: {


### PR DESCRIPTION
This PR fixes https://github.com/gadicc/node-yahoo-finance2/issues/24

## Changes

- `moduleExec`: Change so that we always pass an object to `validateAndCoerceTypes`
- `quote`: no need to default to empty object for overrides since that is done later