### PR TITLE
fix(quote): extend marketState property

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -2635,7 +2635,9 @@
         "marketState": {
           "enum": [
             "CLOSED",
-            "PREPRE"
+            "PREPRE",
+            "POST",
+            "POSTPOST"
           ],
           "type": "string"
         },
@@ -2915,7 +2917,9 @@
         "marketState": {
           "enum": [
             "CLOSED",
-            "PREPRE"
+            "PREPRE",
+            "POST",
+            "POSTPOST"
           ],
           "type": "string"
         },
@@ -3196,7 +3200,9 @@
         "marketState": {
           "enum": [
             "CLOSED",
-            "PREPRE"
+            "PREPRE",
+            "POST",
+            "POSTPOST"
           ],
           "type": "string"
         },
@@ -3477,7 +3483,9 @@
         "marketState": {
           "enum": [
             "CLOSED",
-            "PREPRE"
+            "PREPRE",
+            "POST",
+            "POSTPOST"
           ],
           "type": "string"
         },

--- a/src/modules/quote.ts
+++ b/src/modules/quote.ts
@@ -17,7 +17,7 @@ export interface QuoteBase {
   quoteSourceName: string;               // "Delayed Quote",
   triggerable: boolean;                  // true,
   currency: string;                      // "USD",
-  marketState: "CLOSED" | "PREPRE";
+  marketState: "CLOSED" | "PREPRE" | "POST" | "POSTPOST";
   tradeable: boolean;                    // false,
   exchange: string;                      // "NMS",
   shortName: string;                     // "NVIDIA Corporation",


### PR DESCRIPTION
This PR fixes https://github.com/gadicc/node-yahoo-finance2/issues/32

## Changes

- Extend `QuoteBase. marketState` to also accept `"POST"` and `"POSTPOST"`
- Update `schema.json` by running `yarn generateSchema`