### PR TITLE
chore: prettier to respect editorconfig

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,1 +1,1 @@
-
+editorconfig: true


### PR DESCRIPTION
This PR changes so that Prettier respects `.editorconfig`.

## Issue

Before Visual Studio Code didn't pick up the settings defined in `.editorconfig`, see GIF below.

![image](http://pudge.se/rIs4av+)

## Changes

- add `editorconfig: true` to `.prettierrc.yaml`

## Comments

Personally I tend to only use Prettier, but this seems to be the way to do it when using `.editorconfig` as well.