### PR TITLE
chore(tests): switch from using forEach to using it.each

### DIFF
--- a/src/modules/quote.spec.ts
+++ b/src/modules/quote.spec.ts
@@ -11,20 +11,14 @@ const yf = testYf({ quote });
 
 describe("quote", () => {
   describe("passes validation", () => {
-    testSymbols.forEach((symbol) => {
-      it(symbol, async () => {
-        const devel = `quote-${symbol}.json`;
-        await yf.quote(symbol, {}, { devel });
-      });
+    it.each(testSymbols)("for symbol '%s'", async (symbol) => {
+      const devel = `quote-${symbol}.json`;
+      await yf.quote(symbol, {}, { devel });
     });
-  });
 
-  describe("passes validation", () => {
-    testSymbols.forEach((symbol) => {
-      it(symbol, async () => {
-        const devel = `quote-${symbol}-10am.json`;
-        await yf.quote(symbol, {}, { devel });
-      });
+    it.each(testSymbols)("for symbol %s (for 10AM data)", async (symbol) => {
+      const devel = `quote-${symbol}-10am.json`;
+      await yf.quote(symbol, {}, { devel });
     });
   });
 

--- a/src/modules/recommendationsBySymbol.spec.ts
+++ b/src/modules/recommendationsBySymbol.spec.ts
@@ -15,11 +15,9 @@ const yf = {
 
 describe("recommendationsBySymbol", () => {
   // make sure it passes validation for some symbols
-  testSymbols.forEach((symbol) => {
-    it(`passes validation for symbol: ${symbol}`, async () => {
-      const devel = `recommendationsBySymbol-${symbol}.json`;
-      await yf.recommendationsBySymbol(symbol, {}, { devel });
-    });
+  it.each(testSymbols)("passes validation for symbol '%s'", async (symbol) => {
+    const devel = `recommendationsBySymbol-${symbol}.json`;
+    await yf.recommendationsBySymbol(symbol, {}, { devel });
   });
 
   // make sure it passes validation for multiple symbols


### PR DESCRIPTION
Ref #51
This PR switches from using the JS inbuilt `forEach` function to using the `jest` inbuilt `it.each` function for testing a test against multiple symbols.

## Changes
- Switch from `testSymbols.forEach()` to `it.each(testSymbols)()`
- Add better names for tests using `forEach`