### PR TITLE
chore: change specificity for quote module

### DIFF
--- a/src/modules/quote.ts
+++ b/src/modules/quote.ts
@@ -121,17 +121,17 @@ export default function quote(
 
 export default function quote(
   this: ModuleThis,
-  query: string | string[],
-  queryOptionsOverrides?: QuoteOptions,
-  moduleOptions?: ModuleOptionsWithValidateFalse
-): Promise<any>;
-
-export default function quote(
-  this: ModuleThis,
   query: string,
   queryOptionsOverrides?: QuoteOptions,
   moduleOptions?: ModuleOptionsWithValidateTrue
 ): Promise<Quote>;
+
+export default function quote(
+  this: ModuleThis,
+  query: string | string[],
+  queryOptionsOverrides?: QuoteOptions,
+  moduleOptions?: ModuleOptionsWithValidateFalse
+): Promise<any>;
 
 export default function quote(
   this: ModuleThis,


### PR DESCRIPTION
This PR fixes the type specificity for the function overloading for the quote module, so that we get the correct typed response by default.

## Issue

I noticed that when using the `quote` module I didn't get back the expected `Quote` type, see below.

```
const what = await yahooFinance2.quote('AAPL'); // <-- this was any
```

## Changes

- change specificity for quote module