### PR TITLE
chore(tests): add more symbols to symbols.ts

### DIFF
--- a/tests/http/quote-ADH-10am.json
+++ b/tests/http/quote-ADH-10am.json
@@ -1,0 +1,109 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=ADH"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "cbp8g15g2nrr2"
+      ],
+      "x-yahoo-request-id": [
+        "cbp8g15g2nrr2"
+      ],
+      "x-request-id": [
+        "ece0bc93-6ee2-4717-a9ce-6157be81b084"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "464"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:26 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "MUTUALFUND",
+            "quoteSourceName": "Delayed Quote",
+            "triggerable": false,
+            "fullExchangeName": "YHD",
+            "averageDailyVolume3Month": 212316,
+            "averageDailyVolume10Day": 66219,
+            "fiftyTwoWeekRange": "5.6 - 9.24",
+            "fiftyTwoWeekLow": 5.6,
+            "fiftyTwoWeekHigh": 9.24,
+            "fiftyDayAverage": 6.7838235,
+            "twoHundredDayAverage": 6.3983088,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "firstTradeDateMilliseconds": 1152538200000,
+            "priceHint": 2,
+            "regularMarketTime": 1561759658,
+            "tradeable": false,
+            "marketState": "REGULAR",
+            "exchange": "YHD",
+            "shortName": "54688",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "symbol": "ADH"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-ADH.json
+++ b/tests/http/quote-ADH.json
@@ -1,0 +1,109 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=ADH"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "cbp8g15g2nrr2"
+      ],
+      "x-yahoo-request-id": [
+        "cbp8g15g2nrr2"
+      ],
+      "x-request-id": [
+        "ece0bc93-6ee2-4717-a9ce-6157be81b084"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "464"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:26 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "MUTUALFUND",
+            "quoteSourceName": "Delayed Quote",
+            "triggerable": false,
+            "fullExchangeName": "YHD",
+            "averageDailyVolume3Month": 212316,
+            "averageDailyVolume10Day": 66219,
+            "fiftyTwoWeekRange": "5.6 - 9.24",
+            "fiftyTwoWeekLow": 5.6,
+            "fiftyTwoWeekHigh": 9.24,
+            "fiftyDayAverage": 6.7838235,
+            "twoHundredDayAverage": 6.3983088,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "firstTradeDateMilliseconds": 1152538200000,
+            "priceHint": 2,
+            "regularMarketTime": 1561759658,
+            "tradeable": false,
+            "marketState": "REGULAR",
+            "exchange": "YHD",
+            "shortName": "54688",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "symbol": "ADH"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-AFRAF-10am.json
+++ b/tests/http/quote-AFRAF-10am.json
@@ -1,0 +1,140 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=AFRAF"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "co9le7pg2nrr2"
+      ],
+      "x-yahoo-request-id": [
+        "co9le7pg2nrr2"
+      ],
+      "x-request-id": [
+        "c2736799-106c-4acf-b0bf-4dd10e5a70ed"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "820"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:26 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Delayed Quote",
+            "triggerable": false,
+            "currency": "USD",
+            "exchange": "PNK",
+            "shortName": "AIR FRANCE-KLM",
+            "longName": "Air France-KLM SA",
+            "messageBoardId": "finmb_4463198",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "firstTradeDateMilliseconds": 1331731800000,
+            "marketState": "REGULAR",
+            "priceHint": 2,
+            "regularMarketChange": -0.099999905,
+            "regularMarketChangePercent": -1.6666651,
+            "regularMarketTime": 1613486803,
+            "regularMarketPrice": 5.9,
+            "regularMarketDayHigh": 5.9,
+            "regularMarketDayRange": "5.9 - 5.9",
+            "regularMarketDayLow": 5.9,
+            "regularMarketVolume": 1050,
+            "regularMarketPreviousClose": 6,
+            "bid": 0,
+            "ask": 0,
+            "bidSize": 0,
+            "askSize": 0,
+            "fullExchangeName": "Other OTC",
+            "financialCurrency": "EUR",
+            "regularMarketOpen": 5.9,
+            "averageDailyVolume3Month": 2859,
+            "averageDailyVolume10Day": 1600,
+            "fiftyTwoWeekLowChange": 2.63,
+            "fiftyTwoWeekLowChangePercent": 0.8042814,
+            "fiftyTwoWeekRange": "3.27 - 10.95",
+            "fiftyTwoWeekHighChange": -5.0499997,
+            "fiftyTwoWeekHighChangePercent": -0.46118718,
+            "fiftyTwoWeekLow": 3.27,
+            "fiftyTwoWeekHigh": 10.95,
+            "dividendDate": 1216252800,
+            "epsTrailingTwelveMonths": -1.903,
+            "sharesOutstanding": 427432000,
+            "bookValue": 8.847,
+            "fiftyDayAverage": 5.9954543,
+            "fiftyDayAverageChange": -0.095454216,
+            "fiftyDayAverageChangePercent": -0.015921097,
+            "twoHundredDayAverage": 4.939559,
+            "twoHundredDayAverageChange": 0.9604411,
+            "twoHundredDayAverageChangePercent": 0.19443864,
+            "marketCap": 2474265344,
+            "priceToBook": 0.6668927,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "symbol": "AFRAF"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-AFRAF.json
+++ b/tests/http/quote-AFRAF.json
@@ -1,0 +1,140 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=AFRAF"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "co9le7pg2nrr2"
+      ],
+      "x-yahoo-request-id": [
+        "co9le7pg2nrr2"
+      ],
+      "x-request-id": [
+        "c2736799-106c-4acf-b0bf-4dd10e5a70ed"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "820"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:26 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Delayed Quote",
+            "triggerable": false,
+            "currency": "USD",
+            "exchange": "PNK",
+            "shortName": "AIR FRANCE-KLM",
+            "longName": "Air France-KLM SA",
+            "messageBoardId": "finmb_4463198",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "firstTradeDateMilliseconds": 1331731800000,
+            "marketState": "REGULAR",
+            "priceHint": 2,
+            "regularMarketChange": -0.099999905,
+            "regularMarketChangePercent": -1.6666651,
+            "regularMarketTime": 1613486803,
+            "regularMarketPrice": 5.9,
+            "regularMarketDayHigh": 5.9,
+            "regularMarketDayRange": "5.9 - 5.9",
+            "regularMarketDayLow": 5.9,
+            "regularMarketVolume": 1050,
+            "regularMarketPreviousClose": 6,
+            "bid": 0,
+            "ask": 0,
+            "bidSize": 0,
+            "askSize": 0,
+            "fullExchangeName": "Other OTC",
+            "financialCurrency": "EUR",
+            "regularMarketOpen": 5.9,
+            "averageDailyVolume3Month": 2859,
+            "averageDailyVolume10Day": 1600,
+            "fiftyTwoWeekLowChange": 2.63,
+            "fiftyTwoWeekLowChangePercent": 0.8042814,
+            "fiftyTwoWeekRange": "3.27 - 10.95",
+            "fiftyTwoWeekHighChange": -5.0499997,
+            "fiftyTwoWeekHighChangePercent": -0.46118718,
+            "fiftyTwoWeekLow": 3.27,
+            "fiftyTwoWeekHigh": 10.95,
+            "dividendDate": 1216252800,
+            "epsTrailingTwelveMonths": -1.903,
+            "sharesOutstanding": 427432000,
+            "bookValue": 8.847,
+            "fiftyDayAverage": 5.9954543,
+            "fiftyDayAverageChange": -0.095454216,
+            "fiftyDayAverageChangePercent": -0.015921097,
+            "twoHundredDayAverage": 4.939559,
+            "twoHundredDayAverageChange": 0.9604411,
+            "twoHundredDayAverageChangePercent": 0.19443864,
+            "marketCap": 2474265344,
+            "priceToBook": 0.6668927,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "symbol": "AFRAF"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-AMZN-10am.json
+++ b/tests/http/quote-AMZN-10am.json
@@ -1,0 +1,148 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=AMZN"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "0oj6onpg2nrr2"
+      ],
+      "x-yahoo-request-id": [
+        "0oj6onpg2nrr2"
+      ],
+      "x-request-id": [
+        "851be76d-b5b6-4ce9-836a-f04d1a60ab4d"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "946"
+      ],
+      "x-envoy-upstream-service-time": [
+        "5"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:26 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "firstTradeDateMilliseconds": 863703000000,
+            "regularMarketPrice": 3278.47,
+            "regularMarketDayHigh": 3308,
+            "regularMarketDayRange": "3257.75 - 3308.0",
+            "regularMarketDayLow": 3257.75,
+            "regularMarketVolume": 1135723,
+            "regularMarketPreviousClose": 3277.71,
+            "bid": 3277.55,
+            "ask": 3281.27,
+            "bidSize": 9,
+            "askSize": 11,
+            "fullExchangeName": "NasdaqGS",
+            "financialCurrency": "USD",
+            "regularMarketOpen": 3254.05,
+            "averageDailyVolume3Month": 3657442,
+            "averageDailyVolume10Day": 2649840,
+            "fiftyTwoWeekLowChange": 1652.44,
+            "fiftyTwoWeekLowChangePercent": 1.0162419,
+            "fiftyTwoWeekRange": "1626.03 - 3552.25",
+            "fiftyTwoWeekHighChange": -273.78003,
+            "fiftyTwoWeekHighChangePercent": -0.077072285,
+            "fiftyTwoWeekLow": 1626.03,
+            "fiftyTwoWeekHigh": 3552.25,
+            "earningsTimestamp": 1612281780,
+            "earningsTimestampStart": 1619640000,
+            "earningsTimestampEnd": 1620072000,
+            "trailingPE": 78.376045,
+            "epsTrailingTwelveMonths": 41.83,
+            "epsForward": 66.46,
+            "epsCurrentYear": 47.68,
+            "marketState": "REGULAR",
+            "priceEpsCurrentYear": 68.75986,
+            "sharesOutstanding": 500889984,
+            "bookValue": 185.694,
+            "fiftyDayAverage": 3246.1387,
+            "fiftyDayAverageChange": 32.3313,
+            "fiftyDayAverageChangePercent": 0.009959925,
+            "twoHundredDayAverage": 3205.9446,
+            "twoHundredDayAverageChange": 72.52539,
+            "twoHundredDayAverageChangePercent": 0.02262216,
+            "marketCap": 1650922749952,
+            "forwardPE": 49.32997,
+            "priceToBook": 17.655228,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "priceHint": 2,
+            "regularMarketChange": 0.76000977,
+            "regularMarketChangePercent": 0.023187218,
+            "regularMarketTime": 1613492043,
+            "exchange": "NMS",
+            "shortName": "Amazon.com, Inc.",
+            "longName": "Amazon.com, Inc.",
+            "messageBoardId": "finmb_18749",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "displayName": "Amazon.com",
+            "symbol": "AMZN"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-AMZN.json
+++ b/tests/http/quote-AMZN.json
@@ -1,0 +1,151 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=AMZN"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "6on8u4dg2nrqt"
+      ],
+      "x-yahoo-request-id": [
+        "6on8u4dg2nrqt"
+      ],
+      "x-request-id": [
+        "02bb0302-7743-45a3-b1df-49820f5011e6"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "948"
+      ],
+      "x-envoy-upstream-service-time": [
+        "1"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:21 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "5"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "warning": [
+        "110 Response is stale"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "marketState": "REGULAR",
+            "exchange": "NMS",
+            "shortName": "Amazon.com, Inc.",
+            "longName": "Amazon.com, Inc.",
+            "messageBoardId": "finmb_18749",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "twoHundredDayAverage": 3205.9446,
+            "twoHundredDayAverageChange": 72.52539,
+            "twoHundredDayAverageChangePercent": 0.02262216,
+            "marketCap": 1650922749952,
+            "forwardPE": 49.32997,
+            "priceToBook": 17.655228,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "regularMarketChange": 0.76000977,
+            "regularMarketChangePercent": 0.023187218,
+            "regularMarketTime": 1613492043,
+            "regularMarketPrice": 3278.47,
+            "regularMarketDayHigh": 3308,
+            "regularMarketDayRange": "3257.75 - 3308.0",
+            "regularMarketDayLow": 3257.75,
+            "regularMarketVolume": 1135659,
+            "regularMarketPreviousClose": 3277.71,
+            "bid": 3277.55,
+            "ask": 3281.27,
+            "bidSize": 9,
+            "askSize": 11,
+            "fullExchangeName": "NasdaqGS",
+            "financialCurrency": "USD",
+            "regularMarketOpen": 3254.05,
+            "averageDailyVolume3Month": 3657442,
+            "averageDailyVolume10Day": 2649840,
+            "fiftyTwoWeekLowChange": 1652.44,
+            "fiftyTwoWeekLowChangePercent": 1.0162419,
+            "fiftyTwoWeekRange": "1626.03 - 3552.25",
+            "fiftyTwoWeekHighChange": -273.78003,
+            "fiftyTwoWeekHighChangePercent": -0.077072285,
+            "fiftyTwoWeekLow": 1626.03,
+            "fiftyTwoWeekHigh": 3552.25,
+            "earningsTimestamp": 1612281780,
+            "earningsTimestampStart": 1619640000,
+            "earningsTimestampEnd": 1620072000,
+            "trailingPE": 78.376045,
+            "epsTrailingTwelveMonths": 41.83,
+            "epsForward": 66.46,
+            "epsCurrentYear": 47.68,
+            "priceEpsCurrentYear": 68.75986,
+            "sharesOutstanding": 500889984,
+            "bookValue": 185.694,
+            "fiftyDayAverage": 3246.1387,
+            "fiftyDayAverageChange": 32.3313,
+            "fiftyDayAverageChangePercent": 0.009959925,
+            "firstTradeDateMilliseconds": 863703000000,
+            "priceHint": 2,
+            "displayName": "Amazon.com",
+            "symbol": "AMZN"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-SIX-10am.json
+++ b/tests/http/quote-SIX-10am.json
@@ -1,0 +1,150 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=SIX"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "2ooqvfdg2nuh6"
+      ],
+      "x-yahoo-request-id": [
+        "2ooqvfdg2nuh6"
+      ],
+      "x-request-id": [
+        "e6995fef-63ce-4cc7-aec7-20b12d4d972f"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "967"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:22 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "marketState": "REGULAR",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "exchange": "NYQ",
+            "shortName": "Six Flags Entertainment Corpora",
+            "longName": "Six Flags Entertainment Corporation",
+            "messageBoardId": "finmb_435998",
+            "exchangeTimezoneName": "America/New_York",
+            "fiftyTwoWeekHighChange": -0.7350006,
+            "fiftyTwoWeekHighChangePercent": -0.018025765,
+            "fiftyTwoWeekLow": 8.75,
+            "fiftyTwoWeekHigh": 40.775,
+            "earningsTimestamp": 1614173400,
+            "earningsTimestampStart": 1614173400,
+            "earningsTimestampEnd": 1614173400,
+            "trailingAnnualDividendRate": 1.08,
+            "trailingAnnualDividendYield": 0.027115239,
+            "epsTrailingTwelveMonths": -4.118,
+            "epsForward": -1.09,
+            "epsCurrentYear": -4.85,
+            "priceEpsCurrentYear": -8.255671,
+            "sharesOutstanding": 84977104,
+            "bookValue": -12.674,
+            "fiftyDayAverage": 36.065453,
+            "fiftyDayAverageChange": 3.9745483,
+            "fiftyDayAverageChangePercent": 0.11020376,
+            "twoHundredDayAverage": 27.273088,
+            "twoHundredDayAverageChange": 12.766912,
+            "twoHundredDayAverageChangePercent": 0.46811393,
+            "marketCap": 3402483200,
+            "forwardPE": -36.733944,
+            "priceToBook": -3.1592238,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "regularMarketChange": 0.20999908,
+            "regularMarketChangePercent": 0.5272384,
+            "regularMarketTime": 1613494813,
+            "regularMarketPrice": 40.04,
+            "regularMarketDayHigh": 40.775,
+            "regularMarketDayRange": "39.92 - 40.775",
+            "regularMarketDayLow": 39.92,
+            "regularMarketVolume": 405501,
+            "regularMarketPreviousClose": 39.83,
+            "bid": 40.54,
+            "ask": 40.57,
+            "bidSize": 12,
+            "askSize": 8,
+            "fullExchangeName": "NYSE",
+            "financialCurrency": "USD",
+            "regularMarketOpen": 39.89,
+            "averageDailyVolume3Month": 1642390,
+            "averageDailyVolume10Day": 1090080,
+            "fiftyTwoWeekLowChange": 31.29,
+            "fiftyTwoWeekLowChangePercent": 3.5760002,
+            "fiftyTwoWeekRange": "8.75 - 40.775",
+            "dividendDate": 1583884800,
+            "firstTradeDateMilliseconds": 1273584600000,
+            "priceHint": 2,
+            "displayName": "Six Flags",
+            "symbol": "SIX"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-SIX.json
+++ b/tests/http/quote-SIX.json
@@ -1,0 +1,150 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=SIX"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "2ooqvfdg2nuh6"
+      ],
+      "x-yahoo-request-id": [
+        "2ooqvfdg2nuh6"
+      ],
+      "x-request-id": [
+        "e6995fef-63ce-4cc7-aec7-20b12d4d972f"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "967"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:22 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "marketState": "REGULAR",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "exchange": "NYQ",
+            "shortName": "Six Flags Entertainment Corpora",
+            "longName": "Six Flags Entertainment Corporation",
+            "messageBoardId": "finmb_435998",
+            "exchangeTimezoneName": "America/New_York",
+            "fiftyTwoWeekHighChange": -0.7350006,
+            "fiftyTwoWeekHighChangePercent": -0.018025765,
+            "fiftyTwoWeekLow": 8.75,
+            "fiftyTwoWeekHigh": 40.775,
+            "earningsTimestamp": 1614173400,
+            "earningsTimestampStart": 1614173400,
+            "earningsTimestampEnd": 1614173400,
+            "trailingAnnualDividendRate": 1.08,
+            "trailingAnnualDividendYield": 0.027115239,
+            "epsTrailingTwelveMonths": -4.118,
+            "epsForward": -1.09,
+            "epsCurrentYear": -4.85,
+            "priceEpsCurrentYear": -8.255671,
+            "sharesOutstanding": 84977104,
+            "bookValue": -12.674,
+            "fiftyDayAverage": 36.065453,
+            "fiftyDayAverageChange": 3.9745483,
+            "fiftyDayAverageChangePercent": 0.11020376,
+            "twoHundredDayAverage": 27.273088,
+            "twoHundredDayAverageChange": 12.766912,
+            "twoHundredDayAverageChangePercent": 0.46811393,
+            "marketCap": 3402483200,
+            "forwardPE": -36.733944,
+            "priceToBook": -3.1592238,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "regularMarketChange": 0.20999908,
+            "regularMarketChangePercent": 0.5272384,
+            "regularMarketTime": 1613494813,
+            "regularMarketPrice": 40.04,
+            "regularMarketDayHigh": 40.775,
+            "regularMarketDayRange": "39.92 - 40.775",
+            "regularMarketDayLow": 39.92,
+            "regularMarketVolume": 405501,
+            "regularMarketPreviousClose": 39.83,
+            "bid": 40.54,
+            "ask": 40.57,
+            "bidSize": 12,
+            "askSize": 8,
+            "fullExchangeName": "NYSE",
+            "financialCurrency": "USD",
+            "regularMarketOpen": 39.89,
+            "averageDailyVolume3Month": 1642390,
+            "averageDailyVolume10Day": 1090080,
+            "fiftyTwoWeekLowChange": 31.29,
+            "fiftyTwoWeekLowChangePercent": 3.5760002,
+            "fiftyTwoWeekRange": "8.75 - 40.775",
+            "dividendDate": 1583884800,
+            "firstTradeDateMilliseconds": 1273584600000,
+            "priceHint": 2,
+            "displayName": "Six Flags",
+            "symbol": "SIX"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-WSKT.JK-10am.json
+++ b/tests/http/quote-WSKT.JK-10am.json
@@ -1,0 +1,140 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=WSKT.JK"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "80lkrf9g2nuh6"
+      ],
+      "x-yahoo-request-id": [
+        "80lkrf9g2nuh6"
+      ],
+      "x-request-id": [
+        "12334815-00a4-4f27-9a10-7ab2ce9b4e7d"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "828"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:22 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "triggerable": false,
+            "currency": "IDR",
+            "marketState": "PREPRE",
+            "exchange": "JKT",
+            "shortName": "Waskita Karya (Persero) Tbk.",
+            "longName": "PT Waskita Karya (Persero) Tbk",
+            "messageBoardId": "finmb_32989878",
+            "exchangeTimezoneName": "Asia/Jakarta",
+            "exchangeTimezoneShortName": "WIB",
+            "gmtOffSetMilliseconds": 25200000,
+            "market": "id_market",
+            "esgPopulated": false,
+            "priceHint": 2,
+            "firstTradeDateMilliseconds": 1355882400000,
+            "regularMarketChange": -5,
+            "regularMarketChangePercent": -0.310559,
+            "regularMarketTime": 1613463295,
+            "regularMarketPrice": 1605,
+            "regularMarketDayHigh": 1660,
+            "regularMarketDayRange": "1590.0 - 1660.0",
+            "regularMarketDayLow": 1590,
+            "regularMarketVolume": 228998200,
+            "regularMarketPreviousClose": 1610,
+            "bid": 1605,
+            "ask": 1610,
+            "bidSize": 0,
+            "askSize": 0,
+            "fullExchangeName": "Jakarta",
+            "financialCurrency": "IDR",
+            "regularMarketOpen": 1625,
+            "averageDailyVolume3Month": 269827553,
+            "averageDailyVolume10Day": 198514460,
+            "fiftyTwoWeekLowChange": 1211,
+            "fiftyTwoWeekLowChangePercent": 3.073604,
+            "fiftyTwoWeekRange": "394.0 - 2080.0",
+            "fiftyTwoWeekHighChange": -475,
+            "fiftyTwoWeekHighChangePercent": -0.22836539,
+            "fiftyTwoWeekLow": 394,
+            "fiftyTwoWeekHigh": 2080,
+            "epsTrailingTwelveMonths": -209.899,
+            "epsForward": 234.26,
+            "sharesOutstanding": 13573900288,
+            "bookValue": 983.154,
+            "fiftyDayAverage": 1595.1562,
+            "fiftyDayAverageChange": 9.84375,
+            "fiftyDayAverageChangePercent": 0.0061710253,
+            "twoHundredDayAverage": 980.8309,
+            "twoHundredDayAverageChange": 624.1691,
+            "twoHundredDayAverageChangePercent": 0.63636774,
+            "marketCap": 21786110459904,
+            "forwardPE": 6.8513618,
+            "priceToBook": 1.6325011,
+            "sourceInterval": 10,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "symbol": "WSKT.JK"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-WSKT.JK.json
+++ b/tests/http/quote-WSKT.JK.json
@@ -1,0 +1,140 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=WSKT.JK"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "80lkrf9g2nuh6"
+      ],
+      "x-yahoo-request-id": [
+        "80lkrf9g2nuh6"
+      ],
+      "x-request-id": [
+        "12334815-00a4-4f27-9a10-7ab2ce9b4e7d"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "828"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:22 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "triggerable": false,
+            "currency": "IDR",
+            "marketState": "PREPRE",
+            "exchange": "JKT",
+            "shortName": "Waskita Karya (Persero) Tbk.",
+            "longName": "PT Waskita Karya (Persero) Tbk",
+            "messageBoardId": "finmb_32989878",
+            "exchangeTimezoneName": "Asia/Jakarta",
+            "exchangeTimezoneShortName": "WIB",
+            "gmtOffSetMilliseconds": 25200000,
+            "market": "id_market",
+            "esgPopulated": false,
+            "priceHint": 2,
+            "firstTradeDateMilliseconds": 1355882400000,
+            "regularMarketChange": -5,
+            "regularMarketChangePercent": -0.310559,
+            "regularMarketTime": 1613463295,
+            "regularMarketPrice": 1605,
+            "regularMarketDayHigh": 1660,
+            "regularMarketDayRange": "1590.0 - 1660.0",
+            "regularMarketDayLow": 1590,
+            "regularMarketVolume": 228998200,
+            "regularMarketPreviousClose": 1610,
+            "bid": 1605,
+            "ask": 1610,
+            "bidSize": 0,
+            "askSize": 0,
+            "fullExchangeName": "Jakarta",
+            "financialCurrency": "IDR",
+            "regularMarketOpen": 1625,
+            "averageDailyVolume3Month": 269827553,
+            "averageDailyVolume10Day": 198514460,
+            "fiftyTwoWeekLowChange": 1211,
+            "fiftyTwoWeekLowChangePercent": 3.073604,
+            "fiftyTwoWeekRange": "394.0 - 2080.0",
+            "fiftyTwoWeekHighChange": -475,
+            "fiftyTwoWeekHighChangePercent": -0.22836539,
+            "fiftyTwoWeekLow": 394,
+            "fiftyTwoWeekHigh": 2080,
+            "epsTrailingTwelveMonths": -209.899,
+            "epsForward": 234.26,
+            "sharesOutstanding": 13573900288,
+            "bookValue": 983.154,
+            "fiftyDayAverage": 1595.1562,
+            "fiftyDayAverageChange": 9.84375,
+            "fiftyDayAverageChangePercent": 0.0061710253,
+            "twoHundredDayAverage": 980.8309,
+            "twoHundredDayAverageChange": 624.1691,
+            "twoHundredDayAverageChangePercent": 0.63636774,
+            "marketCap": 21786110459904,
+            "forwardPE": 6.8513618,
+            "priceToBook": 1.6325011,
+            "sourceInterval": 10,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "symbol": "WSKT.JK"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-all-ADH.json
+++ b/tests/http/quoteSummary-all-ADH.json
@@ -1,0 +1,135 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=assetProfile%2CbalanceSheetHistory%2CbalanceSheetHistoryQuarterly%2CcalendarEvents%2CcashflowStatementHistory%2CcashflowStatementHistoryQuarterly%2CdefaultKeyStatistics%2Cearnings%2CearningsHistory%2CearningsTrend%2CfinancialData%2CfundOwnership%2CfundPerformance%2CfundProfile%2CincomeStatementHistory%2CincomeStatementHistoryQuarterly%2CindexTrend%2CindustryTrend%2CinsiderHolders%2CinsiderTransactions%2CinstitutionOwnership%2CmajorDirectHolders%2CmajorHoldersBreakdown%2CnetSharePurchaseActivity%2Cprice%2CquoteType%2CrecommendationTrend%2CsecFilings%2CsectorTrend%2CsummaryDetail%2CsummaryProfile%2CtopHoldings%2CupgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "40ffqo5g2nrri"
+      ],
+      "x-yahoo-request-id": [
+        "40ffqo5g2nrri"
+      ],
+      "x-request-id": [
+        "8ab17996-40b3-4479-9e4a-b810348c5a38"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "570"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:42 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "fundProfile": {
+              "maxAge": 1,
+              "styleBoxUrl": null,
+              "family": null,
+              "categoryName": null,
+              "legalType": null,
+              "managementInfo": {
+                "managerName": null,
+                "managerBio": null
+              },
+              "feesExpensesInvestment": {
+                "projectionValues": {}
+              },
+              "feesExpensesInvestmentCat": {
+                "projectionValuesCat": {}
+              },
+              "brokerages": []
+            },
+            "quoteType": {
+              "exchange": "YHD",
+              "quoteType": "MUTUALFUND",
+              "symbol": "ADH",
+              "underlyingSymbol": "ADH",
+              "shortName": "54688",
+              "longName": null,
+              "firstTradeDateEpochUtc": 1152538200,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "b5097600-41ff-3349-b2d2-500df46ffd88",
+              "messageBoardId": null,
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            },
+            "price": {
+              "maxAge": 1,
+              "regularMarketTime": 1561759658,
+              "priceHint": 2,
+              "averageDailyVolume10Day": 66219,
+              "averageDailyVolume3Month": 212316,
+              "regularMarketSource": "DELAYED",
+              "exchange": "YHD",
+              "exchangeName": "YHD",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "MUTUALFUND",
+              "symbol": "ADH",
+              "underlyingSymbol": null,
+              "shortName": "54688",
+              "longName": null,
+              "quoteSourceName": "Delayed Quote",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-all-AFRAF.json
+++ b/tests/http/quoteSummary-all-AFRAF.json
@@ -1,0 +1,3368 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=assetProfile%2CbalanceSheetHistory%2CbalanceSheetHistoryQuarterly%2CcalendarEvents%2CcashflowStatementHistory%2CcashflowStatementHistoryQuarterly%2CdefaultKeyStatistics%2Cearnings%2CearningsHistory%2CearningsTrend%2CfinancialData%2CfundOwnership%2CfundPerformance%2CfundProfile%2CincomeStatementHistory%2CincomeStatementHistoryQuarterly%2CindexTrend%2CindustryTrend%2CinsiderHolders%2CinsiderTransactions%2CinstitutionOwnership%2CmajorDirectHolders%2CmajorHoldersBreakdown%2CnetSharePurchaseActivity%2Cprice%2CquoteType%2CrecommendationTrend%2CsecFilings%2CsectorTrend%2CsummaryDetail%2CsummaryProfile%2CtopHoldings%2CupgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "36ha0cpg2nrri"
+      ],
+      "x-yahoo-request-id": [
+        "36ha0cpg2nrri"
+      ],
+      "x-request-id": [
+        "14e39885-3856-911a-8de6-907eb282a538"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "10"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:42 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "2 rue Robert Esnault-Pelterie",
+              "city": "Paris",
+              "zip": "75007",
+              "country": "France",
+              "phone": "33 1 43 17 21 96",
+              "website": "http://www.airfranceklm.com",
+              "industry": "Airlines",
+              "sector": "Industrials",
+              "longBusinessSummary": "Air France-KLM SA, together with its subsidiaries, provides passenger transportation services on scheduled flights. The company operates through Network, Maintenance, Transavia, and Other segments. It also offers cargo transportation and aeronautics maintenance, and other air-transport-related services. The company operates in France, Benelux, Europe, Africa, the Middle East, Gulf, India, the Asia-Pacific, North America, Caribbean, West Indies, French Guyana, Indian Ocean, and South America. As of December 31, 2019, it operated fleet of 554 aircraft. The company was founded in 1919 and is headquartered in Paris, France.",
+              "fullTimeEmployees": 82122,
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Benjamin M. Smith",
+                  "age": 49,
+                  "title": "CEO & Director",
+                  "yearBorn": 1971,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. FrÃ©dÃ©ric N. P. P. Gagey",
+                  "age": 64,
+                  "title": "Chief Financial Officer",
+                  "yearBorn": 1956,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Eric  Schramm",
+                  "age": 61,
+                  "title": "Exec. VP of Operations and Accountable Mang.",
+                  "yearBorn": 1959,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Olivier  Gall",
+                  "title": "Head of Investor Relations",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Jean-Christophe  Lalanne",
+                  "age": 58,
+                  "title": "Exec. VP of Information Technology",
+                  "yearBorn": 1962,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Pieter  Bootsma",
+                  "age": 51,
+                  "title": "Chief Revenue Officer",
+                  "yearBorn": 1969,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Pieter J. TH. Elbers",
+                  "age": 50,
+                  "title": "Deputy CEO and CEO & Pres of KLM",
+                  "yearBorn": 1970,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Henri  de Peyrelongue",
+                  "title": "Sr. VP of Commercial Planning and Representative of The Commercial, Sales & Alliances Division",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Henri  Hourcade",
+                  "title": "Sr. VP of Caribbean & Indian Ocean, Central and South America",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Barry Ter Voert",
+                  "title": "Sr. VP of Europe",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "auditRisk": 5,
+              "boardRisk": 3,
+              "compensationRisk": 3,
+              "shareHolderRightsRisk": 10,
+              "overallRisk": 5,
+              "governanceEpochDate": 1606867200,
+              "maxAge": 86400
+            },
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 290000000,
+                    "fmt": "290M",
+                    "longFmt": "290,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 2941000000,
+                    "fmt": "2.94B",
+                    "longFmt": "2,941,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 529000000,
+                    "fmt": "529M",
+                    "longFmt": "529,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 61000000,
+                    "fmt": "61M",
+                    "longFmt": "61,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -133000000,
+                    "fmt": "-133M",
+                    "longFmt": "-133,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -93000000,
+                    "fmt": "-93M",
+                    "longFmt": "-93,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 300000000,
+                    "fmt": "300M",
+                    "longFmt": "300,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 3895000000,
+                    "fmt": "3.9B",
+                    "longFmt": "3,895,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -3372000000,
+                    "fmt": "-3.37B",
+                    "longFmt": "-3,372,000,000"
+                  },
+                  "investments": {
+                    "raw": -72000000,
+                    "fmt": "-72M",
+                    "longFmt": "-72,000,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 14000000,
+                    "fmt": "14M",
+                    "longFmt": "14,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -3318000000,
+                    "fmt": "-3.32B",
+                    "longFmt": "-3,318,000,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -26000000,
+                    "fmt": "-26M",
+                    "longFmt": "-26,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -475000000,
+                    "fmt": "-475M",
+                    "longFmt": "-475,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -447000000,
+                    "fmt": "-447M",
+                    "longFmt": "-447,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 1000000,
+                    "fmt": "1M",
+                    "longFmt": "1,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 131000000,
+                    "fmt": "131M",
+                    "longFmt": "131,000,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 54000000,
+                    "fmt": "54M",
+                    "longFmt": "54,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 420000000,
+                    "fmt": "420M",
+                    "longFmt": "420,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 2870000000,
+                    "fmt": "2.87B",
+                    "longFmt": "2,870,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 252000000,
+                    "fmt": "252M",
+                    "longFmt": "252,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -39000000,
+                    "fmt": "-39M",
+                    "longFmt": "-39,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 57000000,
+                    "fmt": "57M",
+                    "longFmt": "57,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -31000000,
+                    "fmt": "-31M",
+                    "longFmt": "-31,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 269000000,
+                    "fmt": "269M",
+                    "longFmt": "269,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 3798000000,
+                    "fmt": "3.8B",
+                    "longFmt": "3,798,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -2844000000,
+                    "fmt": "-2.84B",
+                    "longFmt": "-2,844,000,000"
+                  },
+                  "investments": {
+                    "raw": 4000000,
+                    "fmt": "4M",
+                    "longFmt": "4,000,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 6000000,
+                    "fmt": "6M",
+                    "longFmt": "6,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -2704000000,
+                    "fmt": "-2.7B",
+                    "longFmt": "-2,704,000,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -38000000,
+                    "fmt": "-38M",
+                    "longFmt": "-38,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -1939000000,
+                    "fmt": "-1.94B",
+                    "longFmt": "-1,939,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -2188000000,
+                    "fmt": "-2.19B",
+                    "longFmt": "-2,188,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 7000000,
+                    "fmt": "7M",
+                    "longFmt": "7,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": -1087000000,
+                    "fmt": "-1.09B",
+                    "longFmt": "-1,087,000,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 54000000,
+                    "fmt": "54M",
+                    "longFmt": "54,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 163000000,
+                    "fmt": "163M",
+                    "longFmt": "163,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 2756000000,
+                    "fmt": "2.76B",
+                    "longFmt": "2,756,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 889000000,
+                    "fmt": "889M",
+                    "longFmt": "889,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -331000000,
+                    "fmt": "-331M",
+                    "longFmt": "-331,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 68000000,
+                    "fmt": "68M",
+                    "longFmt": "68,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 549000000,
+                    "fmt": "549M",
+                    "longFmt": "549,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 4099000000,
+                    "fmt": "4.1B",
+                    "longFmt": "4,099,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -2562000000,
+                    "fmt": "-2.56B",
+                    "longFmt": "-2,562,000,000"
+                  },
+                  "investments": {
+                    "raw": -262000000,
+                    "fmt": "-262M",
+                    "longFmt": "-262,000,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 9000000,
+                    "fmt": "9M",
+                    "longFmt": "9,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -2692000000,
+                    "fmt": "-2.69B",
+                    "longFmt": "-2,692,000,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -38000000,
+                    "fmt": "-38M",
+                    "longFmt": "-38,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -1349000000,
+                    "fmt": "-1.35B",
+                    "longFmt": "-1,349,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -640000000,
+                    "fmt": "-640M",
+                    "longFmt": "-640,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -33000000,
+                    "fmt": "-33M",
+                    "longFmt": "-33,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 734000000,
+                    "fmt": "734M",
+                    "longFmt": "734,000,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 747000000,
+                    "fmt": "747M",
+                    "longFmt": "747,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 792000000,
+                    "fmt": "792M",
+                    "longFmt": "792,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 1571000000,
+                    "fmt": "1.57B",
+                    "longFmt": "1,571,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -191000000,
+                    "fmt": "-191M",
+                    "longFmt": "-191,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -104000000,
+                    "fmt": "-104M",
+                    "longFmt": "-104,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 23000000,
+                    "fmt": "23M",
+                    "longFmt": "23,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -61000000,
+                    "fmt": "-61M",
+                    "longFmt": "-61,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 209000000,
+                    "fmt": "209M",
+                    "longFmt": "209,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 2239000000,
+                    "fmt": "2.24B",
+                    "longFmt": "2,239,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -2072000000,
+                    "fmt": "-2.07B",
+                    "longFmt": "-2,072,000,000"
+                  },
+                  "investments": {
+                    "raw": 992000000,
+                    "fmt": "992M",
+                    "longFmt": "992,000,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 137000000,
+                    "fmt": "137M",
+                    "longFmt": "137,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -727000000,
+                    "fmt": "-727M",
+                    "longFmt": "-727,000,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -38000000,
+                    "fmt": "-38M",
+                    "longFmt": "-38,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -666000000,
+                    "fmt": "-666M",
+                    "longFmt": "-666,000,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 37000000,
+                    "fmt": "37M",
+                    "longFmt": "37,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -667000000,
+                    "fmt": "-667M",
+                    "longFmt": "-667,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -13000000,
+                    "fmt": "-13M",
+                    "longFmt": "-13,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 832000000,
+                    "fmt": "832M",
+                    "longFmt": "832,000,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 747000000,
+                    "fmt": "747M",
+                    "longFmt": "747,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            },
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.49626,
+              "institutionsPercentHeld": 0.12174,
+              "institutionsFloatPercentHeld": 0.24167,
+              "institutionsCount": 99
+            },
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 5917000000,
+                    "fmt": "5.92B",
+                    "longFmt": "5,917,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 443000000,
+                    "fmt": "443M",
+                    "longFmt": "443,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 1731000000,
+                    "fmt": "1.73B",
+                    "longFmt": "1,731,000,000"
+                  },
+                  "inventory": {
+                    "raw": 561000000,
+                    "fmt": "561M",
+                    "longFmt": "561,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 206000000,
+                    "fmt": "206M",
+                    "longFmt": "206,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 9012000000,
+                    "fmt": "9.01B",
+                    "longFmt": "9,012,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 1228000000,
+                    "fmt": "1.23B",
+                    "longFmt": "1,228,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 17333000000,
+                    "fmt": "17.33B",
+                    "longFmt": "17,333,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 216000000,
+                    "fmt": "216M",
+                    "longFmt": "216,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 1253000000,
+                    "fmt": "1.25B",
+                    "longFmt": "1,253,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 543000000,
+                    "fmt": "543M",
+                    "longFmt": "543,000,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 271000000,
+                    "fmt": "271M",
+                    "longFmt": "271,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 29585000000,
+                    "fmt": "29.59B",
+                    "longFmt": "29,585,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1555000000,
+                    "fmt": "1.55B",
+                    "longFmt": "1,555,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 1709000000,
+                    "fmt": "1.71B",
+                    "longFmt": "1,709,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 8136000000,
+                    "fmt": "8.14B",
+                    "longFmt": "8,136,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 7636000000,
+                    "fmt": "7.64B",
+                    "longFmt": "7,636,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 6372000000,
+                    "fmt": "6.37B",
+                    "longFmt": "6,372,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 9000000,
+                    "fmt": "9M",
+                    "longFmt": "9,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 14438000000,
+                    "fmt": "14.44B",
+                    "longFmt": "14,438,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 34258000000,
+                    "fmt": "34.26B",
+                    "longFmt": "34,258,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 429000000,
+                    "fmt": "429M",
+                    "longFmt": "429,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -9250000000,
+                    "fmt": "-9.25B",
+                    "longFmt": "-9,250,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 4139000000,
+                    "fmt": "4.14B",
+                    "longFmt": "4,139,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -9183000000,
+                    "fmt": "-9.18B",
+                    "longFmt": "-9,183,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -4682000000,
+                    "fmt": "-4.68B",
+                    "longFmt": "-4,682,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -6151000000,
+                    "fmt": "-6.15B",
+                    "longFmt": "-6,151,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "cash": {
+                    "raw": 4796000000,
+                    "fmt": "4.8B",
+                    "longFmt": "4,796,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 394000000,
+                    "fmt": "394M",
+                    "longFmt": "394,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 2042000000,
+                    "fmt": "2.04B",
+                    "longFmt": "2,042,000,000"
+                  },
+                  "inventory": {
+                    "raw": 647000000,
+                    "fmt": "647M",
+                    "longFmt": "647,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 246000000,
+                    "fmt": "246M",
+                    "longFmt": "246,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 8298000000,
+                    "fmt": "8.3B",
+                    "longFmt": "8,298,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 1338000000,
+                    "fmt": "1.34B",
+                    "longFmt": "1,338,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 17408000000,
+                    "fmt": "17.41B",
+                    "longFmt": "17,408,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 217000000,
+                    "fmt": "217M",
+                    "longFmt": "217,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 1282000000,
+                    "fmt": "1.28B",
+                    "longFmt": "1,282,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 767000000,
+                    "fmt": "767M",
+                    "longFmt": "767,000,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 282000000,
+                    "fmt": "282M",
+                    "longFmt": "282,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 29310000000,
+                    "fmt": "29.31B",
+                    "longFmt": "29,310,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1476000000,
+                    "fmt": "1.48B",
+                    "longFmt": "1,476,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 1295000000,
+                    "fmt": "1.29B",
+                    "longFmt": "1,295,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 8657000000,
+                    "fmt": "8.66B",
+                    "longFmt": "8,657,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 5292000000,
+                    "fmt": "5.29B",
+                    "longFmt": "5,292,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 6313000000,
+                    "fmt": "6.31B",
+                    "longFmt": "6,313,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 10000000,
+                    "fmt": "10M",
+                    "longFmt": "10,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 14291000000,
+                    "fmt": "14.29B",
+                    "longFmt": "14,291,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 31859000000,
+                    "fmt": "31.86B",
+                    "longFmt": "31,859,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 429000000,
+                    "fmt": "429M",
+                    "longFmt": "429,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -4343000000,
+                    "fmt": "-4.34B",
+                    "longFmt": "-4,343,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -3187000000,
+                    "fmt": "-3.19B",
+                    "longFmt": "-3,187,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 4139000000,
+                    "fmt": "4.14B",
+                    "longFmt": "4,139,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -3120000000,
+                    "fmt": "-3.12B",
+                    "longFmt": "-3,120,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -2962000000,
+                    "fmt": "-2.96B",
+                    "longFmt": "-2,962,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -4461000000,
+                    "fmt": "-4.46B",
+                    "longFmt": "-4,461,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "cash": {
+                    "raw": 5362000000,
+                    "fmt": "5.36B",
+                    "longFmt": "5,362,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 433000000,
+                    "fmt": "433M",
+                    "longFmt": "433,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 1565000000,
+                    "fmt": "1.56B",
+                    "longFmt": "1,565,000,000"
+                  },
+                  "inventory": {
+                    "raw": 691000000,
+                    "fmt": "691M",
+                    "longFmt": "691,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 1246000000,
+                    "fmt": "1.25B",
+                    "longFmt": "1,246,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 9297000000,
+                    "fmt": "9.3B",
+                    "longFmt": "9,297,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 1394000000,
+                    "fmt": "1.39B",
+                    "longFmt": "1,394,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 18161000000,
+                    "fmt": "18.16B",
+                    "longFmt": "18,161,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 218000000,
+                    "fmt": "218M",
+                    "longFmt": "218,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 1347000000,
+                    "fmt": "1.35B",
+                    "longFmt": "1,347,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 1362000000,
+                    "fmt": "1.36B",
+                    "longFmt": "1,362,000,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 325000000,
+                    "fmt": "325M",
+                    "longFmt": "325,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 31779000000,
+                    "fmt": "31.78B",
+                    "longFmt": "31,779,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 2056000000,
+                    "fmt": "2.06B",
+                    "longFmt": "2,056,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2575000000,
+                    "fmt": "2.58B",
+                    "longFmt": "2,575,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 9699000000,
+                    "fmt": "9.7B",
+                    "longFmt": "9,699,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 6730000000,
+                    "fmt": "6.73B",
+                    "longFmt": "6,730,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 6481000000,
+                    "fmt": "6.48B",
+                    "longFmt": "6,481,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 13000000,
+                    "fmt": "13M",
+                    "longFmt": "13,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 15305000000,
+                    "fmt": "15.3B",
+                    "longFmt": "15,305,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 31594000000,
+                    "fmt": "31.59B",
+                    "longFmt": "31,594,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 429000000,
+                    "fmt": "429M",
+                    "longFmt": "429,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -4799000000,
+                    "fmt": "-4.8B",
+                    "longFmt": "-4,799,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 4139000000,
+                    "fmt": "4.14B",
+                    "longFmt": "4,139,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -4732000000,
+                    "fmt": "-4.73B",
+                    "longFmt": "-4,732,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -231000000,
+                    "fmt": "-231M",
+                    "longFmt": "-231,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -1796000000,
+                    "fmt": "-1.8B",
+                    "longFmt": "-1,796,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 3715000000,
+                    "fmt": "3.71B",
+                    "longFmt": "3,715,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 50000000,
+                    "fmt": "50M",
+                    "longFmt": "50,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 2723000000,
+                    "fmt": "2.72B",
+                    "longFmt": "2,723,000,000"
+                  },
+                  "inventory": {
+                    "raw": 737000000,
+                    "fmt": "737M",
+                    "longFmt": "737,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 660000000,
+                    "fmt": "660M",
+                    "longFmt": "660,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 8539000000,
+                    "fmt": "8.54B",
+                    "longFmt": "8,539,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 969000000,
+                    "fmt": "969M",
+                    "longFmt": "969,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 18087000000,
+                    "fmt": "18.09B",
+                    "longFmt": "18,087,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 217000000,
+                    "fmt": "217M",
+                    "longFmt": "217,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 1305000000,
+                    "fmt": "1.3B",
+                    "longFmt": "1,305,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 1618000000,
+                    "fmt": "1.62B",
+                    "longFmt": "1,618,000,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 523000000,
+                    "fmt": "523M",
+                    "longFmt": "523,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 30735000000,
+                    "fmt": "30.73B",
+                    "longFmt": "30,735,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 2379000000,
+                    "fmt": "2.38B",
+                    "longFmt": "2,379,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 307000000,
+                    "fmt": "307M",
+                    "longFmt": "307,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 7332000000,
+                    "fmt": "7.33B",
+                    "longFmt": "7,332,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 3370000000,
+                    "fmt": "3.37B",
+                    "longFmt": "3,370,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 6330000000,
+                    "fmt": "6.33B",
+                    "longFmt": "6,330,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 15000000,
+                    "fmt": "15M",
+                    "longFmt": "15,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 12649000000,
+                    "fmt": "12.65B",
+                    "longFmt": "12,649,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 28436000000,
+                    "fmt": "28.44B",
+                    "longFmt": "28,436,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 429000000,
+                    "fmt": "429M",
+                    "longFmt": "429,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 360000000,
+                    "fmt": "360M",
+                    "longFmt": "360,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -3047000000,
+                    "fmt": "-3.05B",
+                    "longFmt": "-3,047,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 4139000000,
+                    "fmt": "4.14B",
+                    "longFmt": "4,139,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -2980000000,
+                    "fmt": "-2.98B",
+                    "longFmt": "-2,980,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1881000000,
+                    "fmt": "1.88B",
+                    "longFmt": "1,881,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 359000000,
+                    "fmt": "359M",
+                    "longFmt": "359,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 6.26429,
+              "pegRatio": 0.655216,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.258
+                },
+                {
+                  "period": "+1q",
+                  "growth": 0.97400004
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.144
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.158
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0820068
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            },
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            },
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": 2564594688,
+              "profitMargins": -0.38606,
+              "floatShares": 215079742,
+              "sharesOutstanding": 427432000,
+              "heldPercentInsiders": 0.49626,
+              "heldPercentInstitutions": 0.12174,
+              "beta": 2.112234,
+              "category": null,
+              "bookValue": 8.847,
+              "priceToBook": 0.6668927,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1577750400,
+              "nextFiscalYearEnd": 1640908800,
+              "mostRecentQuarter": 1601424000,
+              "trailingEps": -1.903,
+              "lastSplitFactor": null,
+              "52WeekChange": -0.4520548,
+              "SandP52WeekChange": 0.1675049,
+              "lastDividendValue": 0.58,
+              "lastDividendDate": 1215993600
+            },
+            "summaryProfile": {
+              "address1": "2 rue Robert Esnault-Pelterie",
+              "city": "Paris",
+              "zip": "75007",
+              "country": "France",
+              "phone": "33 1 43 17 21 96",
+              "website": "http://www.airfranceklm.com",
+              "industry": "Airlines",
+              "sector": "Industrials",
+              "longBusinessSummary": "Air France-KLM SA, together with its subsidiaries, provides passenger transportation services on scheduled flights. The company operates through Network, Maintenance, Transavia, and Other segments. It also offers cargo transportation and aeronautics maintenance, and other air-transport-related services. The company operates in France, Benelux, Europe, Africa, the Middle East, Gulf, India, the Asia-Pacific, North America, Caribbean, West Indies, French Guyana, Indian Ocean, and South America. As of December 31, 2019, it operated fleet of 554 aircraft. The company was founded in 1919 and is headquartered in Paris, France.",
+              "fullTimeEmployees": 82122,
+              "companyOfficers": [],
+              "maxAge": 86400
+            },
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 0,
+              "buyInfoShares": 0,
+              "sellInfoCount": 0,
+              "netInfoCount": 0,
+              "netInfoShares": 0,
+              "netPercentInsiderShares": 0,
+              "totalInsiderShares": 212117616
+            },
+            "quoteType": {
+              "exchange": "PNK",
+              "quoteType": "EQUITY",
+              "symbol": "AFRAF",
+              "underlyingSymbol": "AFRAF",
+              "shortName": "AIR FRANCE-KLM",
+              "longName": "Air France-KLM SA",
+              "firstTradeDateEpochUtc": 1331731800,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "41a9132e-8a86-3cb7-a251-da914aed6eac",
+              "messageBoardId": "finmb_4463198",
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            },
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 27189000000,
+                    "fmt": "27.19B",
+                    "longFmt": "27,189,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 21273000000,
+                    "fmt": "21.27B",
+                    "longFmt": "21,273,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 5916000000,
+                    "fmt": "5.92B",
+                    "longFmt": "5,916,000,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 1029000000,
+                    "fmt": "1.03B",
+                    "longFmt": "1,029,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 774000000,
+                    "fmt": "774M",
+                    "longFmt": "774,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 26063000000,
+                    "fmt": "26.06B",
+                    "longFmt": "26,063,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 1126000000,
+                    "fmt": "1.13B",
+                    "longFmt": "1,126,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -757000000,
+                    "fmt": "-757M",
+                    "longFmt": "-757,000,000"
+                  },
+                  "ebit": {
+                    "raw": 1126000000,
+                    "fmt": "1.13B",
+                    "longFmt": "1,126,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -385000000,
+                    "fmt": "-385M",
+                    "longFmt": "-385,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 369000000,
+                    "fmt": "369M",
+                    "longFmt": "369,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 76000000,
+                    "fmt": "76M",
+                    "longFmt": "76,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 15000000,
+                    "fmt": "15M",
+                    "longFmt": "15,000,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 293000000,
+                    "fmt": "293M",
+                    "longFmt": "293,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 290000000,
+                    "fmt": "290M",
+                    "longFmt": "290,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 273000000,
+                    "fmt": "273M",
+                    "longFmt": "273,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 26227000000,
+                    "fmt": "26.23B",
+                    "longFmt": "26,227,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 20053000000,
+                    "fmt": "20.05B",
+                    "longFmt": "20,053,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 6174000000,
+                    "fmt": "6.17B",
+                    "longFmt": "6,174,000,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 1034000000,
+                    "fmt": "1.03B",
+                    "longFmt": "1,034,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 774000000,
+                    "fmt": "774M",
+                    "longFmt": "774,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 24749000000,
+                    "fmt": "24.75B",
+                    "longFmt": "24,749,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 1478000000,
+                    "fmt": "1.48B",
+                    "longFmt": "1,478,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -832000000,
+                    "fmt": "-832M",
+                    "longFmt": "-832,000,000"
+                  },
+                  "ebit": {
+                    "raw": 1478000000,
+                    "fmt": "1.48B",
+                    "longFmt": "1,478,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -417000000,
+                    "fmt": "-417M",
+                    "longFmt": "-417,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 646000000,
+                    "fmt": "646M",
+                    "longFmt": "646,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 224000000,
+                    "fmt": "224M",
+                    "longFmt": "224,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 12000000,
+                    "fmt": "12M",
+                    "longFmt": "12,000,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 422000000,
+                    "fmt": "422M",
+                    "longFmt": "422,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 420000000,
+                    "fmt": "420M",
+                    "longFmt": "420,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 395000000,
+                    "fmt": "395M",
+                    "longFmt": "395,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 25867000000,
+                    "fmt": "25.87B",
+                    "longFmt": "25,867,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 19411000000,
+                    "fmt": "19.41B",
+                    "longFmt": "19,411,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 6456000000,
+                    "fmt": "6.46B",
+                    "longFmt": "6,456,000,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 935000000,
+                    "fmt": "935M",
+                    "longFmt": "935,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 660000000,
+                    "fmt": "660M",
+                    "longFmt": "660,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 23846000000,
+                    "fmt": "23.85B",
+                    "longFmt": "23,846,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 2021000000,
+                    "fmt": "2.02B",
+                    "longFmt": "2,021,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -1871000000,
+                    "fmt": "-1.87B",
+                    "longFmt": "-1,871,000,000"
+                  },
+                  "ebit": {
+                    "raw": 2021000000,
+                    "fmt": "2.02B",
+                    "longFmt": "2,021,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -519000000,
+                    "fmt": "-519M",
+                    "longFmt": "-519,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 150000000,
+                    "fmt": "150M",
+                    "longFmt": "150,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -21000000,
+                    "fmt": "-21M",
+                    "longFmt": "-21,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 12000000,
+                    "fmt": "12M",
+                    "longFmt": "12,000,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 171000000,
+                    "fmt": "171M",
+                    "longFmt": "171,000,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -8000000,
+                    "fmt": "-8M",
+                    "longFmt": "-8,000,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 163000000,
+                    "fmt": "163M",
+                    "longFmt": "163,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 138000000,
+                    "fmt": "138M",
+                    "longFmt": "138,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 24846000000,
+                    "fmt": "24.85B",
+                    "longFmt": "24,846,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 19947000000,
+                    "fmt": "19.95B",
+                    "longFmt": "19,947,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 4899000000,
+                    "fmt": "4.9B",
+                    "longFmt": "4,899,000,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 905000000,
+                    "fmt": "905M",
+                    "longFmt": "905,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 1346000000,
+                    "fmt": "1.35B",
+                    "longFmt": "1,346,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 23863000000,
+                    "fmt": "23.86B",
+                    "longFmt": "23,863,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 983000000,
+                    "fmt": "983M",
+                    "longFmt": "983,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -167000000,
+                    "fmt": "-167M",
+                    "longFmt": "-167,000,000"
+                  },
+                  "ebit": {
+                    "raw": 983000000,
+                    "fmt": "983M",
+                    "longFmt": "983,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -229000000,
+                    "fmt": "-229M",
+                    "longFmt": "-229,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 816000000,
+                    "fmt": "816M",
+                    "longFmt": "816,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 294000000,
+                    "fmt": "294M",
+                    "longFmt": "294,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 12000000,
+                    "fmt": "12M",
+                    "longFmt": "12,000,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 522000000,
+                    "fmt": "522M",
+                    "longFmt": "522,000,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": 270000000,
+                    "fmt": "270M",
+                    "longFmt": "270,000,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 792000000,
+                    "fmt": "792M",
+                    "longFmt": "792,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 767000000,
+                    "fmt": "767M",
+                    "longFmt": "767,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "ETF Series Solutions-U.S. Global Jets ETF",
+                  "pctHeld": {
+                    "raw": 0.0091,
+                    "fmt": "0.91%"
+                  },
+                  "position": {
+                    "raw": 3904347,
+                    "fmt": "3.9M",
+                    "longFmt": "3,904,347"
+                  },
+                  "value": {
+                    "raw": 13743301,
+                    "fmt": "13.74M",
+                    "longFmt": "13,743,301"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1604102400,
+                    "fmt": "2020-10-31"
+                  },
+                  "organization": "Vanguard International Stock Index-Total Intl Stock Indx",
+                  "pctHeld": {
+                    "raw": 0.0069999998,
+                    "fmt": "0.70%"
+                  },
+                  "position": {
+                    "raw": 2982812,
+                    "fmt": "2.98M",
+                    "longFmt": "2,982,812"
+                  },
+                  "value": {
+                    "raw": 9753795,
+                    "fmt": "9.75M",
+                    "longFmt": "9,753,795"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Causeway International Value Fund",
+                  "pctHeld": {
+                    "raw": 0.0039,
+                    "fmt": "0.39%"
+                  },
+                  "position": {
+                    "raw": 1674686,
+                    "fmt": "1.67M",
+                    "longFmt": "1,674,686"
+                  },
+                  "value": {
+                    "raw": 5894894,
+                    "fmt": "5.89M",
+                    "longFmt": "5,894,894"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1604102400,
+                    "fmt": "2020-10-31"
+                  },
+                  "organization": "DFA Continental Small Company Series",
+                  "pctHeld": {
+                    "raw": 0.0029,
+                    "fmt": "0.29%"
+                  },
+                  "position": {
+                    "raw": 1233305,
+                    "fmt": "1.23M",
+                    "longFmt": "1,233,305"
+                  },
+                  "value": {
+                    "raw": 4032907,
+                    "fmt": "4.03M",
+                    "longFmt": "4,032,907"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Tax Managed Fund-Vanguard Developed Markets Index Fund",
+                  "pctHeld": {
+                    "raw": 0.0029,
+                    "fmt": "0.29%"
+                  },
+                  "position": {
+                    "raw": 1232316,
+                    "fmt": "1.23M",
+                    "longFmt": "1,232,316"
+                  },
+                  "value": {
+                    "raw": 4337752,
+                    "fmt": "4.34M",
+                    "longFmt": "4,337,752"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "iShares Core MSCI EAFE ETF",
+                  "pctHeld": {
+                    "raw": 0.0022,
+                    "fmt": "0.22%"
+                  },
+                  "position": {
+                    "raw": 963129,
+                    "fmt": "963.13k",
+                    "longFmt": "963,129"
+                  },
+                  "value": {
+                    "raw": 5875086,
+                    "fmt": "5.88M",
+                    "longFmt": "5,875,086"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1604102400,
+                    "fmt": "2020-10-31"
+                  },
+                  "organization": "DFA International Core Equity Portfolio",
+                  "pctHeld": {
+                    "raw": 0.0019,
+                    "fmt": "0.19%"
+                  },
+                  "position": {
+                    "raw": 803774,
+                    "fmt": "803.77k",
+                    "longFmt": "803,774"
+                  },
+                  "value": {
+                    "raw": 2628340,
+                    "fmt": "2.63M",
+                    "longFmt": "2,628,340"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "iShares MSCI EAFE Small Cap ETF",
+                  "pctHeld": {
+                    "raw": 0.0018000001,
+                    "fmt": "0.18%"
+                  },
+                  "position": {
+                    "raw": 752367,
+                    "fmt": "752.37k",
+                    "longFmt": "752,367"
+                  },
+                  "value": {
+                    "raw": 4589438,
+                    "fmt": "4.59M",
+                    "longFmt": "4,589,438"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "PIMCO Equity Series-PIMCO RAE International Fd",
+                  "pctHeld": {
+                    "raw": 0.0017,
+                    "fmt": "0.17%"
+                  },
+                  "position": {
+                    "raw": 741343,
+                    "fmt": "741.34k",
+                    "longFmt": "741,343"
+                  },
+                  "value": {
+                    "raw": 2609527,
+                    "fmt": "2.61M",
+                    "longFmt": "2,609,527"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1604102400,
+                    "fmt": "2020-10-31"
+                  },
+                  "organization": "Domini Impact International Equity Fund",
+                  "pctHeld": {
+                    "raw": 0.0017,
+                    "fmt": "0.17%"
+                  },
+                  "position": {
+                    "raw": 725639,
+                    "fmt": "725.64k",
+                    "longFmt": "725,639"
+                  },
+                  "value": {
+                    "raw": 2372839,
+                    "fmt": "2.37M",
+                    "longFmt": "2,372,839"
+                  }
+                }
+              ]
+            },
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 6,
+              "open": 5.9,
+              "dayLow": 5.9,
+              "dayHigh": 5.9,
+              "regularMarketPreviousClose": 6,
+              "regularMarketOpen": 5.9,
+              "regularMarketDayLow": 5.9,
+              "regularMarketDayHigh": 5.9,
+              "exDividendDate": 1215993600,
+              "payoutRatio": 0,
+              "beta": 2.112234,
+              "volume": 1050,
+              "regularMarketVolume": 1050,
+              "averageVolume": 2859,
+              "averageVolume10days": 1600,
+              "averageDailyVolume10Day": 1600,
+              "bid": 0,
+              "ask": 0,
+              "bidSize": 0,
+              "askSize": 0,
+              "marketCap": 2474265344,
+              "fiftyTwoWeekLow": 3.27,
+              "fiftyTwoWeekHigh": 10.95,
+              "fiftyDayAverage": 5.9954543,
+              "twoHundredDayAverage": 4.939559,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            },
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 2524000000,
+                    "fmt": "2.52B",
+                    "longFmt": "2,524,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 2708000000,
+                    "fmt": "2.71B",
+                    "longFmt": "2,708,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": -184000000,
+                    "fmt": "-184M",
+                    "longFmt": "-184,000,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 61000000,
+                    "fmt": "61M",
+                    "longFmt": "61,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 204000000,
+                    "fmt": "204M",
+                    "longFmt": "204,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 3577000000,
+                    "fmt": "3.58B",
+                    "longFmt": "3,577,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -1053000000,
+                    "fmt": "-1.05B",
+                    "longFmt": "-1,053,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -624000000,
+                    "fmt": "-624M",
+                    "longFmt": "-624,000,000"
+                  },
+                  "ebit": {
+                    "raw": -1053000000,
+                    "fmt": "-1.05B",
+                    "longFmt": "-1,053,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -108000000,
+                    "fmt": "-108M",
+                    "longFmt": "-108,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -1677000000,
+                    "fmt": "-1.68B",
+                    "longFmt": "-1,677,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -12000000,
+                    "fmt": "-12M",
+                    "longFmt": "-12,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 9000000,
+                    "fmt": "9M",
+                    "longFmt": "9,000,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -1665000000,
+                    "fmt": "-1.67B",
+                    "longFmt": "-1,665,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -1665000000,
+                    "fmt": "-1.67B",
+                    "longFmt": "-1,665,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -1656000000,
+                    "fmt": "-1.66B",
+                    "longFmt": "-1,656,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 1181000000,
+                    "fmt": "1.18B",
+                    "longFmt": "1,181,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 1737000000,
+                    "fmt": "1.74B",
+                    "longFmt": "1,737,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": -556000000,
+                    "fmt": "-556M",
+                    "longFmt": "-556,000,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 36000000,
+                    "fmt": "36M",
+                    "longFmt": "36,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 210000000,
+                    "fmt": "210M",
+                    "longFmt": "210,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 2757000000,
+                    "fmt": "2.76B",
+                    "longFmt": "2,757,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -1576000000,
+                    "fmt": "-1.58B",
+                    "longFmt": "-1,576,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -957000000,
+                    "fmt": "-957M",
+                    "longFmt": "-957,000,000"
+                  },
+                  "ebit": {
+                    "raw": -1576000000,
+                    "fmt": "-1.58B",
+                    "longFmt": "-1,576,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -99000000,
+                    "fmt": "-99M",
+                    "longFmt": "-99,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -2533000000,
+                    "fmt": "-2.53B",
+                    "longFmt": "-2,533,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 81000000,
+                    "fmt": "81M",
+                    "longFmt": "81,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 10000000,
+                    "fmt": "10M",
+                    "longFmt": "10,000,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -2614000000,
+                    "fmt": "-2.61B",
+                    "longFmt": "-2,614,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -2612000000,
+                    "fmt": "-2.61B",
+                    "longFmt": "-2,612,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -2621000000,
+                    "fmt": "-2.62B",
+                    "longFmt": "-2,621,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 5020000000,
+                    "fmt": "5.02B",
+                    "longFmt": "5,020,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 4714000000,
+                    "fmt": "4.71B",
+                    "longFmt": "4,714,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 306000000,
+                    "fmt": "306M",
+                    "longFmt": "306,000,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 194000000,
+                    "fmt": "194M",
+                    "longFmt": "194,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 215000000,
+                    "fmt": "215M",
+                    "longFmt": "215,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 5877000000,
+                    "fmt": "5.88B",
+                    "longFmt": "5,877,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -857000000,
+                    "fmt": "-857M",
+                    "longFmt": "-857,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -773000000,
+                    "fmt": "-773M",
+                    "longFmt": "-773,000,000"
+                  },
+                  "ebit": {
+                    "raw": -857000000,
+                    "fmt": "-857M",
+                    "longFmt": "-857,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -89000000,
+                    "fmt": "-89M",
+                    "longFmt": "-89,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -1630000000,
+                    "fmt": "-1.63B",
+                    "longFmt": "-1,630,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 173000000,
+                    "fmt": "173M",
+                    "longFmt": "173,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 13000000,
+                    "fmt": "13M",
+                    "longFmt": "13,000,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -1803000000,
+                    "fmt": "-1.8B",
+                    "longFmt": "-1,803,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -1801000000,
+                    "fmt": "-1.8B",
+                    "longFmt": "-1,801,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -1801000000,
+                    "fmt": "-1.8B",
+                    "longFmt": "-1,801,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 6457000000,
+                    "fmt": "6.46B",
+                    "longFmt": "6,457,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 5266000000,
+                    "fmt": "5.27B",
+                    "longFmt": "5,266,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 1191000000,
+                    "fmt": "1.19B",
+                    "longFmt": "1,191,000,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 246000000,
+                    "fmt": "246M",
+                    "longFmt": "246,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 17000000,
+                    "fmt": "17M",
+                    "longFmt": "17,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 6295000000,
+                    "fmt": "6.29B",
+                    "longFmt": "6,295,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 162000000,
+                    "fmt": "162M",
+                    "longFmt": "162,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -57000000,
+                    "fmt": "-57M",
+                    "longFmt": "-57,000,000"
+                  },
+                  "ebit": {
+                    "raw": 162000000,
+                    "fmt": "162M",
+                    "longFmt": "162,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -74000000,
+                    "fmt": "-74M",
+                    "longFmt": "-74,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 105000000,
+                    "fmt": "105M",
+                    "longFmt": "105,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -60000000,
+                    "fmt": "-60M",
+                    "longFmt": "-60,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 15000000,
+                    "fmt": "15M",
+                    "longFmt": "15,000,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 165000000,
+                    "fmt": "165M",
+                    "longFmt": "165,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 164000000,
+                    "fmt": "164M",
+                    "longFmt": "164,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 159000000,
+                    "fmt": "159M",
+                    "longFmt": "159,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": -1665000000,
+                    "fmt": "-1.67B",
+                    "longFmt": "-1,665,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 638000000,
+                    "fmt": "638M",
+                    "longFmt": "638,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 295000000,
+                    "fmt": "295M",
+                    "longFmt": "295,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 120000000,
+                    "fmt": "120M",
+                    "longFmt": "120,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -730000000,
+                    "fmt": "-730M",
+                    "longFmt": "-730,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 75000000,
+                    "fmt": "75M",
+                    "longFmt": "75,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 658000000,
+                    "fmt": "658M",
+                    "longFmt": "658,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -609000000,
+                    "fmt": "-609M",
+                    "longFmt": "-609,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -370000000,
+                    "fmt": "-370M",
+                    "longFmt": "-370,000,000"
+                  },
+                  "investments": {
+                    "raw": -6000000,
+                    "fmt": "-6M",
+                    "longFmt": "-6,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -367000000,
+                    "fmt": "-367M",
+                    "longFmt": "-367,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 2121000000,
+                    "fmt": "2.12B",
+                    "longFmt": "2,121,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 2121000000,
+                    "fmt": "2.12B",
+                    "longFmt": "2,121,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -22000000,
+                    "fmt": "-22M",
+                    "longFmt": "-22,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 1123000000,
+                    "fmt": "1.12B",
+                    "longFmt": "1,123,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "netIncome": {
+                    "raw": -2612000000,
+                    "fmt": "-2.61B",
+                    "longFmt": "-2,612,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 670000000,
+                    "fmt": "670M",
+                    "longFmt": "670,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 776000000,
+                    "fmt": "776M",
+                    "longFmt": "776,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 107000000,
+                    "fmt": "107M",
+                    "longFmt": "107,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -188000000,
+                    "fmt": "-188M",
+                    "longFmt": "-188,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 37000000,
+                    "fmt": "37M",
+                    "longFmt": "37,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 125000000,
+                    "fmt": "125M",
+                    "longFmt": "125,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -1085000000,
+                    "fmt": "-1.08B",
+                    "longFmt": "-1,085,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -415000000,
+                    "fmt": "-415M",
+                    "longFmt": "-415,000,000"
+                  },
+                  "investments": {
+                    "raw": -3000000,
+                    "fmt": "-3M",
+                    "longFmt": "-3,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -256000000,
+                    "fmt": "-256M",
+                    "longFmt": "-256,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 791000000,
+                    "fmt": "791M",
+                    "longFmt": "791,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 791000000,
+                    "fmt": "791M",
+                    "longFmt": "791,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -14000000,
+                    "fmt": "-14M",
+                    "longFmt": "-14,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": -564000000,
+                    "fmt": "-564M",
+                    "longFmt": "-564,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "netIncome": {
+                    "raw": -1801000000,
+                    "fmt": "-1.8B",
+                    "longFmt": "-1,801,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 743000000,
+                    "fmt": "743M",
+                    "longFmt": "743,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 878000000,
+                    "fmt": "878M",
+                    "longFmt": "878,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 596000000,
+                    "fmt": "596M",
+                    "longFmt": "596,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -309000000,
+                    "fmt": "-309M",
+                    "longFmt": "-309,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 22000000,
+                    "fmt": "22M",
+                    "longFmt": "22,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 153000000,
+                    "fmt": "153M",
+                    "longFmt": "153,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 282000000,
+                    "fmt": "282M",
+                    "longFmt": "282,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -869000000,
+                    "fmt": "-869M",
+                    "longFmt": "-869,000,000"
+                  },
+                  "investments": {
+                    "raw": -3000000,
+                    "fmt": "-3M",
+                    "longFmt": "-3,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -503000000,
+                    "fmt": "-503M",
+                    "longFmt": "-503,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 1870000000,
+                    "fmt": "1.87B",
+                    "longFmt": "1,870,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 1870000000,
+                    "fmt": "1.87B",
+                    "longFmt": "1,870,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -3000000,
+                    "fmt": "-3M",
+                    "longFmt": "-3,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 1646000000,
+                    "fmt": "1.65B",
+                    "longFmt": "1,646,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 164000000,
+                    "fmt": "164M",
+                    "longFmt": "164,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 820000000,
+                    "fmt": "820M",
+                    "longFmt": "820,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -170000000,
+                    "fmt": "-170M",
+                    "longFmt": "-170,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 208000000,
+                    "fmt": "208M",
+                    "longFmt": "208,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -175000000,
+                    "fmt": "-175M",
+                    "longFmt": "-175,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -10000000,
+                    "fmt": "-10M",
+                    "longFmt": "-10,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 40000000,
+                    "fmt": "40M",
+                    "longFmt": "40,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 877000000,
+                    "fmt": "877M",
+                    "longFmt": "877,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -1134000000,
+                    "fmt": "-1.13B",
+                    "longFmt": "-1,134,000,000"
+                  },
+                  "investments": {
+                    "raw": -63000000,
+                    "fmt": "-63M",
+                    "longFmt": "-63,000,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 4000000,
+                    "fmt": "4M",
+                    "longFmt": "4,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -1172000000,
+                    "fmt": "-1.17B",
+                    "longFmt": "-1,172,000,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -25000000,
+                    "fmt": "-25M",
+                    "longFmt": "-25,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -54000000,
+                    "fmt": "-54M",
+                    "longFmt": "-54,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -79000000,
+                    "fmt": "-79M",
+                    "longFmt": "-79,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -8000000,
+                    "fmt": "-8M",
+                    "longFmt": "-8,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": -382000000,
+                    "fmt": "-382M",
+                    "longFmt": "-382,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "insiderHolders": {
+              "holders": [],
+              "maxAge": 1
+            },
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": []
+              },
+              "exDividendDate": 1215993600,
+              "dividendDate": 1216252800
+            },
+            "price": {
+              "maxAge": 1,
+              "regularMarketChangePercent": -0.01666665,
+              "regularMarketChange": -0.099999905,
+              "regularMarketTime": 1613486803,
+              "priceHint": 2,
+              "regularMarketPrice": 5.9,
+              "regularMarketDayHigh": 5.9,
+              "regularMarketDayLow": 5.9,
+              "regularMarketVolume": 1050,
+              "averageDailyVolume10Day": 1600,
+              "averageDailyVolume3Month": 2859,
+              "regularMarketPreviousClose": 6,
+              "regularMarketSource": "DELAYED",
+              "regularMarketOpen": 5.9,
+              "exchange": "PNK",
+              "exchangeName": "Other OTC",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "EQUITY",
+              "symbol": "AFRAF",
+              "underlyingSymbol": null,
+              "shortName": "AIR FRANCE-KLM",
+              "longName": "Air France-KLM SA",
+              "currency": "USD",
+              "quoteSourceName": "Delayed Quote",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 2474265344
+            },
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 3715000000,
+                    "fmt": "3.71B",
+                    "longFmt": "3,715,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 50000000,
+                    "fmt": "50M",
+                    "longFmt": "50,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 2723000000,
+                    "fmt": "2.72B",
+                    "longFmt": "2,723,000,000"
+                  },
+                  "inventory": {
+                    "raw": 737000000,
+                    "fmt": "737M",
+                    "longFmt": "737,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 660000000,
+                    "fmt": "660M",
+                    "longFmt": "660,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 8539000000,
+                    "fmt": "8.54B",
+                    "longFmt": "8,539,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 969000000,
+                    "fmt": "969M",
+                    "longFmt": "969,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 18087000000,
+                    "fmt": "18.09B",
+                    "longFmt": "18,087,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 217000000,
+                    "fmt": "217M",
+                    "longFmt": "217,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 1305000000,
+                    "fmt": "1.3B",
+                    "longFmt": "1,305,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 1618000000,
+                    "fmt": "1.62B",
+                    "longFmt": "1,618,000,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 523000000,
+                    "fmt": "523M",
+                    "longFmt": "523,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 30735000000,
+                    "fmt": "30.73B",
+                    "longFmt": "30,735,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 2379000000,
+                    "fmt": "2.38B",
+                    "longFmt": "2,379,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 307000000,
+                    "fmt": "307M",
+                    "longFmt": "307,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 7332000000,
+                    "fmt": "7.33B",
+                    "longFmt": "7,332,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 3370000000,
+                    "fmt": "3.37B",
+                    "longFmt": "3,370,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 6330000000,
+                    "fmt": "6.33B",
+                    "longFmt": "6,330,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 15000000,
+                    "fmt": "15M",
+                    "longFmt": "15,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 12649000000,
+                    "fmt": "12.65B",
+                    "longFmt": "12,649,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 28436000000,
+                    "fmt": "28.44B",
+                    "longFmt": "28,436,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 429000000,
+                    "fmt": "429M",
+                    "longFmt": "429,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 360000000,
+                    "fmt": "360M",
+                    "longFmt": "360,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -3047000000,
+                    "fmt": "-3.05B",
+                    "longFmt": "-3,047,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 4139000000,
+                    "fmt": "4.14B",
+                    "longFmt": "4,139,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -2980000000,
+                    "fmt": "-2.98B",
+                    "longFmt": "-2,980,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1881000000,
+                    "fmt": "1.88B",
+                    "longFmt": "1,881,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 359000000,
+                    "fmt": "359M",
+                    "longFmt": "359,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "cash": {
+                    "raw": 3585000000,
+                    "fmt": "3.58B",
+                    "longFmt": "3,585,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 2704000000,
+                    "fmt": "2.7B",
+                    "longFmt": "2,704,000,000"
+                  },
+                  "inventory": {
+                    "raw": 633000000,
+                    "fmt": "633M",
+                    "longFmt": "633,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 588000000,
+                    "fmt": "588M",
+                    "longFmt": "588,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 7799000000,
+                    "fmt": "7.8B",
+                    "longFmt": "7,799,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 970000000,
+                    "fmt": "970M",
+                    "longFmt": "970,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 17475000000,
+                    "fmt": "17.48B",
+                    "longFmt": "17,475,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 217000000,
+                    "fmt": "217M",
+                    "longFmt": "217,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 1194000000,
+                    "fmt": "1.19B",
+                    "longFmt": "1,194,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 1982000000,
+                    "fmt": "1.98B",
+                    "longFmt": "1,982,000,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 559000000,
+                    "fmt": "559M",
+                    "longFmt": "559,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 29637000000,
+                    "fmt": "29.64B",
+                    "longFmt": "29,637,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 2454000000,
+                    "fmt": "2.45B",
+                    "longFmt": "2,454,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 191000000,
+                    "fmt": "191M",
+                    "longFmt": "191,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 6996000000,
+                    "fmt": "7B",
+                    "longFmt": "6,996,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 2856000000,
+                    "fmt": "2.86B",
+                    "longFmt": "2,856,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 6188000000,
+                    "fmt": "6.19B",
+                    "longFmt": "6,188,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 12000000,
+                    "fmt": "12M",
+                    "longFmt": "12,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 12342000000,
+                    "fmt": "12.34B",
+                    "longFmt": "12,342,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 27839000000,
+                    "fmt": "27.84B",
+                    "longFmt": "27,839,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 429000000,
+                    "fmt": "429M",
+                    "longFmt": "429,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 490000000,
+                    "fmt": "490M",
+                    "longFmt": "490,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -3675000000,
+                    "fmt": "-3.67B",
+                    "longFmt": "-3,675,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 4139000000,
+                    "fmt": "4.14B",
+                    "longFmt": "4,139,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -3608000000,
+                    "fmt": "-3.61B",
+                    "longFmt": "-3,608,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1383000000,
+                    "fmt": "1.38B",
+                    "longFmt": "1,383,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -28000000,
+                    "fmt": "-28M",
+                    "longFmt": "-28,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "cash": {
+                    "raw": 4673000000,
+                    "fmt": "4.67B",
+                    "longFmt": "4,673,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 93000000,
+                    "fmt": "93M",
+                    "longFmt": "93,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 2617000000,
+                    "fmt": "2.62B",
+                    "longFmt": "2,617,000,000"
+                  },
+                  "inventory": {
+                    "raw": 557000000,
+                    "fmt": "557M",
+                    "longFmt": "557,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 926000000,
+                    "fmt": "926M",
+                    "longFmt": "926,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 9058000000,
+                    "fmt": "9.06B",
+                    "longFmt": "9,058,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 742000000,
+                    "fmt": "742M",
+                    "longFmt": "742,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 16778000000,
+                    "fmt": "16.78B",
+                    "longFmt": "16,778,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 216000000,
+                    "fmt": "216M",
+                    "longFmt": "216,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 1122000000,
+                    "fmt": "1.12B",
+                    "longFmt": "1,122,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 2047000000,
+                    "fmt": "2.05B",
+                    "longFmt": "2,047,000,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 417000000,
+                    "fmt": "417M",
+                    "longFmt": "417,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 29963000000,
+                    "fmt": "29.96B",
+                    "longFmt": "29,963,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 2365000000,
+                    "fmt": "2.37B",
+                    "longFmt": "2,365,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 731000000,
+                    "fmt": "731M",
+                    "longFmt": "731,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 6069000000,
+                    "fmt": "6.07B",
+                    "longFmt": "6,069,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 2833000000,
+                    "fmt": "2.83B",
+                    "longFmt": "2,833,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 5587000000,
+                    "fmt": "5.59B",
+                    "longFmt": "5,587,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 12000000,
+                    "fmt": "12M",
+                    "longFmt": "12,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 12054000000,
+                    "fmt": "12.05B",
+                    "longFmt": "12,054,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 27543000000,
+                    "fmt": "27.54B",
+                    "longFmt": "27,543,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 429000000,
+                    "fmt": "429M",
+                    "longFmt": "429,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 248000000,
+                    "fmt": "248M",
+                    "longFmt": "248,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -3008000000,
+                    "fmt": "-3.01B",
+                    "longFmt": "-3,008,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 4139000000,
+                    "fmt": "4.14B",
+                    "longFmt": "4,139,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -2941000000,
+                    "fmt": "-2.94B",
+                    "longFmt": "-2,941,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1808000000,
+                    "fmt": "1.81B",
+                    "longFmt": "1,808,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 470000000,
+                    "fmt": "470M",
+                    "longFmt": "470,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "cash": {
+                    "raw": 3938000000,
+                    "fmt": "3.94B",
+                    "longFmt": "3,938,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 2276000000,
+                    "fmt": "2.28B",
+                    "longFmt": "2,276,000,000"
+                  },
+                  "inventory": {
+                    "raw": 566000000,
+                    "fmt": "566M",
+                    "longFmt": "566,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 615000000,
+                    "fmt": "615M",
+                    "longFmt": "615,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 7607000000,
+                    "fmt": "7.61B",
+                    "longFmt": "7,607,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 393000000,
+                    "fmt": "393M",
+                    "longFmt": "393,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 10599000000,
+                    "fmt": "10.6B",
+                    "longFmt": "10,599,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 218000000,
+                    "fmt": "218M",
+                    "longFmt": "218,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 1066000000,
+                    "fmt": "1.07B",
+                    "longFmt": "1,066,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 3049000000,
+                    "fmt": "3.05B",
+                    "longFmt": "3,049,000,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 176000000,
+                    "fmt": "176M",
+                    "longFmt": "176,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 22932000000,
+                    "fmt": "22.93B",
+                    "longFmt": "22,932,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 2359000000,
+                    "fmt": "2.36B",
+                    "longFmt": "2,359,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 328000000,
+                    "fmt": "328M",
+                    "longFmt": "328,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 5437000000,
+                    "fmt": "5.44B",
+                    "longFmt": "5,437,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 3926000000,
+                    "fmt": "3.93B",
+                    "longFmt": "3,926,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 4002000000,
+                    "fmt": "4B",
+                    "longFmt": "4,002,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 12000000,
+                    "fmt": "12M",
+                    "longFmt": "12,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 10141000000,
+                    "fmt": "10.14B",
+                    "longFmt": "10,141,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 21636000000,
+                    "fmt": "21.64B",
+                    "longFmt": "21,636,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 300000000,
+                    "fmt": "300M",
+                    "longFmt": "300,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 1038000000,
+                    "fmt": "1.04B",
+                    "longFmt": "1,038,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -3625000000,
+                    "fmt": "-3.62B",
+                    "longFmt": "-3,625,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 2971000000,
+                    "fmt": "2.97B",
+                    "longFmt": "2,971,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -3558000000,
+                    "fmt": "-3.56B",
+                    "longFmt": "-3,558,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 684000000,
+                    "fmt": "684M",
+                    "longFmt": "684,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -600000000,
+                    "fmt": "-600M",
+                    "longFmt": "-600,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 5.9,
+              "recommendationKey": "none",
+              "quickRatio": 0.56,
+              "currentRatio": 0.624,
+              "returnOnAssets": -0.07041,
+              "grossProfits": 5916000000,
+              "revenueGrowth": -0.668,
+              "grossMargins": 0.05006,
+              "ebitdaMargins": -0.12091,
+              "operatingMargins": 0,
+              "profitMargins": -0.38606,
+              "financialCurrency": "EUR"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-all-AMZN.json
+++ b/tests/http/quoteSummary-all-AMZN.json
@@ -1,0 +1,10812 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=assetProfile%2CbalanceSheetHistory%2CbalanceSheetHistoryQuarterly%2CcalendarEvents%2CcashflowStatementHistory%2CcashflowStatementHistoryQuarterly%2CdefaultKeyStatistics%2Cearnings%2CearningsHistory%2CearningsTrend%2CfinancialData%2CfundOwnership%2CfundPerformance%2CfundProfile%2CincomeStatementHistory%2CincomeStatementHistoryQuarterly%2CindexTrend%2CindustryTrend%2CinsiderHolders%2CinsiderTransactions%2CinstitutionOwnership%2CmajorDirectHolders%2CmajorHoldersBreakdown%2CnetSharePurchaseActivity%2Cprice%2CquoteType%2CrecommendationTrend%2CsecFilings%2CsectorTrend%2CsummaryDetail%2CsummaryProfile%2CtopHoldings%2CupgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "14ege8hg2nrri"
+      ],
+      "x-yahoo-request-id": [
+        "14ege8hg2nrri"
+      ],
+      "x-request-id": [
+        "2ba72ad3-095f-4b38-b657-939c56414dfa"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "14"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:42 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "410 Terry Avenue North",
+              "city": "Seattle",
+              "state": "WA",
+              "zip": "98109-5210",
+              "country": "United States",
+              "phone": "206-266-1000",
+              "website": "http://www.amazon.com",
+              "industry": "Internet Retail",
+              "sector": "Consumer Cyclical",
+              "longBusinessSummary": "Amazon.com, Inc. engages in the retail sale of consumer products and subscriptions in North America and internationally. The company operates through three segments: North America, International, and Amazon Web Services (AWS). It sells merchandise and content purchased for resale from third-party sellers through physical and online stores. The company also manufactures and sells electronic devices, including Kindle, Fire tablets, Fire TVs, Rings, and Echo and other devices; provides Kindle Direct Publishing, an online service that allows independent authors and publishers to make their books available in the Kindle Store; and develops and produces media content. In addition, it offers programs that enable sellers to sell their products on its websites, as well as its stores; and programs that allow authors, musicians, filmmakers, skill and app developers, and others to publish and sell content. Further, the company provides compute, storage, database, analytics, machine learning, and other services, as well as fulfillment, advertising, publishing, and digital content subscriptions. Additionally, it offers Amazon Prime, a membership program, which provides free shipping of various items; access to streaming of movies and TV episodes; and other services. The company serves consumers, sellers, developers, enterprises, and content creators. Amazon.com, Inc. was founded in 1994 and is headquartered in Seattle, Washington.",
+              "fullTimeEmployees": 1298000,
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Jeffrey P. Bezos",
+                  "age": 56,
+                  "title": "Founder, Chairman, Pres & CEO",
+                  "yearBorn": 1964,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 1681840,
+                    "fmt": "1.68M",
+                    "longFmt": "1,681,840"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Brian T. Olsavsky",
+                  "age": 56,
+                  "title": "Sr. VP & CFO",
+                  "yearBorn": 1964,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 163200,
+                    "fmt": "163.2k",
+                    "longFmt": "163,200"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Andrew R. Jassy",
+                  "age": 52,
+                  "title": "Chief Exec. Officer of Amazon Web Services Inc.",
+                  "yearBorn": 1968,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 348809,
+                    "fmt": "348.81k",
+                    "longFmt": "348,809"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Shelley L. Reynolds",
+                  "age": 55,
+                  "title": "VP, Worldwide Controller & Principal Accounting Officer",
+                  "yearBorn": 1965,
+                  "fiscalYear": 2009,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Werner  Vogels",
+                  "title": "Chief Technology Officer",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Dave  Fildes",
+                  "title": "Director of Investor Relations",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. David A. Zapolsky",
+                  "age": 56,
+                  "title": "Sr. VP, Gen. Counsel & Sec.",
+                  "yearBorn": 1964,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Ragia  Samir",
+                  "title": "Head of Marketing",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Beth  Galetti",
+                  "title": "Sr. VP of Worldwide HR",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Steven  Kessel",
+                  "age": 54,
+                  "title": "Sr. VP",
+                  "yearBorn": 1966,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "auditRisk": 1,
+              "boardRisk": 9,
+              "compensationRisk": 9,
+              "shareHolderRightsRisk": 2,
+              "overallRisk": 6,
+              "governanceEpochDate": 1606867200,
+              "compensationAsOfEpochDate": 1577750400,
+              "maxAge": 86400
+            },
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 15,
+                  "buy": 28,
+                  "hold": 3,
+                  "sell": 1,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 18,
+                  "buy": 29,
+                  "hold": 3,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 18,
+                  "buy": 29,
+                  "hold": 3,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 18,
+                  "buy": 27,
+                  "hold": 3,
+                  "sell": 1,
+                  "strongSell": 0
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 21331000000,
+                    "fmt": "21.33B",
+                    "longFmt": "21,331,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 25251000000,
+                    "fmt": "25.25B",
+                    "longFmt": "25,251,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 6001000000,
+                    "fmt": "6B",
+                    "longFmt": "6,001,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -8169000000,
+                    "fmt": "-8.17B",
+                    "longFmt": "-8,169,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 18745000000,
+                    "fmt": "18.75B",
+                    "longFmt": "18,745,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -2849000000,
+                    "fmt": "-2.85B",
+                    "longFmt": "-2,849,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 5754000000,
+                    "fmt": "5.75B",
+                    "longFmt": "5,754,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 66064000000,
+                    "fmt": "66.06B",
+                    "longFmt": "66,064,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -40140000000,
+                    "fmt": "-40.14B",
+                    "longFmt": "-40,140,000,000"
+                  },
+                  "investments": {
+                    "raw": -22242000000,
+                    "fmt": "-22.24B",
+                    "longFmt": "-22,242,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -59611000000,
+                    "fmt": "-59.61B",
+                    "longFmt": "-59,611,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -1104000000,
+                    "fmt": "-1.1B",
+                    "longFmt": "-1,104,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -1104000000,
+                    "fmt": "-1.1B",
+                    "longFmt": "-1,104,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 618000000,
+                    "fmt": "618M",
+                    "longFmt": "618,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 5967000000,
+                    "fmt": "5.97B",
+                    "longFmt": "5,967,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 11588000000,
+                    "fmt": "11.59B",
+                    "longFmt": "11,588,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 21789000000,
+                    "fmt": "21.79B",
+                    "longFmt": "21,789,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 7575000000,
+                    "fmt": "7.58B",
+                    "longFmt": "7,575,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -7681000000,
+                    "fmt": "-7.68B",
+                    "longFmt": "-7,681,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 9904000000,
+                    "fmt": "9.9B",
+                    "longFmt": "9,904,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -3278000000,
+                    "fmt": "-3.28B",
+                    "longFmt": "-3,278,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -1383000000,
+                    "fmt": "-1.38B",
+                    "longFmt": "-1,383,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 38514000000,
+                    "fmt": "38.51B",
+                    "longFmt": "38,514,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -16861000000,
+                    "fmt": "-16.86B",
+                    "longFmt": "-16,861,000,000"
+                  },
+                  "investments": {
+                    "raw": -9131000000,
+                    "fmt": "-9.13B",
+                    "longFmt": "-9,131,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -24281000000,
+                    "fmt": "-24.28B",
+                    "longFmt": "-24,281,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -10066000000,
+                    "fmt": "-10.07B",
+                    "longFmt": "-10,066,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -10066000000,
+                    "fmt": "-10.07B",
+                    "longFmt": "-10,066,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 70000000,
+                    "fmt": "70M",
+                    "longFmt": "70,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 4237000000,
+                    "fmt": "4.24B",
+                    "longFmt": "4,237,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 10073000000,
+                    "fmt": "10.07B",
+                    "longFmt": "10,073,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 15341000000,
+                    "fmt": "15.34B",
+                    "longFmt": "15,341,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 6352000000,
+                    "fmt": "6.35B",
+                    "longFmt": "6,352,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -4615000000,
+                    "fmt": "-4.62B",
+                    "longFmt": "-4,615,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 4414000000,
+                    "fmt": "4.41B",
+                    "longFmt": "4,414,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -1314000000,
+                    "fmt": "-1.31B",
+                    "longFmt": "-1,314,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 472000000,
+                    "fmt": "472M",
+                    "longFmt": "472,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 30723000000,
+                    "fmt": "30.72B",
+                    "longFmt": "30,723,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -13427000000,
+                    "fmt": "-13.43B",
+                    "longFmt": "-13,427,000,000"
+                  },
+                  "investments": {
+                    "raw": 1140000000,
+                    "fmt": "1.14B",
+                    "longFmt": "1,140,000,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 2104000000,
+                    "fmt": "2.1B",
+                    "longFmt": "2,104,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -12369000000,
+                    "fmt": "-12.37B",
+                    "longFmt": "-12,369,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -7686000000,
+                    "fmt": "-7.69B",
+                    "longFmt": "-7,686,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -7686000000,
+                    "fmt": "-7.69B",
+                    "longFmt": "-7,686,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -351000000,
+                    "fmt": "-351M",
+                    "longFmt": "-351,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 10317000000,
+                    "fmt": "10.32B",
+                    "longFmt": "10,317,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 3033000000,
+                    "fmt": "3.03B",
+                    "longFmt": "3,033,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 11478000000,
+                    "fmt": "11.48B",
+                    "longFmt": "11,478,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 4096000000,
+                    "fmt": "4.1B",
+                    "longFmt": "4,096,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -4780000000,
+                    "fmt": "-4.78B",
+                    "longFmt": "-4,780,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 7838000000,
+                    "fmt": "7.84B",
+                    "longFmt": "7,838,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -3583000000,
+                    "fmt": "-3.58B",
+                    "longFmt": "-3,583,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 283000000,
+                    "fmt": "283M",
+                    "longFmt": "283,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 18365000000,
+                    "fmt": "18.36B",
+                    "longFmt": "18,365,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -11955000000,
+                    "fmt": "-11.96B",
+                    "longFmt": "-11,955,000,000"
+                  },
+                  "investments": {
+                    "raw": -3054000000,
+                    "fmt": "-3.05B",
+                    "longFmt": "-3,054,000,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 1897000000,
+                    "fmt": "1.9B",
+                    "longFmt": "1,897,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -27084000000,
+                    "fmt": "-27.08B",
+                    "longFmt": "-27,084,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 9928000000,
+                    "fmt": "9.93B",
+                    "longFmt": "9,928,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 9928000000,
+                    "fmt": "9.93B",
+                    "longFmt": "9,928,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 713000000,
+                    "fmt": "713M",
+                    "longFmt": "713,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 1922000000,
+                    "fmt": "1.92B",
+                    "longFmt": "1,922,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 6.26429,
+              "pegRatio": 0.655216,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.258
+                },
+                {
+                  "period": "+1q",
+                  "growth": 0.97400004
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.144
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.158
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0820068
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            },
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": 1667372154880,
+              "forwardPE": 49.344,
+              "profitMargins": 0.05525,
+              "floatShares": 429329229,
+              "sharesOutstanding": 500889984,
+              "sharesShort": 3315887,
+              "sharesShortPriorMonth": 3293474,
+              "sharesShortPreviousMonthDate": 1609372800,
+              "dateShortInterest": 1611878400,
+              "sharesPercentSharesOut": 0.0066000004,
+              "heldPercentInsiders": 0.14556,
+              "heldPercentInstitutions": 0.58663,
+              "shortRatio": 0.88,
+              "shortPercentOfFloat": 0.0077,
+              "beta": 1.143009,
+              "category": null,
+              "bookValue": 185.694,
+              "priceToBook": 17.66025,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1609372800,
+              "nextFiscalYearEnd": 1672444800,
+              "mostRecentQuarter": 1609372800,
+              "earningsQuarterlyGrowth": 1.21,
+              "netIncomeToCommon": 21330999296,
+              "trailingEps": 41.83,
+              "forwardEps": 66.46,
+              "pegRatio": 1.71,
+              "lastSplitFactor": "2:1",
+              "lastSplitDate": 936230400,
+              "enterpriseToRevenue": 4.319,
+              "enterpriseToEbitda": 34.629,
+              "52WeekChange": 0.5205064,
+              "SandP52WeekChange": 0.1675049
+            },
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "quoteType": {
+              "exchange": "NMS",
+              "quoteType": "EQUITY",
+              "symbol": "AMZN",
+              "underlyingSymbol": "AMZN",
+              "shortName": "Amazon.com, Inc.",
+              "longName": "Amazon.com, Inc.",
+              "firstTradeDateEpochUtc": 863703000,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "261fd26b-0151-3813-b0d0-97e4ed4c6505",
+              "messageBoardId": "finmb_18749",
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            },
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 386064000000,
+                    "fmt": "386.06B",
+                    "longFmt": "386,064,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 233307000000,
+                    "fmt": "233.31B",
+                    "longFmt": "233,307,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 152757000000,
+                    "fmt": "152.76B",
+                    "longFmt": "152,757,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 42740000000,
+                    "fmt": "42.74B",
+                    "longFmt": "42,740,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 87193000000,
+                    "fmt": "87.19B",
+                    "longFmt": "87,193,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": -75000000,
+                    "fmt": "-75M",
+                    "longFmt": "-75,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 363165000000,
+                    "fmt": "363.17B",
+                    "longFmt": "363,165,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 22899000000,
+                    "fmt": "22.9B",
+                    "longFmt": "22,899,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 1295000000,
+                    "fmt": "1.29B",
+                    "longFmt": "1,295,000,000"
+                  },
+                  "ebit": {
+                    "raw": 22899000000,
+                    "fmt": "22.9B",
+                    "longFmt": "22,899,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -1647000000,
+                    "fmt": "-1.65B",
+                    "longFmt": "-1,647,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 24194000000,
+                    "fmt": "24.19B",
+                    "longFmt": "24,194,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 2863000000,
+                    "fmt": "2.86B",
+                    "longFmt": "2,863,000,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 21331000000,
+                    "fmt": "21.33B",
+                    "longFmt": "21,331,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 21331000000,
+                    "fmt": "21.33B",
+                    "longFmt": "21,331,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 21331000000,
+                    "fmt": "21.33B",
+                    "longFmt": "21,331,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 280522000000,
+                    "fmt": "280.52B",
+                    "longFmt": "280,522,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 165536000000,
+                    "fmt": "165.54B",
+                    "longFmt": "165,536,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 114986000000,
+                    "fmt": "114.99B",
+                    "longFmt": "114,986,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 35931000000,
+                    "fmt": "35.93B",
+                    "longFmt": "35,931,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 64313000000,
+                    "fmt": "64.31B",
+                    "longFmt": "64,313,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 338000000,
+                    "fmt": "338M",
+                    "longFmt": "338,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 266118000000,
+                    "fmt": "266.12B",
+                    "longFmt": "266,118,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 14404000000,
+                    "fmt": "14.4B",
+                    "longFmt": "14,404,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -442000000,
+                    "fmt": "-442M",
+                    "longFmt": "-442,000,000"
+                  },
+                  "ebit": {
+                    "raw": 14404000000,
+                    "fmt": "14.4B",
+                    "longFmt": "14,404,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -1600000000,
+                    "fmt": "-1.6B",
+                    "longFmt": "-1,600,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 13962000000,
+                    "fmt": "13.96B",
+                    "longFmt": "13,962,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 2374000000,
+                    "fmt": "2.37B",
+                    "longFmt": "2,374,000,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 11588000000,
+                    "fmt": "11.59B",
+                    "longFmt": "11,588,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 11588000000,
+                    "fmt": "11.59B",
+                    "longFmt": "11,588,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 11588000000,
+                    "fmt": "11.59B",
+                    "longFmt": "11,588,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 232887000000,
+                    "fmt": "232.89B",
+                    "longFmt": "232,887,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 139156000000,
+                    "fmt": "139.16B",
+                    "longFmt": "139,156,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 93731000000,
+                    "fmt": "93.73B",
+                    "longFmt": "93,731,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 28837000000,
+                    "fmt": "28.84B",
+                    "longFmt": "28,837,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 52177000000,
+                    "fmt": "52.18B",
+                    "longFmt": "52,177,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 296000000,
+                    "fmt": "296M",
+                    "longFmt": "296,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 220466000000,
+                    "fmt": "220.47B",
+                    "longFmt": "220,466,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 12421000000,
+                    "fmt": "12.42B",
+                    "longFmt": "12,421,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -1151000000,
+                    "fmt": "-1.15B",
+                    "longFmt": "-1,151,000,000"
+                  },
+                  "ebit": {
+                    "raw": 12421000000,
+                    "fmt": "12.42B",
+                    "longFmt": "12,421,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -1417000000,
+                    "fmt": "-1.42B",
+                    "longFmt": "-1,417,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 11270000000,
+                    "fmt": "11.27B",
+                    "longFmt": "11,270,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 1197000000,
+                    "fmt": "1.2B",
+                    "longFmt": "1,197,000,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 10073000000,
+                    "fmt": "10.07B",
+                    "longFmt": "10,073,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 10073000000,
+                    "fmt": "10.07B",
+                    "longFmt": "10,073,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 10073000000,
+                    "fmt": "10.07B",
+                    "longFmt": "10,073,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 177866000000,
+                    "fmt": "177.87B",
+                    "longFmt": "177,866,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 111934000000,
+                    "fmt": "111.93B",
+                    "longFmt": "111,934,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 65932000000,
+                    "fmt": "65.93B",
+                    "longFmt": "65,932,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 22620000000,
+                    "fmt": "22.62B",
+                    "longFmt": "22,620,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 38992000000,
+                    "fmt": "38.99B",
+                    "longFmt": "38,992,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 214000000,
+                    "fmt": "214M",
+                    "longFmt": "214,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 173760000000,
+                    "fmt": "173.76B",
+                    "longFmt": "173,760,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 4106000000,
+                    "fmt": "4.11B",
+                    "longFmt": "4,106,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -304000000,
+                    "fmt": "-304M",
+                    "longFmt": "-304,000,000"
+                  },
+                  "ebit": {
+                    "raw": 4106000000,
+                    "fmt": "4.11B",
+                    "longFmt": "4,106,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -848000000,
+                    "fmt": "-848M",
+                    "longFmt": "-848,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 3802000000,
+                    "fmt": "3.8B",
+                    "longFmt": "3,802,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 769000000,
+                    "fmt": "769M",
+                    "longFmt": "769,000,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 3033000000,
+                    "fmt": "3.03B",
+                    "longFmt": "3,033,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 3033000000,
+                    "fmt": "3.03B",
+                    "longFmt": "3,033,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 3033000000,
+                    "fmt": "3.03B",
+                    "longFmt": "3,033,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Total Stock Market Index Fund",
+                  "pctHeld": {
+                    "raw": 0.023699999,
+                    "fmt": "2.37%"
+                  },
+                  "position": {
+                    "raw": 11939563,
+                    "fmt": "11.94M",
+                    "longFmt": "11,939,563"
+                  },
+                  "value": {
+                    "raw": 37594460204,
+                    "fmt": "37.59B",
+                    "longFmt": "37,594,460,204"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard 500 Index Fund",
+                  "pctHeld": {
+                    "raw": 0.0173,
+                    "fmt": "1.73%"
+                  },
+                  "position": {
+                    "raw": 8734062,
+                    "fmt": "8.73M",
+                    "longFmt": "8,734,062"
+                  },
+                  "value": {
+                    "raw": 27501203041,
+                    "fmt": "27.5B",
+                    "longFmt": "27,501,203,041"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "SPDR S&P 500 ETF Trust",
+                  "pctHeld": {
+                    "raw": 0.0089,
+                    "fmt": "0.89%"
+                  },
+                  "position": {
+                    "raw": 4477608,
+                    "fmt": "4.48M",
+                    "longFmt": "4,477,608"
+                  },
+                  "value": {
+                    "raw": 14583255823,
+                    "fmt": "14.58B",
+                    "longFmt": "14,583,255,823"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Invesco ETF Tr-Invesco QQQ Tr, Series 1 ETF",
+                  "pctHeld": {
+                    "raw": 0.0082,
+                    "fmt": "0.82%"
+                  },
+                  "position": {
+                    "raw": 4143104,
+                    "fmt": "4.14M",
+                    "longFmt": "4,143,104"
+                  },
+                  "value": {
+                    "raw": 13493799710,
+                    "fmt": "13.49B",
+                    "longFmt": "13,493,799,710"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Fidelity 500 Index Fund",
+                  "pctHeld": {
+                    "raw": 0.0077,
+                    "fmt": "0.77%"
+                  },
+                  "position": {
+                    "raw": 3860193,
+                    "fmt": "3.86M",
+                    "longFmt": "3,860,193"
+                  },
+                  "value": {
+                    "raw": 12572378387,
+                    "fmt": "12.57B",
+                    "longFmt": "12,572,378,387"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Fidelity Contrafund Inc",
+                  "pctHeld": {
+                    "raw": 0.0075,
+                    "fmt": "0.75%"
+                  },
+                  "position": {
+                    "raw": 3781672,
+                    "fmt": "3.78M",
+                    "longFmt": "3,781,672"
+                  },
+                  "value": {
+                    "raw": 12316640986,
+                    "fmt": "12.32B",
+                    "longFmt": "12,316,640,986"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Growth Fund Of America Inc",
+                  "pctHeld": {
+                    "raw": 0.0074,
+                    "fmt": "0.74%"
+                  },
+                  "position": {
+                    "raw": 3709684,
+                    "fmt": "3.71M",
+                    "longFmt": "3,709,684"
+                  },
+                  "value": {
+                    "raw": 12082181110,
+                    "fmt": "12.08B",
+                    "longFmt": "12,082,181,110"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Institutional Index Fund-Institutional Index Fund",
+                  "pctHeld": {
+                    "raw": 0.0073,
+                    "fmt": "0.73%"
+                  },
+                  "position": {
+                    "raw": 3654026,
+                    "fmt": "3.65M",
+                    "longFmt": "3,654,026"
+                  },
+                  "value": {
+                    "raw": 11505541286,
+                    "fmt": "11.51B",
+                    "longFmt": "11,505,541,286"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Growth Index Fund",
+                  "pctHeld": {
+                    "raw": 0.0067000003,
+                    "fmt": "0.67%"
+                  },
+                  "position": {
+                    "raw": 3372922,
+                    "fmt": "3.37M",
+                    "longFmt": "3,372,922"
+                  },
+                  "value": {
+                    "raw": 10620420689,
+                    "fmt": "10.62B",
+                    "longFmt": "10,620,420,689"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Price (T.Rowe) Blue Chip Growth Fund Inc.",
+                  "pctHeld": {
+                    "raw": 0.0066000004,
+                    "fmt": "0.66%"
+                  },
+                  "position": {
+                    "raw": 3301177,
+                    "fmt": "3.3M",
+                    "longFmt": "3,301,177"
+                  },
+                  "value": {
+                    "raw": 10751702406,
+                    "fmt": "10.75B",
+                    "longFmt": "10,751,702,406"
+                  }
+                }
+              ]
+            },
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 3277.71,
+              "open": 3254.05,
+              "dayLow": 3257.75,
+              "dayHigh": 3308,
+              "regularMarketPreviousClose": 3277.71,
+              "regularMarketOpen": 3254.05,
+              "regularMarketDayLow": 3257.75,
+              "regularMarketDayHigh": 3308,
+              "payoutRatio": 0,
+              "beta": 1.143009,
+              "trailingPE": 78.39833,
+              "forwardPE": 49.344,
+              "volume": 1136678,
+              "regularMarketVolume": 1136678,
+              "averageVolume": 3657442,
+              "averageVolume10days": 2649840,
+              "averageDailyVolume10Day": 2649840,
+              "bid": 3277.55,
+              "ask": 3281.27,
+              "bidSize": 900,
+              "askSize": 1100,
+              "marketCap": 1651392249856,
+              "fiftyTwoWeekLow": 1626.03,
+              "fiftyTwoWeekHigh": 3552.25,
+              "priceToSalesTrailing12Months": 4.277509,
+              "fiftyDayAverage": 3246.1387,
+              "twoHundredDayAverage": 3205.9446,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            },
+            "insiderHolders": {
+              "holders": [
+                {
+                  "maxAge": 1,
+                  "name": "BEZOS JEFFREY P",
+                  "relation": "Chief Executive Officer",
+                  "url": "",
+                  "transactionDescription": "Stock Gift",
+                  "latestTransDate": {
+                    "raw": 1606867200,
+                    "fmt": "2020-12-02"
+                  },
+                  "positionDirect": {
+                    "raw": 53220600,
+                    "fmt": "53.22M",
+                    "longFmt": "53,220,600"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1606867200,
+                    "fmt": "2020-12-02"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "HUTTENLOCHER DANIEL P",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1605830400,
+                    "fmt": "2020-11-20"
+                  },
+                  "positionDirect": {
+                    "raw": 950,
+                    "fmt": "950",
+                    "longFmt": "950"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605830400,
+                    "fmt": "2020-11-20"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "JASSY ANDREW R",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  },
+                  "positionDirect": {
+                    "raw": 84782,
+                    "fmt": "84.78k",
+                    "longFmt": "84,782"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "MCGRATH JUDITH A",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1612396800,
+                    "fmt": "2021-02-04"
+                  },
+                  "positionDirect": {
+                    "raw": 1984,
+                    "fmt": "1.98k",
+                    "longFmt": "1,984"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1612396800,
+                    "fmt": "2021-02-04"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "OLSAVSKY BRIAN T.",
+                  "relation": "Chief Financial Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  },
+                  "positionDirect": {
+                    "raw": 1571,
+                    "fmt": "1.57k",
+                    "longFmt": "1,571"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "REYNOLDS SHELLEY L",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  },
+                  "positionDirect": {
+                    "raw": 6122,
+                    "fmt": "6.12k",
+                    "longFmt": "6,122"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "RUBINSTEIN JONATHAN J",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1609804800,
+                    "fmt": "2021-01-05"
+                  },
+                  "positionDirect": {
+                    "raw": 6758,
+                    "fmt": "6.76k",
+                    "longFmt": "6,758"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1609804800,
+                    "fmt": "2021-01-05"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "STONESIFER PATRICIA Q",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "positionDirect": {
+                    "raw": 1967,
+                    "fmt": "1.97k",
+                    "longFmt": "1,967"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "WILKE JEFFREY A",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Stock Gift",
+                  "latestTransDate": {
+                    "raw": 1609286400,
+                    "fmt": "2020-12-30"
+                  },
+                  "positionIndirect": {
+                    "raw": 20110,
+                    "fmt": "20.11k",
+                    "longFmt": "20,110"
+                  },
+                  "positionIndirectDate": {
+                    "raw": 1609286400,
+                    "fmt": "2020-12-30"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "ZAPOLSKY DAVID",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  },
+                  "positionDirect": {
+                    "raw": 3605,
+                    "fmt": "3.6k",
+                    "longFmt": "3,605"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  }
+                }
+              ],
+              "maxAge": 1
+            },
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": [
+                  1619568000,
+                  1620000000
+                ],
+                "earningsAverage": 9.51,
+                "earningsLow": 6.41,
+                "earningsHigh": 12,
+                "revenueAverage": 104484000000,
+                "revenueLow": 100459000000,
+                "revenueHigh": 107474000000
+              }
+            },
+            "upgradeDowngradeHistory": {
+              "history": [
+                {
+                  "epochGradeDate": 1612376908,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612376096,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612374298,
+                  "firm": "Cowen & Co.",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612373479,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612371882,
+                  "firm": "Truist Securities",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612371343,
+                  "firm": "Monness, Crespi, Hardt",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612370453,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612369033,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612364844,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612358898,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612355314,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612355019,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612354706,
+                  "firm": "JMP Securities",
+                  "toGrade": "Market Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612354596,
+                  "firm": "Raymond James",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612354525,
+                  "firm": "Pivotal Research",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612348047,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1611769664,
+                  "firm": "Stifel",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1611322523,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1610718858,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1604491113,
+                  "firm": "China Renaissance",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1604420115,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1604077960,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1604076792,
+                  "firm": "Piper Sandler",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1604061065,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1603817616,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1603802435,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1602850533,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1602761580,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1602259918,
+                  "firm": "Mizuho",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1602068039,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1601557302,
+                  "firm": "Pivotal Research",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1600771861,
+                  "firm": "Bernstein",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1596202990,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1596199722,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1596195986,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1596195716,
+                  "firm": "Raymond James",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1596193180,
+                  "firm": "Needham",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1596184984,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1596127912,
+                  "firm": "BMO Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1595859868,
+                  "firm": "B of A Securities",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1595594151,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1595580207,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1595248547,
+                  "firm": "MKM Partners",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1594637221,
+                  "firm": "Mizuho",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1594124960,
+                  "firm": "Baird",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1593523799,
+                  "firm": "Mizuho",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1593178057,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1593177953,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1592385493,
+                  "firm": "Needham",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1591622085,
+                  "firm": "Baird",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1591621294,
+                  "firm": "RBC Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1591013273,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588352186,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588348269,
+                  "firm": "JMP Securities",
+                  "toGrade": "Market Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588344669,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588344475,
+                  "firm": "Guggenheim",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588344239,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588344081,
+                  "firm": "BMO Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588338598,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588338165,
+                  "firm": "MKM Partners",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588334977,
+                  "firm": "B of A Securities",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "reit"
+                },
+                {
+                  "epochGradeDate": 1588334844,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588333861,
+                  "firm": "Susquehanna",
+                  "toGrade": "Positive",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588333153,
+                  "firm": "Raymond James",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588332475,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588330464,
+                  "firm": "Pivotal Research",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588330355,
+                  "firm": "Mizuho",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588330243,
+                  "firm": "RBC Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588327554,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588253465,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1587999963,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1587992689,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1587990385,
+                  "firm": "Oppenheimer",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1587746820,
+                  "firm": "Stifel",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1587646973,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1587568433,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1586965916,
+                  "firm": "Baird",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1585225808,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1584458683,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1581608820,
+                  "firm": "Aegis Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580905628,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580491830,
+                  "firm": "CFRA",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580487947,
+                  "firm": "B of A Securities",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580485543,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580484494,
+                  "firm": "RBC Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580483930,
+                  "firm": "DA Davidson",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "reit"
+                },
+                {
+                  "epochGradeDate": 1580479677,
+                  "firm": "Baird",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580476098,
+                  "firm": "Piper Sandler",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580476024,
+                  "firm": "JMP Securities",
+                  "toGrade": "Market Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580475870,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580475709,
+                  "firm": "Stifel",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580475630,
+                  "firm": "Cowen & Co.",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580475135,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580474740,
+                  "firm": "Raymond James",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580472258,
+                  "firm": "Mizuho",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580472207,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580472088,
+                  "firm": "Wells Fargo",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580467903,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580305170,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580305088,
+                  "firm": "BMO Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580128735,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1579707810,
+                  "firm": "Pivotal Research",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1579265841,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1579183053,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1578660041,
+                  "firm": "Bernstein",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1574781108,
+                  "firm": "China Renaissance",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1572012335,
+                  "firm": "JMP Securities",
+                  "toGrade": "Market Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1572010119,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1572009847,
+                  "firm": "Oppenheimer",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1572009518,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1572007464,
+                  "firm": "MKM Partners",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1572007105,
+                  "firm": "BMO Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1572005722,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1572003330,
+                  "firm": "Piper Jaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1572003267,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1572003183,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1572003125,
+                  "firm": "Raymond James",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1571660240,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1569241247,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1567509298,
+                  "firm": "RBC Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1564148885,
+                  "firm": "Baird",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1564146031,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1564145147,
+                  "firm": "Raymond James",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1564142904,
+                  "firm": "Mizuho",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1564139707,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1563968948,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1563789703,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1563194075,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1556286403,
+                  "firm": "Oppenheimer",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1556286191,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1556285826,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1556285551,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1556284381,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1556284089,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1556283804,
+                  "firm": "Raymond James",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1556283429,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1556283090,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1554744121,
+                  "firm": "Societe Generale",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1553084844,
+                  "firm": "Evercore ISI Group",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1552645126,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Sector Weight",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1549036295,
+                  "firm": "Pivotal Research",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1549026083,
+                  "firm": "Raymond James",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1549025018,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1548247951,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1540568165,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1540563922,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1540562392,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1540300461,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1538046902,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1537880370,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1536581666,
+                  "firm": "Wells Fargo",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1536577864,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1536151685,
+                  "firm": "DA Davidson",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1535541478,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1532705774,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1532705036,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1532704752,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1532703191,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1532702595,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1532699185,
+                  "firm": "BMO Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1532698825,
+                  "firm": "PiperJaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1532692331,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1532691504,
+                  "firm": "JMP Securities",
+                  "toGrade": "Market Outperform",
+                  "fromGrade": "Market Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1531745433,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1531499749,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1531489660,
+                  "firm": "Cowen & Co.",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1528978353,
+                  "firm": "DA Davidson",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1528121868,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "reit"
+                },
+                {
+                  "epochGradeDate": 1525716333,
+                  "firm": "Telsey Advisory Group",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1524840711,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1524835866,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1524834218,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1524831340,
+                  "firm": "JMP Securities",
+                  "toGrade": "Market Outperform",
+                  "fromGrade": "Market Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1524829204,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1524227202,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1524138688,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1519228980,
+                  "firm": "MKM Partners",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1517835243,
+                  "firm": "Nomura",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1517587947,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1517586641,
+                  "firm": "JMP Securities",
+                  "toGrade": "Market Outperform",
+                  "fromGrade": "Market Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1517584163,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1517582814,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1517580664,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1517579506,
+                  "firm": "PiperJaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1516995809,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1516711103,
+                  "firm": "Loop Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1515160436,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1512569124,
+                  "firm": "Evercore ISI Group",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1512418004,
+                  "firm": "Moffett Nathanson",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1511183102,
+                  "firm": "Nomura",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1509385040,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1509132041,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1509127449,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1509126585,
+                  "firm": "Loop Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1509122381,
+                  "firm": "Oppenheimer",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1509119232,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1509107954,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1509106277,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1509103387,
+                  "firm": "Raymond James",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1508846359,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1507732645,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1505297947,
+                  "firm": "Loop Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1504732333,
+                  "firm": "DA Davidson",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1502885453,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1500577730,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1500384110,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1493383553,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "reit"
+                },
+                {
+                  "epochGradeDate": 1493382113,
+                  "firm": "Pacific Crest",
+                  "toGrade": "Sector Weight",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1493128067,
+                  "firm": "Raymond James",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1493034709,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1492703695,
+                  "firm": "Wolfe Research",
+                  "toGrade": "Peer Perform",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1491834059,
+                  "firm": "Needham",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1491315938,
+                  "firm": "BMO Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1490959033,
+                  "firm": "Loop Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1490735835,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1484921793,
+                  "firm": "Aegis Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1480335180,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1480354388,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1477994732,
+                  "firm": "Axiom Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1477294704,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1476692067,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1475679061,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1475679074,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1475231868,
+                  "firm": "JMP Securities",
+                  "toGrade": "Market Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1475219367,
+                  "firm": "Guggenheim",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1475143214,
+                  "firm": "Maxim Group",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1474960027,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1525527134,
+                  "firm": "Argus",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1470143957,
+                  "firm": "MKM Partners",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1469799730,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1469797781,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1469797118,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1469788989,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1469778745,
+                  "firm": "CLSA",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1469776676,
+                  "firm": "Pacific Crest",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1469776606,
+                  "firm": "JMP Securities",
+                  "toGrade": "Market Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1469775942,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1469774582,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1469427403,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1469081816,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1466656112,
+                  "firm": "Maxim Group",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1466063607,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1465539261,
+                  "firm": "William Blair",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1462272184,
+                  "firm": "Nomura",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1461904487,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1461904263,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1461903707,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1461903236,
+                  "firm": "Axiom Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1460030851,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1459492695,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1459239653,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1458624080,
+                  "firm": "Raymond James",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Strong Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1456900614,
+                  "firm": "BMO Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1456731325,
+                  "firm": "Bernstein",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1455769312,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1454054828,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1453203226,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1452841437,
+                  "firm": "Susquehanna",
+                  "toGrade": "Perform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1452572776,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1451893713,
+                  "firm": "Monness Crespi Hardt",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1450774272,
+                  "firm": "Macquarie",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1450162559,
+                  "firm": "MKM Partners",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1449648213,
+                  "firm": "Nomura",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1449559447,
+                  "firm": "Pacific Crest",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1448942499,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1445930684,
+                  "firm": "Axiom Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1445604845,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1445596322,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1445585575,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1445582670,
+                  "firm": "PiperJaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1445580512,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1445579475,
+                  "firm": "JMP Securities",
+                  "toGrade": "Market Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1445579277,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1445579164,
+                  "firm": "RBC Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1445578828,
+                  "firm": "Baird",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1445578813,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1441952731,
+                  "firm": "RBC Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1440658736,
+                  "firm": "Raymond James",
+                  "toGrade": "Strong Buy",
+                  "fromGrade": "Outperform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1440570551,
+                  "firm": "Evercore ISI Group",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1438152957,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1437735600,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1437725582,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1437720750,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1437712416,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1525528836,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1437710308,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1437710143,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Equal-Weight",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1437549413,
+                  "firm": "JMP Securities",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1437375485,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1437375308,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1437375135,
+                  "firm": "Cowen & Co.",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1436946437,
+                  "firm": "Nomura",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1436851298,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1435298143,
+                  "firm": "Mizuho",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1435210363,
+                  "firm": "Evercore ISI Group",
+                  "toGrade": "",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1434354039,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1433305233,
+                  "firm": "PiperJaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1430730000,
+                  "firm": "Oppenheimer",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1525527134,
+                  "firm": "Argus",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1429866000,
+                  "firm": "Nomura",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1429860251,
+                  "firm": "Janney Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1429856558,
+                  "firm": "Raymond James",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1429856435,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1429689230,
+                  "firm": "Monness Crespi Hardt",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1429610895,
+                  "firm": "BGC Financial",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1429002000,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1425979742,
+                  "firm": "Wolfe Research",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Peer Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1425888988,
+                  "firm": "Axiom Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1425882793,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1425449151,
+                  "firm": "Baird",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1424327255,
+                  "firm": "PiperJaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1422608400,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1422349200,
+                  "firm": "JP Morgan",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1422003020,
+                  "firm": "Oppenheimer",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1421855313,
+                  "firm": "BGC Financial",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1421107200,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1417155008,
+                  "firm": "PiperJaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1416528000,
+                  "firm": "Nomura",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1414569337,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1414398600,
+                  "firm": "Monness, Crespi, Hardt",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1414141200,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1414139400,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1413216000,
+                  "firm": "Wolfe Research",
+                  "toGrade": "",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1413189000,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1412931600,
+                  "firm": "Susquehanna",
+                  "toGrade": "Positive",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1406323278,
+                  "firm": "CRT Capital",
+                  "toGrade": "Fair Value",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1406321095,
+                  "firm": "Citigroup",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1406321093,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1406273324,
+                  "firm": "Raymond James",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1525528836,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1406254590,
+                  "firm": "UBS",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1406252455,
+                  "firm": "JP Morgan",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1406248769,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1406247747,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1406010002,
+                  "firm": "Citigroup",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1403764014,
+                  "firm": "Barclays",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1398873600,
+                  "firm": "Edward Jones",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1398467992,
+                  "firm": "Cantor Fitzgerald",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1398412800,
+                  "firm": "Raymond James",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Strong Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1398409757,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1398395478,
+                  "firm": "UBS",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1398393545,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1398391606,
+                  "firm": "JP Morgan",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1398386062,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1397635497,
+                  "firm": "Argus Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1392220800,
+                  "firm": "UBS",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1391169372,
+                  "firm": "FBN Securities",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1391155200,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1391153689,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1391150848,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1390838400,
+                  "firm": "Pacific Crest",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1389686709,
+                  "firm": "FBN Securities",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1389342600,
+                  "firm": "Susquehanna",
+                  "toGrade": "Positive",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1388990834,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1388764800,
+                  "firm": "Topeka",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1388505600,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1387262989,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1384417940,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1382968950,
+                  "firm": "Standpoint",
+                  "toGrade": "Sell",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1382945547,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1382687911,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1382685973,
+                  "firm": "Raymond James",
+                  "toGrade": "Strong Buy",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1382438725,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1382080642,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1379574000,
+                  "firm": "CRT Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1378882402,
+                  "firm": "Wedbush",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1374829535,
+                  "firm": "BMO Capital",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1374824865,
+                  "firm": "Nomura",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1373961231,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1373472676,
+                  "firm": "Susquehanna",
+                  "toGrade": "Positive",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1373390911,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1368691091,
+                  "firm": "Lazard",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1367487786,
+                  "firm": "Tigress Financial",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1366963317,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1366618113,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1366185916,
+                  "firm": "Nomura",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1363680464,
+                  "firm": "JMP Securities",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1363242452,
+                  "firm": "PiperJaffray",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1361347547,
+                  "firm": "Nomura",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1359552425,
+                  "firm": "Barclays",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1359540668,
+                  "firm": "Oppenheimer",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1359540255,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1359533243,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1359531886,
+                  "firm": "Credit Agricole",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1359531597,
+                  "firm": "Nomura",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1359531237,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1359530684,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1359389631,
+                  "firm": "BGC Financial",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1359366009,
+                  "firm": "PiperJaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1359364847,
+                  "firm": "PiperJaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1359109097,
+                  "firm": "ISI Group",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1359101356,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1359043430,
+                  "firm": "ISI Group",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1358496653,
+                  "firm": "Pacific Crest",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Sector Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1357713892,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1357540365,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Equal-Weight",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1351170540,
+                  "firm": "Barclays",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1348208580,
+                  "firm": "Cantor Fitzgerald",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1347365820,
+                  "firm": "Barclays",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1347000720,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1346395500,
+                  "firm": "PiperJaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1343378100,
+                  "firm": "Oppenheimer",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1343372400,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1342506540,
+                  "firm": "Lazard",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1341991740,
+                  "firm": "BMO Capital",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1338965820,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1337061720,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1335526620,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1335522540,
+                  "firm": "BGC Financial",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1335517380,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1335516060,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1335515880,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1335514680,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1335514140,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1335511200,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1335507660,
+                  "firm": "Bank oferica",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1333346760,
+                  "firm": "Bank oferica",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1329373020,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1329291180,
+                  "firm": "PiperJaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1325162820,
+                  "firm": "PiperJaffray",
+                  "toGrade": "",
+                  "fromGrade": "",
+                  "action": "main"
+                }
+              ],
+              "maxAge": 86400
+            },
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": -0.00722148,
+              "preMarketChange": -23.6699,
+              "preMarketTime": 1613485799,
+              "preMarketPrice": 3254.04,
+              "preMarketSource": "FREE_REALTIME",
+              "regularMarketChangePercent": 0.0005163309,
+              "regularMarketChange": 1.6923828,
+              "regularMarketTime": 1613492068,
+              "priceHint": 2,
+              "regularMarketPrice": 3279.4023,
+              "regularMarketDayHigh": 3308,
+              "regularMarketDayLow": 3257.75,
+              "regularMarketVolume": 1136678,
+              "averageDailyVolume10Day": 2649840,
+              "averageDailyVolume3Month": 3657442,
+              "regularMarketPreviousClose": 3277.71,
+              "regularMarketSource": "FREE_REALTIME",
+              "regularMarketOpen": 3254.05,
+              "exchange": "NMS",
+              "exchangeName": "NasdaqGS",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "EQUITY",
+              "symbol": "AMZN",
+              "underlyingSymbol": null,
+              "shortName": "Amazon.com, Inc.",
+              "longName": "Amazon.com, Inc.",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 1651392249856
+            },
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "cash": {
+                    "raw": 42122000000,
+                    "fmt": "42.12B",
+                    "longFmt": "42,122,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 42274000000,
+                    "fmt": "42.27B",
+                    "longFmt": "42,274,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 24309000000,
+                    "fmt": "24.31B",
+                    "longFmt": "24,309,000,000"
+                  },
+                  "inventory": {
+                    "raw": 23795000000,
+                    "fmt": "23.8B",
+                    "longFmt": "23,795,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 233000000,
+                    "fmt": "233M",
+                    "longFmt": "233,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 132733000000,
+                    "fmt": "132.73B",
+                    "longFmt": "132,733,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 5700000000,
+                    "fmt": "5.7B",
+                    "longFmt": "5,700,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 150667000000,
+                    "fmt": "150.67B",
+                    "longFmt": "150,667,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 15017000000,
+                    "fmt": "15.02B",
+                    "longFmt": "15,017,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 4981000000,
+                    "fmt": "4.98B",
+                    "longFmt": "4,981,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 12097000000,
+                    "fmt": "12.1B",
+                    "longFmt": "12,097,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 321195000000,
+                    "fmt": "321.19B",
+                    "longFmt": "321,195,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 72539000000,
+                    "fmt": "72.54B",
+                    "longFmt": "72,539,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 1155000000,
+                    "fmt": "1.16B",
+                    "longFmt": "1,155,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 15267000000,
+                    "fmt": "15.27B",
+                    "longFmt": "15,267,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 31816000000,
+                    "fmt": "31.82B",
+                    "longFmt": "31,816,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 17017000000,
+                    "fmt": "17.02B",
+                    "longFmt": "17,017,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 126385000000,
+                    "fmt": "126.39B",
+                    "longFmt": "126,385,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 227791000000,
+                    "fmt": "227.79B",
+                    "longFmt": "227,791,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 52551000000,
+                    "fmt": "52.55B",
+                    "longFmt": "52,551,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -2017000000,
+                    "fmt": "-2.02B",
+                    "longFmt": "-2,017,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 42865000000,
+                    "fmt": "42.87B",
+                    "longFmt": "42,865,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -180000000,
+                    "fmt": "-180M",
+                    "longFmt": "-180,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 93404000000,
+                    "fmt": "93.4B",
+                    "longFmt": "93,404,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 73406000000,
+                    "fmt": "73.41B",
+                    "longFmt": "73,406,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 36092000000,
+                    "fmt": "36.09B",
+                    "longFmt": "36,092,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 18929000000,
+                    "fmt": "18.93B",
+                    "longFmt": "18,929,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 20540000000,
+                    "fmt": "20.54B",
+                    "longFmt": "20,540,000,000"
+                  },
+                  "inventory": {
+                    "raw": 20497000000,
+                    "fmt": "20.5B",
+                    "longFmt": "20,497,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 276000000,
+                    "fmt": "276M",
+                    "longFmt": "276,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 96334000000,
+                    "fmt": "96.33B",
+                    "longFmt": "96,334,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2169000000,
+                    "fmt": "2.17B",
+                    "longFmt": "2,169,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 97846000000,
+                    "fmt": "97.85B",
+                    "longFmt": "97,846,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 14754000000,
+                    "fmt": "14.75B",
+                    "longFmt": "14,754,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 4049000000,
+                    "fmt": "4.05B",
+                    "longFmt": "4,049,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 10096000000,
+                    "fmt": "10.1B",
+                    "longFmt": "10,096,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 225248000000,
+                    "fmt": "225.25B",
+                    "longFmt": "225,248,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 47183000000,
+                    "fmt": "47.18B",
+                    "longFmt": "47,183,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 1305000000,
+                    "fmt": "1.3B",
+                    "longFmt": "1,305,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 12202000000,
+                    "fmt": "12.2B",
+                    "longFmt": "12,202,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 23414000000,
+                    "fmt": "23.41B",
+                    "longFmt": "23,414,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 12171000000,
+                    "fmt": "12.17B",
+                    "longFmt": "12,171,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 87812000000,
+                    "fmt": "87.81B",
+                    "longFmt": "87,812,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 163188000000,
+                    "fmt": "163.19B",
+                    "longFmt": "163,188,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 31220000000,
+                    "fmt": "31.22B",
+                    "longFmt": "31,220,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -2823000000,
+                    "fmt": "-2.82B",
+                    "longFmt": "-2,823,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 33658000000,
+                    "fmt": "33.66B",
+                    "longFmt": "33,658,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -986000000,
+                    "fmt": "-986M",
+                    "longFmt": "-986,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 62060000000,
+                    "fmt": "62.06B",
+                    "longFmt": "62,060,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 43257000000,
+                    "fmt": "43.26B",
+                    "longFmt": "43,257,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "cash": {
+                    "raw": 31750000000,
+                    "fmt": "31.75B",
+                    "longFmt": "31,750,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 9500000000,
+                    "fmt": "9.5B",
+                    "longFmt": "9,500,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 16259000000,
+                    "fmt": "16.26B",
+                    "longFmt": "16,259,000,000"
+                  },
+                  "inventory": {
+                    "raw": 17174000000,
+                    "fmt": "17.17B",
+                    "longFmt": "17,174,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 418000000,
+                    "fmt": "418M",
+                    "longFmt": "418,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 75101000000,
+                    "fmt": "75.1B",
+                    "longFmt": "75,101,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 722000000,
+                    "fmt": "722M",
+                    "longFmt": "722,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 61797000000,
+                    "fmt": "61.8B",
+                    "longFmt": "61,797,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 14548000000,
+                    "fmt": "14.55B",
+                    "longFmt": "14,548,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 4110000000,
+                    "fmt": "4.11B",
+                    "longFmt": "4,110,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 6370000000,
+                    "fmt": "6.37B",
+                    "longFmt": "6,370,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 162648000000,
+                    "fmt": "162.65B",
+                    "longFmt": "162,648,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 38192000000,
+                    "fmt": "38.19B",
+                    "longFmt": "38,192,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 1371000000,
+                    "fmt": "1.37B",
+                    "longFmt": "1,371,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 9959000000,
+                    "fmt": "9.96B",
+                    "longFmt": "9,959,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 23495000000,
+                    "fmt": "23.5B",
+                    "longFmt": "23,495,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 17563000000,
+                    "fmt": "17.56B",
+                    "longFmt": "17,563,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 68391000000,
+                    "fmt": "68.39B",
+                    "longFmt": "68,391,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 119099000000,
+                    "fmt": "119.1B",
+                    "longFmt": "119,099,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 19625000000,
+                    "fmt": "19.62B",
+                    "longFmt": "19,625,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -2872000000,
+                    "fmt": "-2.87B",
+                    "longFmt": "-2,872,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 26791000000,
+                    "fmt": "26.79B",
+                    "longFmt": "26,791,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -1035000000,
+                    "fmt": "-1.03B",
+                    "longFmt": "-1,035,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 43549000000,
+                    "fmt": "43.55B",
+                    "longFmt": "43,549,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 24891000000,
+                    "fmt": "24.89B",
+                    "longFmt": "24,891,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "cash": {
+                    "raw": 20522000000,
+                    "fmt": "20.52B",
+                    "longFmt": "20,522,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 10464000000,
+                    "fmt": "10.46B",
+                    "longFmt": "10,464,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 11835000000,
+                    "fmt": "11.84B",
+                    "longFmt": "11,835,000,000"
+                  },
+                  "inventory": {
+                    "raw": 16047000000,
+                    "fmt": "16.05B",
+                    "longFmt": "16,047,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 1329000000,
+                    "fmt": "1.33B",
+                    "longFmt": "1,329,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 60197000000,
+                    "fmt": "60.2B",
+                    "longFmt": "60,197,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 441000000,
+                    "fmt": "441M",
+                    "longFmt": "441,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 48866000000,
+                    "fmt": "48.87B",
+                    "longFmt": "48,866,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 13350000000,
+                    "fmt": "13.35B",
+                    "longFmt": "13,350,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 3371000000,
+                    "fmt": "3.37B",
+                    "longFmt": "3,371,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 5085000000,
+                    "fmt": "5.08B",
+                    "longFmt": "5,085,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 131310000000,
+                    "fmt": "131.31B",
+                    "longFmt": "131,310,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 34616000000,
+                    "fmt": "34.62B",
+                    "longFmt": "34,616,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 100000000,
+                    "fmt": "100M",
+                    "longFmt": "100,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 8565000000,
+                    "fmt": "8.56B",
+                    "longFmt": "8,565,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 24743000000,
+                    "fmt": "24.74B",
+                    "longFmt": "24,743,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 7792000000,
+                    "fmt": "7.79B",
+                    "longFmt": "7,792,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 57883000000,
+                    "fmt": "57.88B",
+                    "longFmt": "57,883,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 103601000000,
+                    "fmt": "103.6B",
+                    "longFmt": "103,601,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 8636000000,
+                    "fmt": "8.64B",
+                    "longFmt": "8,636,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -2321000000,
+                    "fmt": "-2.32B",
+                    "longFmt": "-2,321,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 21389000000,
+                    "fmt": "21.39B",
+                    "longFmt": "21,389,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -484000000,
+                    "fmt": "-484M",
+                    "longFmt": "-484,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 27709000000,
+                    "fmt": "27.71B",
+                    "longFmt": "27,709,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 10988000000,
+                    "fmt": "10.99B",
+                    "longFmt": "10,988,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": "2021-03-31",
+                  "growth": {
+                    "raw": 0.898,
+                    "fmt": "89.80%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 9.51,
+                      "fmt": "9.51"
+                    },
+                    "low": {
+                      "raw": 6.41,
+                      "fmt": "6.41"
+                    },
+                    "high": {
+                      "raw": 12,
+                      "fmt": "12"
+                    },
+                    "yearAgoEps": {
+                      "raw": 5.01,
+                      "fmt": "5.01"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 36,
+                      "fmt": "36",
+                      "longFmt": "36"
+                    },
+                    "growth": {
+                      "raw": 0.898,
+                      "fmt": "89.80%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 104484000000,
+                      "fmt": "104.48B",
+                      "longFmt": "104,484,000,000"
+                    },
+                    "low": {
+                      "raw": 100459000000,
+                      "fmt": "100.46B",
+                      "longFmt": "100,459,000,000"
+                    },
+                    "high": {
+                      "raw": 107474000000,
+                      "fmt": "107.47B",
+                      "longFmt": "107,474,000,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 36,
+                      "fmt": "36",
+                      "longFmt": "36"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 75452000000,
+                      "fmt": "75.45B",
+                      "longFmt": "75,452,000,000"
+                    },
+                    "growth": {
+                      "raw": 0.385,
+                      "fmt": "38.50%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 9.51,
+                      "fmt": "9.51"
+                    },
+                    "7daysAgo": {
+                      "raw": 9.51,
+                      "fmt": "9.51"
+                    },
+                    "30daysAgo": {
+                      "raw": 9.1,
+                      "fmt": "9.1"
+                    },
+                    "60daysAgo": {
+                      "raw": 9.2,
+                      "fmt": "9.2"
+                    },
+                    "90daysAgo": {
+                      "raw": 9.2,
+                      "fmt": "9.2"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "upLast30days": {
+                      "raw": 21,
+                      "fmt": "21",
+                      "longFmt": "21"
+                    },
+                    "downLast30days": {
+                      "raw": 3,
+                      "fmt": "3",
+                      "longFmt": "3"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": "2021-06-30",
+                  "growth": {
+                    "raw": 0.062,
+                    "fmt": "6.20%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 10.94,
+                      "fmt": "10.94"
+                    },
+                    "low": {
+                      "raw": 5.21,
+                      "fmt": "5.21"
+                    },
+                    "high": {
+                      "raw": 13.09,
+                      "fmt": "13.09"
+                    },
+                    "yearAgoEps": {
+                      "raw": 10.3,
+                      "fmt": "10.3"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 35,
+                      "fmt": "35",
+                      "longFmt": "35"
+                    },
+                    "growth": {
+                      "raw": 0.062,
+                      "fmt": "6.20%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 107902000000,
+                      "fmt": "107.9B",
+                      "longFmt": "107,902,000,000"
+                    },
+                    "low": {
+                      "raw": 99044000000,
+                      "fmt": "99.04B",
+                      "longFmt": "99,044,000,000"
+                    },
+                    "high": {
+                      "raw": 120590000000,
+                      "fmt": "120.59B",
+                      "longFmt": "120,590,000,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 35,
+                      "fmt": "35",
+                      "longFmt": "35"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 88912000000,
+                      "fmt": "88.91B",
+                      "longFmt": "88,912,000,000"
+                    },
+                    "growth": {
+                      "raw": 0.214,
+                      "fmt": "21.40%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 10.94,
+                      "fmt": "10.94"
+                    },
+                    "7daysAgo": {
+                      "raw": 10.91,
+                      "fmt": "10.91"
+                    },
+                    "30daysAgo": {
+                      "raw": 10.91,
+                      "fmt": "10.91"
+                    },
+                    "60daysAgo": {
+                      "raw": 10.83,
+                      "fmt": "10.83"
+                    },
+                    "90daysAgo": {
+                      "raw": 10.83,
+                      "fmt": "10.83"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 2,
+                      "fmt": "2",
+                      "longFmt": "2"
+                    },
+                    "upLast30days": {
+                      "raw": 21,
+                      "fmt": "21",
+                      "longFmt": "21"
+                    },
+                    "downLast30days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": "2021-12-31",
+                  "growth": {
+                    "raw": 0.14,
+                    "fmt": "14.00%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 47.68,
+                      "fmt": "47.68"
+                    },
+                    "low": {
+                      "raw": 31.49,
+                      "fmt": "31.49"
+                    },
+                    "high": {
+                      "raw": 63.63,
+                      "fmt": "63.63"
+                    },
+                    "yearAgoEps": {
+                      "raw": 41.83,
+                      "fmt": "41.83"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 44,
+                      "fmt": "44",
+                      "longFmt": "44"
+                    },
+                    "growth": {
+                      "raw": 0.14,
+                      "fmt": "14.00%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 474121000000,
+                      "fmt": "474.12B",
+                      "longFmt": "474,121,000,000"
+                    },
+                    "low": {
+                      "raw": 439134000000,
+                      "fmt": "439.13B",
+                      "longFmt": "439,134,000,000"
+                    },
+                    "high": {
+                      "raw": 511167000000,
+                      "fmt": "511.17B",
+                      "longFmt": "511,167,000,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 42,
+                      "fmt": "42",
+                      "longFmt": "42"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 386064000000,
+                      "fmt": "386.06B",
+                      "longFmt": "386,064,000,000"
+                    },
+                    "growth": {
+                      "raw": 0.22799999,
+                      "fmt": "22.80%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 47.68,
+                      "fmt": "47.68"
+                    },
+                    "7daysAgo": {
+                      "raw": 47.65,
+                      "fmt": "47.65"
+                    },
+                    "30daysAgo": {
+                      "raw": 45.47,
+                      "fmt": "45.47"
+                    },
+                    "60daysAgo": {
+                      "raw": 45.38,
+                      "fmt": "45.38"
+                    },
+                    "90daysAgo": {
+                      "raw": 45.84,
+                      "fmt": "45.84"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 4,
+                      "fmt": "4",
+                      "longFmt": "4"
+                    },
+                    "upLast30days": {
+                      "raw": 32,
+                      "fmt": "32",
+                      "longFmt": "32"
+                    },
+                    "downLast30days": {
+                      "raw": 3,
+                      "fmt": "3",
+                      "longFmt": "3"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": "2022-12-31",
+                  "growth": {
+                    "raw": 0.39400002,
+                    "fmt": "39.40%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 66.46,
+                      "fmt": "66.46"
+                    },
+                    "low": {
+                      "raw": 36.71,
+                      "fmt": "36.71"
+                    },
+                    "high": {
+                      "raw": 91.52,
+                      "fmt": "91.52"
+                    },
+                    "yearAgoEps": {
+                      "raw": 47.68,
+                      "fmt": "47.68"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 43,
+                      "fmt": "43",
+                      "longFmt": "43"
+                    },
+                    "growth": {
+                      "raw": 0.39400002,
+                      "fmt": "39.40%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 557143000000,
+                      "fmt": "557.14B",
+                      "longFmt": "557,143,000,000"
+                    },
+                    "low": {
+                      "raw": 505681000000,
+                      "fmt": "505.68B",
+                      "longFmt": "505,681,000,000"
+                    },
+                    "high": {
+                      "raw": 613468000000,
+                      "fmt": "613.47B",
+                      "longFmt": "613,468,000,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 41,
+                      "fmt": "41",
+                      "longFmt": "41"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 474121000000,
+                      "fmt": "474.12B",
+                      "longFmt": "474,121,000,000"
+                    },
+                    "growth": {
+                      "raw": 0.175,
+                      "fmt": "17.50%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 66.46,
+                      "fmt": "66.46"
+                    },
+                    "7daysAgo": {
+                      "raw": 66.48,
+                      "fmt": "66.48"
+                    },
+                    "30daysAgo": {
+                      "raw": 64.73,
+                      "fmt": "64.73"
+                    },
+                    "60daysAgo": {
+                      "raw": 64.62,
+                      "fmt": "64.62"
+                    },
+                    "90daysAgo": {
+                      "raw": 65.45,
+                      "fmt": "65.45"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "upLast30days": {
+                      "raw": 24,
+                      "fmt": "24",
+                      "longFmt": "24"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": 0.38369998,
+                    "fmt": "38.37%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": 1.00597,
+                    "fmt": "100.60%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            },
+            "secFilings": {
+              "filings": [
+                {
+                  "date": "2021-02-03",
+                  "epochDate": 1612350353,
+                  "type": "10-K",
+                  "title": "Annual Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-21-000004&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-02-02",
+                  "epochDate": 1612301458,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Change in Directors or Principal Officers, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-21-000002&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-01-27",
+                  "epochDate": 1611746057,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001193125-21-018066&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-30",
+                  "epochDate": 1604056140,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-20-000030&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-29",
+                  "epochDate": 1604007787,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-20-000028&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-09-09",
+                  "epochDate": 1599685697,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-20-000026&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-08-21",
+                  "epochDate": 1598019657,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001193125-20-226520&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-07-31",
+                  "epochDate": 1596193864,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-20-000021&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-07-30",
+                  "epochDate": 1596154406,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-20-000019&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-06-23",
+                  "epochDate": 1592946902,
+                  "type": "8-K",
+                  "title": "Entry into a Material Definitive Agreement, Creation of a Direct Financial Obligation or an Obligation under an Off-Balance Sheet Arrangement of a Registrant, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001193125-20-176528&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-06-03",
+                  "epochDate": 1591215715,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001193125-20-159531&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-29",
+                  "epochDate": 1590787862,
+                  "type": "8-K",
+                  "title": "Disclosing Amendments to Articles of Inc. or Bylaws; Change in Fiscal Year, Submission of Mat",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-20-000015&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-01",
+                  "epochDate": 1588329988,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-20-000010&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-30",
+                  "epochDate": 1588279428,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-20-000008&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-16",
+                  "epochDate": 1587031458,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001193125-20-108427&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-01-31",
+                  "epochDate": 1580468772,
+                  "type": "10-K",
+                  "title": "Annual Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-20-000004&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-01-30",
+                  "epochDate": 1580420869,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-20-000002&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-10-25",
+                  "epochDate": 1571997935,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-19-000087&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-10-25",
+                  "epochDate": 1571997898,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-19-000089&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-07-26",
+                  "epochDate": 1564135329,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-19-000071&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-07-25",
+                  "epochDate": 1564086875,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-19-000069&nav=1&src=Yahoo",
+                  "maxAge": 1
+                }
+              ],
+              "maxAge": 86400
+            },
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Group, Inc. (The)",
+                  "pctHeld": {
+                    "raw": 0.0651,
+                    "fmt": "6.51%"
+                  },
+                  "position": {
+                    "raw": 32783886,
+                    "fmt": "32.78M",
+                    "longFmt": "32,783,886"
+                  },
+                  "value": {
+                    "raw": 103227605364,
+                    "fmt": "103.23B",
+                    "longFmt": "103,227,605,364"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Blackrock Inc.",
+                  "pctHeld": {
+                    "raw": 0.0547,
+                    "fmt": "5.47%"
+                  },
+                  "position": {
+                    "raw": 27524749,
+                    "fmt": "27.52M",
+                    "longFmt": "27,524,749"
+                  },
+                  "value": {
+                    "raw": 89646180760,
+                    "fmt": "89.65B",
+                    "longFmt": "89,646,180,760"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "State Street Corporation",
+                  "pctHeld": {
+                    "raw": 0.0325,
+                    "fmt": "3.25%"
+                  },
+                  "position": {
+                    "raw": 16344982,
+                    "fmt": "16.34M",
+                    "longFmt": "16,344,982"
+                  },
+                  "value": {
+                    "raw": 51465935172,
+                    "fmt": "51.47B",
+                    "longFmt": "51,465,935,172"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Price (T.Rowe) Associates Inc",
+                  "pctHeld": {
+                    "raw": 0.0312,
+                    "fmt": "3.12%"
+                  },
+                  "position": {
+                    "raw": 15700902,
+                    "fmt": "15.7M",
+                    "longFmt": "15,700,902"
+                  },
+                  "value": {
+                    "raw": 49437901154,
+                    "fmt": "49.44B",
+                    "longFmt": "49,437,901,154"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "FMR, LLC",
+                  "pctHeld": {
+                    "raw": 0.0307,
+                    "fmt": "3.07%"
+                  },
+                  "position": {
+                    "raw": 15472297,
+                    "fmt": "15.47M",
+                    "longFmt": "15,472,297"
+                  },
+                  "value": {
+                    "raw": 50392188268,
+                    "fmt": "50.39B",
+                    "longFmt": "50,392,188,268"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Geode Capital Management, LLC",
+                  "pctHeld": {
+                    "raw": 0.0127,
+                    "fmt": "1.27%"
+                  },
+                  "position": {
+                    "raw": 6398830,
+                    "fmt": "6.4M",
+                    "longFmt": "6,398,830"
+                  },
+                  "value": {
+                    "raw": 20148187985,
+                    "fmt": "20.15B",
+                    "longFmt": "20,148,187,985"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Northern Trust Corporation",
+                  "pctHeld": {
+                    "raw": 0.01,
+                    "fmt": "1.00%"
+                  },
+                  "position": {
+                    "raw": 5016332,
+                    "fmt": "5.02M",
+                    "longFmt": "5,016,332"
+                  },
+                  "value": {
+                    "raw": 15795075058,
+                    "fmt": "15.8B",
+                    "longFmt": "15,795,075,058"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Morgan Stanley",
+                  "pctHeld": {
+                    "raw": 0.0097,
+                    "fmt": "0.97%"
+                  },
+                  "position": {
+                    "raw": 4875392,
+                    "fmt": "4.88M",
+                    "longFmt": "4,875,392"
+                  },
+                  "value": {
+                    "raw": 15351293052,
+                    "fmt": "15.35B",
+                    "longFmt": "15,351,293,052"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Capital Research Global Investors",
+                  "pctHeld": {
+                    "raw": 0.008,
+                    "fmt": "0.80%"
+                  },
+                  "position": {
+                    "raw": 4017791,
+                    "fmt": "4.02M",
+                    "longFmt": "4,017,791"
+                  },
+                  "value": {
+                    "raw": 12650939055,
+                    "fmt": "12.65B",
+                    "longFmt": "12,650,939,055"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Bank Of New York Mellon Corporation",
+                  "pctHeld": {
+                    "raw": 0.007900001,
+                    "fmt": "0.79%"
+                  },
+                  "position": {
+                    "raw": 3983095,
+                    "fmt": "3.98M",
+                    "longFmt": "3,983,095"
+                  },
+                  "value": {
+                    "raw": 12972661598,
+                    "fmt": "12.97B",
+                    "longFmt": "12,972,661,598"
+                  }
+                }
+              ]
+            },
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.14556,
+              "institutionsPercentHeld": 0.58663,
+              "institutionsFloatPercentHeld": 0.68657,
+              "institutionsCount": 4408
+            },
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "cash": {
+                    "raw": 42122000000,
+                    "fmt": "42.12B",
+                    "longFmt": "42,122,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 42274000000,
+                    "fmt": "42.27B",
+                    "longFmt": "42,274,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 24309000000,
+                    "fmt": "24.31B",
+                    "longFmt": "24,309,000,000"
+                  },
+                  "inventory": {
+                    "raw": 23795000000,
+                    "fmt": "23.8B",
+                    "longFmt": "23,795,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 233000000,
+                    "fmt": "233M",
+                    "longFmt": "233,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 132733000000,
+                    "fmt": "132.73B",
+                    "longFmt": "132,733,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 5700000000,
+                    "fmt": "5.7B",
+                    "longFmt": "5,700,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 150667000000,
+                    "fmt": "150.67B",
+                    "longFmt": "150,667,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 15017000000,
+                    "fmt": "15.02B",
+                    "longFmt": "15,017,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 4981000000,
+                    "fmt": "4.98B",
+                    "longFmt": "4,981,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 12097000000,
+                    "fmt": "12.1B",
+                    "longFmt": "12,097,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 321195000000,
+                    "fmt": "321.19B",
+                    "longFmt": "321,195,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 72539000000,
+                    "fmt": "72.54B",
+                    "longFmt": "72,539,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 1155000000,
+                    "fmt": "1.16B",
+                    "longFmt": "1,155,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 15267000000,
+                    "fmt": "15.27B",
+                    "longFmt": "15,267,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 31816000000,
+                    "fmt": "31.82B",
+                    "longFmt": "31,816,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 17017000000,
+                    "fmt": "17.02B",
+                    "longFmt": "17,017,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 126385000000,
+                    "fmt": "126.39B",
+                    "longFmt": "126,385,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 227791000000,
+                    "fmt": "227.79B",
+                    "longFmt": "227,791,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 52551000000,
+                    "fmt": "52.55B",
+                    "longFmt": "52,551,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -2017000000,
+                    "fmt": "-2.02B",
+                    "longFmt": "-2,017,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 42865000000,
+                    "fmt": "42.87B",
+                    "longFmt": "42,865,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -180000000,
+                    "fmt": "-180M",
+                    "longFmt": "-180,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 93404000000,
+                    "fmt": "93.4B",
+                    "longFmt": "93,404,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 73406000000,
+                    "fmt": "73.41B",
+                    "longFmt": "73,406,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 29930000000,
+                    "fmt": "29.93B",
+                    "longFmt": "29,930,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 38472000000,
+                    "fmt": "38.47B",
+                    "longFmt": "38,472,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 20593000000,
+                    "fmt": "20.59B",
+                    "longFmt": "20,593,000,000"
+                  },
+                  "inventory": {
+                    "raw": 23735000000,
+                    "fmt": "23.73B",
+                    "longFmt": "23,735,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 239000000,
+                    "fmt": "239M",
+                    "longFmt": "239,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 112969000000,
+                    "fmt": "112.97B",
+                    "longFmt": "112,969,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 4000000000,
+                    "fmt": "4B",
+                    "longFmt": "4,000,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 134100000000,
+                    "fmt": "134.1B",
+                    "longFmt": "134,100,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 14960000000,
+                    "fmt": "14.96B",
+                    "longFmt": "14,960,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 16150000000,
+                    "fmt": "16.15B",
+                    "longFmt": "16,150,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 282179000000,
+                    "fmt": "282.18B",
+                    "longFmt": "282,179,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 58334000000,
+                    "fmt": "58.33B",
+                    "longFmt": "58,334,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 155000000,
+                    "fmt": "155M",
+                    "longFmt": "155,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 9251000000,
+                    "fmt": "9.25B",
+                    "longFmt": "9,251,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 32929000000,
+                    "fmt": "32.93B",
+                    "longFmt": "32,929,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 15974000000,
+                    "fmt": "15.97B",
+                    "longFmt": "15,974,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 101912000000,
+                    "fmt": "101.91B",
+                    "longFmt": "101,912,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 199404000000,
+                    "fmt": "199.4B",
+                    "longFmt": "199,404,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 45329000000,
+                    "fmt": "45.33B",
+                    "longFmt": "45,329,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -2866000000,
+                    "fmt": "-2.87B",
+                    "longFmt": "-2,866,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 40307000000,
+                    "fmt": "40.31B",
+                    "longFmt": "40,307,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -1029000000,
+                    "fmt": "-1.03B",
+                    "longFmt": "-1,029,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 82775000000,
+                    "fmt": "82.78B",
+                    "longFmt": "82,775,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 67815000000,
+                    "fmt": "67.81B",
+                    "longFmt": "67,815,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "cash": {
+                    "raw": 37466000000,
+                    "fmt": "37.47B",
+                    "longFmt": "37,466,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 33925000000,
+                    "fmt": "33.92B",
+                    "longFmt": "33,925,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 19564000000,
+                    "fmt": "19.56B",
+                    "longFmt": "19,564,000,000"
+                  },
+                  "inventory": {
+                    "raw": 19599000000,
+                    "fmt": "19.6B",
+                    "longFmt": "19,599,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 354000000,
+                    "fmt": "354M",
+                    "longFmt": "354,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 110908000000,
+                    "fmt": "110.91B",
+                    "longFmt": "110,908,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2500000000,
+                    "fmt": "2.5B",
+                    "longFmt": "2,500,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 115054000000,
+                    "fmt": "115.05B",
+                    "longFmt": "115,054,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 14751000000,
+                    "fmt": "14.75B",
+                    "longFmt": "14,751,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 15101000000,
+                    "fmt": "15.1B",
+                    "longFmt": "15,101,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 258314000000,
+                    "fmt": "258.31B",
+                    "longFmt": "258,314,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 51036000000,
+                    "fmt": "51.04B",
+                    "longFmt": "51,036,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 1154000000,
+                    "fmt": "1.15B",
+                    "longFmt": "1,154,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 8997000000,
+                    "fmt": "9B",
+                    "longFmt": "8,997,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 33128000000,
+                    "fmt": "33.13B",
+                    "longFmt": "33,128,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 14764000000,
+                    "fmt": "14.76B",
+                    "longFmt": "14,764,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 93896000000,
+                    "fmt": "93.9B",
+                    "longFmt": "93,896,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 184586000000,
+                    "fmt": "184.59B",
+                    "longFmt": "184,586,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 38998000000,
+                    "fmt": "39B",
+                    "longFmt": "38,998,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -3292000000,
+                    "fmt": "-3.29B",
+                    "longFmt": "-3,292,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 38017000000,
+                    "fmt": "38.02B",
+                    "longFmt": "38,017,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -1455000000,
+                    "fmt": "-1.46B",
+                    "longFmt": "-1,455,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 73728000000,
+                    "fmt": "73.73B",
+                    "longFmt": "73,728,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 58977000000,
+                    "fmt": "58.98B",
+                    "longFmt": "58,977,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "cash": {
+                    "raw": 27201000000,
+                    "fmt": "27.2B",
+                    "longFmt": "27,201,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 22091000000,
+                    "fmt": "22.09B",
+                    "longFmt": "22,091,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 17836000000,
+                    "fmt": "17.84B",
+                    "longFmt": "17,836,000,000"
+                  },
+                  "inventory": {
+                    "raw": 18857000000,
+                    "fmt": "18.86B",
+                    "longFmt": "18,857,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 282000000,
+                    "fmt": "282M",
+                    "longFmt": "282,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 85985000000,
+                    "fmt": "85.98B",
+                    "longFmt": "85,985,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2028000000,
+                    "fmt": "2.03B",
+                    "longFmt": "2,028,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 104058000000,
+                    "fmt": "104.06B",
+                    "longFmt": "104,058,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 14739000000,
+                    "fmt": "14.74B",
+                    "longFmt": "14,739,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 16456000000,
+                    "fmt": "16.46B",
+                    "longFmt": "16,456,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 221238000000,
+                    "fmt": "221.24B",
+                    "longFmt": "221,238,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 40056000000,
+                    "fmt": "40.06B",
+                    "longFmt": "40,056,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 1311000000,
+                    "fmt": "1.31B",
+                    "longFmt": "1,311,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 8864000000,
+                    "fmt": "8.86B",
+                    "longFmt": "8,864,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 23437000000,
+                    "fmt": "23.44B",
+                    "longFmt": "23,437,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 12518000000,
+                    "fmt": "12.52B",
+                    "longFmt": "12,518,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 79711000000,
+                    "fmt": "79.71B",
+                    "longFmt": "79,711,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 155966000000,
+                    "fmt": "155.97B",
+                    "longFmt": "155,966,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 33755000000,
+                    "fmt": "33.76B",
+                    "longFmt": "33,755,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -3900000000,
+                    "fmt": "-3.9B",
+                    "longFmt": "-3,900,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 35412000000,
+                    "fmt": "35.41B",
+                    "longFmt": "35,412,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -2063000000,
+                    "fmt": "-2.06B",
+                    "longFmt": "-2,063,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 65272000000,
+                    "fmt": "65.27B",
+                    "longFmt": "65,272,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 50533000000,
+                    "fmt": "50.53B",
+                    "longFmt": "50,533,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 5.01,
+                    "fmt": "5.01"
+                  },
+                  "epsEstimate": {
+                    "raw": 6.25,
+                    "fmt": "6.25"
+                  },
+                  "epsDifference": {
+                    "raw": -1.24,
+                    "fmt": "-1.24"
+                  },
+                  "surprisePercent": {
+                    "raw": -0.198,
+                    "fmt": "-19.80%"
+                  },
+                  "quarter": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 10.3,
+                    "fmt": "10.3"
+                  },
+                  "epsEstimate": {
+                    "raw": 1.46,
+                    "fmt": "1.46"
+                  },
+                  "epsDifference": {
+                    "raw": 8.84,
+                    "fmt": "8.84"
+                  },
+                  "surprisePercent": {
+                    "raw": 6.055,
+                    "fmt": "605.50%"
+                  },
+                  "quarter": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 12.37,
+                    "fmt": "12.37"
+                  },
+                  "epsEstimate": {
+                    "raw": 7.41,
+                    "fmt": "7.41"
+                  },
+                  "epsDifference": {
+                    "raw": 4.96,
+                    "fmt": "4.96"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.669,
+                    "fmt": "66.90%"
+                  },
+                  "quarter": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 14.09,
+                    "fmt": "14.09"
+                  },
+                  "epsEstimate": {
+                    "raw": 7.23,
+                    "fmt": "7.23"
+                  },
+                  "epsDifference": {
+                    "raw": 6.86,
+                    "fmt": "6.86"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.949,
+                    "fmt": "94.90%"
+                  },
+                  "quarter": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            },
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            },
+            "summaryProfile": {
+              "address1": "410 Terry Avenue North",
+              "city": "Seattle",
+              "state": "WA",
+              "zip": "98109-5210",
+              "country": "United States",
+              "phone": "206-266-1000",
+              "website": "http://www.amazon.com",
+              "industry": "Internet Retail",
+              "sector": "Consumer Cyclical",
+              "longBusinessSummary": "Amazon.com, Inc. engages in the retail sale of consumer products and subscriptions in North America and internationally. The company operates through three segments: North America, International, and Amazon Web Services (AWS). It sells merchandise and content purchased for resale from third-party sellers through physical and online stores. The company also manufactures and sells electronic devices, including Kindle, Fire tablets, Fire TVs, Rings, and Echo and other devices; provides Kindle Direct Publishing, an online service that allows independent authors and publishers to make their books available in the Kindle Store; and develops and produces media content. In addition, it offers programs that enable sellers to sell their products on its websites, as well as its stores; and programs that allow authors, musicians, filmmakers, skill and app developers, and others to publish and sell content. Further, the company provides compute, storage, database, analytics, machine learning, and other services, as well as fulfillment, advertising, publishing, and digital content subscriptions. Additionally, it offers Amazon Prime, a membership program, which provides free shipping of various items; access to streaming of movies and TV episodes; and other services. The company serves consumers, sellers, developers, enterprises, and content creators. Amazon.com, Inc. was founded in 1994 and is headquartered in Seattle, Washington.",
+              "fullTimeEmployees": 1298000,
+              "companyOfficers": [],
+              "maxAge": 86400
+            },
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 32,
+              "buyInfoShares": 300580,
+              "buyPercentInsiderShares": 0.004,
+              "sellInfoCount": 29,
+              "sellInfoShares": 1025226,
+              "sellPercentInsiderShares": 0.0139999995,
+              "netInfoCount": 61,
+              "netInfoShares": -724646,
+              "netPercentInsiderShares": -0.01,
+              "totalInsiderShares": 73298880
+            },
+            "insiderTransactions": {
+              "transactions": [
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 340,
+                    "fmt": "340",
+                    "longFmt": "340"
+                  },
+                  "value": {
+                    "raw": 1131639,
+                    "fmt": "1.13M",
+                    "longFmt": "1,131,639"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3328.35 per share.",
+                  "filerName": "MCGRATH JUDITH A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1612396800,
+                    "fmt": "2021-02-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 314,
+                    "fmt": "314",
+                    "longFmt": "314"
+                  },
+                  "value": {
+                    "raw": 994127,
+                    "fmt": "994.13k",
+                    "longFmt": "994,127"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3166.01 per share.",
+                  "filerName": "RUBINSTEIN JONATHAN J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1609804800,
+                    "fmt": "2021-01-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1510,
+                    "fmt": "1.51k",
+                    "longFmt": "1,510"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1609286400,
+                    "fmt": "2020-12-30"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 31421,
+                    "fmt": "31.42k",
+                    "longFmt": "31,421"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606867200,
+                    "fmt": "2020-12-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 832,
+                    "fmt": "832",
+                    "longFmt": "832"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606780800,
+                    "fmt": "2020-12-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2000,
+                    "fmt": "2k",
+                    "longFmt": "2,000"
+                  },
+                  "value": {
+                    "raw": 6401175,
+                    "fmt": "6.4M",
+                    "longFmt": "6,401,175"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3161.66 - 3242.78 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606780800,
+                    "fmt": "2020-12-01"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 368,
+                    "fmt": "368",
+                    "longFmt": "368"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606176000,
+                    "fmt": "2020-11-24"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1899,
+                    "fmt": "1.9k",
+                    "longFmt": "1,899"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606089600,
+                    "fmt": "2020-11-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 750,
+                    "fmt": "750",
+                    "longFmt": "750"
+                  },
+                  "value": {
+                    "raw": 2318360,
+                    "fmt": "2.32M",
+                    "longFmt": "2,318,360"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3070.30 - 3100.76 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606089600,
+                    "fmt": "2020-11-23"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 172,
+                    "fmt": "172",
+                    "longFmt": "172"
+                  },
+                  "value": {
+                    "raw": 535744,
+                    "fmt": "535.74k",
+                    "longFmt": "535,744"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3100.53 - 3132.71 per share.",
+                  "filerName": "HUTTENLOCHER DANIEL P",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605830400,
+                    "fmt": "2020-11-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 220825,
+                    "fmt": "220.82k",
+                    "longFmt": "220,825"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1200,
+                    "fmt": "1.2k",
+                    "longFmt": "1,200"
+                  },
+                  "value": {
+                    "raw": 3737229,
+                    "fmt": "3.74M",
+                    "longFmt": "3,737,229"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3101.32 - 3126.09 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1099,
+                    "fmt": "1.1k",
+                    "longFmt": "1,099"
+                  },
+                  "value": {
+                    "raw": 3391096,
+                    "fmt": "3.39M",
+                    "longFmt": "3,391,096"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3085.62 per share.",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 293,
+                    "fmt": "293",
+                    "longFmt": "293"
+                  },
+                  "value": {
+                    "raw": 904087,
+                    "fmt": "904.09k",
+                    "longFmt": "904,087"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3085.62 per share.",
+                  "filerName": "REYNOLDS SHELLEY L",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1238,
+                    "fmt": "1.24k",
+                    "longFmt": "1,238"
+                  },
+                  "value": {
+                    "raw": 3819998,
+                    "fmt": "3.82M",
+                    "longFmt": "3,819,998"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3085.62 per share.",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1377,
+                    "fmt": "1.38k",
+                    "longFmt": "1,377"
+                  },
+                  "value": {
+                    "raw": 4248899,
+                    "fmt": "4.25M",
+                    "longFmt": "4,248,899"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3085.62 per share.",
+                  "filerName": "OLSAVSKY BRIAN T.",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 172,
+                    "fmt": "172",
+                    "longFmt": "172"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "STONESIFER PATRICIA Q",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 172,
+                    "fmt": "172",
+                    "longFmt": "172"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "RUBINSTEIN JONATHAN J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 172,
+                    "fmt": "172",
+                    "longFmt": "172"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "RYDER THOMAS O",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2791,
+                    "fmt": "2.79k",
+                    "longFmt": "2,791"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6550,
+                    "fmt": "6.55k",
+                    "longFmt": "6,550"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D/I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2791,
+                    "fmt": "2.79k",
+                    "longFmt": "2,791"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 293,
+                    "fmt": "293",
+                    "longFmt": "293"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "REYNOLDS SHELLEY L",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1377,
+                    "fmt": "1.38k",
+                    "longFmt": "1,377"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 172,
+                    "fmt": "172",
+                    "longFmt": "172"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "HUTTENLOCHER DANIEL P",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1377,
+                    "fmt": "1.38k",
+                    "longFmt": "1,377"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "OLSAVSKY BRIAN T.",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 550,
+                    "fmt": "550",
+                    "longFmt": "550"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "STONESIFER PATRICIA Q",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604620800,
+                    "fmt": "2020-11-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 600,
+                    "fmt": "600",
+                    "longFmt": "600"
+                  },
+                  "value": {
+                    "raw": 1982172,
+                    "fmt": "1.98M",
+                    "longFmt": "1,982,172"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3303.62 per share.",
+                  "filerName": "STONESIFER PATRICIA Q",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604620800,
+                    "fmt": "2020-11-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 309,
+                    "fmt": "309",
+                    "longFmt": "309"
+                  },
+                  "value": {
+                    "raw": 1025871,
+                    "fmt": "1.03M",
+                    "longFmt": "1,025,871"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3319.97 per share.",
+                  "filerName": "RUBINSTEIN JONATHAN J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604534400,
+                    "fmt": "2020-11-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 100809,
+                    "fmt": "100.81k",
+                    "longFmt": "100,809"
+                  },
+                  "value": {
+                    "raw": 305318709,
+                    "fmt": "305.32M",
+                    "longFmt": "305,318,709"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2983.37 - 3079.05 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604361600,
+                    "fmt": "2020-11-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 72076,
+                    "fmt": "72.08k",
+                    "longFmt": "72,076"
+                  },
+                  "value": {
+                    "raw": 218241914,
+                    "fmt": "218.24M",
+                    "longFmt": "218,241,914"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3001.24 - 3043.19 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604361600,
+                    "fmt": "2020-11-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 352307,
+                    "fmt": "352.31k",
+                    "longFmt": "352,307"
+                  },
+                  "value": {
+                    "raw": 1077105854,
+                    "fmt": "1.08B",
+                    "longFmt": "1,077,105,854"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3044.30 - 3073.15 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604361600,
+                    "fmt": "2020-11-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 460,
+                    "fmt": "460",
+                    "longFmt": "460"
+                  },
+                  "value": {
+                    "raw": 1414472,
+                    "fmt": "1.41M",
+                    "longFmt": "1,414,472"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3074.94 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604361600,
+                    "fmt": "2020-11-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 156352,
+                    "fmt": "156.35k",
+                    "longFmt": "156,352"
+                  },
+                  "value": {
+                    "raw": 464489563,
+                    "fmt": "464.49M",
+                    "longFmt": "464,489,563"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2951.01 - 2983.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604275200,
+                    "fmt": "2020-11-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 240060,
+                    "fmt": "240.06k",
+                    "longFmt": "240,060"
+                  },
+                  "value": {
+                    "raw": 719601001,
+                    "fmt": "719.6M",
+                    "longFmt": "719,601,001"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2984.03 - 3014.75 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604275200,
+                    "fmt": "2020-11-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 77936,
+                    "fmt": "77.94k",
+                    "longFmt": "77,936"
+                  },
+                  "value": {
+                    "raw": 236668949,
+                    "fmt": "236.67M",
+                    "longFmt": "236,668,949"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3016.10 - 3052.95 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604275200,
+                    "fmt": "2020-11-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 329,
+                    "fmt": "329",
+                    "longFmt": "329"
+                  },
+                  "value": {
+                    "raw": 1007312,
+                    "fmt": "1.01M",
+                    "longFmt": "1,007,312"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3061.74 per share.",
+                  "filerName": "RUBINSTEIN JONATHAN J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604275200,
+                    "fmt": "2020-11-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1709,
+                    "fmt": "1.71k",
+                    "longFmt": "1,709"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604275200,
+                    "fmt": "2020-11-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2000,
+                    "fmt": "2k",
+                    "longFmt": "2,000"
+                  },
+                  "value": {
+                    "raw": 6022793,
+                    "fmt": "6.02M",
+                    "longFmt": "6,022,793"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3000.60 - 3064.97 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604275200,
+                    "fmt": "2020-11-02"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6945,
+                    "fmt": "6.95k",
+                    "longFmt": "6,945"
+                  },
+                  "value": {
+                    "raw": 21263784,
+                    "fmt": "21.26M",
+                    "longFmt": "21,263,784"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3061.74 per share.",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604275200,
+                    "fmt": "2020-11-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1100,
+                    "fmt": "1.1k",
+                    "longFmt": "1,100"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1603065600,
+                    "fmt": "2020-10-19"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1100,
+                    "fmt": "1.1k",
+                    "longFmt": "1,100"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1599696000,
+                    "fmt": "2020-09-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 360,
+                    "fmt": "360",
+                    "longFmt": "360"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598918400,
+                    "fmt": "2020-09-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3518,
+                    "fmt": "3.52k",
+                    "longFmt": "3,518"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598572800,
+                    "fmt": "2020-08-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7548,
+                    "fmt": "7.55k",
+                    "longFmt": "7,548"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598313600,
+                    "fmt": "2020-08-25"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 750,
+                    "fmt": "750",
+                    "longFmt": "750"
+                  },
+                  "value": {
+                    "raw": 2478209,
+                    "fmt": "2.48M",
+                    "longFmt": "2,478,209"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3286.82 - 3323.27 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598227200,
+                    "fmt": "2020-08-24"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1200,
+                    "fmt": "1.2k",
+                    "longFmt": "1,200"
+                  },
+                  "value": {
+                    "raw": 3809017,
+                    "fmt": "3.81M",
+                    "longFmt": "3,809,017"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3155.09 - 3190.23 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597622400,
+                    "fmt": "2020-08-17"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1099,
+                    "fmt": "1.1k",
+                    "longFmt": "1,099"
+                  },
+                  "value": {
+                    "raw": 3487259,
+                    "fmt": "3.49M",
+                    "longFmt": "3,487,259"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3173.12 per share.",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597622400,
+                    "fmt": "2020-08-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 292,
+                    "fmt": "292",
+                    "longFmt": "292"
+                  },
+                  "value": {
+                    "raw": 926551,
+                    "fmt": "926.55k",
+                    "longFmt": "926,551"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3173.12 per share.",
+                  "filerName": "REYNOLDS SHELLEY L",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597622400,
+                    "fmt": "2020-08-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1238,
+                    "fmt": "1.24k",
+                    "longFmt": "1,238"
+                  },
+                  "value": {
+                    "raw": 3928323,
+                    "fmt": "3.93M",
+                    "longFmt": "3,928,323"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3173.12 per share.",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597622400,
+                    "fmt": "2020-08-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 304,
+                    "fmt": "304",
+                    "longFmt": "304"
+                  },
+                  "value": {
+                    "raw": 964628,
+                    "fmt": "964.63k",
+                    "longFmt": "964,628"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3173.12 per share.",
+                  "filerName": "MCGRATH JUDITH A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597622400,
+                    "fmt": "2020-08-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1377,
+                    "fmt": "1.38k",
+                    "longFmt": "1,377"
+                  },
+                  "value": {
+                    "raw": 4369386,
+                    "fmt": "4.37M",
+                    "longFmt": "4,369,386"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3173.12 per share.",
+                  "filerName": "OLSAVSKY BRIAN T.",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597622400,
+                    "fmt": "2020-08-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2941,
+                    "fmt": "2.94k",
+                    "longFmt": "2,941"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597363200,
+                    "fmt": "2020-08-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2791,
+                    "fmt": "2.79k",
+                    "longFmt": "2,791"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597363200,
+                    "fmt": "2020-08-14"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2791,
+                    "fmt": "2.79k",
+                    "longFmt": "2,791"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597363200,
+                    "fmt": "2020-08-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 292,
+                    "fmt": "292",
+                    "longFmt": "292"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "REYNOLDS SHELLEY L",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597363200,
+                    "fmt": "2020-08-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1377,
+                    "fmt": "1.38k",
+                    "longFmt": "1,377"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597363200,
+                    "fmt": "2020-08-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 304,
+                    "fmt": "304",
+                    "longFmt": "304"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "MCGRATH JUDITH A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597363200,
+                    "fmt": "2020-08-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1377,
+                    "fmt": "1.38k",
+                    "longFmt": "1,377"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "OLSAVSKY BRIAN T.",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597363200,
+                    "fmt": "2020-08-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 550,
+                    "fmt": "550",
+                    "longFmt": "550"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "STONESIFER PATRICIA Q",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596672000,
+                    "fmt": "2020-08-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 600,
+                    "fmt": "600",
+                    "longFmt": "600"
+                  },
+                  "value": {
+                    "raw": 1916616,
+                    "fmt": "1.92M",
+                    "longFmt": "1,916,616"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3194.36 per share.",
+                  "filerName": "STONESIFER PATRICIA Q",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596672000,
+                    "fmt": "2020-08-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 154394,
+                    "fmt": "154.39k",
+                    "longFmt": "154,394"
+                  },
+                  "value": {
+                    "raw": 485072931,
+                    "fmt": "485.07M",
+                    "longFmt": "485,072,931"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3102.85 - 3183.27 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596499200,
+                    "fmt": "2020-08-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 293614,
+                    "fmt": "293.61k",
+                    "longFmt": "293,614"
+                  },
+                  "value": {
+                    "raw": 916281263,
+                    "fmt": "916.28M",
+                    "longFmt": "916,281,263"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3108.33 - 3137.11 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596499200,
+                    "fmt": "2020-08-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 97654,
+                    "fmt": "97.65k",
+                    "longFmt": "97,654"
+                  },
+                  "value": {
+                    "raw": 307619184,
+                    "fmt": "307.62M",
+                    "longFmt": "307,619,184"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3138.51 - 3167.15 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596499200,
+                    "fmt": "2020-08-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 454338,
+                    "fmt": "454.34k",
+                    "longFmt": "454,338"
+                  },
+                  "value": {
+                    "raw": 1420090247,
+                    "fmt": "1.42B",
+                    "longFmt": "1,420,090,247"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3106.29 - 3137.51 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596412800,
+                    "fmt": "2020-08-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6945,
+                    "fmt": "6.95k",
+                    "longFmt": "6,945"
+                  },
+                  "value": {
+                    "raw": 22108644,
+                    "fmt": "22.11M",
+                    "longFmt": "22,108,644"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3183.39 per share.",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596412800,
+                    "fmt": "2020-08-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2602,
+                    "fmt": "2.6k",
+                    "longFmt": "2,602"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 750,
+                    "fmt": "750",
+                    "longFmt": "750"
+                  },
+                  "value": {
+                    "raw": 1832372,
+                    "fmt": "1.83M",
+                    "longFmt": "1,832,372"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2434.48 - 2451.35 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1590105600,
+                    "fmt": "2020-05-22"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4300,
+                    "fmt": "4.3k",
+                    "longFmt": "4,300"
+                  },
+                  "value": {
+                    "raw": 10742038,
+                    "fmt": "10.74M",
+                    "longFmt": "10,742,038"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2496.22 - 2499.01 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589932800,
+                    "fmt": "2020-05-20"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 183,
+                    "fmt": "183",
+                    "longFmt": "183"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "NOOYI INDRA K",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589500800,
+                    "fmt": "2020-05-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 347,
+                    "fmt": "347",
+                    "longFmt": "347"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589500800,
+                    "fmt": "2020-05-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1200,
+                    "fmt": "1.2k",
+                    "longFmt": "1,200"
+                  },
+                  "value": {
+                    "raw": 2859399,
+                    "fmt": "2.86M",
+                    "longFmt": "2,859,399"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2361.61 - 2409.00 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589500800,
+                    "fmt": "2020-05-15"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2791,
+                    "fmt": "2.79k",
+                    "longFmt": "2,791"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589500800,
+                    "fmt": "2020-05-15"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1099,
+                    "fmt": "1.1k",
+                    "longFmt": "1,099"
+                  },
+                  "value": {
+                    "raw": 2608079,
+                    "fmt": "2.61M",
+                    "longFmt": "2,608,079"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2372.34 - 2374.34 per share.",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589500800,
+                    "fmt": "2020-05-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2791,
+                    "fmt": "2.79k",
+                    "longFmt": "2,791"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589500800,
+                    "fmt": "2020-05-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 292,
+                    "fmt": "292",
+                    "longFmt": "292"
+                  },
+                  "value": {
+                    "raw": 693307,
+                    "fmt": "693.31k",
+                    "longFmt": "693,307"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2374.34 per share.",
+                  "filerName": "REYNOLDS SHELLEY L",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589500800,
+                    "fmt": "2020-05-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 292,
+                    "fmt": "292",
+                    "longFmt": "292"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "REYNOLDS SHELLEY L",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589500800,
+                    "fmt": "2020-05-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 424,
+                    "fmt": "424",
+                    "longFmt": "424"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589500800,
+                    "fmt": "2020-05-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1238,
+                    "fmt": "1.24k",
+                    "longFmt": "1,238"
+                  },
+                  "value": {
+                    "raw": 2935467,
+                    "fmt": "2.94M",
+                    "longFmt": "2,935,467"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2362.98 - 2376.05 per share.",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589500800,
+                    "fmt": "2020-05-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1376,
+                    "fmt": "1.38k",
+                    "longFmt": "1,376"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589500800,
+                    "fmt": "2020-05-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1376,
+                    "fmt": "1.38k",
+                    "longFmt": "1,376"
+                  },
+                  "value": {
+                    "raw": 3267092,
+                    "fmt": "3.27M",
+                    "longFmt": "3,267,092"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2374.34 per share.",
+                  "filerName": "OLSAVSKY BRIAN T.",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589500800,
+                    "fmt": "2020-05-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1376,
+                    "fmt": "1.38k",
+                    "longFmt": "1,376"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "OLSAVSKY BRIAN T.",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589500800,
+                    "fmt": "2020-05-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 550,
+                    "fmt": "550",
+                    "longFmt": "550"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "STONESIFER PATRICIA Q",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2200,
+                    "fmt": "2.2k",
+                    "longFmt": "2,200"
+                  },
+                  "value": {
+                    "raw": 5124768,
+                    "fmt": "5.12M",
+                    "longFmt": "5,124,768"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2329.44 per share.",
+                  "filerName": "STONESIFER PATRICIA Q",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3957,
+                    "fmt": "3.96k",
+                    "longFmt": "3,957"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 437,
+                    "fmt": "437",
+                    "longFmt": "437"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "RUBINSTEIN JONATHAN J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588550400,
+                    "fmt": "2020-05-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6945,
+                    "fmt": "6.95k",
+                    "longFmt": "6,945"
+                  },
+                  "value": {
+                    "raw": 15671392,
+                    "fmt": "15.67M",
+                    "longFmt": "15,671,392"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2256.50 per share.",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588550400,
+                    "fmt": "2020-05-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 352,
+                    "fmt": "352",
+                    "longFmt": "352"
+                  },
+                  "value": {
+                    "raw": 809668,
+                    "fmt": "809.67k",
+                    "longFmt": "809,668"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2300.00 - 2301.61 per share.",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1586908800,
+                    "fmt": "2020-04-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 52967,
+                    "fmt": "52.97k",
+                    "longFmt": "52,967"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1585872000,
+                    "fmt": "2020-04-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 524,
+                    "fmt": "524",
+                    "longFmt": "524"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1583107200,
+                    "fmt": "2020-03-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2049,
+                    "fmt": "2.05k",
+                    "longFmt": "2,049"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582502400,
+                    "fmt": "2020-02-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1000,
+                    "fmt": "1k",
+                    "longFmt": "1,000"
+                  },
+                  "value": {
+                    "raw": 2103212,
+                    "fmt": "2.1M",
+                    "longFmt": "2,103,212"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2093.64 - 2118.80 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582243200,
+                    "fmt": "2020-02-21"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3475,
+                    "fmt": "3.48k",
+                    "longFmt": "3,475"
+                  },
+                  "value": {
+                    "raw": 7471245,
+                    "fmt": "7.47M",
+                    "longFmt": "7,471,245"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2134.47 - 2164.88 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581984000,
+                    "fmt": "2020-02-18"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3178,
+                    "fmt": "3.18k",
+                    "longFmt": "3,178"
+                  },
+                  "value": {
+                    "raw": 6814364,
+                    "fmt": "6.81M",
+                    "longFmt": "6,814,364"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2142.60 - 2145.60 per share.",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581984000,
+                    "fmt": "2020-02-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3573,
+                    "fmt": "3.57k",
+                    "longFmt": "3,573"
+                  },
+                  "value": {
+                    "raw": 7652608,
+                    "fmt": "7.65M",
+                    "longFmt": "7,652,608"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2125.35 - 2147.76 per share.",
+                  "filerName": "BLACKBURN JEFFREY M",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581984000,
+                    "fmt": "2020-02-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 380,
+                    "fmt": "380",
+                    "longFmt": "380"
+                  },
+                  "value": {
+                    "raw": 811354,
+                    "fmt": "811.35k",
+                    "longFmt": "811,354"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2126.00 - 2144.05 per share.",
+                  "filerName": "REYNOLDS SHELLEY L",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581984000,
+                    "fmt": "2020-02-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1685,
+                    "fmt": "1.69k",
+                    "longFmt": "1,685"
+                  },
+                  "value": {
+                    "raw": 3601156,
+                    "fmt": "3.6M",
+                    "longFmt": "3,601,156"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2125.02 - 2147.45 per share.",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581984000,
+                    "fmt": "2020-02-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1765,
+                    "fmt": "1.76k",
+                    "longFmt": "1,765"
+                  },
+                  "value": {
+                    "raw": 3750660,
+                    "fmt": "3.75M",
+                    "longFmt": "3,750,660"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2125.02 per share.",
+                  "filerName": "OLSAVSKY BRIAN T.",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581984000,
+                    "fmt": "2020-02-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 190,
+                    "fmt": "190",
+                    "longFmt": "190"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "WEEKS WENDELL P.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581638400,
+                    "fmt": "2020-02-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8073,
+                    "fmt": "8.07k",
+                    "longFmt": "8,073"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581638400,
+                    "fmt": "2020-02-14"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 207,
+                    "fmt": "207",
+                    "longFmt": "207"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "GORELICK JAMIE S. J.D.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581638400,
+                    "fmt": "2020-02-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 190,
+                    "fmt": "190",
+                    "longFmt": "190"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "BREWER ROSALIND G",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581638400,
+                    "fmt": "2020-02-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8073,
+                    "fmt": "8.07k",
+                    "longFmt": "8,073"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581638400,
+                    "fmt": "2020-02-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3573,
+                    "fmt": "3.57k",
+                    "longFmt": "3,573"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "BLACKBURN JEFFREY M",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581638400,
+                    "fmt": "2020-02-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 380,
+                    "fmt": "380",
+                    "longFmt": "380"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "REYNOLDS SHELLEY L",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581638400,
+                    "fmt": "2020-02-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1765,
+                    "fmt": "1.76k",
+                    "longFmt": "1,765"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581638400,
+                    "fmt": "2020-02-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1765,
+                    "fmt": "1.76k",
+                    "longFmt": "1,765"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "OLSAVSKY BRIAN T.",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581638400,
+                    "fmt": "2020-02-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 250,
+                    "fmt": "250",
+                    "longFmt": "250"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GORELICK JAMIE S. J.D.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581033600,
+                    "fmt": "2020-02-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 283632,
+                    "fmt": "283.63k",
+                    "longFmt": "283,632"
+                  },
+                  "value": {
+                    "raw": 579803224,
+                    "fmt": "579.8M",
+                    "longFmt": "579,803,224"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2026.49 - 2056.18 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580947200,
+                    "fmt": "2020-02-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 486226,
+                    "fmt": "486.23k",
+                    "longFmt": "486,226"
+                  },
+                  "value": {
+                    "raw": 987950131,
+                    "fmt": "987.95M",
+                    "longFmt": "987,950,131"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2016.94 - 2041.54 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580860800,
+                    "fmt": "2020-02-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 324686,
+                    "fmt": "324.69k",
+                    "longFmt": "324,686"
+                  },
+                  "value": {
+                    "raw": 666158144,
+                    "fmt": "666.16M",
+                    "longFmt": "666,158,144"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2042.42 - 2070.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580860800,
+                    "fmt": "2020-02-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 229981,
+                    "fmt": "229.98k",
+                    "longFmt": "229,981"
+                  },
+                  "value": {
+                    "raw": 465004659,
+                    "fmt": "465M",
+                    "longFmt": "465,004,659"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2004.85 - 2053.62 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580688000,
+                    "fmt": "2020-02-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 364684,
+                    "fmt": "364.68k",
+                    "longFmt": "364,684"
+                  },
+                  "value": {
+                    "raw": 742649707,
+                    "fmt": "742.65M",
+                    "longFmt": "742,649,707"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2028.19 - 2048.42 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580688000,
+                    "fmt": "2020-02-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 200,
+                    "fmt": "200",
+                    "longFmt": "200"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580688000,
+                    "fmt": "2020-02-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6945,
+                    "fmt": "6.95k",
+                    "longFmt": "6,945"
+                  },
+                  "value": {
+                    "raw": 14025906,
+                    "fmt": "14.03M",
+                    "longFmt": "14,025,906"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2011.77 - 2025.69 per share.",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580688000,
+                    "fmt": "2020-02-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 310791,
+                    "fmt": "310.79k",
+                    "longFmt": "310,791"
+                  },
+                  "value": {
+                    "raw": 629448719,
+                    "fmt": "629.45M",
+                    "longFmt": "629,448,719"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2003.15 - 2042.47 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580428800,
+                    "fmt": "2020-01-31"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 705,
+                    "fmt": "705",
+                    "longFmt": "705"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580428800,
+                    "fmt": "2020-01-31"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3700,
+                    "fmt": "3.7k",
+                    "longFmt": "3,700"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1577404800,
+                    "fmt": "2019-12-27"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 200,
+                    "fmt": "200",
+                    "longFmt": "200"
+                  },
+                  "value": {
+                    "raw": 373067,
+                    "fmt": "373.07k",
+                    "longFmt": "373,067"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1862.03 - 1868.64 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1577318400,
+                    "fmt": "2019-12-26"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 281,
+                    "fmt": "281",
+                    "longFmt": "281"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "RYDER THOMAS O",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1575244800,
+                    "fmt": "2019-12-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 56702,
+                    "fmt": "56.7k",
+                    "longFmt": "56,702"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1574294400,
+                    "fmt": "2019-11-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1000,
+                    "fmt": "1k",
+                    "longFmt": "1,000"
+                  },
+                  "value": {
+                    "raw": 1748043,
+                    "fmt": "1.75M",
+                    "longFmt": "1,748,043"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1736.51 - 1760.18 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1574208000,
+                    "fmt": "2019-11-20"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 359,
+                    "fmt": "359",
+                    "longFmt": "359"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "STONESIFER PATRICIA Q",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 359,
+                    "fmt": "359",
+                    "longFmt": "359"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "RUBINSTEIN JONATHAN J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 359,
+                    "fmt": "359",
+                    "longFmt": "359"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "RYDER THOMAS O",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3475,
+                    "fmt": "3.48k",
+                    "longFmt": "3,475"
+                  },
+                  "value": {
+                    "raw": 6065867,
+                    "fmt": "6.07M",
+                    "longFmt": "6,065,867"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1733.00 - 1751.48 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8073,
+                    "fmt": "8.07k",
+                    "longFmt": "8,073"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3230,
+                    "fmt": "3.23k",
+                    "longFmt": "3,230"
+                  },
+                  "value": {
+                    "raw": 5659554,
+                    "fmt": "5.66M",
+                    "longFmt": "5,659,554"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1745.90 - 1759.86 per share.",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8073,
+                    "fmt": "8.07k",
+                    "longFmt": "8,073"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3573,
+                    "fmt": "3.57k",
+                    "longFmt": "3,573"
+                  },
+                  "value": {
+                    "raw": 6260717,
+                    "fmt": "6.26M",
+                    "longFmt": "6,260,717"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1745.64 - 1759.97 per share.",
+                  "filerName": "BLACKBURN JEFFREY M",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3573,
+                    "fmt": "3.57k",
+                    "longFmt": "3,573"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "BLACKBURN JEFFREY M",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 379,
+                    "fmt": "379",
+                    "longFmt": "379"
+                  },
+                  "value": {
+                    "raw": 663499,
+                    "fmt": "663.5k",
+                    "longFmt": "663,499"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1745.46 - 1760.82 per share.",
+                  "filerName": "REYNOLDS SHELLEY L",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 379,
+                    "fmt": "379",
+                    "longFmt": "379"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "REYNOLDS SHELLEY L",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 222,
+                    "fmt": "222",
+                    "longFmt": "222"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 880,
+                    "fmt": "880",
+                    "longFmt": "880"
+                  },
+                  "value": {
+                    "raw": 1540567,
+                    "fmt": "1.54M",
+                    "longFmt": "1,540,567"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1746.20 - 1759.34 per share.",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1765,
+                    "fmt": "1.76k",
+                    "longFmt": "1,765"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 377,
+                    "fmt": "377",
+                    "longFmt": "377"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "HUTTENLOCHER DANIEL P",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1265,
+                    "fmt": "1.26k",
+                    "longFmt": "1,265"
+                  },
+                  "value": {
+                    "raw": 2226463,
+                    "fmt": "2.23M",
+                    "longFmt": "2,226,463"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1760.05 per share.",
+                  "filerName": "OLSAVSKY BRIAN T.",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1765,
+                    "fmt": "1.76k",
+                    "longFmt": "1,765"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "OLSAVSKY BRIAN T.",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2441,
+                    "fmt": "2.44k",
+                    "longFmt": "2,441"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573603200,
+                    "fmt": "2019-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 304,
+                    "fmt": "304",
+                    "longFmt": "304"
+                  },
+                  "value": {
+                    "raw": 531973,
+                    "fmt": "531.97k",
+                    "longFmt": "531,973"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1749.91 per share.",
+                  "filerName": "MCGRATH JUDITH A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1572220800,
+                    "fmt": "2019-10-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2800,
+                    "fmt": "2.8k",
+                    "longFmt": "2,800"
+                  },
+                  "value": {
+                    "raw": 5173031,
+                    "fmt": "5.17M",
+                    "longFmt": "5,173,031"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1846.48 - 1852.01 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1568246400,
+                    "fmt": "2019-09-12"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2500,
+                    "fmt": "2.5k",
+                    "longFmt": "2,500"
+                  },
+                  "value": {
+                    "raw": 4480255,
+                    "fmt": "4.48M",
+                    "longFmt": "4,480,255"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1781.94 - 1799.81 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1567468800,
+                    "fmt": "2019-09-03"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7144,
+                    "fmt": "7.14k",
+                    "longFmt": "7,144"
+                  },
+                  "value": {
+                    "raw": 12797740,
+                    "fmt": "12.8M",
+                    "longFmt": "12,797,740"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1778.15 - 1797.60 per share.",
+                  "filerName": "BLACKBURN JEFFREY M",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1567036800,
+                    "fmt": "2019-08-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2500,
+                    "fmt": "2.5k",
+                    "longFmt": "2,500"
+                  },
+                  "value": {
+                    "raw": 4397582,
+                    "fmt": "4.4M",
+                    "longFmt": "4,397,582"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1749.92 - 1766.52 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1566777600,
+                    "fmt": "2019-08-26"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 277,
+                    "fmt": "277",
+                    "longFmt": "277"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "RUBINSTEIN JONATHAN J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1566259200,
+                    "fmt": "2019-08-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1000,
+                    "fmt": "1k",
+                    "longFmt": "1,000"
+                  },
+                  "value": {
+                    "raw": 1809204,
+                    "fmt": "1.81M",
+                    "longFmt": "1,809,204"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1804.48 - 1813.28 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1566259200,
+                    "fmt": "2019-08-20"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3475,
+                    "fmt": "3.48k",
+                    "longFmt": "3,475"
+                  },
+                  "value": {
+                    "raw": 6164625,
+                    "fmt": "6.16M",
+                    "longFmt": "6,164,625"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1765.07 - 1780.13 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1565827200,
+                    "fmt": "2019-08-15"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8072,
+                    "fmt": "8.07k",
+                    "longFmt": "8,072"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1565827200,
+                    "fmt": "2019-08-15"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3230,
+                    "fmt": "3.23k",
+                    "longFmt": "3,230"
+                  },
+                  "value": {
+                    "raw": 5734363,
+                    "fmt": "5.73M",
+                    "longFmt": "5,734,363"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1768.36 - 1787.05 per share.",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1565827200,
+                    "fmt": "2019-08-15"
+                  },
+                  "ownership": "D"
+                }
+              ],
+              "maxAge": 1
+            },
+            "sectorTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 125555000000,
+                    "fmt": "125.56B",
+                    "longFmt": "125,555,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 79284000000,
+                    "fmt": "79.28B",
+                    "longFmt": "79,284,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 46271000000,
+                    "fmt": "46.27B",
+                    "longFmt": "46,271,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 16466000000,
+                    "fmt": "16.47B",
+                    "longFmt": "16,466,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 23428000000,
+                    "fmt": "23.43B",
+                    "longFmt": "23,428,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": -496000000,
+                    "fmt": "-496M",
+                    "longFmt": "-496,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 118682000000,
+                    "fmt": "118.68B",
+                    "longFmt": "118,682,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 6873000000,
+                    "fmt": "6.87B",
+                    "longFmt": "6,873,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 914000000,
+                    "fmt": "914M",
+                    "longFmt": "914,000,000"
+                  },
+                  "ebit": {
+                    "raw": 6873000000,
+                    "fmt": "6.87B",
+                    "longFmt": "6,873,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -414000000,
+                    "fmt": "-414M",
+                    "longFmt": "-414,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 7787000000,
+                    "fmt": "7.79B",
+                    "longFmt": "7,787,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 565000000,
+                    "fmt": "565M",
+                    "longFmt": "565,000,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 7222000000,
+                    "fmt": "7.22B",
+                    "longFmt": "7,222,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 7222000000,
+                    "fmt": "7.22B",
+                    "longFmt": "7,222,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 7222000000,
+                    "fmt": "7.22B",
+                    "longFmt": "7,222,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 96145000000,
+                    "fmt": "96.14B",
+                    "longFmt": "96,145,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 57106000000,
+                    "fmt": "57.11B",
+                    "longFmt": "57,106,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 39039000000,
+                    "fmt": "39.04B",
+                    "longFmt": "39,039,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 9334000000,
+                    "fmt": "9.33B",
+                    "longFmt": "9,334,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 23449000000,
+                    "fmt": "23.45B",
+                    "longFmt": "23,449,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 62000000,
+                    "fmt": "62M",
+                    "longFmt": "62,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 89951000000,
+                    "fmt": "89.95B",
+                    "longFmt": "89,951,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 6194000000,
+                    "fmt": "6.19B",
+                    "longFmt": "6,194,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 706000000,
+                    "fmt": "706M",
+                    "longFmt": "706,000,000"
+                  },
+                  "ebit": {
+                    "raw": 6194000000,
+                    "fmt": "6.19B",
+                    "longFmt": "6,194,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -428000000,
+                    "fmt": "-428M",
+                    "longFmt": "-428,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 6900000000,
+                    "fmt": "6.9B",
+                    "longFmt": "6,900,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 569000000,
+                    "fmt": "569M",
+                    "longFmt": "569,000,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 6331000000,
+                    "fmt": "6.33B",
+                    "longFmt": "6,331,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 6331000000,
+                    "fmt": "6.33B",
+                    "longFmt": "6,331,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 6331000000,
+                    "fmt": "6.33B",
+                    "longFmt": "6,331,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 88912000000,
+                    "fmt": "88.91B",
+                    "longFmt": "88,912,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 52660000000,
+                    "fmt": "52.66B",
+                    "longFmt": "52,660,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 36252000000,
+                    "fmt": "36.25B",
+                    "longFmt": "36,252,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 8945000000,
+                    "fmt": "8.95B",
+                    "longFmt": "8,945,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 21174000000,
+                    "fmt": "21.17B",
+                    "longFmt": "21,174,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 290000000,
+                    "fmt": "290M",
+                    "longFmt": "290,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 83069000000,
+                    "fmt": "83.07B",
+                    "longFmt": "83,069,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 5843000000,
+                    "fmt": "5.84B",
+                    "longFmt": "5,843,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 384000000,
+                    "fmt": "384M",
+                    "longFmt": "384,000,000"
+                  },
+                  "ebit": {
+                    "raw": 5843000000,
+                    "fmt": "5.84B",
+                    "longFmt": "5,843,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -403000000,
+                    "fmt": "-403M",
+                    "longFmt": "-403,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 6227000000,
+                    "fmt": "6.23B",
+                    "longFmt": "6,227,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 984000000,
+                    "fmt": "984M",
+                    "longFmt": "984,000,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 5243000000,
+                    "fmt": "5.24B",
+                    "longFmt": "5,243,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 5243000000,
+                    "fmt": "5.24B",
+                    "longFmt": "5,243,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 5243000000,
+                    "fmt": "5.24B",
+                    "longFmt": "5,243,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 75452000000,
+                    "fmt": "75.45B",
+                    "longFmt": "75,452,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 44257000000,
+                    "fmt": "44.26B",
+                    "longFmt": "44,257,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 31195000000,
+                    "fmt": "31.2B",
+                    "longFmt": "31,195,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 9325000000,
+                    "fmt": "9.32B",
+                    "longFmt": "9,325,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 17811000000,
+                    "fmt": "17.81B",
+                    "longFmt": "17,811,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 70000000,
+                    "fmt": "70M",
+                    "longFmt": "70,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 71463000000,
+                    "fmt": "71.46B",
+                    "longFmt": "71,463,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 3989000000,
+                    "fmt": "3.99B",
+                    "longFmt": "3,989,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -741000000,
+                    "fmt": "-741M",
+                    "longFmt": "-741,000,000"
+                  },
+                  "ebit": {
+                    "raw": 3989000000,
+                    "fmt": "3.99B",
+                    "longFmt": "3,989,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -402000000,
+                    "fmt": "-402M",
+                    "longFmt": "-402,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 3279000000,
+                    "fmt": "3.28B",
+                    "longFmt": "3,279,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 744000000,
+                    "fmt": "744M",
+                    "longFmt": "744,000,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 2535000000,
+                    "fmt": "2.54B",
+                    "longFmt": "2,535,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 2535000000,
+                    "fmt": "2.54B",
+                    "longFmt": "2,535,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 2535000000,
+                    "fmt": "2.54B",
+                    "longFmt": "2,535,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 7222000000,
+                    "fmt": "7.22B",
+                    "longFmt": "7,222,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 7618000000,
+                    "fmt": "7.62B",
+                    "longFmt": "7,618,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -888000000,
+                    "fmt": "-888M",
+                    "longFmt": "-888,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -4561000000,
+                    "fmt": "-4.56B",
+                    "longFmt": "-4,561,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 13582000000,
+                    "fmt": "13.58B",
+                    "longFmt": "13,582,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 329000000,
+                    "fmt": "329M",
+                    "longFmt": "329,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 7129000000,
+                    "fmt": "7.13B",
+                    "longFmt": "7,129,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 30431000000,
+                    "fmt": "30.43B",
+                    "longFmt": "30,431,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -14823000000,
+                    "fmt": "-14.82B",
+                    "longFmt": "-14,823,000,000"
+                  },
+                  "investments": {
+                    "raw": -3463000000,
+                    "fmt": "-3.46B",
+                    "longFmt": "-3,463,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -17037000000,
+                    "fmt": "-17.04B",
+                    "longFmt": "-17,037,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -1816000000,
+                    "fmt": "-1.82B",
+                    "longFmt": "-1,816,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -1816000000,
+                    "fmt": "-1.82B",
+                    "longFmt": "-1,816,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 597000000,
+                    "fmt": "597M",
+                    "longFmt": "597,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 12175000000,
+                    "fmt": "12.18B",
+                    "longFmt": "12,175,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 6331000000,
+                    "fmt": "6.33B",
+                    "longFmt": "6,331,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 6523000000,
+                    "fmt": "6.52B",
+                    "longFmt": "6,523,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 1599000000,
+                    "fmt": "1.6B",
+                    "longFmt": "1,599,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -2016000000,
+                    "fmt": "-2.02B",
+                    "longFmt": "-2,016,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 3736000000,
+                    "fmt": "3.74B",
+                    "longFmt": "3,736,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -3899000000,
+                    "fmt": "-3.9B",
+                    "longFmt": "-3,899,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -310000000,
+                    "fmt": "-310M",
+                    "longFmt": "-310,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 11964000000,
+                    "fmt": "11.96B",
+                    "longFmt": "11,964,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -11063000000,
+                    "fmt": "-11.06B",
+                    "longFmt": "-11,063,000,000"
+                  },
+                  "investments": {
+                    "raw": -4333000000,
+                    "fmt": "-4.33B",
+                    "longFmt": "-4,333,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -15876000000,
+                    "fmt": "-15.88B",
+                    "longFmt": "-15,876,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -4105000000,
+                    "fmt": "-4.11B",
+                    "longFmt": "-4,105,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -4105000000,
+                    "fmt": "-4.11B",
+                    "longFmt": "-4,105,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 377000000,
+                    "fmt": "377M",
+                    "longFmt": "377,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": -7640000000,
+                    "fmt": "-7.64B",
+                    "longFmt": "-7,640,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "netIncome": {
+                    "raw": 5243000000,
+                    "fmt": "5.24B",
+                    "longFmt": "5,243,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 5748000000,
+                    "fmt": "5.75B",
+                    "longFmt": "5,748,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 2579000000,
+                    "fmt": "2.58B",
+                    "longFmt": "2,579,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -2854000000,
+                    "fmt": "-2.85B",
+                    "longFmt": "-2,854,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 8863000000,
+                    "fmt": "8.86B",
+                    "longFmt": "8,863,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -672000000,
+                    "fmt": "-672M",
+                    "longFmt": "-672,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 1699000000,
+                    "fmt": "1.7B",
+                    "longFmt": "1,699,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 20606000000,
+                    "fmt": "20.61B",
+                    "longFmt": "20,606,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -7459000000,
+                    "fmt": "-7.46B",
+                    "longFmt": "-7,459,000,000"
+                  },
+                  "investments": {
+                    "raw": -11071000000,
+                    "fmt": "-11.07B",
+                    "longFmt": "-11,071,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -17804000000,
+                    "fmt": "-17.8B",
+                    "longFmt": "-17,804,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 7408000000,
+                    "fmt": "7.41B",
+                    "longFmt": "7,408,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 7408000000,
+                    "fmt": "7.41B",
+                    "longFmt": "7,408,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 127000000,
+                    "fmt": "127M",
+                    "longFmt": "127,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 10337000000,
+                    "fmt": "10.34B",
+                    "longFmt": "10,337,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "netIncome": {
+                    "raw": 2535000000,
+                    "fmt": "2.54B",
+                    "longFmt": "2,535,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 5362000000,
+                    "fmt": "5.36B",
+                    "longFmt": "5,362,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 2711000000,
+                    "fmt": "2.71B",
+                    "longFmt": "2,711,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 1262000000,
+                    "fmt": "1.26B",
+                    "longFmt": "1,262,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -7437000000,
+                    "fmt": "-7.44B",
+                    "longFmt": "-7,437,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 1392000000,
+                    "fmt": "1.39B",
+                    "longFmt": "1,392,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -2761000000,
+                    "fmt": "-2.76B",
+                    "longFmt": "-2,761,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 3064000000,
+                    "fmt": "3.06B",
+                    "longFmt": "3,064,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -6795000000,
+                    "fmt": "-6.79B",
+                    "longFmt": "-6,795,000,000"
+                  },
+                  "investments": {
+                    "raw": -3375000000,
+                    "fmt": "-3.38B",
+                    "longFmt": "-3,375,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -8894000000,
+                    "fmt": "-8.89B",
+                    "longFmt": "-8,894,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -2591000000,
+                    "fmt": "-2.59B",
+                    "longFmt": "-2,591,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -2591000000,
+                    "fmt": "-2.59B",
+                    "longFmt": "-2,591,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -484000000,
+                    "fmt": "-484M",
+                    "longFmt": "-484,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": -8905000000,
+                    "fmt": "-8.9B",
+                    "longFmt": "-8,905,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [
+                  {
+                    "date": "1Q2020",
+                    "actual": 5.01,
+                    "estimate": 6.25
+                  },
+                  {
+                    "date": "2Q2020",
+                    "actual": 10.3,
+                    "estimate": 1.46
+                  },
+                  {
+                    "date": "3Q2020",
+                    "actual": 12.37,
+                    "estimate": 7.41
+                  },
+                  {
+                    "date": "4Q2020",
+                    "actual": 14.09,
+                    "estimate": 7.23
+                  }
+                ],
+                "currentQuarterEstimate": 9.51,
+                "currentQuarterEstimateDate": "1Q",
+                "currentQuarterEstimateYear": 2021,
+                "earningsDate": [
+                  1619568000,
+                  1620000000
+                ]
+              },
+              "financialsChart": {
+                "yearly": [
+                  {
+                    "date": 2017,
+                    "revenue": 177866000000,
+                    "earnings": 3033000000
+                  },
+                  {
+                    "date": 2018,
+                    "revenue": 232887000000,
+                    "earnings": 10073000000
+                  },
+                  {
+                    "date": 2019,
+                    "revenue": 280522000000,
+                    "earnings": 11588000000
+                  },
+                  {
+                    "date": 2020,
+                    "revenue": 386064000000,
+                    "earnings": 21331000000
+                  }
+                ],
+                "quarterly": [
+                  {
+                    "date": "1Q2020",
+                    "revenue": 75452000000,
+                    "earnings": 2535000000
+                  },
+                  {
+                    "date": "2Q2020",
+                    "revenue": 88912000000,
+                    "earnings": 5243000000
+                  },
+                  {
+                    "date": "3Q2020",
+                    "revenue": 96145000000,
+                    "earnings": 6331000000
+                  },
+                  {
+                    "date": "4Q2020",
+                    "revenue": 125555000000,
+                    "earnings": 7222000000
+                  }
+                ]
+              },
+              "financialCurrency": "USD"
+            },
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 3279.4023,
+              "targetHighPrice": 5200,
+              "targetLowPrice": 3048,
+              "targetMeanPrice": 4002.71,
+              "targetMedianPrice": 4000,
+              "recommendationMean": 1.7,
+              "recommendationKey": "buy",
+              "numberOfAnalystOpinions": 45,
+              "totalCash": 84395999232,
+              "totalCashPerShare": 167.597,
+              "ebitda": 48149999616,
+              "totalDebt": 101229002752,
+              "quickRatio": 0.86,
+              "currentRatio": 1.05,
+              "totalRevenue": 386063990784,
+              "debtToEquity": 108.377,
+              "revenuePerShare": 772.128,
+              "returnOnAssets": 0.05238,
+              "returnOnEquity": 0.27442,
+              "grossProfits": 152757000000,
+              "freeCashflow": 36638498816,
+              "operatingCashflow": 66063998976,
+              "earningsGrowth": 1.166,
+              "revenueGrowth": 0.436,
+              "grossMargins": 0.39568,
+              "ebitdaMargins": 0.12472,
+              "operatingMargins": 0.059310004,
+              "profitMargins": 0.05525,
+              "financialCurrency": "USD"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-all-AZT.OL.json
+++ b/tests/http/quoteSummary-all-AZT.OL.json
@@ -1,0 +1,2827 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=assetProfile%2CbalanceSheetHistory%2CbalanceSheetHistoryQuarterly%2CcalendarEvents%2CcashflowStatementHistory%2CcashflowStatementHistoryQuarterly%2CdefaultKeyStatistics%2Cearnings%2CearningsHistory%2CearningsTrend%2CfinancialData%2CfundOwnership%2CfundPerformance%2CfundProfile%2CincomeStatementHistory%2CincomeStatementHistoryQuarterly%2CindexTrend%2CindustryTrend%2CinsiderHolders%2CinsiderTransactions%2CinstitutionOwnership%2CmajorDirectHolders%2CmajorHoldersBreakdown%2CnetSharePurchaseActivity%2Cprice%2CquoteType%2CrecommendationTrend%2CsecFilings%2CsectorTrend%2CsummaryDetail%2CsummaryProfile%2CtopHoldings%2CupgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "18ajqh1g2nrri"
+      ],
+      "x-yahoo-request-id": [
+        "18ajqh1g2nrri"
+      ],
+      "x-request-id": [
+        "4f62fd2f-5871-4a51-8861-3b51c65f5c54"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "11"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:42 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "Sykehusveien 23",
+              "address2": "PO Box 6463",
+              "city": "TromsÃ¸",
+              "zip": "9294",
+              "country": "Norway",
+              "phone": "47 77 64 89 00",
+              "fax": "47 77 64 89 01",
+              "website": "http://arcticzymes.com",
+              "industry": "Biotechnology",
+              "sector": "Healthcare",
+              "longBusinessSummary": "ArcticZymes Technologies ASA develops, manufactures, and markets immunomodulating beta-glucans and recombinant enzymes in Norway, Europe, Asia, Australia, Africa, and the Americas. It operates through two segments, Enzymes and Beta-Glucans. The company provides recombinant enzymes that are primarily derived from cold-water marine species and organisms from other relevant environments for use in molecular research, in vitro diagnostics, and therapeutics. It offers shrimp alkaline phosphatase and derived kits for cleanup prior to Sanger sequencing and next generation sequencing (NGS) processes; cod UNG for use in viral and other molecular diagnostic assays; double-strand specific DNases and derived kits for the removal of DNA from RNA samples; polymerases for technology development for life science, molecular diagnostics, NGS, and synthetic biology; proteinase for microbiological diagnostics and liquid biopsies; salt active nuclease for the removal of nucleic acids during manufacturing of vaccines, viruses, recombinant proteins, and other reagents; and ligases for joining DNA fragments. The company also provides immunomodulating beta-glucans products for the wound care, animal and consumer health, and adjuvants markets. It offers Woulgan wound gel; M-Glucan, a natural immune-stimulating product for fish and animal feed; and M-Gard, a natural immune-stimulating ingredients to enhance physical health. The company was formerly known as Biotec Pharmacon ASA and changed its name to ArcticZymes Technologies ASA in June 2020. ArcticZymes Technologies ASA was founded in 1990 and is headquartered in TromsÃ¸, Norway.",
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Jethro  Holter",
+                  "age": 48,
+                  "title": "Chief Exec. Officer",
+                  "yearBorn": 1972,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 1487000,
+                    "fmt": "1.49M",
+                    "longFmt": "1,487,000"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. BÃ¸rge  SÃ¸rvoll",
+                  "age": 45,
+                  "title": "Chief Financial Officer",
+                  "yearBorn": 1975,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 1331000,
+                    "fmt": "1.33M",
+                    "longFmt": "1,331,000"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Marit Sjo Lorentzen",
+                  "title": "Employee Representative Director & Director of Operations",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Alexander Johann Bjorna",
+                  "title": "Director of IP & Bus. Devel.",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Dino  DiCamillo",
+                  "age": 62,
+                  "title": "Director of Marketing",
+                  "yearBorn": 1958,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "compensationAsOfEpochDate": 1577750400,
+              "maxAge": 86400
+            },
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 84743000,
+                    "fmt": "84.74M",
+                    "longFmt": "84,743,000"
+                  },
+                  "depreciation": {
+                    "raw": 2385000,
+                    "fmt": "2.38M",
+                    "longFmt": "2,385,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -24629000,
+                    "fmt": "-24.63M",
+                    "longFmt": "-24,629,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -22715000,
+                    "fmt": "-22.71M",
+                    "longFmt": "-22,715,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 3098000,
+                    "fmt": "3.1M",
+                    "longFmt": "3,098,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -903000,
+                    "fmt": "-903k",
+                    "longFmt": "-903,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 42233000,
+                    "fmt": "42.23M",
+                    "longFmt": "42,233,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -1794000,
+                    "fmt": "-1.79M",
+                    "longFmt": "-1,794,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 10000,
+                    "fmt": "10k",
+                    "longFmt": "10,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -1784000,
+                    "fmt": "-1.78M",
+                    "longFmt": "-1,784,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -929000,
+                    "fmt": "-929k",
+                    "longFmt": "-929,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 69369000,
+                    "fmt": "69.37M",
+                    "longFmt": "69,369,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 68440000,
+                    "fmt": "68.44M",
+                    "longFmt": "68,440,000"
+                  },
+                  "changeInCash": {
+                    "raw": 108889000,
+                    "fmt": "108.89M",
+                    "longFmt": "108,889,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -6386000,
+                    "fmt": "-6.39M",
+                    "longFmt": "-6,386,000"
+                  },
+                  "depreciation": {
+                    "raw": 3928000,
+                    "fmt": "3.93M",
+                    "longFmt": "3,928,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 1176000,
+                    "fmt": "1.18M",
+                    "longFmt": "1,176,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 2299000,
+                    "fmt": "2.3M",
+                    "longFmt": "2,299,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 1054000,
+                    "fmt": "1.05M",
+                    "longFmt": "1,054,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 739000,
+                    "fmt": "739k",
+                    "longFmt": "739,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 3965000,
+                    "fmt": "3.96M",
+                    "longFmt": "3,965,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -688000,
+                    "fmt": "-688k",
+                    "longFmt": "-688,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 10000,
+                    "fmt": "10k",
+                    "longFmt": "10,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -1100000,
+                    "fmt": "-1.1M",
+                    "longFmt": "-1,100,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -2441000,
+                    "fmt": "-2.44M",
+                    "longFmt": "-2,441,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -797000,
+                    "fmt": "-797k",
+                    "longFmt": "-797,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -3238000,
+                    "fmt": "-3.24M",
+                    "longFmt": "-3,238,000"
+                  },
+                  "changeInCash": {
+                    "raw": -372000,
+                    "fmt": "-372k",
+                    "longFmt": "-372,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -14193000,
+                    "fmt": "-14.19M",
+                    "longFmt": "-14,193,000"
+                  },
+                  "depreciation": {
+                    "raw": 3699000,
+                    "fmt": "3.7M",
+                    "longFmt": "3,699,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 1888000,
+                    "fmt": "1.89M",
+                    "longFmt": "1,888,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -3282000,
+                    "fmt": "-3.28M",
+                    "longFmt": "-3,282,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -2766000,
+                    "fmt": "-2.77M",
+                    "longFmt": "-2,766,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -1549000,
+                    "fmt": "-1.55M",
+                    "longFmt": "-1,549,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -15192000,
+                    "fmt": "-15.19M",
+                    "longFmt": "-15,192,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -1269000,
+                    "fmt": "-1.27M",
+                    "longFmt": "-1,269,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 9000,
+                    "fmt": "9k",
+                    "longFmt": "9,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -2704000,
+                    "fmt": "-2.7M",
+                    "longFmt": "-2,704,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -2221000,
+                    "fmt": "-2.22M",
+                    "longFmt": "-2,221,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -865000,
+                    "fmt": "-865k",
+                    "longFmt": "-865,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 18965000,
+                    "fmt": "18.96M",
+                    "longFmt": "18,965,000"
+                  },
+                  "changeInCash": {
+                    "raw": 1069000,
+                    "fmt": "1.07M",
+                    "longFmt": "1,069,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 22051000,
+                    "fmt": "22.05M",
+                    "longFmt": "22,051,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -24938000,
+                    "fmt": "-24.94M",
+                    "longFmt": "-24,938,000"
+                  },
+                  "depreciation": {
+                    "raw": 1978000,
+                    "fmt": "1.98M",
+                    "longFmt": "1,978,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 1663000,
+                    "fmt": "1.66M",
+                    "longFmt": "1,663,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 2354000,
+                    "fmt": "2.35M",
+                    "longFmt": "2,354,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -877000,
+                    "fmt": "-877k",
+                    "longFmt": "-877,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -2236000,
+                    "fmt": "-2.24M",
+                    "longFmt": "-2,236,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -22056000,
+                    "fmt": "-22.06M",
+                    "longFmt": "-22,056,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -2629000,
+                    "fmt": "-2.63M",
+                    "longFmt": "-2,629,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 27000,
+                    "fmt": "27k",
+                    "longFmt": "27,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -5024000,
+                    "fmt": "-5.02M",
+                    "longFmt": "-5,024,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -2221000,
+                    "fmt": "-2.22M",
+                    "longFmt": "-2,221,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -865000,
+                    "fmt": "-865k",
+                    "longFmt": "-865,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 18965000,
+                    "fmt": "18.96M",
+                    "longFmt": "18,965,000"
+                  },
+                  "changeInCash": {
+                    "raw": -27079000,
+                    "fmt": "-27.08M",
+                    "longFmt": "-27,079,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 22051000,
+                    "fmt": "22.05M",
+                    "longFmt": "22,051,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            },
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.23488002,
+              "institutionsPercentHeld": 0.13869001,
+              "institutionsFloatPercentHeld": 0.18127,
+              "institutionsCount": 12
+            },
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "cash": {
+                    "raw": 140178000,
+                    "fmt": "140.18M",
+                    "longFmt": "140,178,000"
+                  },
+                  "netReceivables": {
+                    "raw": 30705000,
+                    "fmt": "30.7M",
+                    "longFmt": "30,705,000"
+                  },
+                  "inventory": {
+                    "raw": 3889000,
+                    "fmt": "3.89M",
+                    "longFmt": "3,889,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 174772000,
+                    "fmt": "174.77M",
+                    "longFmt": "174,772,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 13573000,
+                    "fmt": "13.57M",
+                    "longFmt": "13,573,000"
+                  },
+                  "otherAssets": {
+                    "raw": 33402000,
+                    "fmt": "33.4M",
+                    "longFmt": "33,402,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 32978000,
+                    "fmt": "32.98M",
+                    "longFmt": "32,978,000"
+                  },
+                  "totalAssets": {
+                    "raw": 221747000,
+                    "fmt": "221.75M",
+                    "longFmt": "221,747,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 3456000,
+                    "fmt": "3.46M",
+                    "longFmt": "3,456,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 3721000,
+                    "fmt": "3.72M",
+                    "longFmt": "3,721,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 420000,
+                    "fmt": "420k",
+                    "longFmt": "420,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 3130000,
+                    "fmt": "3.13M",
+                    "longFmt": "3,130,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 14828000,
+                    "fmt": "14.83M",
+                    "longFmt": "14,828,000"
+                  },
+                  "totalLiab": {
+                    "raw": 24423000,
+                    "fmt": "24.42M",
+                    "longFmt": "24,423,000"
+                  },
+                  "commonStock": {
+                    "raw": 48335000,
+                    "fmt": "48.34M",
+                    "longFmt": "48,335,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -5180000,
+                    "fmt": "-5.18M",
+                    "longFmt": "-5,180,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 151039000,
+                    "fmt": "151.04M",
+                    "longFmt": "151,039,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 194194000,
+                    "fmt": "194.19M",
+                    "longFmt": "194,194,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 194194000,
+                    "fmt": "194.19M",
+                    "longFmt": "194,194,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 69660000,
+                    "fmt": "69.66M",
+                    "longFmt": "69,660,000"
+                  },
+                  "netReceivables": {
+                    "raw": 20754000,
+                    "fmt": "20.75M",
+                    "longFmt": "20,754,000"
+                  },
+                  "inventory": {
+                    "raw": 4876000,
+                    "fmt": "4.88M",
+                    "longFmt": "4,876,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 7640000,
+                    "fmt": "7.64M",
+                    "longFmt": "7,640,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 102930000,
+                    "fmt": "102.93M",
+                    "longFmt": "102,930,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 17051000,
+                    "fmt": "17.05M",
+                    "longFmt": "17,051,000"
+                  },
+                  "otherAssets": {
+                    "raw": 483000,
+                    "fmt": "483k",
+                    "longFmt": "483,000"
+                  },
+                  "totalAssets": {
+                    "raw": 120464000,
+                    "fmt": "120.46M",
+                    "longFmt": "120,464,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 10340000,
+                    "fmt": "10.34M",
+                    "longFmt": "10,340,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 7000,
+                    "fmt": "7k",
+                    "longFmt": "7,000"
+                  },
+                  "otherLiab": {
+                    "raw": 745000,
+                    "fmt": "745k",
+                    "longFmt": "745,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 484000,
+                    "fmt": "484k",
+                    "longFmt": "484,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 3039000,
+                    "fmt": "3.04M",
+                    "longFmt": "3,039,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 10347000,
+                    "fmt": "10.35M",
+                    "longFmt": "10,347,000"
+                  },
+                  "totalLiab": {
+                    "raw": 24835000,
+                    "fmt": "24.84M",
+                    "longFmt": "24,835,000"
+                  },
+                  "commonStock": {
+                    "raw": 48335000,
+                    "fmt": "48.34M",
+                    "longFmt": "48,335,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -106784000,
+                    "fmt": "-106.78M",
+                    "longFmt": "-106,784,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 151039000,
+                    "fmt": "151.04M",
+                    "longFmt": "151,039,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 92590000,
+                    "fmt": "92.59M",
+                    "longFmt": "92,590,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 92590000,
+                    "fmt": "92.59M",
+                    "longFmt": "92,590,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "cash": {
+                    "raw": 56109000,
+                    "fmt": "56.11M",
+                    "longFmt": "56,109,000"
+                  },
+                  "netReceivables": {
+                    "raw": 26660000,
+                    "fmt": "26.66M",
+                    "longFmt": "26,660,000"
+                  },
+                  "inventory": {
+                    "raw": 4439000,
+                    "fmt": "4.44M",
+                    "longFmt": "4,439,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 6961000,
+                    "fmt": "6.96M",
+                    "longFmt": "6,961,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 94169000,
+                    "fmt": "94.17M",
+                    "longFmt": "94,169,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 17887000,
+                    "fmt": "17.89M",
+                    "longFmt": "17,887,000"
+                  },
+                  "otherAssets": {
+                    "raw": 625000,
+                    "fmt": "625k",
+                    "longFmt": "625,000"
+                  },
+                  "totalAssets": {
+                    "raw": 112681000,
+                    "fmt": "112.68M",
+                    "longFmt": "112,681,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 4742000,
+                    "fmt": "4.74M",
+                    "longFmt": "4,742,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 3863000,
+                    "fmt": "3.86M",
+                    "longFmt": "3,863,000"
+                  },
+                  "otherLiab": {
+                    "raw": -1000,
+                    "fmt": "-1k",
+                    "longFmt": "-1,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 547000,
+                    "fmt": "547k",
+                    "longFmt": "547,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 2694000,
+                    "fmt": "2.69M",
+                    "longFmt": "2,694,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 12564000,
+                    "fmt": "12.56M",
+                    "longFmt": "12,564,000"
+                  },
+                  "totalLiab": {
+                    "raw": 26356000,
+                    "fmt": "26.36M",
+                    "longFmt": "26,356,000"
+                  },
+                  "commonStock": {
+                    "raw": 48335000,
+                    "fmt": "48.34M",
+                    "longFmt": "48,335,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -115743000,
+                    "fmt": "-115.74M",
+                    "longFmt": "-115,743,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 151039000,
+                    "fmt": "151.04M",
+                    "longFmt": "151,039,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 83631000,
+                    "fmt": "83.63M",
+                    "longFmt": "83,631,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 83631000,
+                    "fmt": "83.63M",
+                    "longFmt": "83,631,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "cash": {
+                    "raw": 35667000,
+                    "fmt": "35.67M",
+                    "longFmt": "35,667,000"
+                  },
+                  "netReceivables": {
+                    "raw": 23927000,
+                    "fmt": "23.93M",
+                    "longFmt": "23,927,000"
+                  },
+                  "inventory": {
+                    "raw": 4663000,
+                    "fmt": "4.66M",
+                    "longFmt": "4,663,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 8068000,
+                    "fmt": "8.07M",
+                    "longFmt": "8,068,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 72325000,
+                    "fmt": "72.33M",
+                    "longFmt": "72,325,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 18806000,
+                    "fmt": "18.81M",
+                    "longFmt": "18,806,000"
+                  },
+                  "otherAssets": {
+                    "raw": 612000,
+                    "fmt": "612k",
+                    "longFmt": "612,000"
+                  },
+                  "totalAssets": {
+                    "raw": 91743000,
+                    "fmt": "91.74M",
+                    "longFmt": "91,743,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 8206000,
+                    "fmt": "8.21M",
+                    "longFmt": "8,206,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 2640000,
+                    "fmt": "2.64M",
+                    "longFmt": "2,640,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 611000,
+                    "fmt": "611k",
+                    "longFmt": "611,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 1768000,
+                    "fmt": "1.77M",
+                    "longFmt": "1,768,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 17327000,
+                    "fmt": "17.33M",
+                    "longFmt": "17,327,000"
+                  },
+                  "totalLiab": {
+                    "raw": 31471000,
+                    "fmt": "31.47M",
+                    "longFmt": "31,471,000"
+                  },
+                  "commonStock": {
+                    "raw": 48335000,
+                    "fmt": "48.34M",
+                    "longFmt": "48,335,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -140870000,
+                    "fmt": "-140.87M",
+                    "longFmt": "-140,870,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 151039000,
+                    "fmt": "151.04M",
+                    "longFmt": "151,039,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 58504000,
+                    "fmt": "58.5M",
+                    "longFmt": "58,504,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 58504000,
+                    "fmt": "58.5M",
+                    "longFmt": "58,504,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 6.26429,
+              "pegRatio": 0.655216,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.258
+                },
+                {
+                  "period": "+1q",
+                  "growth": 0.97400004
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.144
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.158
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0820068
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            },
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            },
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": 3226973184,
+              "profitMargins": 0.86629,
+              "floatShares": 30973342,
+              "sharesOutstanding": 48334700,
+              "heldPercentInsiders": 0.23488002,
+              "heldPercentInstitutions": 0.13869001,
+              "beta": 1.681382,
+              "category": null,
+              "bookValue": 4.018,
+              "priceToBook": 17.471378,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1609372800,
+              "nextFiscalYearEnd": 1672444800,
+              "mostRecentQuarter": 1609372800,
+              "earningsQuarterlyGrowth": 31.74,
+              "netIncomeToCommon": 75387000,
+              "trailingEps": 1.72,
+              "lastSplitFactor": null,
+              "enterpriseToRevenue": 32.988,
+              "enterpriseToEbitda": 74.31,
+              "SandP52WeekChange": 0.1675049
+            },
+            "summaryProfile": {
+              "address1": "Sykehusveien 23",
+              "address2": "PO Box 6463",
+              "city": "TromsÃ¸",
+              "zip": "9294",
+              "country": "Norway",
+              "phone": "47 77 64 89 00",
+              "fax": "47 77 64 89 01",
+              "website": "http://arcticzymes.com",
+              "industry": "Biotechnology",
+              "sector": "Healthcare",
+              "longBusinessSummary": "ArcticZymes Technologies ASA develops, manufactures, and markets immunomodulating beta-glucans and recombinant enzymes in Norway, Europe, Asia, Australia, Africa, and the Americas. It operates through two segments, Enzymes and Beta-Glucans. The company provides recombinant enzymes that are primarily derived from cold-water marine species and organisms from other relevant environments for use in molecular research, in vitro diagnostics, and therapeutics. It offers shrimp alkaline phosphatase and derived kits for cleanup prior to Sanger sequencing and next generation sequencing (NGS) processes; cod UNG for use in viral and other molecular diagnostic assays; double-strand specific DNases and derived kits for the removal of DNA from RNA samples; polymerases for technology development for life science, molecular diagnostics, NGS, and synthetic biology; proteinase for microbiological diagnostics and liquid biopsies; salt active nuclease for the removal of nucleic acids during manufacturing of vaccines, viruses, recombinant proteins, and other reagents; and ligases for joining DNA fragments. The company also provides immunomodulating beta-glucans products for the wound care, animal and consumer health, and adjuvants markets. It offers Woulgan wound gel; M-Glucan, a natural immune-stimulating product for fish and animal feed; and M-Gard, a natural immune-stimulating ingredients to enhance physical health. The company was formerly known as Biotec Pharmacon ASA and changed its name to ArcticZymes Technologies ASA in June 2020. ArcticZymes Technologies ASA was founded in 1990 and is headquartered in TromsÃ¸, Norway.",
+              "companyOfficers": [],
+              "maxAge": 86400
+            },
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 0,
+              "buyInfoShares": 0,
+              "sellInfoCount": 0,
+              "netInfoCount": 0,
+              "netInfoShares": 0,
+              "netPercentInsiderShares": 0,
+              "totalInsiderShares": 11352848
+            },
+            "quoteType": {
+              "exchange": "OSL",
+              "quoteType": "EQUITY",
+              "symbol": "AZT.OL",
+              "underlyingSymbol": "AZT.OL",
+              "shortName": "ARCTICZYMES TECH",
+              "longName": "ArcticZymes Technologies ASA",
+              "firstTradeDateEpochUtc": null,
+              "timeZoneFullName": "Europe/Oslo",
+              "timeZoneShortName": "CET",
+              "uuid": "f653d689-5ab6-3b70-8909-46de02bfd311",
+              "messageBoardId": "finmb_13529463",
+              "gmtOffSetMilliseconds": 3600000,
+              "maxAge": 1
+            },
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 97823000,
+                    "fmt": "97.82M",
+                    "longFmt": "97,823,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 1131000,
+                    "fmt": "1.13M",
+                    "longFmt": "1,131,000"
+                  },
+                  "grossProfit": {
+                    "raw": 96692000,
+                    "fmt": "96.69M",
+                    "longFmt": "96,692,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 34564000,
+                    "fmt": "34.56M",
+                    "longFmt": "34,564,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 16696000,
+                    "fmt": "16.7M",
+                    "longFmt": "16,696,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 55030000,
+                    "fmt": "55.03M",
+                    "longFmt": "55,030,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 42793000,
+                    "fmt": "42.79M",
+                    "longFmt": "42,793,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -384000,
+                    "fmt": "-384k",
+                    "longFmt": "-384,000"
+                  },
+                  "ebit": {
+                    "raw": 42793000,
+                    "fmt": "42.79M",
+                    "longFmt": "42,793,000"
+                  },
+                  "interestExpense": {
+                    "raw": -384000,
+                    "fmt": "-384k",
+                    "longFmt": "-384,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 42409000,
+                    "fmt": "42.41M",
+                    "longFmt": "42,409,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -32978000,
+                    "fmt": "-32.98M",
+                    "longFmt": "-32,978,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 3130000,
+                    "fmt": "3.13M",
+                    "longFmt": "3,130,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 75387000,
+                    "fmt": "75.39M",
+                    "longFmt": "75,387,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": 9356000,
+                    "fmt": "9.36M",
+                    "longFmt": "9,356,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 84743000,
+                    "fmt": "84.74M",
+                    "longFmt": "84,743,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 84743000,
+                    "fmt": "84.74M",
+                    "longFmt": "84,743,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 84395000,
+                    "fmt": "84.39M",
+                    "longFmt": "84,395,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 18900000,
+                    "fmt": "18.9M",
+                    "longFmt": "18,900,000"
+                  },
+                  "grossProfit": {
+                    "raw": 65495000,
+                    "fmt": "65.5M",
+                    "longFmt": "65,495,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 49768000,
+                    "fmt": "49.77M",
+                    "longFmt": "49,768,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 16399000,
+                    "fmt": "16.4M",
+                    "longFmt": "16,399,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 90150000,
+                    "fmt": "90.15M",
+                    "longFmt": "90,150,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -5755000,
+                    "fmt": "-5.75M",
+                    "longFmt": "-5,755,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -171000,
+                    "fmt": "-171k",
+                    "longFmt": "-171,000"
+                  },
+                  "ebit": {
+                    "raw": -5755000,
+                    "fmt": "-5.75M",
+                    "longFmt": "-5,755,000"
+                  },
+                  "interestExpense": {
+                    "raw": -797000,
+                    "fmt": "-797k",
+                    "longFmt": "-797,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -5926000,
+                    "fmt": "-5.93M",
+                    "longFmt": "-5,926,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "minorityInterest": {
+                    "raw": 1336000,
+                    "fmt": "1.34M",
+                    "longFmt": "1,336,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -5926000,
+                    "fmt": "-5.93M",
+                    "longFmt": "-5,926,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": 9356000,
+                    "fmt": "9.36M",
+                    "longFmt": "9,356,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -6386000,
+                    "fmt": "-6.39M",
+                    "longFmt": "-6,386,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -6386000,
+                    "fmt": "-6.39M",
+                    "longFmt": "-6,386,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 72817000,
+                    "fmt": "72.82M",
+                    "longFmt": "72,817,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 19366000,
+                    "fmt": "19.37M",
+                    "longFmt": "19,366,000"
+                  },
+                  "grossProfit": {
+                    "raw": 53451000,
+                    "fmt": "53.45M",
+                    "longFmt": "53,451,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 45906000,
+                    "fmt": "45.91M",
+                    "longFmt": "45,906,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 16342000,
+                    "fmt": "16.34M",
+                    "longFmt": "16,342,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 86323000,
+                    "fmt": "86.32M",
+                    "longFmt": "86,323,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -13506000,
+                    "fmt": "-13.51M",
+                    "longFmt": "-13,506,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -526000,
+                    "fmt": "-526k",
+                    "longFmt": "-526,000"
+                  },
+                  "ebit": {
+                    "raw": -13506000,
+                    "fmt": "-13.51M",
+                    "longFmt": "-13,506,000"
+                  },
+                  "interestExpense": {
+                    "raw": -865000,
+                    "fmt": "-865k",
+                    "longFmt": "-865,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -14032000,
+                    "fmt": "-14.03M",
+                    "longFmt": "-14,032,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "minorityInterest": {
+                    "raw": 876000,
+                    "fmt": "876k",
+                    "longFmt": "876,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -14032000,
+                    "fmt": "-14.03M",
+                    "longFmt": "-14,032,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": 9356000,
+                    "fmt": "9.36M",
+                    "longFmt": "9,356,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -14193000,
+                    "fmt": "-14.19M",
+                    "longFmt": "-14,193,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -14193000,
+                    "fmt": "-14.19M",
+                    "longFmt": "-14,193,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 72758000,
+                    "fmt": "72.76M",
+                    "longFmt": "72,758,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 21927000,
+                    "fmt": "21.93M",
+                    "longFmt": "21,927,000"
+                  },
+                  "grossProfit": {
+                    "raw": 50831000,
+                    "fmt": "50.83M",
+                    "longFmt": "50,831,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 51965000,
+                    "fmt": "51.97M",
+                    "longFmt": "51,965,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 21803000,
+                    "fmt": "21.8M",
+                    "longFmt": "21,803,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 97673000,
+                    "fmt": "97.67M",
+                    "longFmt": "97,673,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -24915000,
+                    "fmt": "-24.91M",
+                    "longFmt": "-24,915,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 112000,
+                    "fmt": "112k",
+                    "longFmt": "112,000"
+                  },
+                  "ebit": {
+                    "raw": -24915000,
+                    "fmt": "-24.91M",
+                    "longFmt": "-24,915,000"
+                  },
+                  "interestExpense": {
+                    "raw": -695000,
+                    "fmt": "-695k",
+                    "longFmt": "-695,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -24803000,
+                    "fmt": "-24.8M",
+                    "longFmt": "-24,803,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "minorityInterest": {
+                    "raw": 715000,
+                    "fmt": "715k",
+                    "longFmt": "715,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -24803000,
+                    "fmt": "-24.8M",
+                    "longFmt": "-24,803,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": 9356000,
+                    "fmt": "9.36M",
+                    "longFmt": "9,356,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -24938000,
+                    "fmt": "-24.94M",
+                    "longFmt": "-24,938,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -24938000,
+                    "fmt": "-24.94M",
+                    "longFmt": "-24,938,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1606694400,
+                    "fmt": "2020-11-30"
+                  },
+                  "organization": "USAA Mutual Fd Tr-International Fd",
+                  "pctHeld": {
+                    "raw": 0.0013,
+                    "fmt": "0.13%"
+                  },
+                  "position": {
+                    "raw": 64177,
+                    "fmt": "64.18k",
+                    "longFmt": "64,177"
+                  },
+                  "value": {
+                    "raw": 4325529,
+                    "fmt": "4.33M",
+                    "longFmt": "4,325,529"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "SPDR Portfolio Developed World ex-US ETF",
+                  "pctHeld": {
+                    "raw": 0.001,
+                    "fmt": "0.10%"
+                  },
+                  "position": {
+                    "raw": 48642,
+                    "fmt": "48.64k",
+                    "longFmt": "48,642"
+                  },
+                  "value": {
+                    "raw": 3093631,
+                    "fmt": "3.09M",
+                    "longFmt": "3,093,631"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "SPDR (R) Idx Shares-SPDR (R) S&P (R) International Small Cap ETF",
+                  "pctHeld": {
+                    "raw": 0.0004,
+                    "fmt": "0.04%"
+                  },
+                  "position": {
+                    "raw": 20200,
+                    "fmt": "20.2k",
+                    "longFmt": "20,200"
+                  },
+                  "value": {
+                    "raw": 1284720,
+                    "fmt": "1.28M",
+                    "longFmt": "1,284,720"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1604102400,
+                    "fmt": "2020-10-31"
+                  },
+                  "organization": "DFA Investment Dimensions-DFA International Small Cap Growth Port",
+                  "pctHeld": {
+                    "raw": 0.0002,
+                    "fmt": "0.02%"
+                  },
+                  "position": {
+                    "raw": 11505,
+                    "fmt": "11.51k",
+                    "longFmt": "11,505"
+                  },
+                  "value": {
+                    "raw": 687999,
+                    "fmt": "688k",
+                    "longFmt": "687,999"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Wilshire Mutual Funds, Inc.-International Equity Fund",
+                  "pctHeld": {
+                    "raw": 0.0001,
+                    "fmt": "0.01%"
+                  },
+                  "position": {
+                    "raw": 7230,
+                    "fmt": "7.23k",
+                    "longFmt": "7,230"
+                  },
+                  "value": {
+                    "raw": 469950,
+                    "fmt": "469.95k",
+                    "longFmt": "469,950"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1604102400,
+                    "fmt": "2020-10-31"
+                  },
+                  "organization": "DFA Continental Small Company Series",
+                  "pctHeld": {
+                    "raw": 0.0001,
+                    "fmt": "0.01%"
+                  },
+                  "position": {
+                    "raw": 3238,
+                    "fmt": "3.24k",
+                    "longFmt": "3,238"
+                  },
+                  "value": {
+                    "raw": 193632,
+                    "fmt": "193.63k",
+                    "longFmt": "193,632"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Avantis International Equity ETF",
+                  "pctHeld": {
+                    "raw": 0.0001,
+                    "fmt": "0.01%"
+                  },
+                  "position": {
+                    "raw": 2740,
+                    "fmt": "2.74k",
+                    "longFmt": "2,740"
+                  },
+                  "value": {
+                    "raw": 174264,
+                    "fmt": "174.26k",
+                    "longFmt": "174,264"
+                  }
+                }
+              ]
+            },
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 69.4,
+              "open": 68.6,
+              "dayLow": 68.4,
+              "dayHigh": 70.8,
+              "regularMarketPreviousClose": 69.4,
+              "regularMarketOpen": 68.6,
+              "regularMarketDayLow": 68.4,
+              "regularMarketDayHigh": 70.8,
+              "payoutRatio": 0,
+              "beta": 1.681382,
+              "trailingPE": 40.81395,
+              "volume": 286580,
+              "regularMarketVolume": 286580,
+              "bid": 68.6,
+              "ask": 70.8,
+              "marketCap": 3393095680,
+              "fiftyTwoWeekLow": 68.4,
+              "fiftyTwoWeekHigh": 70.8,
+              "priceToSalesTrailing12Months": 34.686073,
+              "currency": "NOK",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            },
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 24013000,
+                    "fmt": "24.01M",
+                    "longFmt": "24,013,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 582000,
+                    "fmt": "582k",
+                    "longFmt": "582,000"
+                  },
+                  "grossProfit": {
+                    "raw": 23431000,
+                    "fmt": "23.43M",
+                    "longFmt": "23,431,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 9835000,
+                    "fmt": "9.84M",
+                    "longFmt": "9,835,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 6757000,
+                    "fmt": "6.76M",
+                    "longFmt": "6,757,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 17832000,
+                    "fmt": "17.83M",
+                    "longFmt": "17,832,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 6181000,
+                    "fmt": "6.18M",
+                    "longFmt": "6,181,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -641000,
+                    "fmt": "-641k",
+                    "longFmt": "-641,000"
+                  },
+                  "ebit": {
+                    "raw": 6181000,
+                    "fmt": "6.18M",
+                    "longFmt": "6,181,000"
+                  },
+                  "interestExpense": {
+                    "raw": -642000,
+                    "fmt": "-642k",
+                    "longFmt": "-642,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 5540000,
+                    "fmt": "5.54M",
+                    "longFmt": "5,540,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -32978000,
+                    "fmt": "-32.98M",
+                    "longFmt": "-32,978,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 3130000,
+                    "fmt": "3.13M",
+                    "longFmt": "3,130,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 38518000,
+                    "fmt": "38.52M",
+                    "longFmt": "38,518,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -2275000,
+                    "fmt": "-2.27M",
+                    "longFmt": "-2,275,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 36243000,
+                    "fmt": "36.24M",
+                    "longFmt": "36,243,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 36243000,
+                    "fmt": "36.24M",
+                    "longFmt": "36,243,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 31550000,
+                    "fmt": "31.55M",
+                    "longFmt": "31,550,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 4736000,
+                    "fmt": "4.74M",
+                    "longFmt": "4,736,000"
+                  },
+                  "grossProfit": {
+                    "raw": 26814000,
+                    "fmt": "26.81M",
+                    "longFmt": "26,814,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 12050000,
+                    "fmt": "12.05M",
+                    "longFmt": "12,050,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 4663000,
+                    "fmt": "4.66M",
+                    "longFmt": "4,663,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 22404000,
+                    "fmt": "22.4M",
+                    "longFmt": "22,404,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 9146000,
+                    "fmt": "9.15M",
+                    "longFmt": "9,146,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -53000,
+                    "fmt": "-53k",
+                    "longFmt": "-53,000"
+                  },
+                  "ebit": {
+                    "raw": 9146000,
+                    "fmt": "9.15M",
+                    "longFmt": "9,146,000"
+                  },
+                  "interestExpense": {
+                    "raw": -51000,
+                    "fmt": "-51k",
+                    "longFmt": "-51,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 9093000,
+                    "fmt": "9.09M",
+                    "longFmt": "9,093,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "minorityInterest": {
+                    "raw": 3039000,
+                    "fmt": "3.04M",
+                    "longFmt": "3,039,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 9093000,
+                    "fmt": "9.09M",
+                    "longFmt": "9,093,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -2275000,
+                    "fmt": "-2.27M",
+                    "longFmt": "-2,275,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 9093000,
+                    "fmt": "9.09M",
+                    "longFmt": "9,093,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 9093000,
+                    "fmt": "9.09M",
+                    "longFmt": "9,093,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 44872000,
+                    "fmt": "44.87M",
+                    "longFmt": "44,872,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 4310000,
+                    "fmt": "4.31M",
+                    "longFmt": "4,310,000"
+                  },
+                  "grossProfit": {
+                    "raw": 40562000,
+                    "fmt": "40.56M",
+                    "longFmt": "40,562,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 7546000,
+                    "fmt": "7.55M",
+                    "longFmt": "7,546,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 5799000,
+                    "fmt": "5.8M",
+                    "longFmt": "5,799,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 18606000,
+                    "fmt": "18.61M",
+                    "longFmt": "18,606,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 26266000,
+                    "fmt": "26.27M",
+                    "longFmt": "26,266,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -578000,
+                    "fmt": "-578k",
+                    "longFmt": "-578,000"
+                  },
+                  "ebit": {
+                    "raw": 26266000,
+                    "fmt": "26.27M",
+                    "longFmt": "26,266,000"
+                  },
+                  "interestExpense": {
+                    "raw": -578000,
+                    "fmt": "-578k",
+                    "longFmt": "-578,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 25688000,
+                    "fmt": "25.69M",
+                    "longFmt": "25,688,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "minorityInterest": {
+                    "raw": 2694000,
+                    "fmt": "2.69M",
+                    "longFmt": "2,694,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 25688000,
+                    "fmt": "25.69M",
+                    "longFmt": "25,688,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -2275000,
+                    "fmt": "-2.27M",
+                    "longFmt": "-2,275,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 25688000,
+                    "fmt": "25.69M",
+                    "longFmt": "25,688,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 25688000,
+                    "fmt": "25.69M",
+                    "longFmt": "25,688,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 35550000,
+                    "fmt": "35.55M",
+                    "longFmt": "35,550,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 8105000,
+                    "fmt": "8.11M",
+                    "longFmt": "8,105,000"
+                  },
+                  "grossProfit": {
+                    "raw": 27445000,
+                    "fmt": "27.45M",
+                    "longFmt": "27,445,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 9903000,
+                    "fmt": "9.9M",
+                    "longFmt": "9,903,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 3782000,
+                    "fmt": "3.78M",
+                    "longFmt": "3,782,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 22749000,
+                    "fmt": "22.75M",
+                    "longFmt": "22,749,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 12801000,
+                    "fmt": "12.8M",
+                    "longFmt": "12,801,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 943000,
+                    "fmt": "943k",
+                    "longFmt": "943,000"
+                  },
+                  "ebit": {
+                    "raw": 12801000,
+                    "fmt": "12.8M",
+                    "longFmt": "12,801,000"
+                  },
+                  "interestExpense": {
+                    "raw": -578000,
+                    "fmt": "-578k",
+                    "longFmt": "-578,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 13744000,
+                    "fmt": "13.74M",
+                    "longFmt": "13,744,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "minorityInterest": {
+                    "raw": 1768000,
+                    "fmt": "1.77M",
+                    "longFmt": "1,768,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 13744000,
+                    "fmt": "13.74M",
+                    "longFmt": "13,744,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -2275000,
+                    "fmt": "-2.27M",
+                    "longFmt": "-2,275,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 13744000,
+                    "fmt": "13.74M",
+                    "longFmt": "13,744,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 13744000,
+                    "fmt": "13.74M",
+                    "longFmt": "13,744,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 36243000,
+                    "fmt": "36.24M",
+                    "longFmt": "36,243,000"
+                  },
+                  "depreciation": {
+                    "raw": 607000,
+                    "fmt": "607k",
+                    "longFmt": "607,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -14107000,
+                    "fmt": "-14.11M",
+                    "longFmt": "-14,107,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -16534000,
+                    "fmt": "-16.53M",
+                    "longFmt": "-16,534,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 7238000,
+                    "fmt": "7.24M",
+                    "longFmt": "7,238,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -444000,
+                    "fmt": "-444k",
+                    "longFmt": "-444,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 13054000,
+                    "fmt": "13.05M",
+                    "longFmt": "13,054,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -619000,
+                    "fmt": "-619k",
+                    "longFmt": "-619,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 9000,
+                    "fmt": "9k",
+                    "longFmt": "9,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -610000,
+                    "fmt": "-610k",
+                    "longFmt": "-610,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -2047000,
+                    "fmt": "-2.05M",
+                    "longFmt": "-2,047,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 69842000,
+                    "fmt": "69.84M",
+                    "longFmt": "69,842,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 67795000,
+                    "fmt": "67.8M",
+                    "longFmt": "67,795,000"
+                  },
+                  "changeInCash": {
+                    "raw": 80239000,
+                    "fmt": "80.24M",
+                    "longFmt": "80,239,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 9093000,
+                    "fmt": "9.09M",
+                    "longFmt": "9,093,000"
+                  },
+                  "depreciation": {
+                    "raw": 892000,
+                    "fmt": "892k",
+                    "longFmt": "892,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 390000,
+                    "fmt": "390k",
+                    "longFmt": "390,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 5880000,
+                    "fmt": "5.88M",
+                    "longFmt": "5,880,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -1997000,
+                    "fmt": "-2M",
+                    "longFmt": "-1,997,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -337000,
+                    "fmt": "-337k",
+                    "longFmt": "-337,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 13984000,
+                    "fmt": "13.98M",
+                    "longFmt": "13,984,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -57000,
+                    "fmt": "-57k",
+                    "longFmt": "-57,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 85000,
+                    "fmt": "85k",
+                    "longFmt": "85,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 28000,
+                    "fmt": "28k",
+                    "longFmt": "28,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -2047000,
+                    "fmt": "-2.05M",
+                    "longFmt": "-2,047,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -461000,
+                    "fmt": "-461k",
+                    "longFmt": "-461,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -461000,
+                    "fmt": "-461k",
+                    "longFmt": "-461,000"
+                  },
+                  "changeInCash": {
+                    "raw": 13551000,
+                    "fmt": "13.55M",
+                    "longFmt": "13,551,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "netIncome": {
+                    "raw": 25688000,
+                    "fmt": "25.69M",
+                    "longFmt": "25,688,000"
+                  },
+                  "depreciation": {
+                    "raw": 888000,
+                    "fmt": "888k",
+                    "longFmt": "888,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 540000,
+                    "fmt": "540k",
+                    "longFmt": "540,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -1993000,
+                    "fmt": "-1.99M",
+                    "longFmt": "-1,993,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -4762000,
+                    "fmt": "-4.76M",
+                    "longFmt": "-4,762,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 590000,
+                    "fmt": "590k",
+                    "longFmt": "590,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 21014000,
+                    "fmt": "21.01M",
+                    "longFmt": "21,014,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -53000,
+                    "fmt": "-53k",
+                    "longFmt": "-53,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -78000,
+                    "fmt": "-78k",
+                    "longFmt": "-78,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -131000,
+                    "fmt": "-131k",
+                    "longFmt": "-131,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -2047000,
+                    "fmt": "-2.05M",
+                    "longFmt": "-2,047,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -442000,
+                    "fmt": "-442k",
+                    "longFmt": "-442,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -442000,
+                    "fmt": "-442k",
+                    "longFmt": "-442,000"
+                  },
+                  "changeInCash": {
+                    "raw": 20442000,
+                    "fmt": "20.44M",
+                    "longFmt": "20,442,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "netIncome": {
+                    "raw": 13744000,
+                    "fmt": "13.74M",
+                    "longFmt": "13,744,000"
+                  },
+                  "depreciation": {
+                    "raw": 896000,
+                    "fmt": "896k",
+                    "longFmt": "896,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 238000,
+                    "fmt": "238k",
+                    "longFmt": "238,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -9992000,
+                    "fmt": "-9.99M",
+                    "longFmt": "-9,992,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 305000,
+                    "fmt": "305k",
+                    "longFmt": "305,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 635000,
+                    "fmt": "635k",
+                    "longFmt": "635,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 5889000,
+                    "fmt": "5.89M",
+                    "longFmt": "5,889,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -1066000,
+                    "fmt": "-1.07M",
+                    "longFmt": "-1,066,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -78000,
+                    "fmt": "-78k",
+                    "longFmt": "-78,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -1066000,
+                    "fmt": "-1.07M",
+                    "longFmt": "-1,066,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -268000,
+                    "fmt": "-268k",
+                    "longFmt": "-268,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -177000,
+                    "fmt": "-177k",
+                    "longFmt": "-177,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -445000,
+                    "fmt": "-445k",
+                    "longFmt": "-445,000"
+                  },
+                  "changeInCash": {
+                    "raw": 4378000,
+                    "fmt": "4.38M",
+                    "longFmt": "4,378,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "insiderHolders": {
+              "holders": [],
+              "maxAge": 1
+            },
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": [
+                  1611792000
+                ]
+              }
+            },
+            "price": {
+              "maxAge": 1,
+              "regularMarketChangePercent": 0.011527311,
+              "regularMarketChange": 0.7999954,
+              "regularMarketTime": 1613489360,
+              "priceHint": 2,
+              "regularMarketPrice": 70.2,
+              "regularMarketDayHigh": 70.8,
+              "regularMarketDayLow": 68.4,
+              "regularMarketVolume": 286580,
+              "regularMarketPreviousClose": 69.4,
+              "regularMarketSource": "DELAYED",
+              "regularMarketOpen": 68.6,
+              "exchange": "OSL",
+              "exchangeName": "Oslo",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "POSTPOST",
+              "quoteType": "EQUITY",
+              "symbol": "AZT.OL",
+              "underlyingSymbol": null,
+              "shortName": "ARCTICZYMES TECH",
+              "longName": "ArcticZymes Technologies ASA",
+              "currency": "NOK",
+              "currencySymbol": "kr",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 3393095680
+            },
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "cash": {
+                    "raw": 140178000,
+                    "fmt": "140.18M",
+                    "longFmt": "140,178,000"
+                  },
+                  "netReceivables": {
+                    "raw": 30705000,
+                    "fmt": "30.7M",
+                    "longFmt": "30,705,000"
+                  },
+                  "inventory": {
+                    "raw": 3889000,
+                    "fmt": "3.89M",
+                    "longFmt": "3,889,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 174772000,
+                    "fmt": "174.77M",
+                    "longFmt": "174,772,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 13573000,
+                    "fmt": "13.57M",
+                    "longFmt": "13,573,000"
+                  },
+                  "otherAssets": {
+                    "raw": 33402000,
+                    "fmt": "33.4M",
+                    "longFmt": "33,402,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 32978000,
+                    "fmt": "32.98M",
+                    "longFmt": "32,978,000"
+                  },
+                  "totalAssets": {
+                    "raw": 221747000,
+                    "fmt": "221.75M",
+                    "longFmt": "221,747,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 3456000,
+                    "fmt": "3.46M",
+                    "longFmt": "3,456,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 3721000,
+                    "fmt": "3.72M",
+                    "longFmt": "3,721,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 420000,
+                    "fmt": "420k",
+                    "longFmt": "420,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 3130000,
+                    "fmt": "3.13M",
+                    "longFmt": "3,130,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 14828000,
+                    "fmt": "14.83M",
+                    "longFmt": "14,828,000"
+                  },
+                  "totalLiab": {
+                    "raw": 24423000,
+                    "fmt": "24.42M",
+                    "longFmt": "24,423,000"
+                  },
+                  "commonStock": {
+                    "raw": 48335000,
+                    "fmt": "48.34M",
+                    "longFmt": "48,335,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -5180000,
+                    "fmt": "-5.18M",
+                    "longFmt": "-5,180,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 151039000,
+                    "fmt": "151.04M",
+                    "longFmt": "151,039,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 194194000,
+                    "fmt": "194.19M",
+                    "longFmt": "194,194,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 194194000,
+                    "fmt": "194.19M",
+                    "longFmt": "194,194,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 31289000,
+                    "fmt": "31.29M",
+                    "longFmt": "31,289,000"
+                  },
+                  "netReceivables": {
+                    "raw": 14309000,
+                    "fmt": "14.31M",
+                    "longFmt": "14,309,000"
+                  },
+                  "inventory": {
+                    "raw": 5298000,
+                    "fmt": "5.3M",
+                    "longFmt": "5,298,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 7250000,
+                    "fmt": "7.25M",
+                    "longFmt": "7,250,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 58591000,
+                    "fmt": "58.59M",
+                    "longFmt": "58,591,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 18344000,
+                    "fmt": "18.34M",
+                    "longFmt": "18,344,000"
+                  },
+                  "otherAssets": {
+                    "raw": 673000,
+                    "fmt": "673k",
+                    "longFmt": "673,000"
+                  },
+                  "totalAssets": {
+                    "raw": 77608000,
+                    "fmt": "77.61M",
+                    "longFmt": "77,608,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 3960000,
+                    "fmt": "3.96M",
+                    "longFmt": "3,960,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 716000,
+                    "fmt": "716k",
+                    "longFmt": "716,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 674000,
+                    "fmt": "674k",
+                    "longFmt": "674,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 1336000,
+                    "fmt": "1.34M",
+                    "longFmt": "1,336,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 18368000,
+                    "fmt": "18.37M",
+                    "longFmt": "18,368,000"
+                  },
+                  "totalLiab": {
+                    "raw": 31132000,
+                    "fmt": "31.13M",
+                    "longFmt": "31,132,000"
+                  },
+                  "commonStock": {
+                    "raw": 48335000,
+                    "fmt": "48.34M",
+                    "longFmt": "48,335,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -154233000,
+                    "fmt": "-154.23M",
+                    "longFmt": "-154,233,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -1000,
+                    "fmt": "-1k",
+                    "longFmt": "-1,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 151039000,
+                    "fmt": "151.04M",
+                    "longFmt": "151,039,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -1000,
+                    "fmt": "-1k",
+                    "longFmt": "-1,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 45140000,
+                    "fmt": "45.14M",
+                    "longFmt": "45,140,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 45140000,
+                    "fmt": "45.14M",
+                    "longFmt": "45,140,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "cash": {
+                    "raw": 31662000,
+                    "fmt": "31.66M",
+                    "longFmt": "31,662,000"
+                  },
+                  "netReceivables": {
+                    "raw": 17182000,
+                    "fmt": "17.18M",
+                    "longFmt": "17,182,000"
+                  },
+                  "inventory": {
+                    "raw": 6560000,
+                    "fmt": "6.56M",
+                    "longFmt": "6,560,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 55867000,
+                    "fmt": "55.87M",
+                    "longFmt": "55,867,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 21051000,
+                    "fmt": "21.05M",
+                    "longFmt": "21,051,000"
+                  },
+                  "otherAssets": {
+                    "raw": 7551000,
+                    "fmt": "7.55M",
+                    "longFmt": "7,551,000"
+                  },
+                  "totalAssets": {
+                    "raw": 84469000,
+                    "fmt": "84.47M",
+                    "longFmt": "84,469,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 6076000,
+                    "fmt": "6.08M",
+                    "longFmt": "6,076,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 7551000,
+                    "fmt": "7.55M",
+                    "longFmt": "7,551,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 876000,
+                    "fmt": "876k",
+                    "longFmt": "876,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 17310000,
+                    "fmt": "17.31M",
+                    "longFmt": "17,310,000"
+                  },
+                  "totalLiab": {
+                    "raw": 31998000,
+                    "fmt": "32M",
+                    "longFmt": "31,998,000"
+                  },
+                  "commonStock": {
+                    "raw": 48335000,
+                    "fmt": "48.34M",
+                    "longFmt": "48,335,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -147778000,
+                    "fmt": "-147.78M",
+                    "longFmt": "-147,778,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -1000,
+                    "fmt": "-1k",
+                    "longFmt": "-1,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 151039000,
+                    "fmt": "151.04M",
+                    "longFmt": "151,039,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -1000,
+                    "fmt": "-1k",
+                    "longFmt": "-1,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 51595000,
+                    "fmt": "51.59M",
+                    "longFmt": "51,595,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 51595000,
+                    "fmt": "51.59M",
+                    "longFmt": "51,595,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "cash": {
+                    "raw": 30593000,
+                    "fmt": "30.59M",
+                    "longFmt": "30,593,000"
+                  },
+                  "netReceivables": {
+                    "raw": 11336000,
+                    "fmt": "11.34M",
+                    "longFmt": "11,336,000"
+                  },
+                  "inventory": {
+                    "raw": 5011000,
+                    "fmt": "5.01M",
+                    "longFmt": "5,011,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": -1000,
+                    "fmt": "-1k",
+                    "longFmt": "-1,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 49966000,
+                    "fmt": "49.97M",
+                    "longFmt": "49,966,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 4589000,
+                    "fmt": "4.59M",
+                    "longFmt": "4,589,000"
+                  },
+                  "otherAssets": {
+                    "raw": 7128000,
+                    "fmt": "7.13M",
+                    "longFmt": "7,128,000"
+                  },
+                  "totalAssets": {
+                    "raw": 61683000,
+                    "fmt": "61.68M",
+                    "longFmt": "61,683,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 5808000,
+                    "fmt": "5.81M",
+                    "longFmt": "5,808,000"
+                  },
+                  "otherLiab": {
+                    "raw": -2000,
+                    "fmt": "-2k",
+                    "longFmt": "-2,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 7119000,
+                    "fmt": "7.12M",
+                    "longFmt": "7,119,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 715000,
+                    "fmt": "715k",
+                    "longFmt": "715,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 16870000,
+                    "fmt": "16.87M",
+                    "longFmt": "16,870,000"
+                  },
+                  "totalLiab": {
+                    "raw": 16868000,
+                    "fmt": "16.87M",
+                    "longFmt": "16,868,000"
+                  },
+                  "commonStock": {
+                    "raw": 43945000,
+                    "fmt": "43.95M",
+                    "longFmt": "43,945,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -133223000,
+                    "fmt": "-133.22M",
+                    "longFmt": "-133,223,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 133378000,
+                    "fmt": "133.38M",
+                    "longFmt": "133,378,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 44100000,
+                    "fmt": "44.1M",
+                    "longFmt": "44,100,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 44100000,
+                    "fmt": "44.1M",
+                    "longFmt": "44,100,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 70.2,
+              "recommendationKey": "none",
+              "totalCash": 140178000,
+              "totalCashPerShare": 2.9,
+              "ebitda": 43426000,
+              "totalDebt": 9595000,
+              "quickRatio": 11.524,
+              "currentRatio": 11.787,
+              "totalRevenue": 97823000,
+              "debtToEquity": 4.862,
+              "revenuePerShare": 2.02,
+              "returnOnAssets": 0.17869,
+              "returnOnEquity": 0.61842996,
+              "grossProfits": 96692000,
+              "freeCashflow": 20620624,
+              "operatingCashflow": 42233000,
+              "earningsGrowth": 30.218,
+              "revenueGrowth": -0.061,
+              "grossMargins": 0.98844004,
+              "ebitdaMargins": 0.44392,
+              "operatingMargins": 0.43745,
+              "profitMargins": 0.86629,
+              "financialCurrency": "NOK"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-all-SIX.json
+++ b/tests/http/quoteSummary-all-SIX.json
@@ -1,0 +1,8848 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=assetProfile%2CbalanceSheetHistory%2CbalanceSheetHistoryQuarterly%2CcalendarEvents%2CcashflowStatementHistory%2CcashflowStatementHistoryQuarterly%2CdefaultKeyStatistics%2Cearnings%2CearningsHistory%2CearningsTrend%2CfinancialData%2CfundOwnership%2CfundPerformance%2CfundProfile%2CincomeStatementHistory%2CincomeStatementHistoryQuarterly%2CindexTrend%2CindustryTrend%2CinsiderHolders%2CinsiderTransactions%2CinstitutionOwnership%2CmajorDirectHolders%2CmajorHoldersBreakdown%2CnetSharePurchaseActivity%2Cprice%2CquoteType%2CrecommendationTrend%2CsecFilings%2CsectorTrend%2CsummaryDetail%2CsummaryProfile%2CtopHoldings%2CupgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "78ho185g2nuhf"
+      ],
+      "x-yahoo-request-id": [
+        "78ho185g2nuhf"
+      ],
+      "x-request-id": [
+        "cfdc3615-dd0a-4aee-a1f8-ec1abfc1a893"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "9"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:31 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "924 Avenue J East",
+              "city": "Grand Prairie",
+              "state": "TX",
+              "zip": "75050",
+              "country": "United States",
+              "phone": "972-595-5000",
+              "website": "http://www.sixflags.com",
+              "industry": "Leisure",
+              "sector": "Consumer Cyclical",
+              "longBusinessSummary": "Six Flags Entertainment Corporation owns and operates regional theme and waterparks under the Six Flags name. The company's parks offer various thrill rides, water attractions, themed areas, concerts and shows, restaurants, game venues, and retail outlets. It owns and operates 26 parks in the United States, Mexico, and Canada. The company was formerly known as Six Flags, Inc. and changed its name to Six Flags Entertainment Corporation in April 2010. Six Flags Entertainment Corporation was founded in 1961 and is based in Grand Prairie, Texas.",
+              "fullTimeEmployees": 2450,
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Michael  Spanos",
+                  "age": 55,
+                  "title": "Pres, CEO & Director",
+                  "yearBorn": 1965,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 512692,
+                    "fmt": "512.69k",
+                    "longFmt": "512,692"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Lance C. Balk",
+                  "age": 62,
+                  "title": "Of Counsel Advisor",
+                  "yearBorn": 1958,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 643600,
+                    "fmt": "643.6k",
+                    "longFmt": "643,600"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 803465,
+                    "fmt": "803.47k",
+                    "longFmt": "803,465"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Sandeep  Reddy",
+                  "age": 49,
+                  "title": "Exec. VP & CFO",
+                  "yearBorn": 1971,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Mario  Centola",
+                  "age": 49,
+                  "title": "VP of International Operations & Bus. Devel.",
+                  "yearBorn": 1971,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Wilson Taylor Brooks",
+                  "age": 33,
+                  "title": "VP & Chief Accounting Officer",
+                  "yearBorn": 1987,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Rafael A. Sanchez",
+                  "title": "Sr. VP & Chief Information Officer",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Laura W. Doerre",
+                  "age": 53,
+                  "title": "Chief Admin. Officer, Exec. VP & Gen. Counsel",
+                  "yearBorn": 1967,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Stephen R. Purtell",
+                  "age": 53,
+                  "title": "Sr. VP of Investor Relations, Treasury & Strategy",
+                  "yearBorn": 1967,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Sandra  Daniels",
+                  "title": "VP of Communications & Diversity",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Kelly  Correia",
+                  "title": "VP of Marketing",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "auditRisk": 1,
+              "boardRisk": 4,
+              "compensationRisk": 7,
+              "shareHolderRightsRisk": 6,
+              "overallRisk": 5,
+              "governanceEpochDate": 1606867200,
+              "compensationAsOfEpochDate": 1577750400,
+              "maxAge": 86400
+            },
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 6,
+                  "buy": 4,
+                  "hold": 1,
+                  "sell": 1,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 4,
+                  "buy": 3,
+                  "hold": 6,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 4,
+                  "buy": 3,
+                  "hold": 6,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 6,
+                  "buy": 3,
+                  "hold": 2,
+                  "sell": 1,
+                  "strongSell": 0
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 179065000,
+                    "fmt": "179.06M",
+                    "longFmt": "179,065,000"
+                  },
+                  "depreciation": {
+                    "raw": 118230000,
+                    "fmt": "118.23M",
+                    "longFmt": "118,230,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 60068000,
+                    "fmt": "60.07M",
+                    "longFmt": "60,068,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 7725000,
+                    "fmt": "7.72M",
+                    "longFmt": "7,725,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 62914000,
+                    "fmt": "62.91M",
+                    "longFmt": "62,914,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -14709000,
+                    "fmt": "-14.71M",
+                    "longFmt": "-14,709,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -6283000,
+                    "fmt": "-6.28M",
+                    "longFmt": "-6,283,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 410573000,
+                    "fmt": "410.57M",
+                    "longFmt": "410,573,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -143913000,
+                    "fmt": "-143.91M",
+                    "longFmt": "-143,913,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 3737000,
+                    "fmt": "3.74M",
+                    "longFmt": "3,737,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -139126000,
+                    "fmt": "-139.13M",
+                    "longFmt": "-139,126,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -278951000,
+                    "fmt": "-278.95M",
+                    "longFmt": "-278,951,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 167250000,
+                    "fmt": "167.25M",
+                    "longFmt": "167,250,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -50881000,
+                    "fmt": "-50.88M",
+                    "longFmt": "-50,881,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -143007000,
+                    "fmt": "-143.01M",
+                    "longFmt": "-143,007,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 1131000,
+                    "fmt": "1.13M",
+                    "longFmt": "1,131,000"
+                  },
+                  "changeInCash": {
+                    "raw": 129571000,
+                    "fmt": "129.57M",
+                    "longFmt": "129,571,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -52000,
+                    "fmt": "-52k",
+                    "longFmt": "-52,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 19627000,
+                    "fmt": "19.63M",
+                    "longFmt": "19,627,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 275996000,
+                    "fmt": "276M",
+                    "longFmt": "275,996,000"
+                  },
+                  "depreciation": {
+                    "raw": 115693000,
+                    "fmt": "115.69M",
+                    "longFmt": "115,693,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -4759000,
+                    "fmt": "-4.76M",
+                    "longFmt": "-4,759,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -39193000,
+                    "fmt": "-39.19M",
+                    "longFmt": "-39,193,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 59143000,
+                    "fmt": "59.14M",
+                    "longFmt": "59,143,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -3769000,
+                    "fmt": "-3.77M",
+                    "longFmt": "-3,769,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 6042000,
+                    "fmt": "6.04M",
+                    "longFmt": "6,042,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 413132000,
+                    "fmt": "413.13M",
+                    "longFmt": "413,132,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -135624000,
+                    "fmt": "-135.62M",
+                    "longFmt": "-135,624,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 2500000,
+                    "fmt": "2.5M",
+                    "longFmt": "2,500,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -152112000,
+                    "fmt": "-152.11M",
+                    "longFmt": "-152,112,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -267044000,
+                    "fmt": "-267.04M",
+                    "longFmt": "-267,044,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 82000000,
+                    "fmt": "82M",
+                    "longFmt": "82,000,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -41153000,
+                    "fmt": "-41.15M",
+                    "longFmt": "-41,153,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -293482000,
+                    "fmt": "-293.48M",
+                    "longFmt": "-293,482,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -426000,
+                    "fmt": "-426k",
+                    "longFmt": "-426,000"
+                  },
+                  "changeInCash": {
+                    "raw": -32888000,
+                    "fmt": "-32.89M",
+                    "longFmt": "-32,888,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -110990000,
+                    "fmt": "-110.99M",
+                    "longFmt": "-110,990,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 43705000,
+                    "fmt": "43.7M",
+                    "longFmt": "43,705,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 273816000,
+                    "fmt": "273.82M",
+                    "longFmt": "273,816,000"
+                  },
+                  "depreciation": {
+                    "raw": 111671000,
+                    "fmt": "111.67M",
+                    "longFmt": "111,671,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 61560000,
+                    "fmt": "61.56M",
+                    "longFmt": "61,560,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -3108000,
+                    "fmt": "-3.11M",
+                    "longFmt": "-3,108,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 3907000,
+                    "fmt": "3.91M",
+                    "longFmt": "3,907,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -1847000,
+                    "fmt": "-1.85M",
+                    "longFmt": "-1,847,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -4993000,
+                    "fmt": "-4.99M",
+                    "longFmt": "-4,993,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 445067000,
+                    "fmt": "445.07M",
+                    "longFmt": "445,067,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -135219000,
+                    "fmt": "-135.22M",
+                    "longFmt": "-135,219,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 4449000,
+                    "fmt": "4.45M",
+                    "longFmt": "4,449,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -130163000,
+                    "fmt": "-130.16M",
+                    "longFmt": "-130,163,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -227101000,
+                    "fmt": "-227.1M",
+                    "longFmt": "-227,101,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 363839000,
+                    "fmt": "363.84M",
+                    "longFmt": "363,839,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -76674000,
+                    "fmt": "-76.67M",
+                    "longFmt": "-76,674,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -376876000,
+                    "fmt": "-376.88M",
+                    "longFmt": "-376,876,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 2083000,
+                    "fmt": "2.08M",
+                    "longFmt": "2,083,000"
+                  },
+                  "changeInCash": {
+                    "raw": -59889000,
+                    "fmt": "-59.89M",
+                    "longFmt": "-59,889,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -499442000,
+                    "fmt": "-499.44M",
+                    "longFmt": "-499,442,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 62502000,
+                    "fmt": "62.5M",
+                    "longFmt": "62,502,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 118302000,
+                    "fmt": "118.3M",
+                    "longFmt": "118,302,000"
+                  },
+                  "depreciation": {
+                    "raw": 106893000,
+                    "fmt": "106.89M",
+                    "longFmt": "106,893,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 159104000,
+                    "fmt": "159.1M",
+                    "longFmt": "159,104,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -6157000,
+                    "fmt": "-6.16M",
+                    "longFmt": "-6,157,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 79420000,
+                    "fmt": "79.42M",
+                    "longFmt": "79,420,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -4948000,
+                    "fmt": "-4.95M",
+                    "longFmt": "-4,948,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 6118000,
+                    "fmt": "6.12M",
+                    "longFmt": "6,118,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 463235000,
+                    "fmt": "463.24M",
+                    "longFmt": "463,235,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -129258000,
+                    "fmt": "-129.26M",
+                    "longFmt": "-129,258,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -570000,
+                    "fmt": "-570k",
+                    "longFmt": "-570,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -127741000,
+                    "fmt": "-127.74M",
+                    "longFmt": "-127,741,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -220314000,
+                    "fmt": "-220.31M",
+                    "longFmt": "-220,314,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 147744000,
+                    "fmt": "147.74M",
+                    "longFmt": "147,744,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -44926000,
+                    "fmt": "-44.93M",
+                    "longFmt": "-44,926,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -292746000,
+                    "fmt": "-292.75M",
+                    "longFmt": "-292,746,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -5123000,
+                    "fmt": "-5.12M",
+                    "longFmt": "-5,123,000"
+                  },
+                  "changeInCash": {
+                    "raw": 37625000,
+                    "fmt": "37.62M",
+                    "longFmt": "37,625,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -211751000,
+                    "fmt": "-211.75M",
+                    "longFmt": "-211,751,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 36501000,
+                    "fmt": "36.5M",
+                    "longFmt": "36,501,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 6.26429,
+              "pegRatio": 0.655216,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.258
+                },
+                {
+                  "period": "+1q",
+                  "growth": 0.97400004
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.144
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.158
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0820068
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            },
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": 6570519040,
+              "forwardPE": -36.733944,
+              "profitMargins": -0.68524003,
+              "floatShares": 71662870,
+              "sharesOutstanding": 84977104,
+              "sharesShort": 6440294,
+              "sharesShortPriorMonth": 8135637,
+              "sharesShortPreviousMonthDate": 1609372800,
+              "dateShortInterest": 1611878400,
+              "sharesPercentSharesOut": 0.0758,
+              "heldPercentInsiders": 0.07217,
+              "heldPercentInstitutions": 0.83259004,
+              "shortRatio": 4.05,
+              "shortPercentOfFloat": 0.084300004,
+              "beta": 2.497331,
+              "category": null,
+              "bookValue": -12.674,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1577750400,
+              "nextFiscalYearEnd": 1640908800,
+              "mostRecentQuarter": 1601424000,
+              "netIncomeToCommon": -348767008,
+              "trailingEps": -4.118,
+              "forwardEps": -1.09,
+              "pegRatio": 0.52,
+              "lastSplitFactor": "2:1",
+              "lastSplitDate": 1372291200,
+              "enterpriseToRevenue": 12.909,
+              "enterpriseToEbitda": -66.208,
+              "52WeekChange": 0.036699772,
+              "SandP52WeekChange": 0.1675049,
+              "lastDividendValue": 0.25,
+              "lastDividendDate": 1583193600
+            },
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "quoteType": {
+              "exchange": "NYQ",
+              "quoteType": "EQUITY",
+              "symbol": "SIX",
+              "underlyingSymbol": "SIX",
+              "shortName": "Six Flags Entertainment Corpora",
+              "longName": "Six Flags Entertainment Corporation",
+              "firstTradeDateEpochUtc": 1273584600,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "48041ef8-474c-3edc-bcf2-fe8996056b7f",
+              "messageBoardId": "finmb_435998",
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            },
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 1487583000,
+                    "fmt": "1.49B",
+                    "longFmt": "1,487,583,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 700301000,
+                    "fmt": "700.3M",
+                    "longFmt": "700,301,000"
+                  },
+                  "grossProfit": {
+                    "raw": 787282000,
+                    "fmt": "787.28M",
+                    "longFmt": "787,282,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 232802000,
+                    "fmt": "232.8M",
+                    "longFmt": "232,802,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 1051333000,
+                    "fmt": "1.05B",
+                    "longFmt": "1,051,333,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 436250000,
+                    "fmt": "436.25M",
+                    "longFmt": "436,250,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -124490000,
+                    "fmt": "-124.49M",
+                    "longFmt": "-124,490,000"
+                  },
+                  "ebit": {
+                    "raw": 436250000,
+                    "fmt": "436.25M",
+                    "longFmt": "436,250,000"
+                  },
+                  "interestExpense": {
+                    "raw": -114703000,
+                    "fmt": "-114.7M",
+                    "longFmt": "-114,703,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 311760000,
+                    "fmt": "311.76M",
+                    "longFmt": "311,760,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 91942000,
+                    "fmt": "91.94M",
+                    "longFmt": "91,942,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 529258000,
+                    "fmt": "529.26M",
+                    "longFmt": "529,258,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 219818000,
+                    "fmt": "219.82M",
+                    "longFmt": "219,818,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 179065000,
+                    "fmt": "179.06M",
+                    "longFmt": "179,065,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 179065000,
+                    "fmt": "179.06M",
+                    "longFmt": "179,065,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 1463707000,
+                    "fmt": "1.46B",
+                    "longFmt": "1,463,707,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 667227000,
+                    "fmt": "667.23M",
+                    "longFmt": "667,227,000"
+                  },
+                  "grossProfit": {
+                    "raw": 796480000,
+                    "fmt": "796.48M",
+                    "longFmt": "796,480,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 156299000,
+                    "fmt": "156.3M",
+                    "longFmt": "156,299,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 939219000,
+                    "fmt": "939.22M",
+                    "longFmt": "939,219,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 524488000,
+                    "fmt": "524.49M",
+                    "longFmt": "524,488,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -112630000,
+                    "fmt": "-112.63M",
+                    "longFmt": "-112,630,000"
+                  },
+                  "ebit": {
+                    "raw": 524488000,
+                    "fmt": "524.49M",
+                    "longFmt": "524,488,000"
+                  },
+                  "interestExpense": {
+                    "raw": -108034000,
+                    "fmt": "-108.03M",
+                    "longFmt": "-108,034,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 411858000,
+                    "fmt": "411.86M",
+                    "longFmt": "411,858,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 95855000,
+                    "fmt": "95.86M",
+                    "longFmt": "95,855,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 525271000,
+                    "fmt": "525.27M",
+                    "longFmt": "525,271,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 316003000,
+                    "fmt": "316M",
+                    "longFmt": "316,003,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 275996000,
+                    "fmt": "276M",
+                    "longFmt": "275,996,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 275996000,
+                    "fmt": "276M",
+                    "longFmt": "275,996,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 1359074000,
+                    "fmt": "1.36B",
+                    "longFmt": "1,359,074,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 622247000,
+                    "fmt": "622.25M",
+                    "longFmt": "622,247,000"
+                  },
+                  "grossProfit": {
+                    "raw": 736827000,
+                    "fmt": "736.83M",
+                    "longFmt": "736,827,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 155748000,
+                    "fmt": "155.75M",
+                    "longFmt": "155,748,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 889666000,
+                    "fmt": "889.67M",
+                    "longFmt": "889,666,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 469408000,
+                    "fmt": "469.41M",
+                    "longFmt": "469,408,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -140356000,
+                    "fmt": "-140.36M",
+                    "longFmt": "-140,356,000"
+                  },
+                  "ebit": {
+                    "raw": 469408000,
+                    "fmt": "469.41M",
+                    "longFmt": "469,408,000"
+                  },
+                  "interestExpense": {
+                    "raw": -99766000,
+                    "fmt": "-99.77M",
+                    "longFmt": "-99,766,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 329052000,
+                    "fmt": "329.05M",
+                    "longFmt": "329,052,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 16026000,
+                    "fmt": "16.03M",
+                    "longFmt": "16,026,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 494431000,
+                    "fmt": "494.43M",
+                    "longFmt": "494,431,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 313026000,
+                    "fmt": "313.03M",
+                    "longFmt": "313,026,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 273816000,
+                    "fmt": "273.82M",
+                    "longFmt": "273,816,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 273816000,
+                    "fmt": "273.82M",
+                    "longFmt": "273,816,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 1319398000,
+                    "fmt": "1.32B",
+                    "longFmt": "1,319,398,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 599695000,
+                    "fmt": "599.7M",
+                    "longFmt": "599,695,000"
+                  },
+                  "grossProfit": {
+                    "raw": 719703000,
+                    "fmt": "719.7M",
+                    "longFmt": "719,703,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 291085000,
+                    "fmt": "291.08M",
+                    "longFmt": "291,085,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 997673000,
+                    "fmt": "997.67M",
+                    "longFmt": "997,673,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 321725000,
+                    "fmt": "321.73M",
+                    "longFmt": "321,725,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -88459000,
+                    "fmt": "-88.46M",
+                    "longFmt": "-88,459,000"
+                  },
+                  "ebit": {
+                    "raw": 321725000,
+                    "fmt": "321.73M",
+                    "longFmt": "321,725,000"
+                  },
+                  "interestExpense": {
+                    "raw": -82377000,
+                    "fmt": "-82.38M",
+                    "longFmt": "-82,377,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 233266000,
+                    "fmt": "233.27M",
+                    "longFmt": "233,266,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 76539000,
+                    "fmt": "76.54M",
+                    "longFmt": "76,539,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 485876000,
+                    "fmt": "485.88M",
+                    "longFmt": "485,876,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 156727000,
+                    "fmt": "156.73M",
+                    "longFmt": "156,727,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 118302000,
+                    "fmt": "118.3M",
+                    "longFmt": "118,302,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 118302000,
+                    "fmt": "118.3M",
+                    "longFmt": "118,302,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Smallcap World Fund",
+                  "pctHeld": {
+                    "raw": 0.0493,
+                    "fmt": "4.93%"
+                  },
+                  "position": {
+                    "raw": 4193532,
+                    "fmt": "4.19M",
+                    "longFmt": "4,193,532"
+                  },
+                  "value": {
+                    "raw": 142999441,
+                    "fmt": "143M",
+                    "longFmt": "142,999,441"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Total Stock Market Index Fund",
+                  "pctHeld": {
+                    "raw": 0.026700001,
+                    "fmt": "2.67%"
+                  },
+                  "position": {
+                    "raw": 2267214,
+                    "fmt": "2.27M",
+                    "longFmt": "2,267,214"
+                  },
+                  "value": {
+                    "raw": 46024444,
+                    "fmt": "46.02M",
+                    "longFmt": "46,024,444"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "iShares Core S&P Midcap ETF",
+                  "pctHeld": {
+                    "raw": 0.0232,
+                    "fmt": "2.32%"
+                  },
+                  "position": {
+                    "raw": 1967613,
+                    "fmt": "1.97M",
+                    "longFmt": "1,967,613"
+                  },
+                  "value": {
+                    "raw": 67095603,
+                    "fmt": "67.1M",
+                    "longFmt": "67,095,603"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Small-Cap Index Fund",
+                  "pctHeld": {
+                    "raw": 0.0221,
+                    "fmt": "2.21%"
+                  },
+                  "position": {
+                    "raw": 1879894,
+                    "fmt": "1.88M",
+                    "longFmt": "1,879,894"
+                  },
+                  "value": {
+                    "raw": 38161848,
+                    "fmt": "38.16M",
+                    "longFmt": "38,161,848"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Small-Cap Growth Index Fund",
+                  "pctHeld": {
+                    "raw": 0.014099999,
+                    "fmt": "1.41%"
+                  },
+                  "position": {
+                    "raw": 1200964,
+                    "fmt": "1.2M",
+                    "longFmt": "1,200,964"
+                  },
+                  "value": {
+                    "raw": 24379569,
+                    "fmt": "24.38M",
+                    "longFmt": "24,379,569"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Extended Market Index Fund",
+                  "pctHeld": {
+                    "raw": 0.0117,
+                    "fmt": "1.17%"
+                  },
+                  "position": {
+                    "raw": 990391,
+                    "fmt": "990.39k",
+                    "longFmt": "990,391"
+                  },
+                  "value": {
+                    "raw": 20104937,
+                    "fmt": "20.1M",
+                    "longFmt": "20,104,937"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "MFS Series Trust XI-MFS Mid Cap Value Fund",
+                  "pctHeld": {
+                    "raw": 0.0084,
+                    "fmt": "0.84%"
+                  },
+                  "position": {
+                    "raw": 714956,
+                    "fmt": "714.96k",
+                    "longFmt": "714,956"
+                  },
+                  "value": {
+                    "raw": 14513606,
+                    "fmt": "14.51M",
+                    "longFmt": "14,513,606"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "SPDR S&P Mid Cap 400 ETF Trust",
+                  "pctHeld": {
+                    "raw": 0.0077,
+                    "fmt": "0.77%"
+                  },
+                  "position": {
+                    "raw": 652225,
+                    "fmt": "652.23k",
+                    "longFmt": "652,225"
+                  },
+                  "value": {
+                    "raw": 22240872,
+                    "fmt": "22.24M",
+                    "longFmt": "22,240,872"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Price (T.Rowe) QM U.S. Small Cap Growth Equity Fd",
+                  "pctHeld": {
+                    "raw": 0.0073,
+                    "fmt": "0.73%"
+                  },
+                  "position": {
+                    "raw": 617800,
+                    "fmt": "617.8k",
+                    "longFmt": "617,800"
+                  },
+                  "value": {
+                    "raw": 21066980,
+                    "fmt": "21.07M",
+                    "longFmt": "21,066,980"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1606694400,
+                    "fmt": "2020-11-30"
+                  },
+                  "organization": "MFS Series Trust XIII-MFS New Discovery Value Fund",
+                  "pctHeld": {
+                    "raw": 0.0070999996,
+                    "fmt": "0.71%"
+                  },
+                  "position": {
+                    "raw": 601122,
+                    "fmt": "601.12k",
+                    "longFmt": "601,122"
+                  },
+                  "value": {
+                    "raw": 18472479,
+                    "fmt": "18.47M",
+                    "longFmt": "18,472,479"
+                  }
+                }
+              ]
+            },
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 39.83,
+              "open": 39.89,
+              "dayLow": 39.92,
+              "dayHigh": 40.775,
+              "regularMarketPreviousClose": 39.83,
+              "regularMarketOpen": 39.89,
+              "regularMarketDayLow": 39.92,
+              "regularMarketDayHigh": 40.775,
+              "exDividendDate": 1583193600,
+              "fiveYearAvgDividendYield": 5.86,
+              "beta": 2.497331,
+              "forwardPE": -36.733944,
+              "volume": 405501,
+              "regularMarketVolume": 405501,
+              "averageVolume": 1642390,
+              "averageVolume10days": 1090080,
+              "averageDailyVolume10Day": 1090080,
+              "bid": 40.54,
+              "ask": 40.57,
+              "bidSize": 1200,
+              "askSize": 800,
+              "marketCap": 3402483200,
+              "fiftyTwoWeekLow": 8.75,
+              "fiftyTwoWeekHigh": 40.775,
+              "priceToSalesTrailing12Months": 6.6849976,
+              "fiftyDayAverage": 36.065453,
+              "twoHundredDayAverage": 27.273088,
+              "trailingAnnualDividendRate": 1.08,
+              "trailingAnnualDividendYield": 0.027115239,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            },
+            "insiderHolders": {
+              "holders": [
+                {
+                  "maxAge": 1,
+                  "name": "ASLIN CATHERINE",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1601596800,
+                    "fmt": "2020-10-02"
+                  },
+                  "positionDirect": {
+                    "raw": 42610,
+                    "fmt": "42.61k",
+                    "longFmt": "42,610"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1601596800,
+                    "fmt": "2020-10-02"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "BALDANZA BASIL BEN",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  },
+                  "positionDirect": {
+                    "raw": 11957,
+                    "fmt": "11.96k",
+                    "longFmt": "11,957"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "BASSOUL SELIM A",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  },
+                  "positionDirect": {
+                    "raw": 30050,
+                    "fmt": "30.05k",
+                    "longFmt": "30,050"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "BRACEY ESI EGGLESTON",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  },
+                  "positionDirect": {
+                    "raw": 7984,
+                    "fmt": "7.98k",
+                    "longFmt": "7,984"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "BROOKS WILSON TAYLOR",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1599177600,
+                    "fmt": "2020-09-04"
+                  },
+                  "positionDirect": {
+                    "raw": 13319,
+                    "fmt": "13.32k",
+                    "longFmt": "13,319"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1599177600,
+                    "fmt": "2020-09-04"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "KREJSA NANCY A.",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  },
+                  "positionDirect": {
+                    "raw": 167259,
+                    "fmt": "167.26k",
+                    "longFmt": "167,259"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "PETIT BRETT",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1601596800,
+                    "fmt": "2020-10-02"
+                  },
+                  "positionDirect": {
+                    "raw": 191762,
+                    "fmt": "191.76k",
+                    "longFmt": "191,762"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1601596800,
+                    "fmt": "2020-10-02"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "ROEDEL RICHARD W",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  },
+                  "positionDirect": {
+                    "raw": 92669,
+                    "fmt": "92.67k",
+                    "longFmt": "92,669"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "RUSS LEONARD A",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1593648000,
+                    "fmt": "2020-07-02"
+                  },
+                  "positionDirect": {
+                    "raw": 96584,
+                    "fmt": "96.58k",
+                    "longFmt": "96,584"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1593648000,
+                    "fmt": "2020-07-02"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "SPANOS MICHAEL",
+                  "relation": "Chief Executive Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1606089600,
+                    "fmt": "2020-11-23"
+                  },
+                  "positionDirect": {
+                    "raw": 385572,
+                    "fmt": "385.57k",
+                    "longFmt": "385,572"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1606089600,
+                    "fmt": "2020-11-23"
+                  }
+                }
+              ],
+              "maxAge": 1
+            },
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": [
+                  1614124800
+                ],
+                "earningsAverage": -0.89,
+                "earningsLow": -1.16,
+                "earningsHigh": 0.46,
+                "revenueAverage": 86590000,
+                "revenueLow": 71030000,
+                "revenueHigh": 146800000
+              },
+              "exDividendDate": 1583193600,
+              "dividendDate": 1583884800
+            },
+            "upgradeDowngradeHistory": {
+              "history": [
+                {
+                  "epochGradeDate": 1604307883,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1604054666,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1601631741,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Sell",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1596122329,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1596099323,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1595938492,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1594295238,
+                  "firm": "Janney Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1592217228,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1590684068,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Sell",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1588683873,
+                  "firm": "Wells Fargo",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588352480,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588346698,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588328370,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1587397727,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1586431567,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1584961440,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1584954791,
+                  "firm": "B. Riley",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1584523978,
+                  "firm": "Oppenheimer",
+                  "toGrade": "Perform",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1583838519,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1582289408,
+                  "firm": "Wedbush",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1582289366,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1582279486,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1578939768,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1578678953,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1578668517,
+                  "firm": "Janney Capital",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1578664468,
+                  "firm": "Wells Fargo",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1578318281,
+                  "firm": "Wedbush",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1577969059,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "reit"
+                },
+                {
+                  "epochGradeDate": 1572610015,
+                  "firm": "Berenberg",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1571996638,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1571921789,
+                  "firm": "B. Riley",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1571918123,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1562673853,
+                  "firm": "Wells Fargo",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1561978552,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Sector Weight",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1560942985,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1555933988,
+                  "firm": "Jefferies",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1550230402,
+                  "firm": "KeyBanc",
+                  "toGrade": "Sector Weight",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1544624375,
+                  "firm": "Berenberg",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1541076814,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1540550519,
+                  "firm": "Macquarie",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Underperform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1540475034,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1532604530,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1532086418,
+                  "firm": "Wedbush",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1531147804,
+                  "firm": "Wells Fargo",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1524757362,
+                  "firm": "Macquarie",
+                  "toGrade": "Underperform",
+                  "fromGrade": "Underperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1525528839,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1524741944,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1507210154,
+                  "firm": "Hilliard Lyons",
+                  "toGrade": "Long-Term Buy",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1504113822,
+                  "firm": "Hilliard Lyons",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1501161984,
+                  "firm": "Macquarie",
+                  "toGrade": "Underperform",
+                  "fromGrade": "Neutral",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1500642892,
+                  "firm": "William Blair",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1492793311,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1492086133,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1491485581,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1525528838,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1480534304,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1471944610,
+                  "firm": "Hilliard Lyons",
+                  "toGrade": "Long-Term Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1469797779,
+                  "firm": "FBR Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1461060494,
+                  "firm": "Stephens & Co.",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1459944784,
+                  "firm": "Oppenheimer",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1459492987,
+                  "firm": "FBR Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1459234553,
+                  "firm": "Sterne Agee CRT",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1456153042,
+                  "firm": "Macquarie",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1449650364,
+                  "firm": "Macquarie",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1442384686,
+                  "firm": "Janney Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1442340055,
+                  "firm": "Janney Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1525528838,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1431706999,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1430109789,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1403297662,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1394693271,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1385537388,
+                  "firm": "FBR Capital",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1366356493,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1364970865,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1355477782,
+                  "firm": "Wells Fargo",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1355306183,
+                  "firm": "Miller Tabak",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1353404640,
+                  "firm": "Longbow Research",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1346835360,
+                  "firm": "Oppenheimer",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1342605600,
+                  "firm": "Miller Tabak",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                }
+              ],
+              "maxAge": 86400
+            },
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": 0.00050205,
+              "preMarketChange": 0.0199966,
+              "preMarketTime": 1613485603,
+              "preMarketPrice": 39.85,
+              "preMarketSource": "FREE_REALTIME",
+              "regularMarketChangePercent": 0.0052723843,
+              "regularMarketChange": 0.20999908,
+              "regularMarketTime": 1613494813,
+              "priceHint": 2,
+              "regularMarketPrice": 40.04,
+              "regularMarketDayHigh": 40.775,
+              "regularMarketDayLow": 39.92,
+              "regularMarketVolume": 405501,
+              "averageDailyVolume10Day": 1090080,
+              "averageDailyVolume3Month": 1642390,
+              "regularMarketPreviousClose": 39.83,
+              "regularMarketSource": "FREE_REALTIME",
+              "regularMarketOpen": 39.89,
+              "exchange": "NYQ",
+              "exchangeName": "NYSE",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "EQUITY",
+              "symbol": "SIX",
+              "underlyingSymbol": null,
+              "shortName": "Six Flags Entertainment Corpora",
+              "longName": "Six Flags Entertainment Corporation",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 3402483200
+            },
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 174179000,
+                    "fmt": "174.18M",
+                    "longFmt": "174,179,000"
+                  },
+                  "netReceivables": {
+                    "raw": 108679000,
+                    "fmt": "108.68M",
+                    "longFmt": "108,679,000"
+                  },
+                  "inventory": {
+                    "raw": 55851000,
+                    "fmt": "55.85M",
+                    "longFmt": "55,851,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 1800000,
+                    "fmt": "1.8M",
+                    "longFmt": "1,800,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 376240000,
+                    "fmt": "376.24M",
+                    "longFmt": "376,240,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 1440000,
+                    "fmt": "1.44M",
+                    "longFmt": "1,440,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 1485124000,
+                    "fmt": "1.49B",
+                    "longFmt": "1,485,124,000"
+                  },
+                  "goodWill": {
+                    "raw": 659618000,
+                    "fmt": "659.62M",
+                    "longFmt": "659,618,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 345212000,
+                    "fmt": "345.21M",
+                    "longFmt": "345,212,000"
+                  },
+                  "otherAssets": {
+                    "raw": 14906000,
+                    "fmt": "14.91M",
+                    "longFmt": "14,906,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2882540000,
+                    "fmt": "2.88B",
+                    "longFmt": "2,882,540,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 32904000,
+                    "fmt": "32.9M",
+                    "longFmt": "32,904,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 8788000,
+                    "fmt": "8.79M",
+                    "longFmt": "8,788,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 144040000,
+                    "fmt": "144.04M",
+                    "longFmt": "144,040,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 2269551000,
+                    "fmt": "2.27B",
+                    "longFmt": "2,269,551,000"
+                  },
+                  "otherLiab": {
+                    "raw": 271968000,
+                    "fmt": "271.97M",
+                    "longFmt": "271,968,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 3624000,
+                    "fmt": "3.62M",
+                    "longFmt": "3,624,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 529258000,
+                    "fmt": "529.26M",
+                    "longFmt": "529,258,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 339732000,
+                    "fmt": "339.73M",
+                    "longFmt": "339,732,000"
+                  },
+                  "totalLiab": {
+                    "raw": 3069400000,
+                    "fmt": "3.07B",
+                    "longFmt": "3,069,400,000"
+                  },
+                  "commonStock": {
+                    "raw": 2116000,
+                    "fmt": "2.12M",
+                    "longFmt": "2,116,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -1709747000,
+                    "fmt": "-1.71B",
+                    "longFmt": "-1,709,747,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -74710000,
+                    "fmt": "-74.71M",
+                    "longFmt": "-74,710,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1066223000,
+                    "fmt": "1.07B",
+                    "longFmt": "1,066,223,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -74710000,
+                    "fmt": "-74.71M",
+                    "longFmt": "-74,710,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -716118000,
+                    "fmt": "-716.12M",
+                    "longFmt": "-716,118,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -1720948000,
+                    "fmt": "-1.72B",
+                    "longFmt": "-1,720,948,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "cash": {
+                    "raw": 44608000,
+                    "fmt": "44.61M",
+                    "longFmt": "44,608,000"
+                  },
+                  "netReceivables": {
+                    "raw": 116043000,
+                    "fmt": "116.04M",
+                    "longFmt": "116,043,000"
+                  },
+                  "inventory": {
+                    "raw": 51679000,
+                    "fmt": "51.68M",
+                    "longFmt": "51,679,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 1600000,
+                    "fmt": "1.6M",
+                    "longFmt": "1,600,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 241929000,
+                    "fmt": "241.93M",
+                    "longFmt": "241,929,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 1253682000,
+                    "fmt": "1.25B",
+                    "longFmt": "1,253,682,000"
+                  },
+                  "goodWill": {
+                    "raw": 659618000,
+                    "fmt": "659.62M",
+                    "longFmt": "659,618,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 349029000,
+                    "fmt": "349.03M",
+                    "longFmt": "349,029,000"
+                  },
+                  "otherAssets": {
+                    "raw": 13070000,
+                    "fmt": "13.07M",
+                    "longFmt": "13,070,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2517328000,
+                    "fmt": "2.52B",
+                    "longFmt": "2,517,328,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 32905000,
+                    "fmt": "32.91M",
+                    "longFmt": "32,905,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 43000000,
+                    "fmt": "43M",
+                    "longFmt": "43,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 146227000,
+                    "fmt": "146.23M",
+                    "longFmt": "146,227,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 2063512000,
+                    "fmt": "2.06B",
+                    "longFmt": "2,063,512,000"
+                  },
+                  "otherLiab": {
+                    "raw": 203278000,
+                    "fmt": "203.28M",
+                    "longFmt": "203,278,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 1793000,
+                    "fmt": "1.79M",
+                    "longFmt": "1,793,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 525271000,
+                    "fmt": "525.27M",
+                    "longFmt": "525,271,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 368360000,
+                    "fmt": "368.36M",
+                    "longFmt": "368,360,000"
+                  },
+                  "totalLiab": {
+                    "raw": 2635150000,
+                    "fmt": "2.64B",
+                    "longFmt": "2,635,150,000"
+                  },
+                  "commonStock": {
+                    "raw": 2099000,
+                    "fmt": "2.1M",
+                    "longFmt": "2,099,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -1611334000,
+                    "fmt": "-1.61B",
+                    "longFmt": "-1,611,334,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -71498000,
+                    "fmt": "-71.5M",
+                    "longFmt": "-71,498,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1037640000,
+                    "fmt": "1.04B",
+                    "longFmt": "1,037,640,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -71498000,
+                    "fmt": "-71.5M",
+                    "longFmt": "-71,498,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -643093000,
+                    "fmt": "-643.09M",
+                    "longFmt": "-643,093,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -1651740000,
+                    "fmt": "-1.65B",
+                    "longFmt": "-1,651,740,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "cash": {
+                    "raw": 77496000,
+                    "fmt": "77.5M",
+                    "longFmt": "77,496,000"
+                  },
+                  "netReceivables": {
+                    "raw": 72693000,
+                    "fmt": "72.69M",
+                    "longFmt": "72,693,000"
+                  },
+                  "inventory": {
+                    "raw": 46060000,
+                    "fmt": "46.06M",
+                    "longFmt": "46,060,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 1900000,
+                    "fmt": "1.9M",
+                    "longFmt": "1,900,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 221072000,
+                    "fmt": "221.07M",
+                    "longFmt": "221,072,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 1237957000,
+                    "fmt": "1.24B",
+                    "longFmt": "1,237,957,000"
+                  },
+                  "goodWill": {
+                    "raw": 630248000,
+                    "fmt": "630.25M",
+                    "longFmt": "630,248,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 351587000,
+                    "fmt": "351.59M",
+                    "longFmt": "351,587,000"
+                  },
+                  "otherAssets": {
+                    "raw": 15812000,
+                    "fmt": "15.81M",
+                    "longFmt": "15,812,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2456676000,
+                    "fmt": "2.46B",
+                    "longFmt": "2,456,676,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 28998000,
+                    "fmt": "29M",
+                    "longFmt": "28,998,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 142014000,
+                    "fmt": "142.01M",
+                    "longFmt": "142,014,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 2021178000,
+                    "fmt": "2.02B",
+                    "longFmt": "2,021,178,000"
+                  },
+                  "otherLiab": {
+                    "raw": 148339000,
+                    "fmt": "148.34M",
+                    "longFmt": "148,339,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 2991000,
+                    "fmt": "2.99M",
+                    "longFmt": "2,991,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 494431000,
+                    "fmt": "494.43M",
+                    "longFmt": "494,431,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 297840000,
+                    "fmt": "297.84M",
+                    "longFmt": "297,840,000"
+                  },
+                  "totalLiab": {
+                    "raw": 2467357000,
+                    "fmt": "2.47B",
+                    "longFmt": "2,467,357,000"
+                  },
+                  "commonStock": {
+                    "raw": 2112000,
+                    "fmt": "2.11M",
+                    "longFmt": "2,112,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -1529608000,
+                    "fmt": "-1.53B",
+                    "longFmt": "-1,529,608,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -63881000,
+                    "fmt": "-63.88M",
+                    "longFmt": "-63,881,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1086265000,
+                    "fmt": "1.09B",
+                    "longFmt": "1,086,265,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -63881000,
+                    "fmt": "-63.88M",
+                    "longFmt": "-63,881,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -505112000,
+                    "fmt": "-505.11M",
+                    "longFmt": "-505,112,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -1486947000,
+                    "fmt": "-1.49B",
+                    "longFmt": "-1,486,947,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "cash": {
+                    "raw": 137385000,
+                    "fmt": "137.38M",
+                    "longFmt": "137,385,000"
+                  },
+                  "netReceivables": {
+                    "raw": 69018000,
+                    "fmt": "69.02M",
+                    "longFmt": "69,018,000"
+                  },
+                  "inventory": {
+                    "raw": 45556000,
+                    "fmt": "45.56M",
+                    "longFmt": "45,556,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 5726000,
+                    "fmt": "5.73M",
+                    "longFmt": "5,726,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 278791000,
+                    "fmt": "278.79M",
+                    "longFmt": "278,791,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 1211255000,
+                    "fmt": "1.21B",
+                    "longFmt": "1,211,255,000"
+                  },
+                  "goodWill": {
+                    "raw": 630248000,
+                    "fmt": "630.25M",
+                    "longFmt": "630,248,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 353972000,
+                    "fmt": "353.97M",
+                    "longFmt": "353,972,000"
+                  },
+                  "otherAssets": {
+                    "raw": 13406000,
+                    "fmt": "13.41M",
+                    "longFmt": "13,406,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2487672000,
+                    "fmt": "2.49B",
+                    "longFmt": "2,487,672,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 26209000,
+                    "fmt": "26.21M",
+                    "longFmt": "26,209,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 30032000,
+                    "fmt": "30.03M",
+                    "longFmt": "30,032,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 123955000,
+                    "fmt": "123.95M",
+                    "longFmt": "123,955,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 1624486000,
+                    "fmt": "1.62B",
+                    "longFmt": "1,624,486,000"
+                  },
+                  "otherLiab": {
+                    "raw": 247848000,
+                    "fmt": "247.85M",
+                    "longFmt": "247,848,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 4188000,
+                    "fmt": "4.19M",
+                    "longFmt": "4,188,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 485876000,
+                    "fmt": "485.88M",
+                    "longFmt": "485,876,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 315952000,
+                    "fmt": "315.95M",
+                    "longFmt": "315,952,000"
+                  },
+                  "totalLiab": {
+                    "raw": 2188286000,
+                    "fmt": "2.19B",
+                    "longFmt": "2,188,286,000"
+                  },
+                  "commonStock": {
+                    "raw": 2271000,
+                    "fmt": "2.27M",
+                    "longFmt": "2,271,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -1237804000,
+                    "fmt": "-1.24B",
+                    "longFmt": "-1,237,804,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -67184000,
+                    "fmt": "-67.18M",
+                    "longFmt": "-67,184,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1116227000,
+                    "fmt": "1.12B",
+                    "longFmt": "1,116,227,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -67184000,
+                    "fmt": "-67.18M",
+                    "longFmt": "-67,184,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -186490000,
+                    "fmt": "-186.49M",
+                    "longFmt": "-186,490,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -1170710000,
+                    "fmt": "-1.17B",
+                    "longFmt": "-1,170,710,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": "2020-12-31",
+                  "growth": {
+                    "raw": -5.8459997,
+                    "fmt": "-584.60%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": -0.89,
+                      "fmt": "-0.89"
+                    },
+                    "low": {
+                      "raw": -1.16,
+                      "fmt": "-1.16"
+                    },
+                    "high": {
+                      "raw": 0.46,
+                      "fmt": "0.46"
+                    },
+                    "yearAgoEps": {
+                      "raw": -0.13,
+                      "fmt": "-0.13"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 12,
+                      "fmt": "12",
+                      "longFmt": "12"
+                    },
+                    "growth": {
+                      "raw": -5.8459997,
+                      "fmt": "-584.60%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 86590000,
+                      "fmt": "86.59M",
+                      "longFmt": "86,590,000"
+                    },
+                    "low": {
+                      "raw": 71030000,
+                      "fmt": "71.03M",
+                      "longFmt": "71,030,000"
+                    },
+                    "high": {
+                      "raw": 146800000,
+                      "fmt": "146.8M",
+                      "longFmt": "146,800,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 13,
+                      "fmt": "13",
+                      "longFmt": "13"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 261000000,
+                      "fmt": "261M",
+                      "longFmt": "261,000,000"
+                    },
+                    "growth": {
+                      "raw": -0.66800004,
+                      "fmt": "-66.80%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": -0.89,
+                      "fmt": "-0.89"
+                    },
+                    "7daysAgo": {
+                      "raw": -0.9,
+                      "fmt": "-0.9"
+                    },
+                    "30daysAgo": {
+                      "raw": -0.9,
+                      "fmt": "-0.9"
+                    },
+                    "60daysAgo": {
+                      "raw": -0.91,
+                      "fmt": "-0.91"
+                    },
+                    "90daysAgo": {
+                      "raw": -0.91,
+                      "fmt": "-0.91"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "upLast30days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": "2021-03-31",
+                  "growth": {
+                    "raw": -0.08,
+                    "fmt": "-8.00%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": -1.08,
+                      "fmt": "-1.08"
+                    },
+                    "low": {
+                      "raw": -1.29,
+                      "fmt": "-1.29"
+                    },
+                    "high": {
+                      "raw": -0.85,
+                      "fmt": "-0.85"
+                    },
+                    "yearAgoEps": {
+                      "raw": -1,
+                      "fmt": "-1"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 8,
+                      "fmt": "8",
+                      "longFmt": "8"
+                    },
+                    "growth": {
+                      "raw": -0.08,
+                      "fmt": "-8.00%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 58110000,
+                      "fmt": "58.11M",
+                      "longFmt": "58,110,000"
+                    },
+                    "low": {
+                      "raw": 30100000,
+                      "fmt": "30.1M",
+                      "longFmt": "30,100,000"
+                    },
+                    "high": {
+                      "raw": 86280000,
+                      "fmt": "86.28M",
+                      "longFmt": "86,280,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 8,
+                      "fmt": "8",
+                      "longFmt": "8"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 102503000,
+                      "fmt": "102.5M",
+                      "longFmt": "102,503,000"
+                    },
+                    "growth": {
+                      "raw": -0.433,
+                      "fmt": "-43.30%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": -1.08,
+                      "fmt": "-1.08"
+                    },
+                    "7daysAgo": {
+                      "raw": -1.08,
+                      "fmt": "-1.08"
+                    },
+                    "30daysAgo": {
+                      "raw": -1.06,
+                      "fmt": "-1.06"
+                    },
+                    "60daysAgo": {
+                      "raw": -1.05,
+                      "fmt": "-1.05"
+                    },
+                    "90daysAgo": {
+                      "raw": -1.06,
+                      "fmt": "-1.06"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": "2020-12-31",
+                  "growth": {
+                    "raw": -3.299,
+                    "fmt": "-329.90%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": -4.85,
+                      "fmt": "-4.85"
+                    },
+                    "low": {
+                      "raw": -5.11,
+                      "fmt": "-5.11"
+                    },
+                    "high": {
+                      "raw": -3.52,
+                      "fmt": "-3.52"
+                    },
+                    "yearAgoEps": {
+                      "raw": 2.11,
+                      "fmt": "2.11"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 11,
+                      "fmt": "11",
+                      "longFmt": "11"
+                    },
+                    "growth": {
+                      "raw": -3.299,
+                      "fmt": "-329.90%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 334690000,
+                      "fmt": "334.69M",
+                      "longFmt": "334,690,000"
+                    },
+                    "low": {
+                      "raw": 319000000,
+                      "fmt": "319M",
+                      "longFmt": "319,000,000"
+                    },
+                    "high": {
+                      "raw": 394700000,
+                      "fmt": "394.7M",
+                      "longFmt": "394,700,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 13,
+                      "fmt": "13",
+                      "longFmt": "13"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 1487580000,
+                      "fmt": "1.49B",
+                      "longFmt": "1,487,580,000"
+                    },
+                    "growth": {
+                      "raw": -0.775,
+                      "fmt": "-77.50%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": -4.85,
+                      "fmt": "-4.85"
+                    },
+                    "7daysAgo": {
+                      "raw": -4.86,
+                      "fmt": "-4.86"
+                    },
+                    "30daysAgo": {
+                      "raw": -4.86,
+                      "fmt": "-4.86"
+                    },
+                    "60daysAgo": {
+                      "raw": -4.87,
+                      "fmt": "-4.87"
+                    },
+                    "90daysAgo": {
+                      "raw": -4.87,
+                      "fmt": "-4.87"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "upLast30days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": "2021-12-31",
+                  "growth": {
+                    "raw": 0.775,
+                    "fmt": "77.50%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": -1.09,
+                      "fmt": "-1.09"
+                    },
+                    "low": {
+                      "raw": -3.13,
+                      "fmt": "-3.13"
+                    },
+                    "high": {
+                      "raw": -0.08,
+                      "fmt": "-0.08"
+                    },
+                    "yearAgoEps": {
+                      "raw": -4.85,
+                      "fmt": "-4.85"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 12,
+                      "fmt": "12",
+                      "longFmt": "12"
+                    },
+                    "growth": {
+                      "raw": 0.775,
+                      "fmt": "77.50%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 920010000,
+                      "fmt": "920.01M",
+                      "longFmt": "920,010,000"
+                    },
+                    "low": {
+                      "raw": 733600000,
+                      "fmt": "733.6M",
+                      "longFmt": "733,600,000"
+                    },
+                    "high": {
+                      "raw": 1049270000,
+                      "fmt": "1.05B",
+                      "longFmt": "1,049,270,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 13,
+                      "fmt": "13",
+                      "longFmt": "13"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 334690000,
+                      "fmt": "334.69M",
+                      "longFmt": "334,690,000"
+                    },
+                    "growth": {
+                      "raw": 1.749,
+                      "fmt": "174.90%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": -1.09,
+                      "fmt": "-1.09"
+                    },
+                    "7daysAgo": {
+                      "raw": -1.1,
+                      "fmt": "-1.1"
+                    },
+                    "30daysAgo": {
+                      "raw": -1.1,
+                      "fmt": "-1.1"
+                    },
+                    "60daysAgo": {
+                      "raw": -1.09,
+                      "fmt": "-1.09"
+                    },
+                    "90daysAgo": {
+                      "raw": -1.16,
+                      "fmt": "-1.16"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "upLast30days": {
+                      "raw": 2,
+                      "fmt": "2",
+                      "longFmt": "2"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": -0.1496,
+                    "fmt": "-14.96%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": 0.2564,
+                    "fmt": "25.64%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            },
+            "secFilings": {
+              "filings": [
+                {
+                  "date": "2021-02-12",
+                  "epochDate": 1613169771,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-21-000002&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-12-28",
+                  "epochDate": 1609190269,
+                  "type": "8-K",
+                  "title": "Entry into a Material Definitive Agreement, Change in Directors or Principal Officers, Amendments to Articles of Inc. or Bylaws; Change in Fiscal Year, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000079&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-28",
+                  "epochDate": 1603921901,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001558370-20-011903&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-28",
+                  "epochDate": 1603883299,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000075&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-13",
+                  "epochDate": 1602627267,
+                  "type": "8-K",
+                  "title": "Other Events",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000072&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-09-11",
+                  "epochDate": 1599863450,
+                  "type": "8-K/A",
+                  "title": "Change in Directors or Principal Officers",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000070&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-08-27",
+                  "epochDate": 1598563818,
+                  "type": "8-K/A",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000067&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-08-27",
+                  "epochDate": 1598563284,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000065&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-08-26",
+                  "epochDate": 1598476912,
+                  "type": "8-K",
+                  "title": "Entry into a Material Definitive Agreement, Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000061&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-08-05",
+                  "epochDate": 1596663713,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers, Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000056&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-07-30",
+                  "epochDate": 1596106982,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001558370-20-008662&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-06-24",
+                  "epochDate": 1593033086,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers, Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000048&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-30",
+                  "epochDate": 1588280792,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001558370-20-004827&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-30",
+                  "epochDate": 1588242354,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements ",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000039&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-23",
+                  "epochDate": 1587641499,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Creation of a Direct Fin",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-049974&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-15",
+                  "epochDate": 1586952494,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure, Other Events, Financial Statements and Exh",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000034&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-08",
+                  "epochDate": 1586377158,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Regulation FD Disclosure",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000028&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-03-31",
+                  "epochDate": 1585687003,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Material Modification to",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000023&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-03-30",
+                  "epochDate": 1585581500,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure, Other Events, Financial Statements and Exh",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000019&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-03-13",
+                  "epochDate": 1584116990,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000017&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-02-25",
+                  "epochDate": 1582629772,
+                  "type": "8-K",
+                  "title": "Disclosing Change in Directors or Principal Officers, Other Events, Financial S",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000014&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-02-20",
+                  "epochDate": 1582235054,
+                  "type": "10-K",
+                  "title": "Annual Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001558370-20-001092&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-02-20",
+                  "epochDate": 1582196898,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Other Events, Financi",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000009&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-01-31",
+                  "epochDate": 1580471880,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Change in Directors or P",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000006&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-18",
+                  "epochDate": 1574082365,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-19-000160&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-15",
+                  "epochDate": 1573855057,
+                  "type": "8-K",
+                  "title": "Disclosing Change in Directors or Principal Officers, Financial Statements and ",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-19-000157&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-10-25",
+                  "epochDate": 1571997973,
+                  "type": "8-K",
+                  "title": "Disclosing Change in Directors or Principal Officers, Regulation FD Disclosure,",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001558370-19-009095&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-10-23",
+                  "epochDate": 1571862025,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-19-000147&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-10-22",
+                  "epochDate": 1571775037,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements ",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-19-000143&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-10-18",
+                  "epochDate": 1571431332,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Financial Statements and",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-19-000138&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-08-23",
+                  "epochDate": 1566561949,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-19-000133&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-07-24",
+                  "epochDate": 1564001782,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001558370-19-006272&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-07-24",
+                  "epochDate": 1563962772,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-19-000120&nav=1&src=Yahoo",
+                  "maxAge": 1
+                }
+              ],
+              "maxAge": 86400
+            },
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "H Partners Management, LLC",
+                  "pctHeld": {
+                    "raw": 0.091800004,
+                    "fmt": "9.18%"
+                  },
+                  "position": {
+                    "raw": 7800000,
+                    "fmt": "7.8M",
+                    "longFmt": "7,800,000"
+                  },
+                  "value": {
+                    "raw": 158340000,
+                    "fmt": "158.34M",
+                    "longFmt": "158,340,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Group, Inc. (The)",
+                  "pctHeld": {
+                    "raw": 0.081999995,
+                    "fmt": "8.20%"
+                  },
+                  "position": {
+                    "raw": 6965424,
+                    "fmt": "6.97M",
+                    "longFmt": "6,965,424"
+                  },
+                  "value": {
+                    "raw": 141398107,
+                    "fmt": "141.4M",
+                    "longFmt": "141,398,107"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Blackrock Inc.",
+                  "pctHeld": {
+                    "raw": 0.0779,
+                    "fmt": "7.79%"
+                  },
+                  "position": {
+                    "raw": 6615731,
+                    "fmt": "6.62M",
+                    "longFmt": "6,615,731"
+                  },
+                  "value": {
+                    "raw": 225596427,
+                    "fmt": "225.6M",
+                    "longFmt": "225,596,427"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Thunderbird Partners LLP",
+                  "pctHeld": {
+                    "raw": 0.0319,
+                    "fmt": "3.19%"
+                  },
+                  "position": {
+                    "raw": 2708443,
+                    "fmt": "2.71M",
+                    "longFmt": "2,708,443"
+                  },
+                  "value": {
+                    "raw": 54981392,
+                    "fmt": "54.98M",
+                    "longFmt": "54,981,392"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Kohlberg Kravis Roberts & Co. L.P.",
+                  "pctHeld": {
+                    "raw": 0.028800001,
+                    "fmt": "2.88%"
+                  },
+                  "position": {
+                    "raw": 2446441,
+                    "fmt": "2.45M",
+                    "longFmt": "2,446,441"
+                  },
+                  "value": {
+                    "raw": 49662752,
+                    "fmt": "49.66M",
+                    "longFmt": "49,662,752"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Capital International Investors",
+                  "pctHeld": {
+                    "raw": 0.0286,
+                    "fmt": "2.86%"
+                  },
+                  "position": {
+                    "raw": 2429784,
+                    "fmt": "2.43M",
+                    "longFmt": "2,429,784"
+                  },
+                  "value": {
+                    "raw": 49324615,
+                    "fmt": "49.32M",
+                    "longFmt": "49,324,615"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Samlyn Capital, LLC",
+                  "pctHeld": {
+                    "raw": 0.0249,
+                    "fmt": "2.49%"
+                  },
+                  "position": {
+                    "raw": 2111952,
+                    "fmt": "2.11M",
+                    "longFmt": "2,111,952"
+                  },
+                  "value": {
+                    "raw": 42872625,
+                    "fmt": "42.87M",
+                    "longFmt": "42,872,625"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Massachusetts Financial Services Co.",
+                  "pctHeld": {
+                    "raw": 0.023,
+                    "fmt": "2.30%"
+                  },
+                  "position": {
+                    "raw": 1953622,
+                    "fmt": "1.95M",
+                    "longFmt": "1,953,622"
+                  },
+                  "value": {
+                    "raw": 39658526,
+                    "fmt": "39.66M",
+                    "longFmt": "39,658,526"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Jericho Capital Asset Management, LP",
+                  "pctHeld": {
+                    "raw": 0.0225,
+                    "fmt": "2.25%"
+                  },
+                  "position": {
+                    "raw": 1912578,
+                    "fmt": "1.91M",
+                    "longFmt": "1,912,578"
+                  },
+                  "value": {
+                    "raw": 38825333,
+                    "fmt": "38.83M",
+                    "longFmt": "38,825,333"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "State Street Corporation",
+                  "pctHeld": {
+                    "raw": 0.0221,
+                    "fmt": "2.21%"
+                  },
+                  "position": {
+                    "raw": 1878913,
+                    "fmt": "1.88M",
+                    "longFmt": "1,878,913"
+                  },
+                  "value": {
+                    "raw": 38141933,
+                    "fmt": "38.14M",
+                    "longFmt": "38,141,933"
+                  }
+                }
+              ]
+            },
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.07217,
+              "institutionsPercentHeld": 0.83259004,
+              "institutionsFloatPercentHeld": 0.89735,
+              "institutionsCount": 350
+            },
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 213907000,
+                    "fmt": "213.91M",
+                    "longFmt": "213,907,000"
+                  },
+                  "netReceivables": {
+                    "raw": 48500000,
+                    "fmt": "48.5M",
+                    "longFmt": "48,500,000"
+                  },
+                  "inventory": {
+                    "raw": 43892000,
+                    "fmt": "43.89M",
+                    "longFmt": "43,892,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 381565000,
+                    "fmt": "381.56M",
+                    "longFmt": "381,565,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 1160000,
+                    "fmt": "1.16M",
+                    "longFmt": "1,160,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 1463694000,
+                    "fmt": "1.46B",
+                    "longFmt": "1,463,694,000"
+                  },
+                  "goodWill": {
+                    "raw": 659618000,
+                    "fmt": "659.62M",
+                    "longFmt": "659,618,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 344203000,
+                    "fmt": "344.2M",
+                    "longFmt": "344,203,000"
+                  },
+                  "otherAssets": {
+                    "raw": 14732000,
+                    "fmt": "14.73M",
+                    "longFmt": "14,732,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2864972000,
+                    "fmt": "2.86B",
+                    "longFmt": "2,864,972,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 36716000,
+                    "fmt": "36.72M",
+                    "longFmt": "36,716,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 9292000,
+                    "fmt": "9.29M",
+                    "longFmt": "9,292,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 198563000,
+                    "fmt": "198.56M",
+                    "longFmt": "198,563,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 2645353000,
+                    "fmt": "2.65B",
+                    "longFmt": "2,645,353,000"
+                  },
+                  "otherLiab": {
+                    "raw": 140883000,
+                    "fmt": "140.88M",
+                    "longFmt": "140,883,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 7568000,
+                    "fmt": "7.57M",
+                    "longFmt": "7,568,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 544020000,
+                    "fmt": "544.02M",
+                    "longFmt": "544,020,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 428356000,
+                    "fmt": "428.36M",
+                    "longFmt": "428,356,000"
+                  },
+                  "totalLiab": {
+                    "raw": 3397657000,
+                    "fmt": "3.4B",
+                    "longFmt": "3,397,657,000"
+                  },
+                  "commonStock": {
+                    "raw": 2124000,
+                    "fmt": "2.12M",
+                    "longFmt": "2,124,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -2067600000,
+                    "fmt": "-2.07B",
+                    "longFmt": "-2,067,600,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -97450000,
+                    "fmt": "-97.45M",
+                    "longFmt": "-97,450,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1086221000,
+                    "fmt": "1.09B",
+                    "longFmt": "1,086,221,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -97450000,
+                    "fmt": "-97.45M",
+                    "longFmt": "-97,450,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -1076705000,
+                    "fmt": "-1.08B",
+                    "longFmt": "-1,076,705,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -2080526000,
+                    "fmt": "-2.08B",
+                    "longFmt": "-2,080,526,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "cash": {
+                    "raw": 295956000,
+                    "fmt": "295.96M",
+                    "longFmt": "295,956,000"
+                  },
+                  "netReceivables": {
+                    "raw": 47003000,
+                    "fmt": "47M",
+                    "longFmt": "47,003,000"
+                  },
+                  "inventory": {
+                    "raw": 43456000,
+                    "fmt": "43.46M",
+                    "longFmt": "43,456,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 463175000,
+                    "fmt": "463.18M",
+                    "longFmt": "463,175,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 677000,
+                    "fmt": "677k",
+                    "longFmt": "677,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 1484772000,
+                    "fmt": "1.48B",
+                    "longFmt": "1,484,772,000"
+                  },
+                  "goodWill": {
+                    "raw": 659618000,
+                    "fmt": "659.62M",
+                    "longFmt": "659,618,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 344209000,
+                    "fmt": "344.21M",
+                    "longFmt": "344,209,000"
+                  },
+                  "otherAssets": {
+                    "raw": 16483000,
+                    "fmt": "16.48M",
+                    "longFmt": "16,483,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2968934000,
+                    "fmt": "2.97B",
+                    "longFmt": "2,968,934,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 27457000,
+                    "fmt": "27.46M",
+                    "longFmt": "27,457,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 8984000,
+                    "fmt": "8.98M",
+                    "longFmt": "8,984,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 182386000,
+                    "fmt": "182.39M",
+                    "longFmt": "182,386,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 2645017000,
+                    "fmt": "2.65B",
+                    "longFmt": "2,645,017,000"
+                  },
+                  "otherLiab": {
+                    "raw": 178437000,
+                    "fmt": "178.44M",
+                    "longFmt": "178,437,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 7451000,
+                    "fmt": "7.45M",
+                    "longFmt": "7,451,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 544020000,
+                    "fmt": "544.02M",
+                    "longFmt": "544,020,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 380385000,
+                    "fmt": "380.38M",
+                    "longFmt": "380,385,000"
+                  },
+                  "totalLiab": {
+                    "raw": 3395696000,
+                    "fmt": "3.4B",
+                    "longFmt": "3,395,696,000"
+                  },
+                  "commonStock": {
+                    "raw": 2119000,
+                    "fmt": "2.12M",
+                    "longFmt": "2,119,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -1951428000,
+                    "fmt": "-1.95B",
+                    "longFmt": "-1,951,428,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -99421000,
+                    "fmt": "-99.42M",
+                    "longFmt": "-99,421,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1077948000,
+                    "fmt": "1.08B",
+                    "longFmt": "1,077,948,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -99421000,
+                    "fmt": "-99.42M",
+                    "longFmt": "-99,421,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -970782000,
+                    "fmt": "-970.78M",
+                    "longFmt": "-970,782,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -1974609000,
+                    "fmt": "-1.97B",
+                    "longFmt": "-1,974,609,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "cash": {
+                    "raw": 22811000,
+                    "fmt": "22.81M",
+                    "longFmt": "22,811,000"
+                  },
+                  "netReceivables": {
+                    "raw": 71558000,
+                    "fmt": "71.56M",
+                    "longFmt": "71,558,000"
+                  },
+                  "inventory": {
+                    "raw": 42397000,
+                    "fmt": "42.4M",
+                    "longFmt": "42,397,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 216262000,
+                    "fmt": "216.26M",
+                    "longFmt": "216,262,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 1486193000,
+                    "fmt": "1.49B",
+                    "longFmt": "1,486,193,000"
+                  },
+                  "goodWill": {
+                    "raw": 659618000,
+                    "fmt": "659.62M",
+                    "longFmt": "659,618,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 344611000,
+                    "fmt": "344.61M",
+                    "longFmt": "344,611,000"
+                  },
+                  "otherAssets": {
+                    "raw": 13865000,
+                    "fmt": "13.87M",
+                    "longFmt": "13,865,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2720549000,
+                    "fmt": "2.72B",
+                    "longFmt": "2,720,549,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 48994000,
+                    "fmt": "48.99M",
+                    "longFmt": "48,994,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 15689000,
+                    "fmt": "15.69M",
+                    "longFmt": "15,689,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 149111000,
+                    "fmt": "149.11M",
+                    "longFmt": "149,111,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 2238589000,
+                    "fmt": "2.24B",
+                    "longFmt": "2,238,589,000"
+                  },
+                  "otherLiab": {
+                    "raw": 234481000,
+                    "fmt": "234.48M",
+                    "longFmt": "234,481,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 3413000,
+                    "fmt": "3.41M",
+                    "longFmt": "3,413,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 529276000,
+                    "fmt": "529.28M",
+                    "longFmt": "529,276,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 385005000,
+                    "fmt": "385M",
+                    "longFmt": "385,005,000"
+                  },
+                  "totalLiab": {
+                    "raw": 3044137000,
+                    "fmt": "3.04B",
+                    "longFmt": "3,044,137,000"
+                  },
+                  "commonStock": {
+                    "raw": 2116000,
+                    "fmt": "2.12M",
+                    "longFmt": "2,116,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -1815457000,
+                    "fmt": "-1.82B",
+                    "longFmt": "-1,815,457,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -110423000,
+                    "fmt": "-110.42M",
+                    "longFmt": "-110,423,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1070900000,
+                    "fmt": "1.07B",
+                    "longFmt": "1,070,900,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -110423000,
+                    "fmt": "-110.42M",
+                    "longFmt": "-110,423,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -852864000,
+                    "fmt": "-852.86M",
+                    "longFmt": "-852,864,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -1857093000,
+                    "fmt": "-1.86B",
+                    "longFmt": "-1,857,093,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 174179000,
+                    "fmt": "174.18M",
+                    "longFmt": "174,179,000"
+                  },
+                  "netReceivables": {
+                    "raw": 108679000,
+                    "fmt": "108.68M",
+                    "longFmt": "108,679,000"
+                  },
+                  "inventory": {
+                    "raw": 55851000,
+                    "fmt": "55.85M",
+                    "longFmt": "55,851,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 1800000,
+                    "fmt": "1.8M",
+                    "longFmt": "1,800,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 376240000,
+                    "fmt": "376.24M",
+                    "longFmt": "376,240,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 1440000,
+                    "fmt": "1.44M",
+                    "longFmt": "1,440,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 1485124000,
+                    "fmt": "1.49B",
+                    "longFmt": "1,485,124,000"
+                  },
+                  "goodWill": {
+                    "raw": 659618000,
+                    "fmt": "659.62M",
+                    "longFmt": "659,618,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 345212000,
+                    "fmt": "345.21M",
+                    "longFmt": "345,212,000"
+                  },
+                  "otherAssets": {
+                    "raw": 14906000,
+                    "fmt": "14.91M",
+                    "longFmt": "14,906,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2882540000,
+                    "fmt": "2.88B",
+                    "longFmt": "2,882,540,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 32904000,
+                    "fmt": "32.9M",
+                    "longFmt": "32,904,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 8788000,
+                    "fmt": "8.79M",
+                    "longFmt": "8,788,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 144040000,
+                    "fmt": "144.04M",
+                    "longFmt": "144,040,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 2269551000,
+                    "fmt": "2.27B",
+                    "longFmt": "2,269,551,000"
+                  },
+                  "otherLiab": {
+                    "raw": 271968000,
+                    "fmt": "271.97M",
+                    "longFmt": "271,968,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 3624000,
+                    "fmt": "3.62M",
+                    "longFmt": "3,624,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 529258000,
+                    "fmt": "529.26M",
+                    "longFmt": "529,258,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 339732000,
+                    "fmt": "339.73M",
+                    "longFmt": "339,732,000"
+                  },
+                  "totalLiab": {
+                    "raw": 3069400000,
+                    "fmt": "3.07B",
+                    "longFmt": "3,069,400,000"
+                  },
+                  "commonStock": {
+                    "raw": 2116000,
+                    "fmt": "2.12M",
+                    "longFmt": "2,116,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -1709747000,
+                    "fmt": "-1.71B",
+                    "longFmt": "-1,709,747,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -74710000,
+                    "fmt": "-74.71M",
+                    "longFmt": "-74,710,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1066223000,
+                    "fmt": "1.07B",
+                    "longFmt": "1,066,223,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -74710000,
+                    "fmt": "-74.71M",
+                    "longFmt": "-74,710,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -716118000,
+                    "fmt": "-716.12M",
+                    "longFmt": "-716,118,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -1720948000,
+                    "fmt": "-1.72B",
+                    "longFmt": "-1,720,948,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": -0.13,
+                    "fmt": "-0.13"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.14,
+                    "fmt": "0.14"
+                  },
+                  "epsDifference": {
+                    "raw": -0.27,
+                    "fmt": "-0.27"
+                  },
+                  "surprisePercent": {
+                    "raw": -1.9289999,
+                    "fmt": "-192.90%"
+                  },
+                  "quarter": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": -1,
+                    "fmt": "-1"
+                  },
+                  "epsEstimate": {
+                    "raw": -1.06,
+                    "fmt": "-1.06"
+                  },
+                  "epsDifference": {
+                    "raw": 0.06,
+                    "fmt": "0.06"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.056999996,
+                    "fmt": "5.70%"
+                  },
+                  "quarter": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": -1.62,
+                    "fmt": "-1.62"
+                  },
+                  "epsEstimate": {
+                    "raw": -1.01,
+                    "fmt": "-1.01"
+                  },
+                  "epsDifference": {
+                    "raw": -0.61,
+                    "fmt": "-0.61"
+                  },
+                  "surprisePercent": {
+                    "raw": -0.60400003,
+                    "fmt": "-60.40%"
+                  },
+                  "quarter": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": -1.37,
+                    "fmt": "-1.37"
+                  },
+                  "epsEstimate": {
+                    "raw": -1,
+                    "fmt": "-1"
+                  },
+                  "epsDifference": {
+                    "raw": -0.37,
+                    "fmt": "-0.37"
+                  },
+                  "surprisePercent": {
+                    "raw": -0.37,
+                    "fmt": "-37.00%"
+                  },
+                  "quarter": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            },
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            },
+            "summaryProfile": {
+              "address1": "924 Avenue J East",
+              "city": "Grand Prairie",
+              "state": "TX",
+              "zip": "75050",
+              "country": "United States",
+              "phone": "972-595-5000",
+              "website": "http://www.sixflags.com",
+              "industry": "Leisure",
+              "sector": "Consumer Cyclical",
+              "longBusinessSummary": "Six Flags Entertainment Corporation owns and operates regional theme and waterparks under the Six Flags name. The company's parks offer various thrill rides, water attractions, themed areas, concerts and shows, restaurants, game venues, and retail outlets. It owns and operates 26 parks in the United States, Mexico, and Canada. The company was formerly known as Six Flags, Inc. and changed its name to Six Flags Entertainment Corporation in April 2010. Six Flags Entertainment Corporation was founded in 1961 and is based in Grand Prairie, Texas.",
+              "fullTimeEmployees": 2450,
+              "companyOfficers": [],
+              "maxAge": 86400
+            },
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 17,
+              "buyInfoShares": 50871,
+              "buyPercentInsiderShares": 0.008,
+              "sellInfoCount": 7,
+              "sellInfoShares": 31845,
+              "sellPercentInsiderShares": 0.005,
+              "netInfoCount": 24,
+              "netInfoShares": 19026,
+              "netPercentInsiderShares": 0.003,
+              "totalInsiderShares": 6132795
+            },
+            "insiderTransactions": {
+              "transactions": [
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1102,
+                    "fmt": "1.1k",
+                    "longFmt": "1,102"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BALDANZA BASIL BEN",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1973,
+                    "fmt": "1.97k",
+                    "longFmt": "1,973"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BASSOUL SELIM A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 603,
+                    "fmt": "603",
+                    "longFmt": "603"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROEDEL RICHARD W",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2041,
+                    "fmt": "2.04k",
+                    "longFmt": "2,041"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "KREJSA NANCY A.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1008,
+                    "fmt": "1.01k",
+                    "longFmt": "1,008"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BRACEY ESI EGGLESTON",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 13677,
+                    "fmt": "13.68k",
+                    "longFmt": "13,677"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "ROEDEL RICHARD W",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1609200000,
+                    "fmt": "2020-12-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 902,
+                    "fmt": "902",
+                    "longFmt": "902"
+                  },
+                  "value": {
+                    "raw": 27977,
+                    "fmt": "27.98k",
+                    "longFmt": "27,977"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 31.02 per share.",
+                  "filerName": "SPANOS MICHAEL",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606089600,
+                    "fmt": "2020-11-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3505,
+                    "fmt": "3.5k",
+                    "longFmt": "3,505"
+                  },
+                  "value": {
+                    "raw": 103993,
+                    "fmt": "103.99k",
+                    "longFmt": "103,993"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 29.67 per share.",
+                  "filerName": "SPANOS MICHAEL",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3900,
+                    "fmt": "3.9k",
+                    "longFmt": "3,900"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SPANOS MICHAEL",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 25000,
+                    "fmt": "25k",
+                    "longFmt": "25,000"
+                  },
+                  "value": {
+                    "raw": 725750,
+                    "fmt": "725.75k",
+                    "longFmt": "725,750"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 29.03 per share.",
+                  "filerName": "KREJSA NANCY A.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604966400,
+                    "fmt": "2020-11-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5700,
+                    "fmt": "5.7k",
+                    "longFmt": "5,700"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "KREJSA NANCY A.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604275200,
+                    "fmt": "2020-11-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4470,
+                    "fmt": "4.47k",
+                    "longFmt": "4,470"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1601596800,
+                    "fmt": "2020-10-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5004,
+                    "fmt": "5k",
+                    "longFmt": "5,004"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1601596800,
+                    "fmt": "2020-10-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1730,
+                    "fmt": "1.73k",
+                    "longFmt": "1,730"
+                  },
+                  "value": {
+                    "raw": 36814,
+                    "fmt": "36.81k",
+                    "longFmt": "36,814"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 21.28 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1599177600,
+                    "fmt": "2020-09-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 444,
+                    "fmt": "444",
+                    "longFmt": "444"
+                  },
+                  "value": {
+                    "raw": 9448,
+                    "fmt": "9.45k",
+                    "longFmt": "9,448"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 21.28 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1599177600,
+                    "fmt": "2020-09-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3459,
+                    "fmt": "3.46k",
+                    "longFmt": "3,459"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598572800,
+                    "fmt": "2020-08-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3459,
+                    "fmt": "3.46k",
+                    "longFmt": "3,459"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598572800,
+                    "fmt": "2020-08-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1109,
+                    "fmt": "1.11k",
+                    "longFmt": "1,109"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598572800,
+                    "fmt": "2020-08-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 147,
+                    "fmt": "147",
+                    "longFmt": "147"
+                  },
+                  "value": {
+                    "raw": 3087,
+                    "fmt": "3.09k",
+                    "longFmt": "3,087"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 21.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598486400,
+                    "fmt": "2020-08-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 117,
+                    "fmt": "117",
+                    "longFmt": "117"
+                  },
+                  "value": {
+                    "raw": 2457,
+                    "fmt": "2.46k",
+                    "longFmt": "2,457"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 21.00 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598486400,
+                    "fmt": "2020-08-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1956,
+                    "fmt": "1.96k",
+                    "longFmt": "1,956"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598227200,
+                    "fmt": "2020-08-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 293,
+                    "fmt": "293",
+                    "longFmt": "293"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598227200,
+                    "fmt": "2020-08-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 293,
+                    "fmt": "293",
+                    "longFmt": "293"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598227200,
+                    "fmt": "2020-08-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6976,
+                    "fmt": "6.98k",
+                    "longFmt": "6,976"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BRACEY ESI EGGLESTON",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596585600,
+                    "fmt": "2020-08-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 329,
+                    "fmt": "329",
+                    "longFmt": "329"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RUSS LEONARD A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1593648000,
+                    "fmt": "2020-07-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 90590,
+                    "fmt": "90.59k",
+                    "longFmt": "90,590"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "REDDY SANDEEP",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1593561600,
+                    "fmt": "2020-07-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1011,
+                    "fmt": "1.01k",
+                    "longFmt": "1,011"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "ROEDEL RICHARD W",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589155200,
+                    "fmt": "2020-05-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2970,
+                    "fmt": "2.97k",
+                    "longFmt": "2,970"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "ROEDEL RICHARD W",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588809600,
+                    "fmt": "2020-05-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8417,
+                    "fmt": "8.42k",
+                    "longFmt": "8,417"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BALDANZA BASIL BEN",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8417,
+                    "fmt": "8.42k",
+                    "longFmt": "8,417"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BASSOUL SELIM A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 19324,
+                    "fmt": "19.32k",
+                    "longFmt": "19,324"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROEDEL RICHARD W",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8417,
+                    "fmt": "8.42k",
+                    "longFmt": "8,417"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CELLAR KURT MATTHEW",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 22658,
+                    "fmt": "22.66k",
+                    "longFmt": "22,658"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 22658,
+                    "fmt": "22.66k",
+                    "longFmt": "22,658"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RUSS LEONARD A",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 42083,
+                    "fmt": "42.08k",
+                    "longFmt": "42,083"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DOERRE LAURA W.",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8417,
+                    "fmt": "8.42k",
+                    "longFmt": "8,417"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "KREJSA NANCY A.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 315623,
+                    "fmt": "315.62k",
+                    "longFmt": "315,623"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SPANOS MICHAEL",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 22658,
+                    "fmt": "22.66k",
+                    "longFmt": "22,658"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10621,
+                    "fmt": "10.62k",
+                    "longFmt": "10,621"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6135,
+                    "fmt": "6.13k",
+                    "longFmt": "6,135"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RUSS LEONARD A",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1585699200,
+                    "fmt": "2020-04-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 31546,
+                    "fmt": "31.55k",
+                    "longFmt": "31,546"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DOERRE LAURA W.",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1583712000,
+                    "fmt": "2020-03-09"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 800,
+                    "fmt": "800",
+                    "longFmt": "800"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BALDANZA BASIL BEN",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582502400,
+                    "fmt": "2020-02-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 800,
+                    "fmt": "800",
+                    "longFmt": "800"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BASSOUL SELIM A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582502400,
+                    "fmt": "2020-02-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5360,
+                    "fmt": "5.36k",
+                    "longFmt": "5,360"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582070400,
+                    "fmt": "2020-02-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 297,
+                    "fmt": "297",
+                    "longFmt": "297"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BALK LANCE C",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581033600,
+                    "fmt": "2020-02-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 297,
+                    "fmt": "297",
+                    "longFmt": "297"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581033600,
+                    "fmt": "2020-02-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 297,
+                    "fmt": "297",
+                    "longFmt": "297"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581033600,
+                    "fmt": "2020-02-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 178,
+                    "fmt": "178",
+                    "longFmt": "178"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581033600,
+                    "fmt": "2020-02-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 169,
+                    "fmt": "169",
+                    "longFmt": "169"
+                  },
+                  "value": {
+                    "raw": 7512,
+                    "fmt": "7.51k",
+                    "longFmt": "7,512"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 44.45 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1578355200,
+                    "fmt": "2020-01-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 338,
+                    "fmt": "338",
+                    "longFmt": "338"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1578009600,
+                    "fmt": "2020-01-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10000,
+                    "fmt": "10k",
+                    "longFmt": "10,000"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BALK LANCE C",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1575504000,
+                    "fmt": "2019-12-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1011,
+                    "fmt": "1.01k",
+                    "longFmt": "1,011"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROEDEL RICHARD W",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1574035200,
+                    "fmt": "2019-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 48282,
+                    "fmt": "48.28k",
+                    "longFmt": "48,282"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Former",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1574035200,
+                    "fmt": "2019-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 43431,
+                    "fmt": "43.43k",
+                    "longFmt": "43,431"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SPANOS MICHAEL",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1574035200,
+                    "fmt": "2019-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 85,
+                    "fmt": "85",
+                    "longFmt": "85"
+                  },
+                  "value": {
+                    "raw": 4954,
+                    "fmt": "4.95k",
+                    "longFmt": "4,954"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 58.28 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1567555200,
+                    "fmt": "2019-09-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 990,
+                    "fmt": "990",
+                    "longFmt": "990"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BALK LANCE C",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1567123200,
+                    "fmt": "2019-08-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 990,
+                    "fmt": "990",
+                    "longFmt": "990"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1567123200,
+                    "fmt": "2019-08-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 791,
+                    "fmt": "791",
+                    "longFmt": "791"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1567123200,
+                    "fmt": "2019-08-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 791,
+                    "fmt": "791",
+                    "longFmt": "791"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1567123200,
+                    "fmt": "2019-08-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 213,
+                    "fmt": "213",
+                    "longFmt": "213"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1567123200,
+                    "fmt": "2019-08-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 468,
+                    "fmt": "468",
+                    "longFmt": "468"
+                  },
+                  "value": {
+                    "raw": 27603,
+                    "fmt": "27.6k",
+                    "longFmt": "27,603"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 58.98 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1566864000,
+                    "fmt": "2019-08-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 90,
+                    "fmt": "90",
+                    "longFmt": "90"
+                  },
+                  "value": {
+                    "raw": 5308,
+                    "fmt": "5.31k",
+                    "longFmt": "5,308"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 58.98 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1566864000,
+                    "fmt": "2019-08-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1500,
+                    "fmt": "1.5k",
+                    "longFmt": "1,500"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BALK LANCE C",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1566518400,
+                    "fmt": "2019-08-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 935,
+                    "fmt": "935",
+                    "longFmt": "935"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1566518400,
+                    "fmt": "2019-08-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1500,
+                    "fmt": "1.5k",
+                    "longFmt": "1,500"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1566518400,
+                    "fmt": "2019-08-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 224,
+                    "fmt": "224",
+                    "longFmt": "224"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1566518400,
+                    "fmt": "2019-08-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 224,
+                    "fmt": "224",
+                    "longFmt": "224"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1566518400,
+                    "fmt": "2019-08-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2800,
+                    "fmt": "2.8k",
+                    "longFmt": "2,800"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "KREJSA NANCY A.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1566345600,
+                    "fmt": "2019-08-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 14378,
+                    "fmt": "14.38k",
+                    "longFmt": "14,378"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1563408000,
+                    "fmt": "2019-07-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2520,
+                    "fmt": "2.52k",
+                    "longFmt": "2,520"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "ROEDEL RICHARD W",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1557273600,
+                    "fmt": "2019-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4965,
+                    "fmt": "4.96k",
+                    "longFmt": "4,965"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROEDEL RICHARD W",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556668800,
+                    "fmt": "2019-05-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2970,
+                    "fmt": "2.97k",
+                    "longFmt": "2,970"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CELLAR KURT MATTHEW",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556668800,
+                    "fmt": "2019-05-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2970,
+                    "fmt": "2.97k",
+                    "longFmt": "2,970"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "OWENS STEPHEN D",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556668800,
+                    "fmt": "2019-05-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3666,
+                    "fmt": "3.67k",
+                    "longFmt": "3,666"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "LUTHER JON L",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556668800,
+                    "fmt": "2019-05-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4269,
+                    "fmt": "4.27k",
+                    "longFmt": "4,269"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "NABI USMAN S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556668800,
+                    "fmt": "2019-05-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2970,
+                    "fmt": "2.97k",
+                    "longFmt": "2,970"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "KREJSA NANCY A.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556668800,
+                    "fmt": "2019-05-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2865,
+                    "fmt": "2.87k",
+                    "longFmt": "2,865"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1551657600,
+                    "fmt": "2019-03-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 286,
+                    "fmt": "286",
+                    "longFmt": "286"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1551657600,
+                    "fmt": "2019-03-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1275,
+                    "fmt": "1.27k",
+                    "longFmt": "1,275"
+                  },
+                  "value": {
+                    "raw": 72012,
+                    "fmt": "72.01k",
+                    "longFmt": "72,012"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 56.48 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550793600,
+                    "fmt": "2019-02-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 20439,
+                    "fmt": "20.44k",
+                    "longFmt": "20,439"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550707200,
+                    "fmt": "2019-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 112500,
+                    "fmt": "112.5k",
+                    "longFmt": "112,500"
+                  },
+                  "value": {
+                    "raw": 5591250,
+                    "fmt": "5.59M",
+                    "longFmt": "5,591,250"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 47.60 - 51.38 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550534400,
+                    "fmt": "2019-02-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2550,
+                    "fmt": "2.55k",
+                    "longFmt": "2,550"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550534400,
+                    "fmt": "2019-02-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 114,
+                    "fmt": "114",
+                    "longFmt": "114"
+                  },
+                  "value": {
+                    "raw": 7233,
+                    "fmt": "7.23k",
+                    "longFmt": "7,233"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 63.45 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550016000,
+                    "fmt": "2019-02-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 114,
+                    "fmt": "114",
+                    "longFmt": "114"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BALK LANCE C",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1549584000,
+                    "fmt": "2019-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 114,
+                    "fmt": "114",
+                    "longFmt": "114"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1549584000,
+                    "fmt": "2019-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 114,
+                    "fmt": "114",
+                    "longFmt": "114"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1549584000,
+                    "fmt": "2019-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 68,
+                    "fmt": "68",
+                    "longFmt": "68"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1549584000,
+                    "fmt": "2019-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 27750,
+                    "fmt": "27.75k",
+                    "longFmt": "27,750"
+                  },
+                  "value": {
+                    "raw": 1748250,
+                    "fmt": "1.75M",
+                    "longFmt": "1,748,250"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 63.00 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1547596800,
+                    "fmt": "2019-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 27750,
+                    "fmt": "27.75k",
+                    "longFmt": "27,750"
+                  },
+                  "value": {
+                    "raw": 1073722,
+                    "fmt": "1.07M",
+                    "longFmt": "1,073,722"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 34.49 - 42.34 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1547596800,
+                    "fmt": "2019-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 325,
+                    "fmt": "325",
+                    "longFmt": "325"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "KREJSA NANCY A.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1547164800,
+                    "fmt": "2019-01-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 174,
+                    "fmt": "174",
+                    "longFmt": "174"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1546473600,
+                    "fmt": "2019-01-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1860,
+                    "fmt": "1.86k",
+                    "longFmt": "1,860"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "KREJSA NANCY A.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1544400000,
+                    "fmt": "2018-12-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 69,
+                    "fmt": "69",
+                    "longFmt": "69"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BALK LANCE C",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1536537600,
+                    "fmt": "2018-09-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 69,
+                    "fmt": "69",
+                    "longFmt": "69"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1536537600,
+                    "fmt": "2018-09-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10768,
+                    "fmt": "10.77k",
+                    "longFmt": "10,768"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "CELLAR KURT MATTHEW",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1536537600,
+                    "fmt": "2018-09-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 55,
+                    "fmt": "55",
+                    "longFmt": "55"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1536537600,
+                    "fmt": "2018-09-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 55,
+                    "fmt": "55",
+                    "longFmt": "55"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1536537600,
+                    "fmt": "2018-09-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8,
+                    "fmt": "8",
+                    "longFmt": "8"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1536537600,
+                    "fmt": "2018-09-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10,
+                    "fmt": "10",
+                    "longFmt": "10"
+                  },
+                  "value": {
+                    "raw": 686,
+                    "fmt": "686",
+                    "longFmt": "686"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 68.60 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1536192000,
+                    "fmt": "2018-09-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 277,
+                    "fmt": "277",
+                    "longFmt": "277"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BALK LANCE C",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535587200,
+                    "fmt": "2018-08-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 277,
+                    "fmt": "277",
+                    "longFmt": "277"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535587200,
+                    "fmt": "2018-08-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 222,
+                    "fmt": "222",
+                    "longFmt": "222"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535587200,
+                    "fmt": "2018-08-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 222,
+                    "fmt": "222",
+                    "longFmt": "222"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535587200,
+                    "fmt": "2018-08-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 33,
+                    "fmt": "33",
+                    "longFmt": "33"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535587200,
+                    "fmt": "2018-08-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 62500,
+                    "fmt": "62.5k",
+                    "longFmt": "62,500"
+                  },
+                  "value": {
+                    "raw": 2346250,
+                    "fmt": "2.35M",
+                    "longFmt": "2,346,250"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 37.54 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535414400,
+                    "fmt": "2018-08-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 449,
+                    "fmt": "449",
+                    "longFmt": "449"
+                  },
+                  "value": {
+                    "raw": 29279,
+                    "fmt": "29.28k",
+                    "longFmt": "29,279"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 65.21 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535414400,
+                    "fmt": "2018-08-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 50,
+                    "fmt": "50",
+                    "longFmt": "50"
+                  },
+                  "value": {
+                    "raw": 3260,
+                    "fmt": "3.26k",
+                    "longFmt": "3,260"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 65.21 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535414400,
+                    "fmt": "2018-08-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2425,
+                    "fmt": "2.42k",
+                    "longFmt": "2,425"
+                  },
+                  "value": {
+                    "raw": 162111,
+                    "fmt": "162.11k",
+                    "longFmt": "162,111"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 66.85 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535328000,
+                    "fmt": "2018-08-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3000,
+                    "fmt": "3k",
+                    "longFmt": "3,000"
+                  },
+                  "value": {
+                    "raw": 103470,
+                    "fmt": "103.47k",
+                    "longFmt": "103,470"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 34.49 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535328000,
+                    "fmt": "2018-08-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1973,
+                    "fmt": "1.97k",
+                    "longFmt": "1,973"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BALK LANCE C",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535068800,
+                    "fmt": "2018-08-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9109,
+                    "fmt": "9.11k",
+                    "longFmt": "9,109"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535068800,
+                    "fmt": "2018-08-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 898,
+                    "fmt": "898",
+                    "longFmt": "898"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535068800,
+                    "fmt": "2018-08-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1790,
+                    "fmt": "1.79k",
+                    "longFmt": "1,790"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535068800,
+                    "fmt": "2018-08-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 258,
+                    "fmt": "258",
+                    "longFmt": "258"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535068800,
+                    "fmt": "2018-08-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 167,
+                    "fmt": "167",
+                    "longFmt": "167"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535068800,
+                    "fmt": "2018-08-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5191,
+                    "fmt": "5.19k",
+                    "longFmt": "5,191"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1531872000,
+                    "fmt": "2018-07-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 125000,
+                    "fmt": "125k",
+                    "longFmt": "125,000"
+                  },
+                  "value": {
+                    "raw": 7126250,
+                    "fmt": "7.13M",
+                    "longFmt": "7,126,250"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 57.01 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1531872000,
+                    "fmt": "2018-07-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9062,
+                    "fmt": "9.06k",
+                    "longFmt": "9,062"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BALK LANCE C",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1529452800,
+                    "fmt": "2018-06-20"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 35815,
+                    "fmt": "35.81k",
+                    "longFmt": "35,815"
+                  },
+                  "value": {
+                    "raw": 2597693,
+                    "fmt": "2.6M",
+                    "longFmt": "2,597,693"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 72.50 - 72.53 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1529452800,
+                    "fmt": "2018-06-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 64185,
+                    "fmt": "64.19k",
+                    "longFmt": "64,185"
+                  },
+                  "value": {
+                    "raw": 4657311,
+                    "fmt": "4.66M",
+                    "longFmt": "4,657,311"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 72.49 - 72.57 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1529020800,
+                    "fmt": "2018-06-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 100000,
+                    "fmt": "100k",
+                    "longFmt": "100,000"
+                  },
+                  "value": {
+                    "raw": 7014783,
+                    "fmt": "7.01M",
+                    "longFmt": "7,014,783"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 70.09 - 70.16 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "President",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1528416000,
+                    "fmt": "2018-06-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2429,
+                    "fmt": "2.43k",
+                    "longFmt": "2,429"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "ROEDEL RICHARD W",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1526515200,
+                    "fmt": "2018-05-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4065,
+                    "fmt": "4.07k",
+                    "longFmt": "4,065"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROEDEL RICHARD W",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525219200,
+                    "fmt": "2018-05-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2520,
+                    "fmt": "2.52k",
+                    "longFmt": "2,520"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CELLAR KURT MATTHEW",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525219200,
+                    "fmt": "2018-05-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2520,
+                    "fmt": "2.52k",
+                    "longFmt": "2,520"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "OWENS STEPHEN D",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525219200,
+                    "fmt": "2018-05-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4065,
+                    "fmt": "4.07k",
+                    "longFmt": "4,065"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "LUTHER JON L",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525219200,
+                    "fmt": "2018-05-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2520,
+                    "fmt": "2.52k",
+                    "longFmt": "2,520"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "NABI USMAN S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525219200,
+                    "fmt": "2018-05-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2520,
+                    "fmt": "2.52k",
+                    "longFmt": "2,520"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "KREJSA NANCY A.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525219200,
+                    "fmt": "2018-05-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1809,
+                    "fmt": "1.81k",
+                    "longFmt": "1,809"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1520208000,
+                    "fmt": "2018-03-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 226,
+                    "fmt": "226",
+                    "longFmt": "226"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1520208000,
+                    "fmt": "2018-03-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 100000,
+                    "fmt": "100k",
+                    "longFmt": "100,000"
+                  },
+                  "value": {
+                    "raw": 6566645,
+                    "fmt": "6.57M",
+                    "longFmt": "6,566,645"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 65.49 - 66.40 per share.",
+                  "filerName": "BALK LANCE C",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519689600,
+                    "fmt": "2018-02-27"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5166,
+                    "fmt": "5.17k",
+                    "longFmt": "5,166"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519603200,
+                    "fmt": "2018-02-26"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 597,
+                    "fmt": "597",
+                    "longFmt": "597"
+                  },
+                  "value": {
+                    "raw": 39742,
+                    "fmt": "39.74k",
+                    "longFmt": "39,742"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 66.57 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519171200,
+                    "fmt": "2018-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 150000,
+                    "fmt": "150k",
+                    "longFmt": "150,000"
+                  },
+                  "value": {
+                    "raw": 7092000,
+                    "fmt": "7.09M",
+                    "longFmt": "7,092,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 40.02 - 51.38 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519084800,
+                    "fmt": "2018-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 13653,
+                    "fmt": "13.65k",
+                    "longFmt": "13,653"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518998400,
+                    "fmt": "2018-02-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1194,
+                    "fmt": "1.19k",
+                    "longFmt": "1,194"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518998400,
+                    "fmt": "2018-02-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 26,
+                    "fmt": "26",
+                    "longFmt": "26"
+                  },
+                  "value": {
+                    "raw": 1703,
+                    "fmt": "1.7k",
+                    "longFmt": "1,703"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 65.51 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518480000,
+                    "fmt": "2018-02-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 24,
+                    "fmt": "24",
+                    "longFmt": "24"
+                  },
+                  "value": {
+                    "raw": 1572,
+                    "fmt": "1.57k",
+                    "longFmt": "1,572"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 65.51 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518480000,
+                    "fmt": "2018-02-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 51,
+                    "fmt": "51",
+                    "longFmt": "51"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BALK LANCE C",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518048000,
+                    "fmt": "2018-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 51,
+                    "fmt": "51",
+                    "longFmt": "51"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518048000,
+                    "fmt": "2018-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 51,
+                    "fmt": "51",
+                    "longFmt": "51"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518048000,
+                    "fmt": "2018-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 20,
+                    "fmt": "20",
+                    "longFmt": "20"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CENTOLA MARIO L",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518048000,
+                    "fmt": "2018-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 30,
+                    "fmt": "30",
+                    "longFmt": "30"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518048000,
+                    "fmt": "2018-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 54,
+                    "fmt": "54",
+                    "longFmt": "54"
+                  },
+                  "value": {
+                    "raw": 3578,
+                    "fmt": "3.58k",
+                    "longFmt": "3,578"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 66.26 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1515456000,
+                    "fmt": "2018-01-09"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 30976,
+                    "fmt": "30.98k",
+                    "longFmt": "30,976"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1514937600,
+                    "fmt": "2018-01-03"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 30976,
+                    "fmt": "30.98k",
+                    "longFmt": "30,976"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1514937600,
+                    "fmt": "2018-01-03"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 67,
+                    "fmt": "67",
+                    "longFmt": "67"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1514937600,
+                    "fmt": "2018-01-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 77310,
+                    "fmt": "77.31k",
+                    "longFmt": "77,310"
+                  },
+                  "value": {
+                    "raw": 5220312,
+                    "fmt": "5.22M",
+                    "longFmt": "5,220,312"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 67.52 - 67.53 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1513900800,
+                    "fmt": "2017-12-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 800,
+                    "fmt": "800",
+                    "longFmt": "800"
+                  },
+                  "value": {
+                    "raw": 53880,
+                    "fmt": "53.88k",
+                    "longFmt": "53,880"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 67.35 per share.",
+                  "filerName": "KREJSA NANCY A.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1513814400,
+                    "fmt": "2017-12-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 42690,
+                    "fmt": "42.69k",
+                    "longFmt": "42,690"
+                  },
+                  "value": {
+                    "raw": 2883983,
+                    "fmt": "2.88M",
+                    "longFmt": "2,883,983"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 67.56 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1513641600,
+                    "fmt": "2017-12-19"
+                  },
+                  "ownership": "D"
+                }
+              ],
+              "maxAge": 1
+            },
+            "sectorTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 126327000,
+                    "fmt": "126.33M",
+                    "longFmt": "126,327,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 125621000,
+                    "fmt": "125.62M",
+                    "longFmt": "125,621,000"
+                  },
+                  "grossProfit": {
+                    "raw": 706000,
+                    "fmt": "706k",
+                    "longFmt": "706,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 41765000,
+                    "fmt": "41.77M",
+                    "longFmt": "41,765,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 196171000,
+                    "fmt": "196.17M",
+                    "longFmt": "196,171,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -69844000,
+                    "fmt": "-69.84M",
+                    "longFmt": "-69,844,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -61927000,
+                    "fmt": "-61.93M",
+                    "longFmt": "-61,927,000"
+                  },
+                  "ebit": {
+                    "raw": -69844000,
+                    "fmt": "-69.84M",
+                    "longFmt": "-69,844,000"
+                  },
+                  "interestExpense": {
+                    "raw": -38500000,
+                    "fmt": "-38.5M",
+                    "longFmt": "-38,500,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -131771000,
+                    "fmt": "-131.77M",
+                    "longFmt": "-131,771,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -36243000,
+                    "fmt": "-36.24M",
+                    "longFmt": "-36,243,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 544020000,
+                    "fmt": "544.02M",
+                    "longFmt": "544,020,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -95528000,
+                    "fmt": "-95.53M",
+                    "longFmt": "-95,528,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -116172000,
+                    "fmt": "-116.17M",
+                    "longFmt": "-116,172,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -116172000,
+                    "fmt": "-116.17M",
+                    "longFmt": "-116,172,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 19143000,
+                    "fmt": "19.14M",
+                    "longFmt": "19,143,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 63780000,
+                    "fmt": "63.78M",
+                    "longFmt": "63,780,000"
+                  },
+                  "grossProfit": {
+                    "raw": -44637000,
+                    "fmt": "-44.64M",
+                    "longFmt": "-44,637,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 36941000,
+                    "fmt": "36.94M",
+                    "longFmt": "36,941,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 130155000,
+                    "fmt": "130.16M",
+                    "longFmt": "130,155,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -111012000,
+                    "fmt": "-111.01M",
+                    "longFmt": "-111,012,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -60899000,
+                    "fmt": "-60.9M",
+                    "longFmt": "-60,899,000"
+                  },
+                  "ebit": {
+                    "raw": -111012000,
+                    "fmt": "-111.01M",
+                    "longFmt": "-111,012,000"
+                  },
+                  "interestExpense": {
+                    "raw": -51248000,
+                    "fmt": "-51.25M",
+                    "longFmt": "-51,248,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -171911000,
+                    "fmt": "-171.91M",
+                    "longFmt": "-171,911,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -55661000,
+                    "fmt": "-55.66M",
+                    "longFmt": "-55,661,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 544020000,
+                    "fmt": "544.02M",
+                    "longFmt": "544,020,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -116250000,
+                    "fmt": "-116.25M",
+                    "longFmt": "-116,250,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -136894000,
+                    "fmt": "-136.89M",
+                    "longFmt": "-136,894,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -136894000,
+                    "fmt": "-136.89M",
+                    "longFmt": "-136,894,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 102503000,
+                    "fmt": "102.5M",
+                    "longFmt": "102,503,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 112158000,
+                    "fmt": "112.16M",
+                    "longFmt": "112,158,000"
+                  },
+                  "grossProfit": {
+                    "raw": -9655000,
+                    "fmt": "-9.65M",
+                    "longFmt": "-9,655,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 36660000,
+                    "fmt": "36.66M",
+                    "longFmt": "36,660,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 179482000,
+                    "fmt": "179.48M",
+                    "longFmt": "179,482,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -76979000,
+                    "fmt": "-76.98M",
+                    "longFmt": "-76,979,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -29616000,
+                    "fmt": "-29.62M",
+                    "longFmt": "-29,616,000"
+                  },
+                  "ebit": {
+                    "raw": -76979000,
+                    "fmt": "-76.98M",
+                    "longFmt": "-76,979,000"
+                  },
+                  "interestExpense": {
+                    "raw": -27486000,
+                    "fmt": "-27.49M",
+                    "longFmt": "-27,486,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -106595000,
+                    "fmt": "-106.59M",
+                    "longFmt": "-106,595,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -22049000,
+                    "fmt": "-22.05M",
+                    "longFmt": "-22,049,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 529276000,
+                    "fmt": "529.28M",
+                    "longFmt": "529,276,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -84546000,
+                    "fmt": "-84.55M",
+                    "longFmt": "-84,546,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -84546000,
+                    "fmt": "-84.55M",
+                    "longFmt": "-84,546,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -84546000,
+                    "fmt": "-84.55M",
+                    "longFmt": "-84,546,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 261000000,
+                    "fmt": "261M",
+                    "longFmt": "261,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 136219000,
+                    "fmt": "136.22M",
+                    "longFmt": "136,219,000"
+                  },
+                  "grossProfit": {
+                    "raw": 124781000,
+                    "fmt": "124.78M",
+                    "longFmt": "124,781,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 55069000,
+                    "fmt": "55.07M",
+                    "longFmt": "55,069,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 220485000,
+                    "fmt": "220.49M",
+                    "longFmt": "220,485,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 40515000,
+                    "fmt": "40.52M",
+                    "longFmt": "40,515,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -30372000,
+                    "fmt": "-30.37M",
+                    "longFmt": "-30,372,000"
+                  },
+                  "ebit": {
+                    "raw": 40515000,
+                    "fmt": "40.52M",
+                    "longFmt": "40,515,000"
+                  },
+                  "interestExpense": {
+                    "raw": -27738000,
+                    "fmt": "-27.74M",
+                    "longFmt": "-27,738,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 10143000,
+                    "fmt": "10.14M",
+                    "longFmt": "10,143,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 21298000,
+                    "fmt": "21.3M",
+                    "longFmt": "21,298,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 529258000,
+                    "fmt": "529.26M",
+                    "longFmt": "529,258,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -11155000,
+                    "fmt": "-11.15M",
+                    "longFmt": "-11,155,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -11155000,
+                    "fmt": "-11.15M",
+                    "longFmt": "-11,155,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -11155000,
+                    "fmt": "-11.15M",
+                    "longFmt": "-11,155,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": -116172000,
+                    "fmt": "-116.17M",
+                    "longFmt": "-116,172,000"
+                  },
+                  "depreciation": {
+                    "raw": 28785000,
+                    "fmt": "28.79M",
+                    "longFmt": "28,785,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 38108000,
+                    "fmt": "38.11M",
+                    "longFmt": "38,108,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -1195000,
+                    "fmt": "-1.2M",
+                    "longFmt": "-1,195,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -6578000,
+                    "fmt": "-6.58M",
+                    "longFmt": "-6,578,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 1413000,
+                    "fmt": "1.41M",
+                    "longFmt": "1,413,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 10287000,
+                    "fmt": "10.29M",
+                    "longFmt": "10,287,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -43261000,
+                    "fmt": "-43.26M",
+                    "longFmt": "-43,261,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -17337000,
+                    "fmt": "-17.34M",
+                    "longFmt": "-17,337,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -17337000,
+                    "fmt": "-17.34M",
+                    "longFmt": "-17,337,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -1079000,
+                    "fmt": "-1.08M",
+                    "longFmt": "-1,079,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -212000,
+                    "fmt": "-212k",
+                    "longFmt": "-212,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -21453000,
+                    "fmt": "-21.45M",
+                    "longFmt": "-21,453,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -22373000,
+                    "fmt": "-22.37M",
+                    "longFmt": "-22,373,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 922000,
+                    "fmt": "922k",
+                    "longFmt": "922,000"
+                  },
+                  "changeInCash": {
+                    "raw": -82049000,
+                    "fmt": "-82.05M",
+                    "longFmt": "-82,049,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -48000,
+                    "fmt": "-48k",
+                    "longFmt": "-48,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 419000,
+                    "fmt": "419k",
+                    "longFmt": "419,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "netIncome": {
+                    "raw": -136894000,
+                    "fmt": "-136.89M",
+                    "longFmt": "-136,894,000"
+                  },
+                  "depreciation": {
+                    "raw": 29434000,
+                    "fmt": "29.43M",
+                    "longFmt": "29,434,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 31517000,
+                    "fmt": "31.52M",
+                    "longFmt": "31,517,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 24825000,
+                    "fmt": "24.82M",
+                    "longFmt": "24,825,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -18362000,
+                    "fmt": "-18.36M",
+                    "longFmt": "-18,362,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 2002000,
+                    "fmt": "2M",
+                    "longFmt": "2,002,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 15551000,
+                    "fmt": "15.55M",
+                    "longFmt": "15,551,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -50316000,
+                    "fmt": "-50.32M",
+                    "longFmt": "-50,316,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -22165000,
+                    "fmt": "-22.16M",
+                    "longFmt": "-22,165,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 472000,
+                    "fmt": "472k",
+                    "longFmt": "472,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -21693000,
+                    "fmt": "-21.69M",
+                    "longFmt": "-21,693,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -51000,
+                    "fmt": "-51k",
+                    "longFmt": "-51,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 369816000,
+                    "fmt": "369.82M",
+                    "longFmt": "369,816,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -26438000,
+                    "fmt": "-26.44M",
+                    "longFmt": "-26,438,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 344358000,
+                    "fmt": "344.36M",
+                    "longFmt": "344,358,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 796000,
+                    "fmt": "796k",
+                    "longFmt": "796,000"
+                  },
+                  "changeInCash": {
+                    "raw": 273145000,
+                    "fmt": "273.14M",
+                    "longFmt": "273,145,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -48000,
+                    "fmt": "-48k",
+                    "longFmt": "-48,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 1031000,
+                    "fmt": "1.03M",
+                    "longFmt": "1,031,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "netIncome": {
+                    "raw": -84546000,
+                    "fmt": "-84.55M",
+                    "longFmt": "-84,546,000"
+                  },
+                  "depreciation": {
+                    "raw": 30664000,
+                    "fmt": "30.66M",
+                    "longFmt": "30,664,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 7165000,
+                    "fmt": "7.17M",
+                    "longFmt": "7,165,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 35159000,
+                    "fmt": "35.16M",
+                    "longFmt": "35,159,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -20025000,
+                    "fmt": "-20.02M",
+                    "longFmt": "-20,025,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -30794000,
+                    "fmt": "-30.79M",
+                    "longFmt": "-30,794,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 1134000,
+                    "fmt": "1.13M",
+                    "longFmt": "1,134,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -60387000,
+                    "fmt": "-60.39M",
+                    "longFmt": "-60,387,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -53458000,
+                    "fmt": "-53.46M",
+                    "longFmt": "-53,458,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 2042000,
+                    "fmt": "2.04M",
+                    "longFmt": "2,042,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -51416000,
+                    "fmt": "-51.42M",
+                    "longFmt": "-51,416,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -21367000,
+                    "fmt": "-21.37M",
+                    "longFmt": "-21,367,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -12510000,
+                    "fmt": "-12.51M",
+                    "longFmt": "-12,510,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -26438000,
+                    "fmt": "-26.44M",
+                    "longFmt": "-26,438,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -33462000,
+                    "fmt": "-33.46M",
+                    "longFmt": "-33,462,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -6103000,
+                    "fmt": "-6.1M",
+                    "longFmt": "-6,103,000"
+                  },
+                  "changeInCash": {
+                    "raw": -151368000,
+                    "fmt": "-151.37M",
+                    "longFmt": "-151,368,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -6000,
+                    "fmt": "-6k",
+                    "longFmt": "-6,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 421000,
+                    "fmt": "421k",
+                    "longFmt": "421,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -11155000,
+                    "fmt": "-11.15M",
+                    "longFmt": "-11,155,000"
+                  },
+                  "depreciation": {
+                    "raw": 29197000,
+                    "fmt": "29.2M",
+                    "longFmt": "29,197,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -2300000,
+                    "fmt": "-2.3M",
+                    "longFmt": "-2,300,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 90786000,
+                    "fmt": "90.79M",
+                    "longFmt": "90,786,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -50305000,
+                    "fmt": "-50.3M",
+                    "longFmt": "-50,305,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 4479000,
+                    "fmt": "4.48M",
+                    "longFmt": "4,479,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 8146000,
+                    "fmt": "8.15M",
+                    "longFmt": "8,146,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 69708000,
+                    "fmt": "69.71M",
+                    "longFmt": "69,708,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -20251000,
+                    "fmt": "-20.25M",
+                    "longFmt": "-20,251,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 2100000,
+                    "fmt": "2.1M",
+                    "longFmt": "2,100,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -17125000,
+                    "fmt": "-17.12M",
+                    "longFmt": "-17,125,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -70211000,
+                    "fmt": "-70.21M",
+                    "longFmt": "-70,211,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -2000000,
+                    "fmt": "-2M",
+                    "longFmt": "-2,000,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -21361000,
+                    "fmt": "-21.36M",
+                    "longFmt": "-21,361,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -91336000,
+                    "fmt": "-91.34M",
+                    "longFmt": "-91,336,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 1135000,
+                    "fmt": "1.14M",
+                    "longFmt": "1,135,000"
+                  },
+                  "changeInCash": {
+                    "raw": -37618000,
+                    "fmt": "-37.62M",
+                    "longFmt": "-37,618,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -6000,
+                    "fmt": "-6k",
+                    "longFmt": "-6,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 2236000,
+                    "fmt": "2.24M",
+                    "longFmt": "2,236,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [
+                  {
+                    "date": "4Q2019",
+                    "actual": -0.13,
+                    "estimate": 0.14
+                  },
+                  {
+                    "date": "1Q2020",
+                    "actual": -1,
+                    "estimate": -1.06
+                  },
+                  {
+                    "date": "2Q2020",
+                    "actual": -1.62,
+                    "estimate": -1.01
+                  },
+                  {
+                    "date": "3Q2020",
+                    "actual": -1.37,
+                    "estimate": -1
+                  }
+                ],
+                "currentQuarterEstimate": -0.89,
+                "currentQuarterEstimateDate": "4Q",
+                "currentQuarterEstimateYear": 2020,
+                "earningsDate": [
+                  1614124800
+                ]
+              },
+              "financialsChart": {
+                "yearly": [
+                  {
+                    "date": 2016,
+                    "revenue": 1319398000,
+                    "earnings": 118302000
+                  },
+                  {
+                    "date": 2017,
+                    "revenue": 1359074000,
+                    "earnings": 273816000
+                  },
+                  {
+                    "date": 2018,
+                    "revenue": 1463707000,
+                    "earnings": 275996000
+                  },
+                  {
+                    "date": 2019,
+                    "revenue": 1487583000,
+                    "earnings": 179065000
+                  }
+                ],
+                "quarterly": [
+                  {
+                    "date": "4Q2019",
+                    "revenue": 261000000,
+                    "earnings": -11155000
+                  },
+                  {
+                    "date": "1Q2020",
+                    "revenue": 102503000,
+                    "earnings": -84546000
+                  },
+                  {
+                    "date": "2Q2020",
+                    "revenue": 19143000,
+                    "earnings": -136894000
+                  },
+                  {
+                    "date": "3Q2020",
+                    "revenue": 126327000,
+                    "earnings": -116172000
+                  }
+                ]
+              },
+              "financialCurrency": "USD"
+            },
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 40.04,
+              "targetHighPrice": 50,
+              "targetLowPrice": 17,
+              "targetMeanPrice": 32.91,
+              "targetMedianPrice": 32,
+              "recommendationMean": 2.2,
+              "recommendationKey": "buy",
+              "numberOfAnalystOpinions": 11,
+              "totalCash": 214651008,
+              "totalCashPerShare": 2.526,
+              "ebitda": -99240000,
+              "totalDebt": 2856513024,
+              "quickRatio": 0.614,
+              "currentRatio": 0.891,
+              "totalRevenue": 508972992,
+              "revenuePerShare": 6.01,
+              "returnOnAssets": -0.04615,
+              "grossProfits": 787282000,
+              "freeCashflow": -58257500,
+              "operatingCashflow": -84256000,
+              "revenueGrowth": -0.797,
+              "grossMargins": 0.18232,
+              "ebitdaMargins": -0.19498,
+              "operatingMargins": -0.42698002,
+              "profitMargins": -0.68524003,
+              "financialCurrency": "USD"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-all-WSKT.JK.json
+++ b/tests/http/quoteSummary-all-WSKT.JK.json
@@ -1,0 +1,3709 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=assetProfile%2CbalanceSheetHistory%2CbalanceSheetHistoryQuarterly%2CcalendarEvents%2CcashflowStatementHistory%2CcashflowStatementHistoryQuarterly%2CdefaultKeyStatistics%2Cearnings%2CearningsHistory%2CearningsTrend%2CfinancialData%2CfundOwnership%2CfundPerformance%2CfundProfile%2CincomeStatementHistory%2CincomeStatementHistoryQuarterly%2CindexTrend%2CindustryTrend%2CinsiderHolders%2CinsiderTransactions%2CinstitutionOwnership%2CmajorDirectHolders%2CmajorHoldersBreakdown%2CnetSharePurchaseActivity%2Cprice%2CquoteType%2CrecommendationTrend%2CsecFilings%2CsectorTrend%2CsummaryDetail%2CsummaryProfile%2CtopHoldings%2CupgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "74usdbpg2nuhf"
+      ],
+      "x-yahoo-request-id": [
+        "74usdbpg2nuhf"
+      ],
+      "x-request-id": [
+        "2172ec9b-7440-466f-bc49-4d346fb1f961"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "10"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:31 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "Gedung Waskita",
+              "address2": "Jl. MT Haryono Kav. No.10 Cawang",
+              "city": "Jakarta",
+              "zip": "13340",
+              "country": "Indonesia",
+              "phone": "62 21 850 8510",
+              "fax": "62 21 850 8506",
+              "website": "http://www.waskita.co.id",
+              "industry": "Engineering & Construction",
+              "sector": "Industrials",
+              "longBusinessSummary": "PT Waskita Karya (Persero) Tbk, together with its subsidiaries, engages in the engineering, procurement, and construction works in Indonesia. It constructs building projects, transportation facilities, and water resources and energy projects; invests in various toll roads; and operates realty projects. The company is also involved in the hotel management business; building and equipment rental business; and production of precast concrete. In addition, it operates as an independent power producer; and develops real estate properties. PT Waskita Karya (Persero) Tbk was founded in 1961 and is headquartered in Jakarta, Indonesia.",
+              "fullTimeEmployees": 2333,
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Engineer Destiawan  Soewardjono M.M., MM, MBA",
+                  "age": 59,
+                  "title": "Pres Director",
+                  "yearBorn": 1961,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Taufik Hendra Kusuma",
+                  "title": "Director of Fin. & Director",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Y. Ariandi Siregar SE",
+                  "age": 51,
+                  "title": "Gen. Mang. of Accounting & Tax",
+                  "yearBorn": 1969,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Inggir Elerida Lumban Toruan",
+                  "age": 49,
+                  "title": "Sr. VP of Accounting Division",
+                  "yearBorn": 1971,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Novianto Ari Nugroho",
+                  "age": 54,
+                  "title": "Sr. VP of Legal Division",
+                  "yearBorn": 1966,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Adi  Sutrisno",
+                  "age": 54,
+                  "title": "Sr. VP of Marketing Division",
+                  "yearBorn": 1966,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Engineer Hadjar Seti Adji MEng Sc IPU",
+                  "age": 55,
+                  "title": "Director of Human Capital Management & System Devel. and Director",
+                  "yearBorn": 1965,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Didit Oemar Prihadi Ir. & MM",
+                  "age": 60,
+                  "title": "Director of Operation I & Director",
+                  "yearBorn": 1960,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Pius Sutrisno Riyanto",
+                  "age": 57,
+                  "title": "Sr. VP of Internal Audit",
+                  "yearBorn": 1963,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Jonni  Hutahaen SE & MM",
+                  "age": 59,
+                  "title": "Head of Internal Audit",
+                  "yearBorn": 1961,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 6,
+                  "buy": 6,
+                  "hold": 3,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 6,
+                  "buy": 6,
+                  "hold": 4,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 6,
+                  "buy": 7,
+                  "hold": 3,
+                  "sell": 0,
+                  "strongSell": 0
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 938142364887,
+                    "fmt": "938.14B",
+                    "longFmt": "938,142,364,887"
+                  },
+                  "depreciation": {
+                    "raw": 717909241157,
+                    "fmt": "717.91B",
+                    "longFmt": "717,909,241,157"
+                  },
+                  "changeToNetincome": {
+                    "raw": 7358197834018,
+                    "fmt": "7.36T",
+                    "longFmt": "7,358,197,834,018"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 9014249440062,
+                    "fmt": "9.01T",
+                    "longFmt": "9,014,249,440,062"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -2742933949138,
+                    "fmt": "-2.74T",
+                    "longFmt": "-2,742,933,949,138"
+                  },
+                  "investments": {
+                    "raw": -1659684950790,
+                    "fmt": "-1.66T",
+                    "longFmt": "-1,659,684,950,790"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -32298146709,
+                    "fmt": "-32.3B",
+                    "longFmt": "-32,298,146,709"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -14924743305937,
+                    "fmt": "-14.92T",
+                    "longFmt": "-14,924,743,305,937"
+                  },
+                  "dividendsPaid": {
+                    "raw": -990709745083,
+                    "fmt": "-990.71B",
+                    "longFmt": "-990,709,745,083"
+                  },
+                  "netBorrowings": {
+                    "raw": 7782081216482,
+                    "fmt": "7.78T",
+                    "longFmt": "7,782,081,216,482"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -2456427184926,
+                    "fmt": "-2.46T",
+                    "longFmt": "-2,456,427,184,926"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 4334944286473,
+                    "fmt": "4.33T",
+                    "longFmt": "4,334,944,286,473"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -11818609407,
+                    "fmt": "-11.82B",
+                    "longFmt": "-11,818,609,407"
+                  },
+                  "changeInCash": {
+                    "raw": -1587368188809,
+                    "fmt": "-1.59T",
+                    "longFmt": "-1,587,368,188,809"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 3962838031865,
+                    "fmt": "3.96T",
+                    "longFmt": "3,962,838,031,865"
+                  },
+                  "depreciation": {
+                    "raw": 647085215580,
+                    "fmt": "647.09B",
+                    "longFmt": "647,085,215,580"
+                  },
+                  "changeToNetincome": {
+                    "raw": -598383168871,
+                    "fmt": "-598.38B",
+                    "longFmt": "-598,383,168,871"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 4011540078574,
+                    "fmt": "4.01T",
+                    "longFmt": "4,011,540,078,574"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -2962349807081,
+                    "fmt": "-2.96T",
+                    "longFmt": "-2,962,349,807,081"
+                  },
+                  "investments": {
+                    "raw": -4119777610204,
+                    "fmt": "-4.12T",
+                    "longFmt": "-4,119,777,610,204"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 698558079882,
+                    "fmt": "698.56B",
+                    "longFmt": "698,558,079,882"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -18768151650463,
+                    "fmt": "-18.77T",
+                    "longFmt": "-18,768,151,650,463"
+                  },
+                  "dividendsPaid": {
+                    "raw": -776342383468,
+                    "fmt": "-776.34B",
+                    "longFmt": "-776,342,383,468"
+                  },
+                  "netBorrowings": {
+                    "raw": 19973053792889,
+                    "fmt": "19.97T",
+                    "longFmt": "19,973,053,792,889"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 494371440036,
+                    "fmt": "494.37B",
+                    "longFmt": "494,371,440,036"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 19691082849457,
+                    "fmt": "19.69T",
+                    "longFmt": "19,691,082,849,457"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 11113410916,
+                    "fmt": "11.11B",
+                    "longFmt": "11,113,410,916"
+                  },
+                  "changeInCash": {
+                    "raw": 4756715630454,
+                    "fmt": "4.76T",
+                    "longFmt": "4,756,715,630,454"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 3881711917338,
+                    "fmt": "3.88T",
+                    "longFmt": "3,881,711,917,338"
+                  },
+                  "depreciation": {
+                    "raw": 600374669280,
+                    "fmt": "600.37B",
+                    "longFmt": "600,374,669,280"
+                  },
+                  "changeToNetincome": {
+                    "raw": -10441649022077,
+                    "fmt": "-10.44T",
+                    "longFmt": "-10,441,649,022,077"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -5959562435459,
+                    "fmt": "-5.96T",
+                    "longFmt": "-5,959,562,435,459"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -2434808757933,
+                    "fmt": "-2.43T",
+                    "longFmt": "-2,434,808,757,933"
+                  },
+                  "investments": {
+                    "raw": 1534441645590,
+                    "fmt": "1.53T",
+                    "longFmt": "1,534,441,645,590"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 698558079882,
+                    "fmt": "698.56B",
+                    "longFmt": "698,558,079,882"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -19238718205754,
+                    "fmt": "-19.24T",
+                    "longFmt": "-19,238,718,205,754"
+                  },
+                  "dividendsPaid": {
+                    "raw": -513978185018,
+                    "fmt": "-513.98B",
+                    "longFmt": "-513,978,185,018"
+                  },
+                  "netBorrowings": {
+                    "raw": 18512110501373,
+                    "fmt": "18.51T",
+                    "longFmt": "18,512,110,501,373"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 3212308760319,
+                    "fmt": "3.21T",
+                    "longFmt": "3,212,308,760,319"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 20630919145126,
+                    "fmt": "20.63T",
+                    "longFmt": "20,630,919,145,126"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 327579903,
+                    "fmt": "327.58M",
+                    "longFmt": "327,579,903"
+                  },
+                  "changeInCash": {
+                    "raw": -4567033916184,
+                    "fmt": "-4.57T",
+                    "longFmt": "-4,567,033,916,184"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -579682828561,
+                    "fmt": "-579.68B",
+                    "longFmt": "-579,682,828,561"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 160897013,
+                    "fmt": "160.9M",
+                    "longFmt": "160,897,013"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 1713260616725,
+                    "fmt": "1.71T",
+                    "longFmt": "1,713,260,616,725"
+                  },
+                  "depreciation": {
+                    "raw": 251144952664,
+                    "fmt": "251.14B",
+                    "longFmt": "251,144,952,664"
+                  },
+                  "changeToNetincome": {
+                    "raw": -9726819344592,
+                    "fmt": "-9.73T",
+                    "longFmt": "-9,726,819,344,592"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -7762413775203,
+                    "fmt": "-7.76T",
+                    "longFmt": "-7,762,413,775,203"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -611419778706,
+                    "fmt": "-611.42B",
+                    "longFmt": "-611,419,778,706"
+                  },
+                  "investments": {
+                    "raw": -3467889128716,
+                    "fmt": "-3.47T",
+                    "longFmt": "-3,467,889,128,716"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 100000000000,
+                    "fmt": "100B",
+                    "longFmt": "100,000,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -9552720853199,
+                    "fmt": "-9.55T",
+                    "longFmt": "-9,552,720,853,199"
+                  },
+                  "dividendsPaid": {
+                    "raw": -209547624362,
+                    "fmt": "-209.55B",
+                    "longFmt": "-209,547,624,362"
+                  },
+                  "netBorrowings": {
+                    "raw": 17227212829448,
+                    "fmt": "17.23T",
+                    "longFmt": "17,227,212,829,448"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 5440911757064,
+                    "fmt": "5.44T",
+                    "longFmt": "5,440,911,757,064"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 22459333440495,
+                    "fmt": "22.46T",
+                    "longFmt": "22,459,333,440,495"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 609611060,
+                    "fmt": "609.61M",
+                    "longFmt": "609,611,060"
+                  },
+                  "changeInCash": {
+                    "raw": 5144808423153,
+                    "fmt": "5.14T",
+                    "longFmt": "5,144,808,423,153"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -579682828561,
+                    "fmt": "-579.68B",
+                    "longFmt": "-579,682,828,561"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 756478345,
+                    "fmt": "756.48M",
+                    "longFmt": "756,478,345"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 6.26429,
+              "pegRatio": 0.655216,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.258
+                },
+                {
+                  "period": "+1q",
+                  "growth": 0.97400004
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.144
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.158
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0820068
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            },
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": 100142262779904,
+              "profitMargins": -0.13495,
+              "floatShares": 4608627844,
+              "sharesOutstanding": 13573900288,
+              "heldPercentInsiders": 0.71228,
+              "heldPercentInstitutions": 0.108,
+              "beta": 2.181707,
+              "category": null,
+              "bookValue": 983.154,
+              "priceToBook": 1.6325011,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1577750400,
+              "nextFiscalYearEnd": 1640908800,
+              "mostRecentQuarter": 1601424000,
+              "netIncomeToCommon": -2849158987776,
+              "trailingEps": -209.899,
+              "forwardEps": 234.26,
+              "lastSplitFactor": null,
+              "enterpriseToRevenue": 4.743,
+              "enterpriseToEbitda": 90.033,
+              "52WeekChange": 0.37610614,
+              "SandP52WeekChange": 0.1675049,
+              "lastDividendValue": 3.4557,
+              "lastDividendDate": 1592265600
+            },
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "quoteType": {
+              "exchange": "JKT",
+              "quoteType": "EQUITY",
+              "symbol": "WSKT.JK",
+              "underlyingSymbol": "WSKT.JK",
+              "shortName": "Waskita Karya (Persero) Tbk.",
+              "longName": "PT Waskita Karya (Persero) Tbk",
+              "firstTradeDateEpochUtc": 1355882400,
+              "timeZoneFullName": "Asia/Jakarta",
+              "timeZoneShortName": "WIB",
+              "uuid": "e93eb405-3e83-3735-8abd-6a04213faba8",
+              "messageBoardId": "finmb_32989878",
+              "gmtOffSetMilliseconds": 25200000,
+              "maxAge": 1
+            },
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 31387389629869,
+                    "fmt": "31.39T",
+                    "longFmt": "31,387,389,629,869"
+                  },
+                  "costOfRevenue": {
+                    "raw": 25782746866464,
+                    "fmt": "25.78T",
+                    "longFmt": "25,782,746,866,464"
+                  },
+                  "grossProfit": {
+                    "raw": 5604642763405,
+                    "fmt": "5.6T",
+                    "longFmt": "5,604,642,763,405"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 1371547283663,
+                    "fmt": "1.37T",
+                    "longFmt": "1,371,547,283,663"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 197802480370,
+                    "fmt": "197.8B",
+                    "longFmt": "197,802,480,370"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 27352096630497,
+                    "fmt": "27.35T",
+                    "longFmt": "27,352,096,630,497"
+                  },
+                  "operatingIncome": {
+                    "raw": 4035292999372,
+                    "fmt": "4.04T",
+                    "longFmt": "4,035,292,999,372"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -2000225656219,
+                    "fmt": "-2T",
+                    "longFmt": "-2,000,225,656,219"
+                  },
+                  "ebit": {
+                    "raw": 4035292999372,
+                    "fmt": "4.04T",
+                    "longFmt": "4,035,292,999,372"
+                  },
+                  "interestExpense": {
+                    "raw": -3620533969507,
+                    "fmt": "-3.62T",
+                    "longFmt": "-3,620,533,969,507"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 2035067343153,
+                    "fmt": "2.04T",
+                    "longFmt": "2,035,067,343,153"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 1006168975262,
+                    "fmt": "1.01T",
+                    "longFmt": "1,006,168,975,262"
+                  },
+                  "minorityInterest": {
+                    "raw": 11236061197428,
+                    "fmt": "11.24T",
+                    "longFmt": "11,236,061,197,428"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 1028898367891,
+                    "fmt": "1.03T",
+                    "longFmt": "1,028,898,367,891"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 938142364887,
+                    "fmt": "938.14B",
+                    "longFmt": "938,142,364,887"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 938142364887,
+                    "fmt": "938.14B",
+                    "longFmt": "938,142,364,887"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 48788950838822,
+                    "fmt": "48.79T",
+                    "longFmt": "48,788,950,838,822"
+                  },
+                  "costOfRevenue": {
+                    "raw": 39926332089924,
+                    "fmt": "39.93T",
+                    "longFmt": "39,926,332,089,924"
+                  },
+                  "grossProfit": {
+                    "raw": 8862618748898,
+                    "fmt": "8.86T",
+                    "longFmt": "8,862,618,748,898"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 1667745969535,
+                    "fmt": "1.67T",
+                    "longFmt": "1,667,745,969,535"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 423475576187,
+                    "fmt": "423.48B",
+                    "longFmt": "423,475,576,187"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 42017553635646,
+                    "fmt": "42.02T",
+                    "longFmt": "42,017,553,635,646"
+                  },
+                  "operatingIncome": {
+                    "raw": 6771397203176,
+                    "fmt": "6.77T",
+                    "longFmt": "6,771,397,203,176"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 254560670874,
+                    "fmt": "254.56B",
+                    "longFmt": "254,560,670,874"
+                  },
+                  "ebit": {
+                    "raw": 6771397203176,
+                    "fmt": "6.77T",
+                    "longFmt": "6,771,397,203,176"
+                  },
+                  "interestExpense": {
+                    "raw": -2459241670378,
+                    "fmt": "-2.46T",
+                    "longFmt": "-2,459,241,670,378"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 7025957874050,
+                    "fmt": "7.03T",
+                    "longFmt": "7,025,957,874,050"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 2406390168497,
+                    "fmt": "2.41T",
+                    "longFmt": "2,406,390,168,497"
+                  },
+                  "minorityInterest": {
+                    "raw": 10886002685490,
+                    "fmt": "10.89T",
+                    "longFmt": "10,886,002,685,490"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 4619567705553,
+                    "fmt": "4.62T",
+                    "longFmt": "4,619,567,705,553"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 3962838031865,
+                    "fmt": "3.96T",
+                    "longFmt": "3,962,838,031,865"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 3962838031865,
+                    "fmt": "3.96T",
+                    "longFmt": "3,962,838,031,865"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 45212897632604,
+                    "fmt": "45.21T",
+                    "longFmt": "45,212,897,632,604"
+                  },
+                  "costOfRevenue": {
+                    "raw": 35749365206806,
+                    "fmt": "35.75T",
+                    "longFmt": "35,749,365,206,806"
+                  },
+                  "grossProfit": {
+                    "raw": 9463532425798,
+                    "fmt": "9.46T",
+                    "longFmt": "9,463,532,425,798"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 2103899171263,
+                    "fmt": "2.1T",
+                    "longFmt": "2,103,899,171,263"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 170448268152,
+                    "fmt": "170.45B",
+                    "longFmt": "170,448,268,152"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 38023712646221,
+                    "fmt": "38.02T",
+                    "longFmt": "38,023,712,646,221"
+                  },
+                  "operatingIncome": {
+                    "raw": 7189184986383,
+                    "fmt": "7.19T",
+                    "longFmt": "7,189,184,986,383"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -1133897951258,
+                    "fmt": "-1.13T",
+                    "longFmt": "-1,133,897,951,258"
+                  },
+                  "ebit": {
+                    "raw": 7189184986383,
+                    "fmt": "7.19T",
+                    "longFmt": "7,189,184,986,383"
+                  },
+                  "interestExpense": {
+                    "raw": -1932084162136,
+                    "fmt": "-1.93T",
+                    "longFmt": "-1,932,084,162,136"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 6055287035125,
+                    "fmt": "6.06T",
+                    "longFmt": "6,055,287,035,125"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 1853714544371,
+                    "fmt": "1.85T",
+                    "longFmt": "1,853,714,544,371"
+                  },
+                  "minorityInterest": {
+                    "raw": 8748386520139,
+                    "fmt": "8.75T",
+                    "longFmt": "8,748,386,520,139"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 4201572490754,
+                    "fmt": "4.2T",
+                    "longFmt": "4,201,572,490,754"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 3881711917338,
+                    "fmt": "3.88T",
+                    "longFmt": "3,881,711,917,338"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 3881711917338,
+                    "fmt": "3.88T",
+                    "longFmt": "3,881,711,917,338"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 23788322626347,
+                    "fmt": "23.79T",
+                    "longFmt": "23,788,322,626,347"
+                  },
+                  "costOfRevenue": {
+                    "raw": 19820484367904,
+                    "fmt": "19.82T",
+                    "longFmt": "19,820,484,367,904"
+                  },
+                  "grossProfit": {
+                    "raw": 3967838258443,
+                    "fmt": "3.97T",
+                    "longFmt": "3,967,838,258,443"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 788282594058,
+                    "fmt": "788.28B",
+                    "longFmt": "788,282,594,058"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 43695297650,
+                    "fmt": "43.7B",
+                    "longFmt": "43,695,297,650"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 20652462259612,
+                    "fmt": "20.65T",
+                    "longFmt": "20,652,462,259,612"
+                  },
+                  "operatingIncome": {
+                    "raw": 3135860366735,
+                    "fmt": "3.14T",
+                    "longFmt": "3,135,860,366,735"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -655966823303,
+                    "fmt": "-655.97B",
+                    "longFmt": "-655,966,823,303"
+                  },
+                  "ebit": {
+                    "raw": 3135860366735,
+                    "fmt": "3.14T",
+                    "longFmt": "3,135,860,366,735"
+                  },
+                  "interestExpense": {
+                    "raw": -982835623286,
+                    "fmt": "-982.84B",
+                    "longFmt": "-982,835,623,286"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 2479893543432,
+                    "fmt": "2.48T",
+                    "longFmt": "2,479,893,543,432"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 666824926648,
+                    "fmt": "666.82B",
+                    "longFmt": "666,824,926,648"
+                  },
+                  "minorityInterest": {
+                    "raw": 5703665307835,
+                    "fmt": "5.7T",
+                    "longFmt": "5,703,665,307,835"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 1813068616784,
+                    "fmt": "1.81T",
+                    "longFmt": "1,813,068,616,784"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 1713260616725,
+                    "fmt": "1.71T",
+                    "longFmt": "1,713,260,616,725"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 1713260616725,
+                    "fmt": "1.71T",
+                    "longFmt": "1,713,260,616,725"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            },
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 1610,
+              "open": 1625,
+              "dayLow": 1590,
+              "dayHigh": 1660,
+              "regularMarketPreviousClose": 1610,
+              "regularMarketOpen": 1625,
+              "regularMarketDayLow": 1590,
+              "regularMarketDayHigh": 1660,
+              "dividendRate": 3.46,
+              "dividendYield": 0.0021,
+              "exDividendDate": 1592265600,
+              "fiveYearAvgDividendYield": 2.67,
+              "beta": 2.181707,
+              "forwardPE": 6.8513618,
+              "volume": 228998200,
+              "regularMarketVolume": 228998200,
+              "averageVolume": 269827553,
+              "averageVolume10days": 198514460,
+              "averageDailyVolume10Day": 198514460,
+              "bid": 1605,
+              "ask": 1610,
+              "bidSize": 0,
+              "askSize": 0,
+              "marketCap": 21786110459904,
+              "fiftyTwoWeekLow": 394,
+              "fiftyTwoWeekHigh": 2080,
+              "priceToSalesTrailing12Months": 1.0318944,
+              "fiftyDayAverage": 1595.1562,
+              "twoHundredDayAverage": 980.8309,
+              "currency": "IDR",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            },
+            "insiderHolders": {
+              "holders": [],
+              "maxAge": 1
+            },
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": []
+              },
+              "exDividendDate": 1592265600
+            },
+            "price": {
+              "maxAge": 1,
+              "regularMarketChangePercent": -0.0031055901,
+              "regularMarketChange": -5,
+              "regularMarketTime": 1613463295,
+              "priceHint": 2,
+              "regularMarketPrice": 1605,
+              "regularMarketDayHigh": 1660,
+              "regularMarketDayLow": 1590,
+              "regularMarketVolume": 228998200,
+              "averageDailyVolume10Day": 198514460,
+              "averageDailyVolume3Month": 269827553,
+              "regularMarketPreviousClose": 1610,
+              "regularMarketSource": "DELAYED",
+              "regularMarketOpen": 1625,
+              "exchange": "JKT",
+              "exchangeName": "Jakarta",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "PREPRE",
+              "quoteType": "EQUITY",
+              "symbol": "WSKT.JK",
+              "underlyingSymbol": null,
+              "shortName": "Waskita Karya (Persero) Tbk.",
+              "longName": "PT Waskita Karya (Persero) Tbk",
+              "currency": "IDR",
+              "quoteSourceName": "Delayed Quote",
+              "currencySymbol": "Rp",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 21786110459904
+            },
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 9258310028392,
+                    "fmt": "9.26T",
+                    "longFmt": "9,258,310,028,392"
+                  },
+                  "netReceivables": {
+                    "raw": 31735705540115,
+                    "fmt": "31.74T",
+                    "longFmt": "31,735,705,540,115"
+                  },
+                  "inventory": {
+                    "raw": 4470845549423,
+                    "fmt": "4.47T",
+                    "longFmt": "4,470,845,549,423"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 3395288657104,
+                    "fmt": "3.4T",
+                    "longFmt": "3,395,288,657,104"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 49037842886120,
+                    "fmt": "49.04T",
+                    "longFmt": "49,037,842,886,120"
+                  },
+                  "longTermInvestments": {
+                    "raw": 5831251114741,
+                    "fmt": "5.83T",
+                    "longFmt": "5,831,251,114,741"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 8663216063821,
+                    "fmt": "8.66T",
+                    "longFmt": "8,663,216,063,821"
+                  },
+                  "goodWill": {
+                    "raw": 1995908825753,
+                    "fmt": "2T",
+                    "longFmt": "1,995,908,825,753"
+                  },
+                  "intangibleAssets": {
+                    "raw": 55407004501205,
+                    "fmt": "55.41T",
+                    "longFmt": "55,407,004,501,205"
+                  },
+                  "otherAssets": {
+                    "raw": 1654035958931,
+                    "fmt": "1.65T",
+                    "longFmt": "1,654,035,958,931"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 1542424572,
+                    "fmt": "1.54B",
+                    "longFmt": "1,542,424,572"
+                  },
+                  "totalAssets": {
+                    "raw": 122589259350571,
+                    "fmt": "122.59T",
+                    "longFmt": "122,589,259,350,571"
+                  },
+                  "accountsPayable": {
+                    "raw": 11005539197920,
+                    "fmt": "11.01T",
+                    "longFmt": "11,005,539,197,920"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 4098002350931,
+                    "fmt": "4.1T",
+                    "longFmt": "4,098,002,350,931"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 4340597615238,
+                    "fmt": "4.34T",
+                    "longFmt": "4,340,597,615,238"
+                  },
+                  "longTermDebt": {
+                    "raw": 43894161654013,
+                    "fmt": "43.89T",
+                    "longFmt": "43,894,161,654,013"
+                  },
+                  "otherLiab": {
+                    "raw": 4553133367976,
+                    "fmt": "4.55T",
+                    "longFmt": "4,553,133,367,976"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 754641393913,
+                    "fmt": "754.64B",
+                    "longFmt": "754,641,393,913"
+                  },
+                  "minorityInterest": {
+                    "raw": 11236061197428,
+                    "fmt": "11.24T",
+                    "longFmt": "11,236,061,197,428"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 45023495139583,
+                    "fmt": "45.02T",
+                    "longFmt": "45,023,495,139,583"
+                  },
+                  "totalLiab": {
+                    "raw": 93470790161572,
+                    "fmt": "93.47T",
+                    "longFmt": "93,470,790,161,572"
+                  },
+                  "commonStock": {
+                    "raw": 1357390259999,
+                    "fmt": "1.36T",
+                    "longFmt": "1,357,390,259,999"
+                  },
+                  "retainedEarnings": {
+                    "raw": 10233409821327,
+                    "fmt": "10.23T",
+                    "longFmt": "10,233,409,821,327"
+                  },
+                  "treasuryStock": {
+                    "raw": 739581647808,
+                    "fmt": "739.58B",
+                    "longFmt": "739,581,647,808"
+                  },
+                  "capitalSurplus": {
+                    "raw": 5552026262437,
+                    "fmt": "5.55T",
+                    "longFmt": "5,552,026,262,437"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 739581647808,
+                    "fmt": "739.58B",
+                    "longFmt": "739,581,647,808"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 17882407991571,
+                    "fmt": "17.88T",
+                    "longFmt": "17,882,407,991,571"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -39520505335387,
+                    "fmt": "-39.52T",
+                    "longFmt": "-39,520,505,335,387"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "cash": {
+                    "raw": 10845678217201,
+                    "fmt": "10.85T",
+                    "longFmt": "10,845,678,217,201"
+                  },
+                  "netReceivables": {
+                    "raw": 47464287061607,
+                    "fmt": "47.46T",
+                    "longFmt": "47,464,287,061,607"
+                  },
+                  "inventory": {
+                    "raw": 5089231071244,
+                    "fmt": "5.09T",
+                    "longFmt": "5,089,231,071,244"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 3526907204627,
+                    "fmt": "3.53T",
+                    "longFmt": "3,526,907,204,627"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 66989129822191,
+                    "fmt": "66.99T",
+                    "longFmt": "66,989,129,822,191"
+                  },
+                  "longTermInvestments": {
+                    "raw": 6999294170541,
+                    "fmt": "7T",
+                    "longFmt": "6,999,294,170,541"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 7091121159643,
+                    "fmt": "7.09T",
+                    "longFmt": "7,091,121,159,643"
+                  },
+                  "goodWill": {
+                    "raw": 1995908825753,
+                    "fmt": "2T",
+                    "longFmt": "1,995,908,825,753"
+                  },
+                  "intangibleAssets": {
+                    "raw": 40279389428306,
+                    "fmt": "40.28T",
+                    "longFmt": "40,279,389,428,306"
+                  },
+                  "otherAssets": {
+                    "raw": 1036738217202,
+                    "fmt": "1.04T",
+                    "longFmt": "1,036,738,217,202"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 1557248071,
+                    "fmt": "1.56B",
+                    "longFmt": "1,557,248,071"
+                  },
+                  "totalAssets": {
+                    "raw": 124391581623636,
+                    "fmt": "124.39T",
+                    "longFmt": "124,391,581,623,636"
+                  },
+                  "accountsPayable": {
+                    "raw": 13992926025275,
+                    "fmt": "13.99T",
+                    "longFmt": "13,992,926,025,275"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2415988819622,
+                    "fmt": "2.42T",
+                    "longFmt": "2,415,988,819,622"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 8473013438526,
+                    "fmt": "8.47T",
+                    "longFmt": "8,473,013,438,526"
+                  },
+                  "longTermDebt": {
+                    "raw": 33063410723347,
+                    "fmt": "33.06T",
+                    "longFmt": "33,063,410,723,347"
+                  },
+                  "otherLiab": {
+                    "raw": 5641327050079,
+                    "fmt": "5.64T",
+                    "longFmt": "5,641,327,050,079"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 391791699443,
+                    "fmt": "391.79B",
+                    "longFmt": "391,791,699,443"
+                  },
+                  "minorityInterest": {
+                    "raw": 10886002685490,
+                    "fmt": "10.89T",
+                    "longFmt": "10,886,002,685,490"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 56799725099343,
+                    "fmt": "56.8T",
+                    "longFmt": "56,799,725,099,343"
+                  },
+                  "totalLiab": {
+                    "raw": 95504462872769,
+                    "fmt": "95.5T",
+                    "longFmt": "95,504,462,872,769"
+                  },
+                  "commonStock": {
+                    "raw": 1357390259999,
+                    "fmt": "1.36T",
+                    "longFmt": "1,357,390,259,999"
+                  },
+                  "retainedEarnings": {
+                    "raw": 10347404260305,
+                    "fmt": "10.35T",
+                    "longFmt": "10,347,404,260,305"
+                  },
+                  "treasuryStock": {
+                    "raw": 744295282636,
+                    "fmt": "744.3B",
+                    "longFmt": "744,295,282,636"
+                  },
+                  "capitalSurplus": {
+                    "raw": 5552026262437,
+                    "fmt": "5.55T",
+                    "longFmt": "5,552,026,262,437"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 744295282636,
+                    "fmt": "744.3B",
+                    "longFmt": "744,295,282,636"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 18001116065377,
+                    "fmt": "18T",
+                    "longFmt": "18,001,116,065,377"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -24274182188682,
+                    "fmt": "-24.27T",
+                    "longFmt": "-24,274,182,188,682"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "cash": {
+                    "raw": 6088962586747,
+                    "fmt": "6.09T",
+                    "longFmt": "6,088,962,586,747"
+                  },
+                  "netReceivables": {
+                    "raw": 39408619945371,
+                    "fmt": "39.41T",
+                    "longFmt": "39,408,619,945,371"
+                  },
+                  "inventory": {
+                    "raw": 3235500802811,
+                    "fmt": "3.24T",
+                    "longFmt": "3,235,500,802,811"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 3385713793217,
+                    "fmt": "3.39T",
+                    "longFmt": "3,385,713,793,217"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 52427017359620,
+                    "fmt": "52.43T",
+                    "longFmt": "52,427,017,359,620"
+                  },
+                  "longTermInvestments": {
+                    "raw": 3736960384503,
+                    "fmt": "3.74T",
+                    "longFmt": "3,736,960,384,503"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 4742288130361,
+                    "fmt": "4.74T",
+                    "longFmt": "4,742,288,130,361"
+                  },
+                  "goodWill": {
+                    "raw": 2235779910646,
+                    "fmt": "2.24T",
+                    "longFmt": "2,235,779,910,646"
+                  },
+                  "intangibleAssets": {
+                    "raw": 33952839928823,
+                    "fmt": "33.95T",
+                    "longFmt": "33,952,839,928,823"
+                  },
+                  "otherAssets": {
+                    "raw": 800875124671,
+                    "fmt": "800.88B",
+                    "longFmt": "800,875,124,671"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 43924035581,
+                    "fmt": "43.92B",
+                    "longFmt": "43,924,035,581"
+                  },
+                  "totalAssets": {
+                    "raw": 97895760838624,
+                    "fmt": "97.9T",
+                    "longFmt": "97,895,760,838,624"
+                  },
+                  "accountsPayable": {
+                    "raw": 13302261188858,
+                    "fmt": "13.3T",
+                    "longFmt": "13,302,261,188,858"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 5629492556,
+                    "fmt": "5.63B",
+                    "longFmt": "5,629,492,556"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 10459520855433,
+                    "fmt": "10.46T",
+                    "longFmt": "10,459,520,855,433"
+                  },
+                  "longTermDebt": {
+                    "raw": 18015354771288,
+                    "fmt": "18.02T",
+                    "longFmt": "18,015,354,771,288"
+                  },
+                  "otherLiab": {
+                    "raw": 4816383399778,
+                    "fmt": "4.82T",
+                    "longFmt": "4,816,383,399,778"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 82881610012,
+                    "fmt": "82.88B",
+                    "longFmt": "82,881,610,012"
+                  },
+                  "minorityInterest": {
+                    "raw": 8748386520139,
+                    "fmt": "8.75T",
+                    "longFmt": "8,748,386,520,139"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 52309197858063,
+                    "fmt": "52.31T",
+                    "longFmt": "52,309,197,858,063"
+                  },
+                  "totalLiab": {
+                    "raw": 75140936029129,
+                    "fmt": "75.14T",
+                    "longFmt": "75,140,936,029,129"
+                  },
+                  "commonStock": {
+                    "raw": 1357390259999,
+                    "fmt": "1.36T",
+                    "longFmt": "1,357,390,259,999"
+                  },
+                  "retainedEarnings": {
+                    "raw": 6681081107614,
+                    "fmt": "6.68T",
+                    "longFmt": "6,681,081,107,614"
+                  },
+                  "treasuryStock": {
+                    "raw": 500948439660,
+                    "fmt": "500.95B",
+                    "longFmt": "500,948,439,660"
+                  },
+                  "capitalSurplus": {
+                    "raw": 5467018482083,
+                    "fmt": "5.47T",
+                    "longFmt": "5,467,018,482,083"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 500948439660,
+                    "fmt": "500.95B",
+                    "longFmt": "500,948,439,660"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 14006438289356,
+                    "fmt": "14.01T",
+                    "longFmt": "14,006,438,289,356"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -22182181550113,
+                    "fmt": "-22.18T",
+                    "longFmt": "-22,182,181,550,113"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "cash": {
+                    "raw": 10655996501931,
+                    "fmt": "10.66T",
+                    "longFmt": "10,655,996,501,931"
+                  },
+                  "netReceivables": {
+                    "raw": 22990628619814,
+                    "fmt": "22.99T",
+                    "longFmt": "22,990,628,619,814"
+                  },
+                  "inventory": {
+                    "raw": 2556731823542,
+                    "fmt": "2.56T",
+                    "longFmt": "2,556,731,823,542"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 3270562557214,
+                    "fmt": "3.27T",
+                    "longFmt": "3,270,562,557,214"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 39712575190796,
+                    "fmt": "39.71T",
+                    "longFmt": "39,712,575,190,796"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2619104734761,
+                    "fmt": "2.62T",
+                    "longFmt": "2,619,104,734,761"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 3013846252216,
+                    "fmt": "3.01T",
+                    "longFmt": "3,013,846,252,216"
+                  },
+                  "goodWill": {
+                    "raw": 1710769397469,
+                    "fmt": "1.71T",
+                    "longFmt": "1,710,769,397,469"
+                  },
+                  "intangibleAssets": {
+                    "raw": 11165160066676,
+                    "fmt": "11.17T",
+                    "longFmt": "11,165,160,066,676"
+                  },
+                  "otherAssets": {
+                    "raw": 3211556532529,
+                    "fmt": "3.21T",
+                    "longFmt": "3,211,556,532,529"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 195138147024,
+                    "fmt": "195.14B",
+                    "longFmt": "195,138,147,024"
+                  },
+                  "totalAssets": {
+                    "raw": 61433012174447,
+                    "fmt": "61.43T",
+                    "longFmt": "61,433,012,174,447"
+                  },
+                  "accountsPayable": {
+                    "raw": 6736101006394,
+                    "fmt": "6.74T",
+                    "longFmt": "6,736,101,006,394"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 5616284004,
+                    "fmt": "5.62B",
+                    "longFmt": "5,616,284,004"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 8190647584185,
+                    "fmt": "8.19T",
+                    "longFmt": "8,190,647,584,185"
+                  },
+                  "longTermDebt": {
+                    "raw": 9890719214953,
+                    "fmt": "9.89T",
+                    "longFmt": "9,890,719,214,953"
+                  },
+                  "otherLiab": {
+                    "raw": 3485420602242,
+                    "fmt": "3.49T",
+                    "longFmt": "3,485,420,602,242"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 39391831786,
+                    "fmt": "39.39B",
+                    "longFmt": "39,391,831,786"
+                  },
+                  "minorityInterest": {
+                    "raw": 5703665307835,
+                    "fmt": "5.7T",
+                    "longFmt": "5,703,665,307,835"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 31283653800304,
+                    "fmt": "31.28T",
+                    "longFmt": "31,283,653,800,304"
+                  },
+                  "totalLiab": {
+                    "raw": 44659793617499,
+                    "fmt": "44.66T",
+                    "longFmt": "44,659,793,617,499"
+                  },
+                  "commonStock": {
+                    "raw": 1357365455000,
+                    "fmt": "1.36T",
+                    "longFmt": "1,357,365,455,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 3334161614252,
+                    "fmt": "3.33T",
+                    "longFmt": "3,334,161,614,252"
+                  },
+                  "treasuryStock": {
+                    "raw": 495349287477,
+                    "fmt": "495.35B",
+                    "longFmt": "495,349,287,477"
+                  },
+                  "capitalSurplus": {
+                    "raw": 5882676892384,
+                    "fmt": "5.88T",
+                    "longFmt": "5,882,676,892,384"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 495349287477,
+                    "fmt": "495.35B",
+                    "longFmt": "495,349,287,477"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 11069553249113,
+                    "fmt": "11.07T",
+                    "longFmt": "11,069,553,249,113"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -1806376215032,
+                    "fmt": "-1.81T",
+                    "longFmt": "-1,806,376,215,032"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": -0.1325,
+                    "fmt": "-13.25%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            },
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            },
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.71228,
+              "institutionsPercentHeld": 0.108,
+              "institutionsFloatPercentHeld": 0.37535,
+              "institutionsCount": 34
+            },
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 1196916435771,
+                    "fmt": "1.2T",
+                    "longFmt": "1,196,916,435,771"
+                  },
+                  "netReceivables": {
+                    "raw": 26928085920268,
+                    "fmt": "26.93T",
+                    "longFmt": "26,928,085,920,268"
+                  },
+                  "inventory": {
+                    "raw": 6263183669294,
+                    "fmt": "6.26T",
+                    "longFmt": "6,263,183,669,294"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 2796544135411,
+                    "fmt": "2.8T",
+                    "longFmt": "2,796,544,135,411"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 37537617902373,
+                    "fmt": "37.54T",
+                    "longFmt": "37,537,617,902,373"
+                  },
+                  "longTermInvestments": {
+                    "raw": 5190918736054,
+                    "fmt": "5.19T",
+                    "longFmt": "5,190,918,736,054"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 8628639628135,
+                    "fmt": "8.63T",
+                    "longFmt": "8,628,639,628,135"
+                  },
+                  "goodWill": {
+                    "raw": 1995908825753,
+                    "fmt": "2T",
+                    "longFmt": "1,995,908,825,753"
+                  },
+                  "intangibleAssets": {
+                    "raw": 60902303757246,
+                    "fmt": "60.9T",
+                    "longFmt": "60,902,303,757,246"
+                  },
+                  "otherAssets": {
+                    "raw": 1373033621408,
+                    "fmt": "1.37T",
+                    "longFmt": "1,373,033,621,408"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 1542424572,
+                    "fmt": "1.54B",
+                    "longFmt": "1,542,424,572"
+                  },
+                  "totalAssets": {
+                    "raw": 115628422470969,
+                    "fmt": "115.63T",
+                    "longFmt": "115,628,422,470,969"
+                  },
+                  "accountsPayable": {
+                    "raw": 11465814751576,
+                    "fmt": "11.47T",
+                    "longFmt": "11,465,814,751,576"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 3351983886623,
+                    "fmt": "3.35T",
+                    "longFmt": "3,351,983,886,623"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 2269165024494,
+                    "fmt": "2.27T",
+                    "longFmt": "2,269,165,024,494"
+                  },
+                  "longTermDebt": {
+                    "raw": 47297590750350,
+                    "fmt": "47.3T",
+                    "longFmt": "47,297,590,750,350"
+                  },
+                  "otherLiab": {
+                    "raw": 5696103647600,
+                    "fmt": "5.7T",
+                    "longFmt": "5,696,103,647,600"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 492605345220,
+                    "fmt": "492.61B",
+                    "longFmt": "492,605,345,220"
+                  },
+                  "minorityInterest": {
+                    "raw": 10421911999730,
+                    "fmt": "10.42T",
+                    "longFmt": "10,421,911,999,730"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 38791359723845,
+                    "fmt": "38.79T",
+                    "longFmt": "38,791,359,723,845"
+                  },
+                  "totalLiab": {
+                    "raw": 91861232033380,
+                    "fmt": "91.86T",
+                    "longFmt": "91,861,232,033,380"
+                  },
+                  "commonStock": {
+                    "raw": 1357395099999,
+                    "fmt": "1.36T",
+                    "longFmt": "1,357,395,099,999"
+                  },
+                  "retainedEarnings": {
+                    "raw": 5691130393923,
+                    "fmt": "5.69T",
+                    "longFmt": "5,691,130,393,923"
+                  },
+                  "treasuryStock": {
+                    "raw": 744726681500,
+                    "fmt": "744.73B",
+                    "longFmt": "744,726,681,500"
+                  },
+                  "capitalSurplus": {
+                    "raw": 5552026262437,
+                    "fmt": "5.55T",
+                    "longFmt": "5,552,026,262,437"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 744726681500,
+                    "fmt": "744.73B",
+                    "longFmt": "744,726,681,500"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 13345278437859,
+                    "fmt": "13.35T",
+                    "longFmt": "13,345,278,437,859"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -49552934145140,
+                    "fmt": "-49.55T",
+                    "longFmt": "-49,552,934,145,140"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "cash": {
+                    "raw": 1366299381863,
+                    "fmt": "1.37T",
+                    "longFmt": "1,366,299,381,863"
+                  },
+                  "netReceivables": {
+                    "raw": 26186958985246,
+                    "fmt": "26.19T",
+                    "longFmt": "26,186,958,985,246"
+                  },
+                  "inventory": {
+                    "raw": 6317148827173,
+                    "fmt": "6.32T",
+                    "longFmt": "6,317,148,827,173"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 2591061621433,
+                    "fmt": "2.59T",
+                    "longFmt": "2,591,061,621,433"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 37025926290746,
+                    "fmt": "37.03T",
+                    "longFmt": "37,025,926,290,746"
+                  },
+                  "longTermInvestments": {
+                    "raw": 5263732229721,
+                    "fmt": "5.26T",
+                    "longFmt": "5,263,732,229,721"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 8761422244907,
+                    "fmt": "8.76T",
+                    "longFmt": "8,761,422,244,907"
+                  },
+                  "goodWill": {
+                    "raw": 1995908825753,
+                    "fmt": "2T",
+                    "longFmt": "1,995,908,825,753"
+                  },
+                  "intangibleAssets": {
+                    "raw": 59221238536004,
+                    "fmt": "59.22T",
+                    "longFmt": "59,221,238,536,004"
+                  },
+                  "otherAssets": {
+                    "raw": 1803969074991,
+                    "fmt": "1.8T",
+                    "longFmt": "1,803,969,074,991"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 1542424572,
+                    "fmt": "1.54B",
+                    "longFmt": "1,542,424,572"
+                  },
+                  "totalAssets": {
+                    "raw": 114072197202122,
+                    "fmt": "114.07T",
+                    "longFmt": "114,072,197,202,122"
+                  },
+                  "accountsPayable": {
+                    "raw": 10804444033232,
+                    "fmt": "10.8T",
+                    "longFmt": "10,804,444,033,232"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 3351671053395,
+                    "fmt": "3.35T",
+                    "longFmt": "3,351,671,053,395"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 1694021208195,
+                    "fmt": "1.69T",
+                    "longFmt": "1,694,021,208,195"
+                  },
+                  "longTermDebt": {
+                    "raw": 45152950254070,
+                    "fmt": "45.15T",
+                    "longFmt": "45,152,950,254,070"
+                  },
+                  "otherLiab": {
+                    "raw": 6125619272650,
+                    "fmt": "6.13T",
+                    "longFmt": "6,125,619,272,650"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 897764063758,
+                    "fmt": "897.76B",
+                    "longFmt": "897,764,063,758"
+                  },
+                  "minorityInterest": {
+                    "raw": 10937396959806,
+                    "fmt": "10.94T",
+                    "longFmt": "10,937,396,959,806"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 36897628462130,
+                    "fmt": "36.9T",
+                    "longFmt": "36,897,628,462,130"
+                  },
+                  "totalLiab": {
+                    "raw": 88248305812373,
+                    "fmt": "88.25T",
+                    "longFmt": "88,248,305,812,373"
+                  },
+                  "commonStock": {
+                    "raw": 1357390259999,
+                    "fmt": "1.36T",
+                    "longFmt": "1,357,390,259,999"
+                  },
+                  "retainedEarnings": {
+                    "raw": 7233006294697,
+                    "fmt": "7.23T",
+                    "longFmt": "7,233,006,294,697"
+                  },
+                  "treasuryStock": {
+                    "raw": 744071612810,
+                    "fmt": "744.07B",
+                    "longFmt": "744,071,612,810"
+                  },
+                  "capitalSurplus": {
+                    "raw": 5552026262437,
+                    "fmt": "5.55T",
+                    "longFmt": "5,552,026,262,437"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 744071612810,
+                    "fmt": "744.07B",
+                    "longFmt": "744,071,612,810"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 14886494429943,
+                    "fmt": "14.89T",
+                    "longFmt": "14,886,494,429,943"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -46330652931814,
+                    "fmt": "-46.33T",
+                    "longFmt": "-46,330,652,931,814"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "cash": {
+                    "raw": 6095716333927,
+                    "fmt": "6.1T",
+                    "longFmt": "6,095,716,333,927"
+                  },
+                  "netReceivables": {
+                    "raw": 25496655733611,
+                    "fmt": "25.5T",
+                    "longFmt": "25,496,655,733,611"
+                  },
+                  "inventory": {
+                    "raw": 5906201926405,
+                    "fmt": "5.91T",
+                    "longFmt": "5,906,201,926,405"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 2718232886651,
+                    "fmt": "2.72T",
+                    "longFmt": "2,718,232,886,651"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 40574034824419,
+                    "fmt": "40.57T",
+                    "longFmt": "40,574,034,824,419"
+                  },
+                  "longTermInvestments": {
+                    "raw": 6156475861107,
+                    "fmt": "6.16T",
+                    "longFmt": "6,156,475,861,107"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 8783961962045,
+                    "fmt": "8.78T",
+                    "longFmt": "8,783,961,962,045"
+                  },
+                  "goodWill": {
+                    "raw": 1995908825753,
+                    "fmt": "2T",
+                    "longFmt": "1,995,908,825,753"
+                  },
+                  "intangibleAssets": {
+                    "raw": 57127719260218,
+                    "fmt": "57.13T",
+                    "longFmt": "57,127,719,260,218"
+                  },
+                  "otherAssets": {
+                    "raw": 1727761993991,
+                    "fmt": "1.73T",
+                    "longFmt": "1,727,761,993,991"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 1542424572,
+                    "fmt": "1.54B",
+                    "longFmt": "1,542,424,572"
+                  },
+                  "totalAssets": {
+                    "raw": 116365862727533,
+                    "fmt": "116.37T",
+                    "longFmt": "116,365,862,727,533"
+                  },
+                  "accountsPayable": {
+                    "raw": 11379107135168,
+                    "fmt": "11.38T",
+                    "longFmt": "11,379,107,135,168"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 3351360509549,
+                    "fmt": "3.35T",
+                    "longFmt": "3,351,360,509,549"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 3067343739436,
+                    "fmt": "3.07T",
+                    "longFmt": "3,067,343,739,436"
+                  },
+                  "longTermDebt": {
+                    "raw": 43518251267218,
+                    "fmt": "43.52T",
+                    "longFmt": "43,518,251,267,218"
+                  },
+                  "otherLiab": {
+                    "raw": 5400046297919,
+                    "fmt": "5.4T",
+                    "longFmt": "5,400,046,297,919"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 858452764306,
+                    "fmt": "858.45B",
+                    "longFmt": "858,452,764,306"
+                  },
+                  "minorityInterest": {
+                    "raw": 11203544702256,
+                    "fmt": "11.2T",
+                    "longFmt": "11,203,544,702,256"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 40110874635803,
+                    "fmt": "40.11T",
+                    "longFmt": "40,110,874,635,803"
+                  },
+                  "totalLiab": {
+                    "raw": 89095812601411,
+                    "fmt": "89.1T",
+                    "longFmt": "89,095,812,601,411"
+                  },
+                  "commonStock": {
+                    "raw": 1357390259999,
+                    "fmt": "1.36T",
+                    "longFmt": "1,357,390,259,999"
+                  },
+                  "retainedEarnings": {
+                    "raw": 8417704785780,
+                    "fmt": "8.42T",
+                    "longFmt": "8,417,704,785,780"
+                  },
+                  "treasuryStock": {
+                    "raw": 739384115650,
+                    "fmt": "739.38B",
+                    "longFmt": "739,384,115,650"
+                  },
+                  "capitalSurplus": {
+                    "raw": 5552026262437,
+                    "fmt": "5.55T",
+                    "longFmt": "5,552,026,262,437"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 739384115650,
+                    "fmt": "739.38B",
+                    "longFmt": "739,384,115,650"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 16066505423866,
+                    "fmt": "16.07T",
+                    "longFmt": "16,066,505,423,866"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -43057122662105,
+                    "fmt": "-43.06T",
+                    "longFmt": "-43,057,122,662,105"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 9258310028392,
+                    "fmt": "9.26T",
+                    "longFmt": "9,258,310,028,392"
+                  },
+                  "netReceivables": {
+                    "raw": 31735705540115,
+                    "fmt": "31.74T",
+                    "longFmt": "31,735,705,540,115"
+                  },
+                  "inventory": {
+                    "raw": 4470845549423,
+                    "fmt": "4.47T",
+                    "longFmt": "4,470,845,549,423"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 3395288657104,
+                    "fmt": "3.4T",
+                    "longFmt": "3,395,288,657,104"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 49037842886120,
+                    "fmt": "49.04T",
+                    "longFmt": "49,037,842,886,120"
+                  },
+                  "longTermInvestments": {
+                    "raw": 5831251114741,
+                    "fmt": "5.83T",
+                    "longFmt": "5,831,251,114,741"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 8663216063821,
+                    "fmt": "8.66T",
+                    "longFmt": "8,663,216,063,821"
+                  },
+                  "goodWill": {
+                    "raw": 1995908825753,
+                    "fmt": "2T",
+                    "longFmt": "1,995,908,825,753"
+                  },
+                  "intangibleAssets": {
+                    "raw": 55407004501205,
+                    "fmt": "55.41T",
+                    "longFmt": "55,407,004,501,205"
+                  },
+                  "otherAssets": {
+                    "raw": 1654035958931,
+                    "fmt": "1.65T",
+                    "longFmt": "1,654,035,958,931"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 1542424572,
+                    "fmt": "1.54B",
+                    "longFmt": "1,542,424,572"
+                  },
+                  "totalAssets": {
+                    "raw": 122589259350571,
+                    "fmt": "122.59T",
+                    "longFmt": "122,589,259,350,571"
+                  },
+                  "accountsPayable": {
+                    "raw": 11005539197920,
+                    "fmt": "11.01T",
+                    "longFmt": "11,005,539,197,920"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 4098002350931,
+                    "fmt": "4.1T",
+                    "longFmt": "4,098,002,350,931"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 4340597615238,
+                    "fmt": "4.34T",
+                    "longFmt": "4,340,597,615,238"
+                  },
+                  "longTermDebt": {
+                    "raw": 43894161654013,
+                    "fmt": "43.89T",
+                    "longFmt": "43,894,161,654,013"
+                  },
+                  "otherLiab": {
+                    "raw": 4553133367976,
+                    "fmt": "4.55T",
+                    "longFmt": "4,553,133,367,976"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 754641393913,
+                    "fmt": "754.64B",
+                    "longFmt": "754,641,393,913"
+                  },
+                  "minorityInterest": {
+                    "raw": 11236061197428,
+                    "fmt": "11.24T",
+                    "longFmt": "11,236,061,197,428"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 45023495139583,
+                    "fmt": "45.02T",
+                    "longFmt": "45,023,495,139,583"
+                  },
+                  "totalLiab": {
+                    "raw": 93470790161572,
+                    "fmt": "93.47T",
+                    "longFmt": "93,470,790,161,572"
+                  },
+                  "commonStock": {
+                    "raw": 1357390259999,
+                    "fmt": "1.36T",
+                    "longFmt": "1,357,390,259,999"
+                  },
+                  "retainedEarnings": {
+                    "raw": 10233409821327,
+                    "fmt": "10.23T",
+                    "longFmt": "10,233,409,821,327"
+                  },
+                  "treasuryStock": {
+                    "raw": 739581647808,
+                    "fmt": "739.58B",
+                    "longFmt": "739,581,647,808"
+                  },
+                  "capitalSurplus": {
+                    "raw": 5552026262437,
+                    "fmt": "5.55T",
+                    "longFmt": "5,552,026,262,437"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 739581647808,
+                    "fmt": "739.58B",
+                    "longFmt": "739,581,647,808"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 17882407991571,
+                    "fmt": "17.88T",
+                    "longFmt": "17,882,407,991,571"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -39520505335387,
+                    "fmt": "-39.52T",
+                    "longFmt": "-39,520,505,335,387"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            },
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            },
+            "summaryProfile": {
+              "address1": "Gedung Waskita",
+              "address2": "Jl. MT Haryono Kav. No.10 Cawang",
+              "city": "Jakarta",
+              "zip": "13340",
+              "country": "Indonesia",
+              "phone": "62 21 850 8510",
+              "fax": "62 21 850 8506",
+              "website": "http://www.waskita.co.id",
+              "industry": "Engineering & Construction",
+              "sector": "Industrials",
+              "longBusinessSummary": "PT Waskita Karya (Persero) Tbk, together with its subsidiaries, engages in the engineering, procurement, and construction works in Indonesia. It constructs building projects, transportation facilities, and water resources and energy projects; invests in various toll roads; and operates realty projects. The company is also involved in the hotel management business; building and equipment rental business; and production of precast concrete. In addition, it operates as an independent power producer; and develops real estate properties. PT Waskita Karya (Persero) Tbk was founded in 1961 and is headquartered in Jakarta, Indonesia.",
+              "fullTimeEmployees": 2333,
+              "companyOfficers": [],
+              "maxAge": 86400
+            },
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 0,
+              "buyInfoShares": 0,
+              "sellInfoCount": 0,
+              "netInfoCount": 0,
+              "netInfoShares": 0,
+              "netPercentInsiderShares": 0,
+              "totalInsiderShares": 9668453376
+            },
+            "sectorTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 3702444815840,
+                    "fmt": "3.7T",
+                    "longFmt": "3,702,444,815,840"
+                  },
+                  "costOfRevenue": {
+                    "raw": 4000156906933,
+                    "fmt": "4T",
+                    "longFmt": "4,000,156,906,933"
+                  },
+                  "grossProfit": {
+                    "raw": -297712091093,
+                    "fmt": "-297.71B",
+                    "longFmt": "-297,712,091,093"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 250353444864,
+                    "fmt": "250.35B",
+                    "longFmt": "250,353,444,864"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 512412339527,
+                    "fmt": "512.41B",
+                    "longFmt": "512,412,339,527"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 4762922691324,
+                    "fmt": "4.76T",
+                    "longFmt": "4,762,922,691,324"
+                  },
+                  "operatingIncome": {
+                    "raw": -1060477875484,
+                    "fmt": "-1.06T",
+                    "longFmt": "-1,060,477,875,484"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -915830264077,
+                    "fmt": "-915.83B",
+                    "longFmt": "-915,830,264,077"
+                  },
+                  "ebit": {
+                    "raw": -1060477875484,
+                    "fmt": "-1.06T",
+                    "longFmt": "-1,060,477,875,484"
+                  },
+                  "interestExpense": {
+                    "raw": -1081591970173,
+                    "fmt": "-1.08T",
+                    "longFmt": "-1,081,591,970,173"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -1976308139561,
+                    "fmt": "-1.98T",
+                    "longFmt": "-1,976,308,139,561"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 81052721385,
+                    "fmt": "81.05B",
+                    "longFmt": "81,052,721,385"
+                  },
+                  "minorityInterest": {
+                    "raw": 10421911999730,
+                    "fmt": "10.42T",
+                    "longFmt": "10,421,911,999,730"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -2057360860946,
+                    "fmt": "-2.06T",
+                    "longFmt": "-2,057,360,860,946"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -1541875900774,
+                    "fmt": "-1.54T",
+                    "longFmt": "-1,541,875,900,774"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -1541875900774,
+                    "fmt": "-1.54T",
+                    "longFmt": "-1,541,875,900,774"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 3867906986507,
+                    "fmt": "3.87T",
+                    "longFmt": "3,867,906,986,507"
+                  },
+                  "costOfRevenue": {
+                    "raw": 3638479716687,
+                    "fmt": "3.64T",
+                    "longFmt": "3,638,479,716,687"
+                  },
+                  "grossProfit": {
+                    "raw": 229427269820,
+                    "fmt": "229.43B",
+                    "longFmt": "229,427,269,820"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 277196426825,
+                    "fmt": "277.2B",
+                    "longFmt": "277,196,426,825"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 19838121455,
+                    "fmt": "19.84B",
+                    "longFmt": "19,838,121,455"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 3935514264967,
+                    "fmt": "3.94T",
+                    "longFmt": "3,935,514,264,967"
+                  },
+                  "operatingIncome": {
+                    "raw": -67607278460,
+                    "fmt": "-67.61B",
+                    "longFmt": "-67,607,278,460"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -1190849027335,
+                    "fmt": "-1.19T",
+                    "longFmt": "-1,190,849,027,335"
+                  },
+                  "ebit": {
+                    "raw": -67607278460,
+                    "fmt": "-67.61B",
+                    "longFmt": "-67,607,278,460"
+                  },
+                  "interestExpense": {
+                    "raw": -1224736795485,
+                    "fmt": "-1.22T",
+                    "longFmt": "-1,224,736,795,485"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -1258456305795,
+                    "fmt": "-1.26T",
+                    "longFmt": "-1,258,456,305,795"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 73975034586,
+                    "fmt": "73.98B",
+                    "longFmt": "73,975,034,586"
+                  },
+                  "minorityInterest": {
+                    "raw": 10937396959806,
+                    "fmt": "10.94T",
+                    "longFmt": "10,937,396,959,806"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -1332431340381,
+                    "fmt": "-1.33T",
+                    "longFmt": "-1,332,431,340,381"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -1137790988612,
+                    "fmt": "-1.14T",
+                    "longFmt": "-1,137,790,988,612"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -1137790988612,
+                    "fmt": "-1.14T",
+                    "longFmt": "-1,137,790,988,612"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 4169887433590,
+                    "fmt": "4.17T",
+                    "longFmt": "4,169,887,433,590"
+                  },
+                  "costOfRevenue": {
+                    "raw": 3332972919201,
+                    "fmt": "3.33T",
+                    "longFmt": "3,332,972,919,201"
+                  },
+                  "grossProfit": {
+                    "raw": 836914514389,
+                    "fmt": "836.91B",
+                    "longFmt": "836,914,514,389"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 210954179587,
+                    "fmt": "210.95B",
+                    "longFmt": "210,954,179,587"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 24092664799,
+                    "fmt": "24.09B",
+                    "longFmt": "24,092,664,799"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 3568019763587,
+                    "fmt": "3.57T",
+                    "longFmt": "3,568,019,763,587"
+                  },
+                  "operatingIncome": {
+                    "raw": 601867670003,
+                    "fmt": "601.87B",
+                    "longFmt": "601,867,670,003"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -486212050524,
+                    "fmt": "-486.21B",
+                    "longFmt": "-486,212,050,524"
+                  },
+                  "ebit": {
+                    "raw": 601867670003,
+                    "fmt": "601.87B",
+                    "longFmt": "601,867,670,003"
+                  },
+                  "interestExpense": {
+                    "raw": -701040339582,
+                    "fmt": "-701.04B",
+                    "longFmt": "-701,040,339,582"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 115655619479,
+                    "fmt": "115.66B",
+                    "longFmt": "115,655,619,479"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 105475763996,
+                    "fmt": "105.48B",
+                    "longFmt": "105,475,763,996"
+                  },
+                  "minorityInterest": {
+                    "raw": 11203544702256,
+                    "fmt": "11.2T",
+                    "longFmt": "11,203,544,702,256"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 10179855483,
+                    "fmt": "10.18B",
+                    "longFmt": "10,179,855,483"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 42696350655,
+                    "fmt": "42.7B",
+                    "longFmt": "42,696,350,655"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 42696350655,
+                    "fmt": "42.7B",
+                    "longFmt": "42,696,350,655"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 9372493217765,
+                    "fmt": "9.37T",
+                    "longFmt": "9,372,493,217,765"
+                  },
+                  "costOfRevenue": {
+                    "raw": 7924139656299,
+                    "fmt": "7.92T",
+                    "longFmt": "7,924,139,656,299"
+                  },
+                  "grossProfit": {
+                    "raw": 1448353561466,
+                    "fmt": "1.45T",
+                    "longFmt": "1,448,353,561,466"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 596747885424,
+                    "fmt": "596.75B",
+                    "longFmt": "596,747,885,424"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 135923296923,
+                    "fmt": "135.92B",
+                    "longFmt": "135,923,296,923"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 8656810838646,
+                    "fmt": "8.66T",
+                    "longFmt": "8,656,810,838,646"
+                  },
+                  "operatingIncome": {
+                    "raw": 715682379119,
+                    "fmt": "715.68B",
+                    "longFmt": "715,682,379,119"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -460554709593,
+                    "fmt": "-460.55B",
+                    "longFmt": "-460,554,709,593"
+                  },
+                  "ebit": {
+                    "raw": 715682379119,
+                    "fmt": "715.68B",
+                    "longFmt": "715,682,379,119"
+                  },
+                  "interestExpense": {
+                    "raw": -1031364328349,
+                    "fmt": "-1.03T",
+                    "longFmt": "-1,031,364,328,349"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 255127669526,
+                    "fmt": "255.13B",
+                    "longFmt": "255,127,669,526"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 329179388870,
+                    "fmt": "329.18B",
+                    "longFmt": "329,179,388,870"
+                  },
+                  "minorityInterest": {
+                    "raw": 11236061197428,
+                    "fmt": "11.24T",
+                    "longFmt": "11,236,061,197,428"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -74051719344,
+                    "fmt": "-74.05B",
+                    "longFmt": "-74,051,719,344"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -212188468091,
+                    "fmt": "-212.19B",
+                    "longFmt": "-212,188,468,091"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -212188468091,
+                    "fmt": "-212.19B",
+                    "longFmt": "-212,188,468,091"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": -1541875900774,
+                    "fmt": "-1.54T",
+                    "longFmt": "-1,541,875,900,774"
+                  },
+                  "depreciation": {
+                    "raw": 231091569531,
+                    "fmt": "231.09B",
+                    "longFmt": "231,091,569,531"
+                  },
+                  "changeToNetincome": {
+                    "raw": -81314580296,
+                    "fmt": "-81.31B",
+                    "longFmt": "-81,314,580,296"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -1392098911539,
+                    "fmt": "-1.39T",
+                    "longFmt": "-1,392,098,911,539"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -302225459186,
+                    "fmt": "-302.23B",
+                    "longFmt": "-302,225,459,186"
+                  },
+                  "investments": {
+                    "raw": -62161137293,
+                    "fmt": "-62.16B",
+                    "longFmt": "-62,161,137,293"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 1127172556007,
+                    "fmt": "1.13T",
+                    "longFmt": "1,127,172,556,007"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -827619194480,
+                    "fmt": "-827.62B",
+                    "longFmt": "-827,619,194,480"
+                  },
+                  "dividendsPaid": {
+                    "raw": -45317667578,
+                    "fmt": "-45.32B",
+                    "longFmt": "-45,317,667,578"
+                  },
+                  "netBorrowings": {
+                    "raw": 2837577322870,
+                    "fmt": "2.84T",
+                    "longFmt": "2,837,577,322,870"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -760265508940,
+                    "fmt": "-760.27B",
+                    "longFmt": "-760,265,508,940"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 2031994146352,
+                    "fmt": "2.03T",
+                    "longFmt": "2,031,994,146,352"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 18341013574,
+                    "fmt": "18.34B",
+                    "longFmt": "18,341,013,574"
+                  },
+                  "changeInCash": {
+                    "raw": -169382946093,
+                    "fmt": "-169.38B",
+                    "longFmt": "-169,382,946,093"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "netIncome": {
+                    "raw": -1137790988612,
+                    "fmt": "-1.14T",
+                    "longFmt": "-1,137,790,988,612"
+                  },
+                  "depreciation": {
+                    "raw": 223004624316,
+                    "fmt": "223B",
+                    "longFmt": "223,004,624,316"
+                  },
+                  "changeToNetincome": {
+                    "raw": -192337207128,
+                    "fmt": "-192.34B",
+                    "longFmt": "-192,337,207,128"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -1107123571424,
+                    "fmt": "-1.11T",
+                    "longFmt": "-1,107,123,571,424"
+                  },
+                  "capitalExpenditures": {
+                    "raw": 69155856242,
+                    "fmt": "69.16B",
+                    "longFmt": "69,155,856,242"
+                  },
+                  "investments": {
+                    "raw": 1322690801657,
+                    "fmt": "1.32T",
+                    "longFmt": "1,322,690,801,657"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -248093352584,
+                    "fmt": "-248.09B",
+                    "longFmt": "-248,093,352,584"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -1405024004580,
+                    "fmt": "-1.41T",
+                    "longFmt": "-1,405,024,004,580"
+                  },
+                  "dividendsPaid": {
+                    "raw": -45317667578,
+                    "fmt": "-45.32B",
+                    "longFmt": "-45,317,667,578"
+                  },
+                  "netBorrowings": {
+                    "raw": 384478651233,
+                    "fmt": "384.48B",
+                    "longFmt": "384,478,651,233"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -2581555857971,
+                    "fmt": "-2.58T",
+                    "longFmt": "-2,581,555,857,971"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -2197077206738,
+                    "fmt": "-2.2T",
+                    "longFmt": "-2,197,077,206,738"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -20192169322,
+                    "fmt": "-20.19B",
+                    "longFmt": "-20,192,169,322"
+                  },
+                  "changeInCash": {
+                    "raw": -4729416952064,
+                    "fmt": "-4.73T",
+                    "longFmt": "-4,729,416,952,064"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "netIncome": {
+                    "raw": 42696350655,
+                    "fmt": "42.7B",
+                    "longFmt": "42,696,350,655"
+                  },
+                  "depreciation": {
+                    "raw": 385127294046,
+                    "fmt": "385.13B",
+                    "longFmt": "385,127,294,046"
+                  },
+                  "changeToNetincome": {
+                    "raw": 2378732914830,
+                    "fmt": "2.38T",
+                    "longFmt": "2,378,732,914,830"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 2806556559531,
+                    "fmt": "2.81T",
+                    "longFmt": "2,806,556,559,531"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -634768146204,
+                    "fmt": "-634.77B",
+                    "longFmt": "-634,768,146,204"
+                  },
+                  "investments": {
+                    "raw": 1648320186286,
+                    "fmt": "1.65T",
+                    "longFmt": "1,648,320,186,286"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -2905468528,
+                    "fmt": "-2.91B",
+                    "longFmt": "-2,905,468,528"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -494127049424,
+                    "fmt": "-494.13B",
+                    "longFmt": "-494,127,049,424"
+                  },
+                  "dividendsPaid": {
+                    "raw": -45317667578,
+                    "fmt": "-45.32B",
+                    "longFmt": "-45,317,667,578"
+                  },
+                  "netBorrowings": {
+                    "raw": -5095472197442,
+                    "fmt": "-5.1T",
+                    "longFmt": "-5,095,472,197,442"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -398405755081,
+                    "fmt": "-398.41B",
+                    "longFmt": "-398,405,755,081"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -5493877952523,
+                    "fmt": "-5.49T",
+                    "longFmt": "-5,493,877,952,523"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 18854747951,
+                    "fmt": "18.85B",
+                    "longFmt": "18,854,747,951"
+                  },
+                  "changeInCash": {
+                    "raw": -3162593694465,
+                    "fmt": "-3.16T",
+                    "longFmt": "-3,162,593,694,465"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -212188468091,
+                    "fmt": "-212.19B",
+                    "longFmt": "-212,188,468,091"
+                  },
+                  "depreciation": {
+                    "raw": 250963763494,
+                    "fmt": "250.96B",
+                    "longFmt": "250,963,763,494"
+                  },
+                  "changeToNetincome": {
+                    "raw": 13851278449112,
+                    "fmt": "13.85T",
+                    "longFmt": "13,851,278,449,112"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 13890053744515,
+                    "fmt": "13.89T",
+                    "longFmt": "13,890,053,744,515"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -855007643428,
+                    "fmt": "-855.01B",
+                    "longFmt": "-855,007,643,428"
+                  },
+                  "investments": {
+                    "raw": -2394544824643,
+                    "fmt": "-2.39T",
+                    "longFmt": "-2,394,544,824,643"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -30109245841,
+                    "fmt": "-30.11B",
+                    "longFmt": "-30,109,245,841"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -1456372203453,
+                    "fmt": "-1.46T",
+                    "longFmt": "-1,456,372,203,453"
+                  },
+                  "dividendsPaid": {
+                    "raw": -196260589054,
+                    "fmt": "-196.26B",
+                    "longFmt": "-196,260,589,054"
+                  },
+                  "netBorrowings": {
+                    "raw": -3812577734424,
+                    "fmt": "-3.81T",
+                    "longFmt": "-3,812,577,734,424"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -2660696919498,
+                    "fmt": "-2.66T",
+                    "longFmt": "-2,660,696,919,498"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -6669535242976,
+                    "fmt": "-6.67T",
+                    "longFmt": "-6,669,535,242,976"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -1890326095,
+                    "fmt": "-1.89B",
+                    "longFmt": "-1,890,326,095"
+                  },
+                  "changeInCash": {
+                    "raw": 5762255971991,
+                    "fmt": "5.76T",
+                    "longFmt": "5,762,255,971,991"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [],
+                "earningsDate": []
+              },
+              "financialsChart": {
+                "yearly": [
+                  {
+                    "date": 2016,
+                    "revenue": 23788322626347,
+                    "earnings": 1713260616725
+                  },
+                  {
+                    "date": 2017,
+                    "revenue": 45212897632604,
+                    "earnings": 3881711917338
+                  },
+                  {
+                    "date": 2018,
+                    "revenue": 48788950838822,
+                    "earnings": 3962838031865
+                  },
+                  {
+                    "date": 2019,
+                    "revenue": 31387389629869,
+                    "earnings": 938142364887
+                  }
+                ],
+                "quarterly": [
+                  {
+                    "date": "4Q2019",
+                    "revenue": 9372493217765,
+                    "earnings": -212188468091
+                  },
+                  {
+                    "date": "1Q2020",
+                    "revenue": 4169887433590,
+                    "earnings": 42696350655
+                  },
+                  {
+                    "date": "2Q2020",
+                    "revenue": 3867906986507,
+                    "earnings": -1137790988612
+                  },
+                  {
+                    "date": "3Q2020",
+                    "revenue": 3702444815840,
+                    "earnings": -1541875900774
+                  }
+                ]
+              },
+              "financialCurrency": "IDR"
+            },
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 1605,
+              "targetHighPrice": 3600,
+              "targetLowPrice": 1650,
+              "targetMeanPrice": 2471.4,
+              "targetMedianPrice": 2310,
+              "recommendationKey": "none",
+              "numberOfAnalystOpinions": 11,
+              "totalCash": 1196916473856,
+              "totalCashPerShare": 88.177,
+              "ebitda": 1112281972736,
+              "totalDebt": 69063208337408,
+              "quickRatio": 0.638,
+              "currentRatio": 0.968,
+              "totalRevenue": 21112731729920,
+              "debtToEquity": 290.582,
+              "revenuePerShare": 1555.387,
+              "returnOnAssets": 0.00093999994,
+              "returnOnEquity": -0.13034001,
+              "grossProfits": 5604642763405,
+              "freeCashflow": 18182632898560,
+              "operatingCashflow": 10596487528448,
+              "revenueGrowth": -0.487,
+              "grossMargins": 0.10501,
+              "ebitdaMargins": 0.05268,
+              "operatingMargins": 0.00897,
+              "profitMargins": -0.13495,
+              "financialCurrency": "IDR"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-assetProfile-ADH.json
+++ b/tests/http/quoteSummary-assetProfile-ADH.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=assetProfile"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "2cocdopg2nrr2"
+      ],
+      "x-yahoo-request-id": [
+        "2cocdopg2nrr2"
+      ],
+      "x-request-id": [
+        "6746d12e-e4f2-4e6d-a4fd-4e4a793fa313"
+      ],
+      "content-length": [
+        "145"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:26 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=assetProfile"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-assetProfile-AFRAF.json
+++ b/tests/http/quoteSummary-assetProfile-AFRAF.json
@@ -1,0 +1,264 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=assetProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "a1lrbehg2nrr2"
+      ],
+      "x-yahoo-request-id": [
+        "a1lrbehg2nrr2"
+      ],
+      "x-request-id": [
+        "eb032700-5d10-4f80-9d27-8e2a123b1df7"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1148"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:26 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "2 rue Robert Esnault-Pelterie",
+              "city": "Paris",
+              "zip": "75007",
+              "country": "France",
+              "phone": "33 1 43 17 21 96",
+              "website": "http://www.airfranceklm.com",
+              "industry": "Airlines",
+              "sector": "Industrials",
+              "longBusinessSummary": "Air France-KLM SA, together with its subsidiaries, provides passenger transportation services on scheduled flights. The company operates through Network, Maintenance, Transavia, and Other segments. It also offers cargo transportation and aeronautics maintenance, and other air-transport-related services. The company operates in France, Benelux, Europe, Africa, the Middle East, Gulf, India, the Asia-Pacific, North America, Caribbean, West Indies, French Guyana, Indian Ocean, and South America. As of December 31, 2019, it operated fleet of 554 aircraft. The company was founded in 1919 and is headquartered in Paris, France.",
+              "fullTimeEmployees": 82122,
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Benjamin M. Smith",
+                  "age": 49,
+                  "title": "CEO & Director",
+                  "yearBorn": 1971,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. FrÃ©dÃ©ric N. P. P. Gagey",
+                  "age": 64,
+                  "title": "Chief Financial Officer",
+                  "yearBorn": 1956,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Eric  Schramm",
+                  "age": 61,
+                  "title": "Exec. VP of Operations and Accountable Mang.",
+                  "yearBorn": 1959,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Olivier  Gall",
+                  "title": "Head of Investor Relations",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Jean-Christophe  Lalanne",
+                  "age": 58,
+                  "title": "Exec. VP of Information Technology",
+                  "yearBorn": 1962,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Pieter  Bootsma",
+                  "age": 51,
+                  "title": "Chief Revenue Officer",
+                  "yearBorn": 1969,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Pieter J. TH. Elbers",
+                  "age": 50,
+                  "title": "Deputy CEO and CEO & Pres of KLM",
+                  "yearBorn": 1970,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Henri  de Peyrelongue",
+                  "title": "Sr. VP of Commercial Planning and Representative of The Commercial, Sales & Alliances Division",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Henri  Hourcade",
+                  "title": "Sr. VP of Caribbean & Indian Ocean, Central and South America",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Barry Ter Voert",
+                  "title": "Sr. VP of Europe",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "auditRisk": 5,
+              "boardRisk": 3,
+              "compensationRisk": 3,
+              "shareHolderRightsRisk": 10,
+              "overallRisk": 5,
+              "governanceEpochDate": 1606867200,
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-assetProfile-AMZN.json
+++ b/tests/http/quoteSummary-assetProfile-AMZN.json
@@ -1,0 +1,285 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=assetProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "6kbq7t1g2nrr3"
+      ],
+      "x-yahoo-request-id": [
+        "6kbq7t1g2nrr3"
+      ],
+      "x-request-id": [
+        "c6ed8329-154e-4af6-9068-af5b6a8a6473"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1535"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:26 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "410 Terry Avenue North",
+              "city": "Seattle",
+              "state": "WA",
+              "zip": "98109-5210",
+              "country": "United States",
+              "phone": "206-266-1000",
+              "website": "http://www.amazon.com",
+              "industry": "Internet Retail",
+              "sector": "Consumer Cyclical",
+              "longBusinessSummary": "Amazon.com, Inc. engages in the retail sale of consumer products and subscriptions in North America and internationally. The company operates through three segments: North America, International, and Amazon Web Services (AWS). It sells merchandise and content purchased for resale from third-party sellers through physical and online stores. The company also manufactures and sells electronic devices, including Kindle, Fire tablets, Fire TVs, Rings, and Echo and other devices; provides Kindle Direct Publishing, an online service that allows independent authors and publishers to make their books available in the Kindle Store; and develops and produces media content. In addition, it offers programs that enable sellers to sell their products on its websites, as well as its stores; and programs that allow authors, musicians, filmmakers, skill and app developers, and others to publish and sell content. Further, the company provides compute, storage, database, analytics, machine learning, and other services, as well as fulfillment, advertising, publishing, and digital content subscriptions. Additionally, it offers Amazon Prime, a membership program, which provides free shipping of various items; access to streaming of movies and TV episodes; and other services. The company serves consumers, sellers, developers, enterprises, and content creators. Amazon.com, Inc. was founded in 1994 and is headquartered in Seattle, Washington.",
+              "fullTimeEmployees": 1298000,
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Jeffrey P. Bezos",
+                  "age": 56,
+                  "title": "Founder, Chairman, Pres & CEO",
+                  "yearBorn": 1964,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 1681840,
+                    "fmt": "1.68M",
+                    "longFmt": "1,681,840"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Brian T. Olsavsky",
+                  "age": 56,
+                  "title": "Sr. VP & CFO",
+                  "yearBorn": 1964,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 163200,
+                    "fmt": "163.2k",
+                    "longFmt": "163,200"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Andrew R. Jassy",
+                  "age": 52,
+                  "title": "Chief Exec. Officer of Amazon Web Services Inc.",
+                  "yearBorn": 1968,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 348809,
+                    "fmt": "348.81k",
+                    "longFmt": "348,809"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Shelley L. Reynolds",
+                  "age": 55,
+                  "title": "VP, Worldwide Controller & Principal Accounting Officer",
+                  "yearBorn": 1965,
+                  "fiscalYear": 2009,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Werner  Vogels",
+                  "title": "Chief Technology Officer",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Dave  Fildes",
+                  "title": "Director of Investor Relations",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. David A. Zapolsky",
+                  "age": 56,
+                  "title": "Sr. VP, Gen. Counsel & Sec.",
+                  "yearBorn": 1964,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Ragia  Samir",
+                  "title": "Head of Marketing",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Beth  Galetti",
+                  "title": "Sr. VP of Worldwide HR",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Steven  Kessel",
+                  "age": 54,
+                  "title": "Sr. VP",
+                  "yearBorn": 1966,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "auditRisk": 1,
+              "boardRisk": 9,
+              "compensationRisk": 9,
+              "shareHolderRightsRisk": 2,
+              "overallRisk": 6,
+              "governanceEpochDate": 1606867200,
+              "compensationAsOfEpochDate": 1577750400,
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-assetProfile-AZT.OL.json
+++ b/tests/http/quoteSummary-assetProfile-AZT.OL.json
@@ -1,0 +1,191 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=assetProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "58a6p71g2nrr3"
+      ],
+      "x-yahoo-request-id": [
+        "58a6p71g2nrr3"
+      ],
+      "x-request-id": [
+        "67964993-ad3d-4416-a8d7-6c13a127ef69"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1359"
+      ],
+      "x-envoy-upstream-service-time": [
+        "94"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:27 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "Sykehusveien 23",
+              "address2": "PO Box 6463",
+              "city": "TromsÃ¸",
+              "zip": "9294",
+              "country": "Norway",
+              "phone": "47 77 64 89 00",
+              "fax": "47 77 64 89 01",
+              "website": "http://arcticzymes.com",
+              "industry": "Biotechnology",
+              "sector": "Healthcare",
+              "longBusinessSummary": "ArcticZymes Technologies ASA develops, manufactures, and markets immunomodulating beta-glucans and recombinant enzymes in Norway, Europe, Asia, Australia, Africa, and the Americas. It operates through two segments, Enzymes and Beta-Glucans. The company provides recombinant enzymes that are primarily derived from cold-water marine species and organisms from other relevant environments for use in molecular research, in vitro diagnostics, and therapeutics. It offers shrimp alkaline phosphatase and derived kits for cleanup prior to Sanger sequencing and next generation sequencing (NGS) processes; cod UNG for use in viral and other molecular diagnostic assays; double-strand specific DNases and derived kits for the removal of DNA from RNA samples; polymerases for technology development for life science, molecular diagnostics, NGS, and synthetic biology; proteinase for microbiological diagnostics and liquid biopsies; salt active nuclease for the removal of nucleic acids during manufacturing of vaccines, viruses, recombinant proteins, and other reagents; and ligases for joining DNA fragments. The company also provides immunomodulating beta-glucans products for the wound care, animal and consumer health, and adjuvants markets. It offers Woulgan wound gel; M-Glucan, a natural immune-stimulating product for fish and animal feed; and M-Gard, a natural immune-stimulating ingredients to enhance physical health. The company was formerly known as Biotec Pharmacon ASA and changed its name to ArcticZymes Technologies ASA in June 2020. ArcticZymes Technologies ASA was founded in 1990 and is headquartered in TromsÃ¸, Norway.",
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Jethro  Holter",
+                  "age": 48,
+                  "title": "Chief Exec. Officer",
+                  "yearBorn": 1972,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 1487000,
+                    "fmt": "1.49M",
+                    "longFmt": "1,487,000"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. BÃ¸rge  SÃ¸rvoll",
+                  "age": 45,
+                  "title": "Chief Financial Officer",
+                  "yearBorn": 1975,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 1331000,
+                    "fmt": "1.33M",
+                    "longFmt": "1,331,000"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Marit Sjo Lorentzen",
+                  "title": "Employee Representative Director & Director of Operations",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Alexander Johann Bjorna",
+                  "title": "Director of IP & Bus. Devel.",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Dino  DiCamillo",
+                  "age": 62,
+                  "title": "Director of Marketing",
+                  "yearBorn": 1958,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "compensationAsOfEpochDate": 1577750400,
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-assetProfile-SIX.json
+++ b/tests/http/quoteSummary-assetProfile-SIX.json
@@ -1,0 +1,280 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=assetProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "924uvqlg2nuh7"
+      ],
+      "x-yahoo-request-id": [
+        "924uvqlg2nuh7"
+      ],
+      "x-request-id": [
+        "70fd81b1-c4f9-4595-9217-d75717137bcb"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1130"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:23 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "924 Avenue J East",
+              "city": "Grand Prairie",
+              "state": "TX",
+              "zip": "75050",
+              "country": "United States",
+              "phone": "972-595-5000",
+              "website": "http://www.sixflags.com",
+              "industry": "Leisure",
+              "sector": "Consumer Cyclical",
+              "longBusinessSummary": "Six Flags Entertainment Corporation owns and operates regional theme and waterparks under the Six Flags name. The company's parks offer various thrill rides, water attractions, themed areas, concerts and shows, restaurants, game venues, and retail outlets. It owns and operates 26 parks in the United States, Mexico, and Canada. The company was formerly known as Six Flags, Inc. and changed its name to Six Flags Entertainment Corporation in April 2010. Six Flags Entertainment Corporation was founded in 1961 and is based in Grand Prairie, Texas.",
+              "fullTimeEmployees": 2450,
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Michael  Spanos",
+                  "age": 55,
+                  "title": "Pres, CEO & Director",
+                  "yearBorn": 1965,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 512692,
+                    "fmt": "512.69k",
+                    "longFmt": "512,692"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Lance C. Balk",
+                  "age": 62,
+                  "title": "Of Counsel Advisor",
+                  "yearBorn": 1958,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 643600,
+                    "fmt": "643.6k",
+                    "longFmt": "643,600"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 803465,
+                    "fmt": "803.47k",
+                    "longFmt": "803,465"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Sandeep  Reddy",
+                  "age": 49,
+                  "title": "Exec. VP & CFO",
+                  "yearBorn": 1971,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Mario  Centola",
+                  "age": 49,
+                  "title": "VP of International Operations & Bus. Devel.",
+                  "yearBorn": 1971,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Wilson Taylor Brooks",
+                  "age": 33,
+                  "title": "VP & Chief Accounting Officer",
+                  "yearBorn": 1987,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Rafael A. Sanchez",
+                  "title": "Sr. VP & Chief Information Officer",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Laura W. Doerre",
+                  "age": 53,
+                  "title": "Chief Admin. Officer, Exec. VP & Gen. Counsel",
+                  "yearBorn": 1967,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Stephen R. Purtell",
+                  "age": 53,
+                  "title": "Sr. VP of Investor Relations, Treasury & Strategy",
+                  "yearBorn": 1967,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Sandra  Daniels",
+                  "title": "VP of Communications & Diversity",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Kelly  Correia",
+                  "title": "VP of Marketing",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "auditRisk": 1,
+              "boardRisk": 4,
+              "compensationRisk": 7,
+              "shareHolderRightsRisk": 6,
+              "overallRisk": 5,
+              "governanceEpochDate": 1606867200,
+              "compensationAsOfEpochDate": 1577750400,
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-assetProfile-WSKT.JK.json
+++ b/tests/http/quoteSummary-assetProfile-WSKT.JK.json
@@ -1,0 +1,266 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=assetProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "20cgradg2nuh7"
+      ],
+      "x-yahoo-request-id": [
+        "20cgradg2nuh7"
+      ],
+      "x-request-id": [
+        "62d915f2-02af-4c47-a439-58cd6bc10856"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1081"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:22 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "Gedung Waskita",
+              "address2": "Jl. MT Haryono Kav. No.10 Cawang",
+              "city": "Jakarta",
+              "zip": "13340",
+              "country": "Indonesia",
+              "phone": "62 21 850 8510",
+              "fax": "62 21 850 8506",
+              "website": "http://www.waskita.co.id",
+              "industry": "Engineering & Construction",
+              "sector": "Industrials",
+              "longBusinessSummary": "PT Waskita Karya (Persero) Tbk, together with its subsidiaries, engages in the engineering, procurement, and construction works in Indonesia. It constructs building projects, transportation facilities, and water resources and energy projects; invests in various toll roads; and operates realty projects. The company is also involved in the hotel management business; building and equipment rental business; and production of precast concrete. In addition, it operates as an independent power producer; and develops real estate properties. PT Waskita Karya (Persero) Tbk was founded in 1961 and is headquartered in Jakarta, Indonesia.",
+              "fullTimeEmployees": 2333,
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Engineer Destiawan  Soewardjono M.M., MM, MBA",
+                  "age": 59,
+                  "title": "Pres Director",
+                  "yearBorn": 1961,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Taufik Hendra Kusuma",
+                  "title": "Director of Fin. & Director",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Y. Ariandi Siregar SE",
+                  "age": 51,
+                  "title": "Gen. Mang. of Accounting & Tax",
+                  "yearBorn": 1969,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Inggir Elerida Lumban Toruan",
+                  "age": 49,
+                  "title": "Sr. VP of Accounting Division",
+                  "yearBorn": 1971,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Novianto Ari Nugroho",
+                  "age": 54,
+                  "title": "Sr. VP of Legal Division",
+                  "yearBorn": 1966,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Adi  Sutrisno",
+                  "age": 54,
+                  "title": "Sr. VP of Marketing Division",
+                  "yearBorn": 1966,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Engineer Hadjar Seti Adji MEng Sc IPU",
+                  "age": 55,
+                  "title": "Director of Human Capital Management & System Devel. and Director",
+                  "yearBorn": 1965,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Didit Oemar Prihadi Ir. & MM",
+                  "age": 60,
+                  "title": "Director of Operation I & Director",
+                  "yearBorn": 1960,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Pius Sutrisno Riyanto",
+                  "age": 57,
+                  "title": "Sr. VP of Internal Audit",
+                  "yearBorn": 1963,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Jonni  Hutahaen SE & MM",
+                  "age": 59,
+                  "title": "Head of Internal Audit",
+                  "yearBorn": 1961,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistory-ADH.json
+++ b/tests/http/quoteSummary-balanceSheetHistory-ADH.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=balanceSheetHistory"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "ed9vcghg2nrr3"
+      ],
+      "x-yahoo-request-id": [
+        "ed9vcghg2nrr3"
+      ],
+      "x-request-id": [
+        "fa945c7a-b088-46fd-8f66-54c503537cf7"
+      ],
+      "content-length": [
+        "152"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:27 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=balanceSheetHistory"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistory-AFRAF.json
+++ b/tests/http/quoteSummary-balanceSheetHistory-AFRAF.json
@@ -1,0 +1,669 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=balanceSheetHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "9f7s7q5g2nrr3"
+      ],
+      "x-yahoo-request-id": [
+        "9f7s7q5g2nrr3"
+      ],
+      "x-request-id": [
+        "2772a169-73b3-4118-9816-525107f8563e"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:27 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 3715000000,
+                    "fmt": "3.71B",
+                    "longFmt": "3,715,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 50000000,
+                    "fmt": "50M",
+                    "longFmt": "50,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 2723000000,
+                    "fmt": "2.72B",
+                    "longFmt": "2,723,000,000"
+                  },
+                  "inventory": {
+                    "raw": 737000000,
+                    "fmt": "737M",
+                    "longFmt": "737,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 660000000,
+                    "fmt": "660M",
+                    "longFmt": "660,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 8539000000,
+                    "fmt": "8.54B",
+                    "longFmt": "8,539,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 969000000,
+                    "fmt": "969M",
+                    "longFmt": "969,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 18087000000,
+                    "fmt": "18.09B",
+                    "longFmt": "18,087,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 217000000,
+                    "fmt": "217M",
+                    "longFmt": "217,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 1305000000,
+                    "fmt": "1.3B",
+                    "longFmt": "1,305,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 1618000000,
+                    "fmt": "1.62B",
+                    "longFmt": "1,618,000,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 523000000,
+                    "fmt": "523M",
+                    "longFmt": "523,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 30735000000,
+                    "fmt": "30.73B",
+                    "longFmt": "30,735,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 2379000000,
+                    "fmt": "2.38B",
+                    "longFmt": "2,379,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 307000000,
+                    "fmt": "307M",
+                    "longFmt": "307,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 7332000000,
+                    "fmt": "7.33B",
+                    "longFmt": "7,332,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 3370000000,
+                    "fmt": "3.37B",
+                    "longFmt": "3,370,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 6330000000,
+                    "fmt": "6.33B",
+                    "longFmt": "6,330,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 15000000,
+                    "fmt": "15M",
+                    "longFmt": "15,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 12649000000,
+                    "fmt": "12.65B",
+                    "longFmt": "12,649,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 28436000000,
+                    "fmt": "28.44B",
+                    "longFmt": "28,436,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 429000000,
+                    "fmt": "429M",
+                    "longFmt": "429,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 360000000,
+                    "fmt": "360M",
+                    "longFmt": "360,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -3047000000,
+                    "fmt": "-3.05B",
+                    "longFmt": "-3,047,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 4139000000,
+                    "fmt": "4.14B",
+                    "longFmt": "4,139,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -2980000000,
+                    "fmt": "-2.98B",
+                    "longFmt": "-2,980,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1881000000,
+                    "fmt": "1.88B",
+                    "longFmt": "1,881,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 359000000,
+                    "fmt": "359M",
+                    "longFmt": "359,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "cash": {
+                    "raw": 3585000000,
+                    "fmt": "3.58B",
+                    "longFmt": "3,585,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 2704000000,
+                    "fmt": "2.7B",
+                    "longFmt": "2,704,000,000"
+                  },
+                  "inventory": {
+                    "raw": 633000000,
+                    "fmt": "633M",
+                    "longFmt": "633,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 588000000,
+                    "fmt": "588M",
+                    "longFmt": "588,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 7799000000,
+                    "fmt": "7.8B",
+                    "longFmt": "7,799,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 970000000,
+                    "fmt": "970M",
+                    "longFmt": "970,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 17475000000,
+                    "fmt": "17.48B",
+                    "longFmt": "17,475,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 217000000,
+                    "fmt": "217M",
+                    "longFmt": "217,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 1194000000,
+                    "fmt": "1.19B",
+                    "longFmt": "1,194,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 1982000000,
+                    "fmt": "1.98B",
+                    "longFmt": "1,982,000,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 559000000,
+                    "fmt": "559M",
+                    "longFmt": "559,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 29637000000,
+                    "fmt": "29.64B",
+                    "longFmt": "29,637,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 2454000000,
+                    "fmt": "2.45B",
+                    "longFmt": "2,454,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 191000000,
+                    "fmt": "191M",
+                    "longFmt": "191,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 6996000000,
+                    "fmt": "7B",
+                    "longFmt": "6,996,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 2856000000,
+                    "fmt": "2.86B",
+                    "longFmt": "2,856,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 6188000000,
+                    "fmt": "6.19B",
+                    "longFmt": "6,188,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 12000000,
+                    "fmt": "12M",
+                    "longFmt": "12,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 12342000000,
+                    "fmt": "12.34B",
+                    "longFmt": "12,342,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 27839000000,
+                    "fmt": "27.84B",
+                    "longFmt": "27,839,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 429000000,
+                    "fmt": "429M",
+                    "longFmt": "429,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 490000000,
+                    "fmt": "490M",
+                    "longFmt": "490,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -3675000000,
+                    "fmt": "-3.67B",
+                    "longFmt": "-3,675,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 4139000000,
+                    "fmt": "4.14B",
+                    "longFmt": "4,139,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -3608000000,
+                    "fmt": "-3.61B",
+                    "longFmt": "-3,608,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1383000000,
+                    "fmt": "1.38B",
+                    "longFmt": "1,383,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -28000000,
+                    "fmt": "-28M",
+                    "longFmt": "-28,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "cash": {
+                    "raw": 4673000000,
+                    "fmt": "4.67B",
+                    "longFmt": "4,673,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 93000000,
+                    "fmt": "93M",
+                    "longFmt": "93,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 2617000000,
+                    "fmt": "2.62B",
+                    "longFmt": "2,617,000,000"
+                  },
+                  "inventory": {
+                    "raw": 557000000,
+                    "fmt": "557M",
+                    "longFmt": "557,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 926000000,
+                    "fmt": "926M",
+                    "longFmt": "926,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 9058000000,
+                    "fmt": "9.06B",
+                    "longFmt": "9,058,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 742000000,
+                    "fmt": "742M",
+                    "longFmt": "742,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 16778000000,
+                    "fmt": "16.78B",
+                    "longFmt": "16,778,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 216000000,
+                    "fmt": "216M",
+                    "longFmt": "216,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 1122000000,
+                    "fmt": "1.12B",
+                    "longFmt": "1,122,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 2047000000,
+                    "fmt": "2.05B",
+                    "longFmt": "2,047,000,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 417000000,
+                    "fmt": "417M",
+                    "longFmt": "417,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 29963000000,
+                    "fmt": "29.96B",
+                    "longFmt": "29,963,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 2365000000,
+                    "fmt": "2.37B",
+                    "longFmt": "2,365,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 731000000,
+                    "fmt": "731M",
+                    "longFmt": "731,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 6069000000,
+                    "fmt": "6.07B",
+                    "longFmt": "6,069,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 2833000000,
+                    "fmt": "2.83B",
+                    "longFmt": "2,833,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 5587000000,
+                    "fmt": "5.59B",
+                    "longFmt": "5,587,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 12000000,
+                    "fmt": "12M",
+                    "longFmt": "12,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 12054000000,
+                    "fmt": "12.05B",
+                    "longFmt": "12,054,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 27543000000,
+                    "fmt": "27.54B",
+                    "longFmt": "27,543,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 429000000,
+                    "fmt": "429M",
+                    "longFmt": "429,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 248000000,
+                    "fmt": "248M",
+                    "longFmt": "248,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -3008000000,
+                    "fmt": "-3.01B",
+                    "longFmt": "-3,008,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 4139000000,
+                    "fmt": "4.14B",
+                    "longFmt": "4,139,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -2941000000,
+                    "fmt": "-2.94B",
+                    "longFmt": "-2,941,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1808000000,
+                    "fmt": "1.81B",
+                    "longFmt": "1,808,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 470000000,
+                    "fmt": "470M",
+                    "longFmt": "470,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "cash": {
+                    "raw": 3938000000,
+                    "fmt": "3.94B",
+                    "longFmt": "3,938,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 2276000000,
+                    "fmt": "2.28B",
+                    "longFmt": "2,276,000,000"
+                  },
+                  "inventory": {
+                    "raw": 566000000,
+                    "fmt": "566M",
+                    "longFmt": "566,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 615000000,
+                    "fmt": "615M",
+                    "longFmt": "615,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 7607000000,
+                    "fmt": "7.61B",
+                    "longFmt": "7,607,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 393000000,
+                    "fmt": "393M",
+                    "longFmt": "393,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 10599000000,
+                    "fmt": "10.6B",
+                    "longFmt": "10,599,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 218000000,
+                    "fmt": "218M",
+                    "longFmt": "218,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 1066000000,
+                    "fmt": "1.07B",
+                    "longFmt": "1,066,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 3049000000,
+                    "fmt": "3.05B",
+                    "longFmt": "3,049,000,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 176000000,
+                    "fmt": "176M",
+                    "longFmt": "176,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 22932000000,
+                    "fmt": "22.93B",
+                    "longFmt": "22,932,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 2359000000,
+                    "fmt": "2.36B",
+                    "longFmt": "2,359,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 328000000,
+                    "fmt": "328M",
+                    "longFmt": "328,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 5437000000,
+                    "fmt": "5.44B",
+                    "longFmt": "5,437,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 3926000000,
+                    "fmt": "3.93B",
+                    "longFmt": "3,926,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 4002000000,
+                    "fmt": "4B",
+                    "longFmt": "4,002,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 12000000,
+                    "fmt": "12M",
+                    "longFmt": "12,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 10141000000,
+                    "fmt": "10.14B",
+                    "longFmt": "10,141,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 21636000000,
+                    "fmt": "21.64B",
+                    "longFmt": "21,636,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 300000000,
+                    "fmt": "300M",
+                    "longFmt": "300,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 1038000000,
+                    "fmt": "1.04B",
+                    "longFmt": "1,038,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -3625000000,
+                    "fmt": "-3.62B",
+                    "longFmt": "-3,625,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 2971000000,
+                    "fmt": "2.97B",
+                    "longFmt": "2,971,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -3558000000,
+                    "fmt": "-3.56B",
+                    "longFmt": "-3,558,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 684000000,
+                    "fmt": "684M",
+                    "longFmt": "684,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -600000000,
+                    "fmt": "-600M",
+                    "longFmt": "-600,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistory-AMZN.json
+++ b/tests/http/quoteSummary-balanceSheetHistory-AMZN.json
@@ -1,0 +1,634 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=balanceSheetHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "fim20etg2nrr3"
+      ],
+      "x-yahoo-request-id": [
+        "fim20etg2nrr3"
+      ],
+      "x-request-id": [
+        "76b720a4-add5-43c0-8c8d-39bc1b746127"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:27 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "cash": {
+                    "raw": 42122000000,
+                    "fmt": "42.12B",
+                    "longFmt": "42,122,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 42274000000,
+                    "fmt": "42.27B",
+                    "longFmt": "42,274,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 24309000000,
+                    "fmt": "24.31B",
+                    "longFmt": "24,309,000,000"
+                  },
+                  "inventory": {
+                    "raw": 23795000000,
+                    "fmt": "23.8B",
+                    "longFmt": "23,795,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 233000000,
+                    "fmt": "233M",
+                    "longFmt": "233,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 132733000000,
+                    "fmt": "132.73B",
+                    "longFmt": "132,733,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 5700000000,
+                    "fmt": "5.7B",
+                    "longFmt": "5,700,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 150667000000,
+                    "fmt": "150.67B",
+                    "longFmt": "150,667,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 15017000000,
+                    "fmt": "15.02B",
+                    "longFmt": "15,017,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 4981000000,
+                    "fmt": "4.98B",
+                    "longFmt": "4,981,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 12097000000,
+                    "fmt": "12.1B",
+                    "longFmt": "12,097,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 321195000000,
+                    "fmt": "321.19B",
+                    "longFmt": "321,195,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 72539000000,
+                    "fmt": "72.54B",
+                    "longFmt": "72,539,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 1155000000,
+                    "fmt": "1.16B",
+                    "longFmt": "1,155,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 15267000000,
+                    "fmt": "15.27B",
+                    "longFmt": "15,267,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 31816000000,
+                    "fmt": "31.82B",
+                    "longFmt": "31,816,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 17017000000,
+                    "fmt": "17.02B",
+                    "longFmt": "17,017,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 126385000000,
+                    "fmt": "126.39B",
+                    "longFmt": "126,385,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 227791000000,
+                    "fmt": "227.79B",
+                    "longFmt": "227,791,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 52551000000,
+                    "fmt": "52.55B",
+                    "longFmt": "52,551,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -2017000000,
+                    "fmt": "-2.02B",
+                    "longFmt": "-2,017,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 42865000000,
+                    "fmt": "42.87B",
+                    "longFmt": "42,865,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -180000000,
+                    "fmt": "-180M",
+                    "longFmt": "-180,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 93404000000,
+                    "fmt": "93.4B",
+                    "longFmt": "93,404,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 73406000000,
+                    "fmt": "73.41B",
+                    "longFmt": "73,406,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 36092000000,
+                    "fmt": "36.09B",
+                    "longFmt": "36,092,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 18929000000,
+                    "fmt": "18.93B",
+                    "longFmt": "18,929,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 20540000000,
+                    "fmt": "20.54B",
+                    "longFmt": "20,540,000,000"
+                  },
+                  "inventory": {
+                    "raw": 20497000000,
+                    "fmt": "20.5B",
+                    "longFmt": "20,497,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 276000000,
+                    "fmt": "276M",
+                    "longFmt": "276,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 96334000000,
+                    "fmt": "96.33B",
+                    "longFmt": "96,334,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2169000000,
+                    "fmt": "2.17B",
+                    "longFmt": "2,169,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 97846000000,
+                    "fmt": "97.85B",
+                    "longFmt": "97,846,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 14754000000,
+                    "fmt": "14.75B",
+                    "longFmt": "14,754,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 4049000000,
+                    "fmt": "4.05B",
+                    "longFmt": "4,049,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 10096000000,
+                    "fmt": "10.1B",
+                    "longFmt": "10,096,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 225248000000,
+                    "fmt": "225.25B",
+                    "longFmt": "225,248,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 47183000000,
+                    "fmt": "47.18B",
+                    "longFmt": "47,183,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 1305000000,
+                    "fmt": "1.3B",
+                    "longFmt": "1,305,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 12202000000,
+                    "fmt": "12.2B",
+                    "longFmt": "12,202,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 23414000000,
+                    "fmt": "23.41B",
+                    "longFmt": "23,414,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 12171000000,
+                    "fmt": "12.17B",
+                    "longFmt": "12,171,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 87812000000,
+                    "fmt": "87.81B",
+                    "longFmt": "87,812,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 163188000000,
+                    "fmt": "163.19B",
+                    "longFmt": "163,188,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 31220000000,
+                    "fmt": "31.22B",
+                    "longFmt": "31,220,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -2823000000,
+                    "fmt": "-2.82B",
+                    "longFmt": "-2,823,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 33658000000,
+                    "fmt": "33.66B",
+                    "longFmt": "33,658,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -986000000,
+                    "fmt": "-986M",
+                    "longFmt": "-986,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 62060000000,
+                    "fmt": "62.06B",
+                    "longFmt": "62,060,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 43257000000,
+                    "fmt": "43.26B",
+                    "longFmt": "43,257,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "cash": {
+                    "raw": 31750000000,
+                    "fmt": "31.75B",
+                    "longFmt": "31,750,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 9500000000,
+                    "fmt": "9.5B",
+                    "longFmt": "9,500,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 16259000000,
+                    "fmt": "16.26B",
+                    "longFmt": "16,259,000,000"
+                  },
+                  "inventory": {
+                    "raw": 17174000000,
+                    "fmt": "17.17B",
+                    "longFmt": "17,174,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 418000000,
+                    "fmt": "418M",
+                    "longFmt": "418,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 75101000000,
+                    "fmt": "75.1B",
+                    "longFmt": "75,101,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 722000000,
+                    "fmt": "722M",
+                    "longFmt": "722,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 61797000000,
+                    "fmt": "61.8B",
+                    "longFmt": "61,797,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 14548000000,
+                    "fmt": "14.55B",
+                    "longFmt": "14,548,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 4110000000,
+                    "fmt": "4.11B",
+                    "longFmt": "4,110,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 6370000000,
+                    "fmt": "6.37B",
+                    "longFmt": "6,370,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 162648000000,
+                    "fmt": "162.65B",
+                    "longFmt": "162,648,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 38192000000,
+                    "fmt": "38.19B",
+                    "longFmt": "38,192,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 1371000000,
+                    "fmt": "1.37B",
+                    "longFmt": "1,371,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 9959000000,
+                    "fmt": "9.96B",
+                    "longFmt": "9,959,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 23495000000,
+                    "fmt": "23.5B",
+                    "longFmt": "23,495,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 17563000000,
+                    "fmt": "17.56B",
+                    "longFmt": "17,563,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 68391000000,
+                    "fmt": "68.39B",
+                    "longFmt": "68,391,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 119099000000,
+                    "fmt": "119.1B",
+                    "longFmt": "119,099,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 19625000000,
+                    "fmt": "19.62B",
+                    "longFmt": "19,625,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -2872000000,
+                    "fmt": "-2.87B",
+                    "longFmt": "-2,872,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 26791000000,
+                    "fmt": "26.79B",
+                    "longFmt": "26,791,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -1035000000,
+                    "fmt": "-1.03B",
+                    "longFmt": "-1,035,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 43549000000,
+                    "fmt": "43.55B",
+                    "longFmt": "43,549,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 24891000000,
+                    "fmt": "24.89B",
+                    "longFmt": "24,891,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "cash": {
+                    "raw": 20522000000,
+                    "fmt": "20.52B",
+                    "longFmt": "20,522,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 10464000000,
+                    "fmt": "10.46B",
+                    "longFmt": "10,464,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 11835000000,
+                    "fmt": "11.84B",
+                    "longFmt": "11,835,000,000"
+                  },
+                  "inventory": {
+                    "raw": 16047000000,
+                    "fmt": "16.05B",
+                    "longFmt": "16,047,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 1329000000,
+                    "fmt": "1.33B",
+                    "longFmt": "1,329,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 60197000000,
+                    "fmt": "60.2B",
+                    "longFmt": "60,197,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 441000000,
+                    "fmt": "441M",
+                    "longFmt": "441,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 48866000000,
+                    "fmt": "48.87B",
+                    "longFmt": "48,866,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 13350000000,
+                    "fmt": "13.35B",
+                    "longFmt": "13,350,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 3371000000,
+                    "fmt": "3.37B",
+                    "longFmt": "3,371,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 5085000000,
+                    "fmt": "5.08B",
+                    "longFmt": "5,085,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 131310000000,
+                    "fmt": "131.31B",
+                    "longFmt": "131,310,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 34616000000,
+                    "fmt": "34.62B",
+                    "longFmt": "34,616,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 100000000,
+                    "fmt": "100M",
+                    "longFmt": "100,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 8565000000,
+                    "fmt": "8.56B",
+                    "longFmt": "8,565,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 24743000000,
+                    "fmt": "24.74B",
+                    "longFmt": "24,743,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 7792000000,
+                    "fmt": "7.79B",
+                    "longFmt": "7,792,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 57883000000,
+                    "fmt": "57.88B",
+                    "longFmt": "57,883,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 103601000000,
+                    "fmt": "103.6B",
+                    "longFmt": "103,601,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 8636000000,
+                    "fmt": "8.64B",
+                    "longFmt": "8,636,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -2321000000,
+                    "fmt": "-2.32B",
+                    "longFmt": "-2,321,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 21389000000,
+                    "fmt": "21.39B",
+                    "longFmt": "21,389,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -484000000,
+                    "fmt": "-484M",
+                    "longFmt": "-484,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 27709000000,
+                    "fmt": "27.71B",
+                    "longFmt": "27,709,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 10988000000,
+                    "fmt": "10.99B",
+                    "longFmt": "10,988,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistory-AZT.OL.json
+++ b/tests/http/quoteSummary-balanceSheetHistory-AZT.OL.json
@@ -1,0 +1,504 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=balanceSheetHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "6flanatg2nrr3"
+      ],
+      "x-yahoo-request-id": [
+        "6flanatg2nrr3"
+      ],
+      "x-request-id": [
+        "e583284b-1c6f-4ca6-8c2a-29f286d57a0a"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1337"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:27 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "cash": {
+                    "raw": 140178000,
+                    "fmt": "140.18M",
+                    "longFmt": "140,178,000"
+                  },
+                  "netReceivables": {
+                    "raw": 30705000,
+                    "fmt": "30.7M",
+                    "longFmt": "30,705,000"
+                  },
+                  "inventory": {
+                    "raw": 3889000,
+                    "fmt": "3.89M",
+                    "longFmt": "3,889,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 174772000,
+                    "fmt": "174.77M",
+                    "longFmt": "174,772,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 13573000,
+                    "fmt": "13.57M",
+                    "longFmt": "13,573,000"
+                  },
+                  "otherAssets": {
+                    "raw": 33402000,
+                    "fmt": "33.4M",
+                    "longFmt": "33,402,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 32978000,
+                    "fmt": "32.98M",
+                    "longFmt": "32,978,000"
+                  },
+                  "totalAssets": {
+                    "raw": 221747000,
+                    "fmt": "221.75M",
+                    "longFmt": "221,747,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 3456000,
+                    "fmt": "3.46M",
+                    "longFmt": "3,456,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 3721000,
+                    "fmt": "3.72M",
+                    "longFmt": "3,721,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 420000,
+                    "fmt": "420k",
+                    "longFmt": "420,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 3130000,
+                    "fmt": "3.13M",
+                    "longFmt": "3,130,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 14828000,
+                    "fmt": "14.83M",
+                    "longFmt": "14,828,000"
+                  },
+                  "totalLiab": {
+                    "raw": 24423000,
+                    "fmt": "24.42M",
+                    "longFmt": "24,423,000"
+                  },
+                  "commonStock": {
+                    "raw": 48335000,
+                    "fmt": "48.34M",
+                    "longFmt": "48,335,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -5180000,
+                    "fmt": "-5.18M",
+                    "longFmt": "-5,180,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 151039000,
+                    "fmt": "151.04M",
+                    "longFmt": "151,039,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 194194000,
+                    "fmt": "194.19M",
+                    "longFmt": "194,194,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 194194000,
+                    "fmt": "194.19M",
+                    "longFmt": "194,194,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 31289000,
+                    "fmt": "31.29M",
+                    "longFmt": "31,289,000"
+                  },
+                  "netReceivables": {
+                    "raw": 14309000,
+                    "fmt": "14.31M",
+                    "longFmt": "14,309,000"
+                  },
+                  "inventory": {
+                    "raw": 5298000,
+                    "fmt": "5.3M",
+                    "longFmt": "5,298,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 7250000,
+                    "fmt": "7.25M",
+                    "longFmt": "7,250,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 58591000,
+                    "fmt": "58.59M",
+                    "longFmt": "58,591,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 18344000,
+                    "fmt": "18.34M",
+                    "longFmt": "18,344,000"
+                  },
+                  "otherAssets": {
+                    "raw": 673000,
+                    "fmt": "673k",
+                    "longFmt": "673,000"
+                  },
+                  "totalAssets": {
+                    "raw": 77608000,
+                    "fmt": "77.61M",
+                    "longFmt": "77,608,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 3960000,
+                    "fmt": "3.96M",
+                    "longFmt": "3,960,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 716000,
+                    "fmt": "716k",
+                    "longFmt": "716,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 674000,
+                    "fmt": "674k",
+                    "longFmt": "674,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 1336000,
+                    "fmt": "1.34M",
+                    "longFmt": "1,336,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 18368000,
+                    "fmt": "18.37M",
+                    "longFmt": "18,368,000"
+                  },
+                  "totalLiab": {
+                    "raw": 31132000,
+                    "fmt": "31.13M",
+                    "longFmt": "31,132,000"
+                  },
+                  "commonStock": {
+                    "raw": 48335000,
+                    "fmt": "48.34M",
+                    "longFmt": "48,335,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -154233000,
+                    "fmt": "-154.23M",
+                    "longFmt": "-154,233,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -1000,
+                    "fmt": "-1k",
+                    "longFmt": "-1,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 151039000,
+                    "fmt": "151.04M",
+                    "longFmt": "151,039,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -1000,
+                    "fmt": "-1k",
+                    "longFmt": "-1,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 45140000,
+                    "fmt": "45.14M",
+                    "longFmt": "45,140,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 45140000,
+                    "fmt": "45.14M",
+                    "longFmt": "45,140,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "cash": {
+                    "raw": 31662000,
+                    "fmt": "31.66M",
+                    "longFmt": "31,662,000"
+                  },
+                  "netReceivables": {
+                    "raw": 17182000,
+                    "fmt": "17.18M",
+                    "longFmt": "17,182,000"
+                  },
+                  "inventory": {
+                    "raw": 6560000,
+                    "fmt": "6.56M",
+                    "longFmt": "6,560,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 55867000,
+                    "fmt": "55.87M",
+                    "longFmt": "55,867,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 21051000,
+                    "fmt": "21.05M",
+                    "longFmt": "21,051,000"
+                  },
+                  "otherAssets": {
+                    "raw": 7551000,
+                    "fmt": "7.55M",
+                    "longFmt": "7,551,000"
+                  },
+                  "totalAssets": {
+                    "raw": 84469000,
+                    "fmt": "84.47M",
+                    "longFmt": "84,469,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 6076000,
+                    "fmt": "6.08M",
+                    "longFmt": "6,076,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 7551000,
+                    "fmt": "7.55M",
+                    "longFmt": "7,551,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 876000,
+                    "fmt": "876k",
+                    "longFmt": "876,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 17310000,
+                    "fmt": "17.31M",
+                    "longFmt": "17,310,000"
+                  },
+                  "totalLiab": {
+                    "raw": 31998000,
+                    "fmt": "32M",
+                    "longFmt": "31,998,000"
+                  },
+                  "commonStock": {
+                    "raw": 48335000,
+                    "fmt": "48.34M",
+                    "longFmt": "48,335,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -147778000,
+                    "fmt": "-147.78M",
+                    "longFmt": "-147,778,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -1000,
+                    "fmt": "-1k",
+                    "longFmt": "-1,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 151039000,
+                    "fmt": "151.04M",
+                    "longFmt": "151,039,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -1000,
+                    "fmt": "-1k",
+                    "longFmt": "-1,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 51595000,
+                    "fmt": "51.59M",
+                    "longFmt": "51,595,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 51595000,
+                    "fmt": "51.59M",
+                    "longFmt": "51,595,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "cash": {
+                    "raw": 30593000,
+                    "fmt": "30.59M",
+                    "longFmt": "30,593,000"
+                  },
+                  "netReceivables": {
+                    "raw": 11336000,
+                    "fmt": "11.34M",
+                    "longFmt": "11,336,000"
+                  },
+                  "inventory": {
+                    "raw": 5011000,
+                    "fmt": "5.01M",
+                    "longFmt": "5,011,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": -1000,
+                    "fmt": "-1k",
+                    "longFmt": "-1,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 49966000,
+                    "fmt": "49.97M",
+                    "longFmt": "49,966,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 4589000,
+                    "fmt": "4.59M",
+                    "longFmt": "4,589,000"
+                  },
+                  "otherAssets": {
+                    "raw": 7128000,
+                    "fmt": "7.13M",
+                    "longFmt": "7,128,000"
+                  },
+                  "totalAssets": {
+                    "raw": 61683000,
+                    "fmt": "61.68M",
+                    "longFmt": "61,683,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 5808000,
+                    "fmt": "5.81M",
+                    "longFmt": "5,808,000"
+                  },
+                  "otherLiab": {
+                    "raw": -2000,
+                    "fmt": "-2k",
+                    "longFmt": "-2,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 7119000,
+                    "fmt": "7.12M",
+                    "longFmt": "7,119,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 715000,
+                    "fmt": "715k",
+                    "longFmt": "715,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 16870000,
+                    "fmt": "16.87M",
+                    "longFmt": "16,870,000"
+                  },
+                  "totalLiab": {
+                    "raw": 16868000,
+                    "fmt": "16.87M",
+                    "longFmt": "16,868,000"
+                  },
+                  "commonStock": {
+                    "raw": 43945000,
+                    "fmt": "43.95M",
+                    "longFmt": "43,945,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -133223000,
+                    "fmt": "-133.22M",
+                    "longFmt": "-133,223,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 133378000,
+                    "fmt": "133.38M",
+                    "longFmt": "133,378,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 44100000,
+                    "fmt": "44.1M",
+                    "longFmt": "44,100,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 44100000,
+                    "fmt": "44.1M",
+                    "longFmt": "44,100,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistory-SIX.json
+++ b/tests/http/quoteSummary-balanceSheetHistory-SIX.json
@@ -1,0 +1,634 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=balanceSheetHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "15gf98hg2nuh7"
+      ],
+      "x-yahoo-request-id": [
+        "15gf98hg2nuh7"
+      ],
+      "x-request-id": [
+        "cf7b0ee9-ca45-46d8-a7a1-a3c8ff23bc0b"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1920"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:23 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 174179000,
+                    "fmt": "174.18M",
+                    "longFmt": "174,179,000"
+                  },
+                  "netReceivables": {
+                    "raw": 108679000,
+                    "fmt": "108.68M",
+                    "longFmt": "108,679,000"
+                  },
+                  "inventory": {
+                    "raw": 55851000,
+                    "fmt": "55.85M",
+                    "longFmt": "55,851,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 1800000,
+                    "fmt": "1.8M",
+                    "longFmt": "1,800,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 376240000,
+                    "fmt": "376.24M",
+                    "longFmt": "376,240,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 1440000,
+                    "fmt": "1.44M",
+                    "longFmt": "1,440,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 1485124000,
+                    "fmt": "1.49B",
+                    "longFmt": "1,485,124,000"
+                  },
+                  "goodWill": {
+                    "raw": 659618000,
+                    "fmt": "659.62M",
+                    "longFmt": "659,618,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 345212000,
+                    "fmt": "345.21M",
+                    "longFmt": "345,212,000"
+                  },
+                  "otherAssets": {
+                    "raw": 14906000,
+                    "fmt": "14.91M",
+                    "longFmt": "14,906,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2882540000,
+                    "fmt": "2.88B",
+                    "longFmt": "2,882,540,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 32904000,
+                    "fmt": "32.9M",
+                    "longFmt": "32,904,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 8788000,
+                    "fmt": "8.79M",
+                    "longFmt": "8,788,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 144040000,
+                    "fmt": "144.04M",
+                    "longFmt": "144,040,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 2269551000,
+                    "fmt": "2.27B",
+                    "longFmt": "2,269,551,000"
+                  },
+                  "otherLiab": {
+                    "raw": 271968000,
+                    "fmt": "271.97M",
+                    "longFmt": "271,968,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 3624000,
+                    "fmt": "3.62M",
+                    "longFmt": "3,624,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 529258000,
+                    "fmt": "529.26M",
+                    "longFmt": "529,258,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 339732000,
+                    "fmt": "339.73M",
+                    "longFmt": "339,732,000"
+                  },
+                  "totalLiab": {
+                    "raw": 3069400000,
+                    "fmt": "3.07B",
+                    "longFmt": "3,069,400,000"
+                  },
+                  "commonStock": {
+                    "raw": 2116000,
+                    "fmt": "2.12M",
+                    "longFmt": "2,116,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -1709747000,
+                    "fmt": "-1.71B",
+                    "longFmt": "-1,709,747,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -74710000,
+                    "fmt": "-74.71M",
+                    "longFmt": "-74,710,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1066223000,
+                    "fmt": "1.07B",
+                    "longFmt": "1,066,223,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -74710000,
+                    "fmt": "-74.71M",
+                    "longFmt": "-74,710,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -716118000,
+                    "fmt": "-716.12M",
+                    "longFmt": "-716,118,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -1720948000,
+                    "fmt": "-1.72B",
+                    "longFmt": "-1,720,948,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "cash": {
+                    "raw": 44608000,
+                    "fmt": "44.61M",
+                    "longFmt": "44,608,000"
+                  },
+                  "netReceivables": {
+                    "raw": 116043000,
+                    "fmt": "116.04M",
+                    "longFmt": "116,043,000"
+                  },
+                  "inventory": {
+                    "raw": 51679000,
+                    "fmt": "51.68M",
+                    "longFmt": "51,679,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 1600000,
+                    "fmt": "1.6M",
+                    "longFmt": "1,600,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 241929000,
+                    "fmt": "241.93M",
+                    "longFmt": "241,929,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 1253682000,
+                    "fmt": "1.25B",
+                    "longFmt": "1,253,682,000"
+                  },
+                  "goodWill": {
+                    "raw": 659618000,
+                    "fmt": "659.62M",
+                    "longFmt": "659,618,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 349029000,
+                    "fmt": "349.03M",
+                    "longFmt": "349,029,000"
+                  },
+                  "otherAssets": {
+                    "raw": 13070000,
+                    "fmt": "13.07M",
+                    "longFmt": "13,070,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2517328000,
+                    "fmt": "2.52B",
+                    "longFmt": "2,517,328,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 32905000,
+                    "fmt": "32.91M",
+                    "longFmt": "32,905,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 43000000,
+                    "fmt": "43M",
+                    "longFmt": "43,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 146227000,
+                    "fmt": "146.23M",
+                    "longFmt": "146,227,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 2063512000,
+                    "fmt": "2.06B",
+                    "longFmt": "2,063,512,000"
+                  },
+                  "otherLiab": {
+                    "raw": 203278000,
+                    "fmt": "203.28M",
+                    "longFmt": "203,278,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 1793000,
+                    "fmt": "1.79M",
+                    "longFmt": "1,793,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 525271000,
+                    "fmt": "525.27M",
+                    "longFmt": "525,271,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 368360000,
+                    "fmt": "368.36M",
+                    "longFmt": "368,360,000"
+                  },
+                  "totalLiab": {
+                    "raw": 2635150000,
+                    "fmt": "2.64B",
+                    "longFmt": "2,635,150,000"
+                  },
+                  "commonStock": {
+                    "raw": 2099000,
+                    "fmt": "2.1M",
+                    "longFmt": "2,099,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -1611334000,
+                    "fmt": "-1.61B",
+                    "longFmt": "-1,611,334,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -71498000,
+                    "fmt": "-71.5M",
+                    "longFmt": "-71,498,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1037640000,
+                    "fmt": "1.04B",
+                    "longFmt": "1,037,640,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -71498000,
+                    "fmt": "-71.5M",
+                    "longFmt": "-71,498,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -643093000,
+                    "fmt": "-643.09M",
+                    "longFmt": "-643,093,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -1651740000,
+                    "fmt": "-1.65B",
+                    "longFmt": "-1,651,740,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "cash": {
+                    "raw": 77496000,
+                    "fmt": "77.5M",
+                    "longFmt": "77,496,000"
+                  },
+                  "netReceivables": {
+                    "raw": 72693000,
+                    "fmt": "72.69M",
+                    "longFmt": "72,693,000"
+                  },
+                  "inventory": {
+                    "raw": 46060000,
+                    "fmt": "46.06M",
+                    "longFmt": "46,060,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 1900000,
+                    "fmt": "1.9M",
+                    "longFmt": "1,900,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 221072000,
+                    "fmt": "221.07M",
+                    "longFmt": "221,072,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 1237957000,
+                    "fmt": "1.24B",
+                    "longFmt": "1,237,957,000"
+                  },
+                  "goodWill": {
+                    "raw": 630248000,
+                    "fmt": "630.25M",
+                    "longFmt": "630,248,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 351587000,
+                    "fmt": "351.59M",
+                    "longFmt": "351,587,000"
+                  },
+                  "otherAssets": {
+                    "raw": 15812000,
+                    "fmt": "15.81M",
+                    "longFmt": "15,812,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2456676000,
+                    "fmt": "2.46B",
+                    "longFmt": "2,456,676,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 28998000,
+                    "fmt": "29M",
+                    "longFmt": "28,998,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 142014000,
+                    "fmt": "142.01M",
+                    "longFmt": "142,014,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 2021178000,
+                    "fmt": "2.02B",
+                    "longFmt": "2,021,178,000"
+                  },
+                  "otherLiab": {
+                    "raw": 148339000,
+                    "fmt": "148.34M",
+                    "longFmt": "148,339,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 2991000,
+                    "fmt": "2.99M",
+                    "longFmt": "2,991,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 494431000,
+                    "fmt": "494.43M",
+                    "longFmt": "494,431,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 297840000,
+                    "fmt": "297.84M",
+                    "longFmt": "297,840,000"
+                  },
+                  "totalLiab": {
+                    "raw": 2467357000,
+                    "fmt": "2.47B",
+                    "longFmt": "2,467,357,000"
+                  },
+                  "commonStock": {
+                    "raw": 2112000,
+                    "fmt": "2.11M",
+                    "longFmt": "2,112,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -1529608000,
+                    "fmt": "-1.53B",
+                    "longFmt": "-1,529,608,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -63881000,
+                    "fmt": "-63.88M",
+                    "longFmt": "-63,881,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1086265000,
+                    "fmt": "1.09B",
+                    "longFmt": "1,086,265,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -63881000,
+                    "fmt": "-63.88M",
+                    "longFmt": "-63,881,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -505112000,
+                    "fmt": "-505.11M",
+                    "longFmt": "-505,112,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -1486947000,
+                    "fmt": "-1.49B",
+                    "longFmt": "-1,486,947,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "cash": {
+                    "raw": 137385000,
+                    "fmt": "137.38M",
+                    "longFmt": "137,385,000"
+                  },
+                  "netReceivables": {
+                    "raw": 69018000,
+                    "fmt": "69.02M",
+                    "longFmt": "69,018,000"
+                  },
+                  "inventory": {
+                    "raw": 45556000,
+                    "fmt": "45.56M",
+                    "longFmt": "45,556,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 5726000,
+                    "fmt": "5.73M",
+                    "longFmt": "5,726,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 278791000,
+                    "fmt": "278.79M",
+                    "longFmt": "278,791,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 1211255000,
+                    "fmt": "1.21B",
+                    "longFmt": "1,211,255,000"
+                  },
+                  "goodWill": {
+                    "raw": 630248000,
+                    "fmt": "630.25M",
+                    "longFmt": "630,248,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 353972000,
+                    "fmt": "353.97M",
+                    "longFmt": "353,972,000"
+                  },
+                  "otherAssets": {
+                    "raw": 13406000,
+                    "fmt": "13.41M",
+                    "longFmt": "13,406,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2487672000,
+                    "fmt": "2.49B",
+                    "longFmt": "2,487,672,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 26209000,
+                    "fmt": "26.21M",
+                    "longFmt": "26,209,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 30032000,
+                    "fmt": "30.03M",
+                    "longFmt": "30,032,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 123955000,
+                    "fmt": "123.95M",
+                    "longFmt": "123,955,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 1624486000,
+                    "fmt": "1.62B",
+                    "longFmt": "1,624,486,000"
+                  },
+                  "otherLiab": {
+                    "raw": 247848000,
+                    "fmt": "247.85M",
+                    "longFmt": "247,848,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 4188000,
+                    "fmt": "4.19M",
+                    "longFmt": "4,188,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 485876000,
+                    "fmt": "485.88M",
+                    "longFmt": "485,876,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 315952000,
+                    "fmt": "315.95M",
+                    "longFmt": "315,952,000"
+                  },
+                  "totalLiab": {
+                    "raw": 2188286000,
+                    "fmt": "2.19B",
+                    "longFmt": "2,188,286,000"
+                  },
+                  "commonStock": {
+                    "raw": 2271000,
+                    "fmt": "2.27M",
+                    "longFmt": "2,271,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -1237804000,
+                    "fmt": "-1.24B",
+                    "longFmt": "-1,237,804,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -67184000,
+                    "fmt": "-67.18M",
+                    "longFmt": "-67,184,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1116227000,
+                    "fmt": "1.12B",
+                    "longFmt": "1,116,227,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -67184000,
+                    "fmt": "-67.18M",
+                    "longFmt": "-67,184,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -186490000,
+                    "fmt": "-186.49M",
+                    "longFmt": "-186,490,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -1170710000,
+                    "fmt": "-1.17B",
+                    "longFmt": "-1,170,710,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistory-WSKT.JK.json
+++ b/tests/http/quoteSummary-balanceSheetHistory-WSKT.JK.json
@@ -1,0 +1,674 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=balanceSheetHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "a3jk61hg2nuh7"
+      ],
+      "x-yahoo-request-id": [
+        "a3jk61hg2nuh7"
+      ],
+      "x-request-id": [
+        "b81e8e93-2e4c-435d-83f0-1979f06645ab"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:22 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 9258310028392,
+                    "fmt": "9.26T",
+                    "longFmt": "9,258,310,028,392"
+                  },
+                  "netReceivables": {
+                    "raw": 31735705540115,
+                    "fmt": "31.74T",
+                    "longFmt": "31,735,705,540,115"
+                  },
+                  "inventory": {
+                    "raw": 4470845549423,
+                    "fmt": "4.47T",
+                    "longFmt": "4,470,845,549,423"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 3395288657104,
+                    "fmt": "3.4T",
+                    "longFmt": "3,395,288,657,104"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 49037842886120,
+                    "fmt": "49.04T",
+                    "longFmt": "49,037,842,886,120"
+                  },
+                  "longTermInvestments": {
+                    "raw": 5831251114741,
+                    "fmt": "5.83T",
+                    "longFmt": "5,831,251,114,741"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 8663216063821,
+                    "fmt": "8.66T",
+                    "longFmt": "8,663,216,063,821"
+                  },
+                  "goodWill": {
+                    "raw": 1995908825753,
+                    "fmt": "2T",
+                    "longFmt": "1,995,908,825,753"
+                  },
+                  "intangibleAssets": {
+                    "raw": 55407004501205,
+                    "fmt": "55.41T",
+                    "longFmt": "55,407,004,501,205"
+                  },
+                  "otherAssets": {
+                    "raw": 1654035958931,
+                    "fmt": "1.65T",
+                    "longFmt": "1,654,035,958,931"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 1542424572,
+                    "fmt": "1.54B",
+                    "longFmt": "1,542,424,572"
+                  },
+                  "totalAssets": {
+                    "raw": 122589259350571,
+                    "fmt": "122.59T",
+                    "longFmt": "122,589,259,350,571"
+                  },
+                  "accountsPayable": {
+                    "raw": 11005539197920,
+                    "fmt": "11.01T",
+                    "longFmt": "11,005,539,197,920"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 4098002350931,
+                    "fmt": "4.1T",
+                    "longFmt": "4,098,002,350,931"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 4340597615238,
+                    "fmt": "4.34T",
+                    "longFmt": "4,340,597,615,238"
+                  },
+                  "longTermDebt": {
+                    "raw": 43894161654013,
+                    "fmt": "43.89T",
+                    "longFmt": "43,894,161,654,013"
+                  },
+                  "otherLiab": {
+                    "raw": 4553133367976,
+                    "fmt": "4.55T",
+                    "longFmt": "4,553,133,367,976"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 754641393913,
+                    "fmt": "754.64B",
+                    "longFmt": "754,641,393,913"
+                  },
+                  "minorityInterest": {
+                    "raw": 11236061197428,
+                    "fmt": "11.24T",
+                    "longFmt": "11,236,061,197,428"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 45023495139583,
+                    "fmt": "45.02T",
+                    "longFmt": "45,023,495,139,583"
+                  },
+                  "totalLiab": {
+                    "raw": 93470790161572,
+                    "fmt": "93.47T",
+                    "longFmt": "93,470,790,161,572"
+                  },
+                  "commonStock": {
+                    "raw": 1357390259999,
+                    "fmt": "1.36T",
+                    "longFmt": "1,357,390,259,999"
+                  },
+                  "retainedEarnings": {
+                    "raw": 10233409821327,
+                    "fmt": "10.23T",
+                    "longFmt": "10,233,409,821,327"
+                  },
+                  "treasuryStock": {
+                    "raw": 739581647808,
+                    "fmt": "739.58B",
+                    "longFmt": "739,581,647,808"
+                  },
+                  "capitalSurplus": {
+                    "raw": 5552026262437,
+                    "fmt": "5.55T",
+                    "longFmt": "5,552,026,262,437"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 739581647808,
+                    "fmt": "739.58B",
+                    "longFmt": "739,581,647,808"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 17882407991571,
+                    "fmt": "17.88T",
+                    "longFmt": "17,882,407,991,571"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -39520505335387,
+                    "fmt": "-39.52T",
+                    "longFmt": "-39,520,505,335,387"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "cash": {
+                    "raw": 10845678217201,
+                    "fmt": "10.85T",
+                    "longFmt": "10,845,678,217,201"
+                  },
+                  "netReceivables": {
+                    "raw": 47464287061607,
+                    "fmt": "47.46T",
+                    "longFmt": "47,464,287,061,607"
+                  },
+                  "inventory": {
+                    "raw": 5089231071244,
+                    "fmt": "5.09T",
+                    "longFmt": "5,089,231,071,244"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 3526907204627,
+                    "fmt": "3.53T",
+                    "longFmt": "3,526,907,204,627"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 66989129822191,
+                    "fmt": "66.99T",
+                    "longFmt": "66,989,129,822,191"
+                  },
+                  "longTermInvestments": {
+                    "raw": 6999294170541,
+                    "fmt": "7T",
+                    "longFmt": "6,999,294,170,541"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 7091121159643,
+                    "fmt": "7.09T",
+                    "longFmt": "7,091,121,159,643"
+                  },
+                  "goodWill": {
+                    "raw": 1995908825753,
+                    "fmt": "2T",
+                    "longFmt": "1,995,908,825,753"
+                  },
+                  "intangibleAssets": {
+                    "raw": 40279389428306,
+                    "fmt": "40.28T",
+                    "longFmt": "40,279,389,428,306"
+                  },
+                  "otherAssets": {
+                    "raw": 1036738217202,
+                    "fmt": "1.04T",
+                    "longFmt": "1,036,738,217,202"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 1557248071,
+                    "fmt": "1.56B",
+                    "longFmt": "1,557,248,071"
+                  },
+                  "totalAssets": {
+                    "raw": 124391581623636,
+                    "fmt": "124.39T",
+                    "longFmt": "124,391,581,623,636"
+                  },
+                  "accountsPayable": {
+                    "raw": 13992926025275,
+                    "fmt": "13.99T",
+                    "longFmt": "13,992,926,025,275"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2415988819622,
+                    "fmt": "2.42T",
+                    "longFmt": "2,415,988,819,622"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 8473013438526,
+                    "fmt": "8.47T",
+                    "longFmt": "8,473,013,438,526"
+                  },
+                  "longTermDebt": {
+                    "raw": 33063410723347,
+                    "fmt": "33.06T",
+                    "longFmt": "33,063,410,723,347"
+                  },
+                  "otherLiab": {
+                    "raw": 5641327050079,
+                    "fmt": "5.64T",
+                    "longFmt": "5,641,327,050,079"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 391791699443,
+                    "fmt": "391.79B",
+                    "longFmt": "391,791,699,443"
+                  },
+                  "minorityInterest": {
+                    "raw": 10886002685490,
+                    "fmt": "10.89T",
+                    "longFmt": "10,886,002,685,490"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 56799725099343,
+                    "fmt": "56.8T",
+                    "longFmt": "56,799,725,099,343"
+                  },
+                  "totalLiab": {
+                    "raw": 95504462872769,
+                    "fmt": "95.5T",
+                    "longFmt": "95,504,462,872,769"
+                  },
+                  "commonStock": {
+                    "raw": 1357390259999,
+                    "fmt": "1.36T",
+                    "longFmt": "1,357,390,259,999"
+                  },
+                  "retainedEarnings": {
+                    "raw": 10347404260305,
+                    "fmt": "10.35T",
+                    "longFmt": "10,347,404,260,305"
+                  },
+                  "treasuryStock": {
+                    "raw": 744295282636,
+                    "fmt": "744.3B",
+                    "longFmt": "744,295,282,636"
+                  },
+                  "capitalSurplus": {
+                    "raw": 5552026262437,
+                    "fmt": "5.55T",
+                    "longFmt": "5,552,026,262,437"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 744295282636,
+                    "fmt": "744.3B",
+                    "longFmt": "744,295,282,636"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 18001116065377,
+                    "fmt": "18T",
+                    "longFmt": "18,001,116,065,377"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -24274182188682,
+                    "fmt": "-24.27T",
+                    "longFmt": "-24,274,182,188,682"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "cash": {
+                    "raw": 6088962586747,
+                    "fmt": "6.09T",
+                    "longFmt": "6,088,962,586,747"
+                  },
+                  "netReceivables": {
+                    "raw": 39408619945371,
+                    "fmt": "39.41T",
+                    "longFmt": "39,408,619,945,371"
+                  },
+                  "inventory": {
+                    "raw": 3235500802811,
+                    "fmt": "3.24T",
+                    "longFmt": "3,235,500,802,811"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 3385713793217,
+                    "fmt": "3.39T",
+                    "longFmt": "3,385,713,793,217"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 52427017359620,
+                    "fmt": "52.43T",
+                    "longFmt": "52,427,017,359,620"
+                  },
+                  "longTermInvestments": {
+                    "raw": 3736960384503,
+                    "fmt": "3.74T",
+                    "longFmt": "3,736,960,384,503"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 4742288130361,
+                    "fmt": "4.74T",
+                    "longFmt": "4,742,288,130,361"
+                  },
+                  "goodWill": {
+                    "raw": 2235779910646,
+                    "fmt": "2.24T",
+                    "longFmt": "2,235,779,910,646"
+                  },
+                  "intangibleAssets": {
+                    "raw": 33952839928823,
+                    "fmt": "33.95T",
+                    "longFmt": "33,952,839,928,823"
+                  },
+                  "otherAssets": {
+                    "raw": 800875124671,
+                    "fmt": "800.88B",
+                    "longFmt": "800,875,124,671"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 43924035581,
+                    "fmt": "43.92B",
+                    "longFmt": "43,924,035,581"
+                  },
+                  "totalAssets": {
+                    "raw": 97895760838624,
+                    "fmt": "97.9T",
+                    "longFmt": "97,895,760,838,624"
+                  },
+                  "accountsPayable": {
+                    "raw": 13302261188858,
+                    "fmt": "13.3T",
+                    "longFmt": "13,302,261,188,858"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 5629492556,
+                    "fmt": "5.63B",
+                    "longFmt": "5,629,492,556"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 10459520855433,
+                    "fmt": "10.46T",
+                    "longFmt": "10,459,520,855,433"
+                  },
+                  "longTermDebt": {
+                    "raw": 18015354771288,
+                    "fmt": "18.02T",
+                    "longFmt": "18,015,354,771,288"
+                  },
+                  "otherLiab": {
+                    "raw": 4816383399778,
+                    "fmt": "4.82T",
+                    "longFmt": "4,816,383,399,778"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 82881610012,
+                    "fmt": "82.88B",
+                    "longFmt": "82,881,610,012"
+                  },
+                  "minorityInterest": {
+                    "raw": 8748386520139,
+                    "fmt": "8.75T",
+                    "longFmt": "8,748,386,520,139"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 52309197858063,
+                    "fmt": "52.31T",
+                    "longFmt": "52,309,197,858,063"
+                  },
+                  "totalLiab": {
+                    "raw": 75140936029129,
+                    "fmt": "75.14T",
+                    "longFmt": "75,140,936,029,129"
+                  },
+                  "commonStock": {
+                    "raw": 1357390259999,
+                    "fmt": "1.36T",
+                    "longFmt": "1,357,390,259,999"
+                  },
+                  "retainedEarnings": {
+                    "raw": 6681081107614,
+                    "fmt": "6.68T",
+                    "longFmt": "6,681,081,107,614"
+                  },
+                  "treasuryStock": {
+                    "raw": 500948439660,
+                    "fmt": "500.95B",
+                    "longFmt": "500,948,439,660"
+                  },
+                  "capitalSurplus": {
+                    "raw": 5467018482083,
+                    "fmt": "5.47T",
+                    "longFmt": "5,467,018,482,083"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 500948439660,
+                    "fmt": "500.95B",
+                    "longFmt": "500,948,439,660"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 14006438289356,
+                    "fmt": "14.01T",
+                    "longFmt": "14,006,438,289,356"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -22182181550113,
+                    "fmt": "-22.18T",
+                    "longFmt": "-22,182,181,550,113"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "cash": {
+                    "raw": 10655996501931,
+                    "fmt": "10.66T",
+                    "longFmt": "10,655,996,501,931"
+                  },
+                  "netReceivables": {
+                    "raw": 22990628619814,
+                    "fmt": "22.99T",
+                    "longFmt": "22,990,628,619,814"
+                  },
+                  "inventory": {
+                    "raw": 2556731823542,
+                    "fmt": "2.56T",
+                    "longFmt": "2,556,731,823,542"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 3270562557214,
+                    "fmt": "3.27T",
+                    "longFmt": "3,270,562,557,214"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 39712575190796,
+                    "fmt": "39.71T",
+                    "longFmt": "39,712,575,190,796"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2619104734761,
+                    "fmt": "2.62T",
+                    "longFmt": "2,619,104,734,761"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 3013846252216,
+                    "fmt": "3.01T",
+                    "longFmt": "3,013,846,252,216"
+                  },
+                  "goodWill": {
+                    "raw": 1710769397469,
+                    "fmt": "1.71T",
+                    "longFmt": "1,710,769,397,469"
+                  },
+                  "intangibleAssets": {
+                    "raw": 11165160066676,
+                    "fmt": "11.17T",
+                    "longFmt": "11,165,160,066,676"
+                  },
+                  "otherAssets": {
+                    "raw": 3211556532529,
+                    "fmt": "3.21T",
+                    "longFmt": "3,211,556,532,529"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 195138147024,
+                    "fmt": "195.14B",
+                    "longFmt": "195,138,147,024"
+                  },
+                  "totalAssets": {
+                    "raw": 61433012174447,
+                    "fmt": "61.43T",
+                    "longFmt": "61,433,012,174,447"
+                  },
+                  "accountsPayable": {
+                    "raw": 6736101006394,
+                    "fmt": "6.74T",
+                    "longFmt": "6,736,101,006,394"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 5616284004,
+                    "fmt": "5.62B",
+                    "longFmt": "5,616,284,004"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 8190647584185,
+                    "fmt": "8.19T",
+                    "longFmt": "8,190,647,584,185"
+                  },
+                  "longTermDebt": {
+                    "raw": 9890719214953,
+                    "fmt": "9.89T",
+                    "longFmt": "9,890,719,214,953"
+                  },
+                  "otherLiab": {
+                    "raw": 3485420602242,
+                    "fmt": "3.49T",
+                    "longFmt": "3,485,420,602,242"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 39391831786,
+                    "fmt": "39.39B",
+                    "longFmt": "39,391,831,786"
+                  },
+                  "minorityInterest": {
+                    "raw": 5703665307835,
+                    "fmt": "5.7T",
+                    "longFmt": "5,703,665,307,835"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 31283653800304,
+                    "fmt": "31.28T",
+                    "longFmt": "31,283,653,800,304"
+                  },
+                  "totalLiab": {
+                    "raw": 44659793617499,
+                    "fmt": "44.66T",
+                    "longFmt": "44,659,793,617,499"
+                  },
+                  "commonStock": {
+                    "raw": 1357365455000,
+                    "fmt": "1.36T",
+                    "longFmt": "1,357,365,455,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 3334161614252,
+                    "fmt": "3.33T",
+                    "longFmt": "3,334,161,614,252"
+                  },
+                  "treasuryStock": {
+                    "raw": 495349287477,
+                    "fmt": "495.35B",
+                    "longFmt": "495,349,287,477"
+                  },
+                  "capitalSurplus": {
+                    "raw": 5882676892384,
+                    "fmt": "5.88T",
+                    "longFmt": "5,882,676,892,384"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 495349287477,
+                    "fmt": "495.35B",
+                    "longFmt": "495,349,287,477"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 11069553249113,
+                    "fmt": "11.07T",
+                    "longFmt": "11,069,553,249,113"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -1806376215032,
+                    "fmt": "-1.81T",
+                    "longFmt": "-1,806,376,215,032"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistoryQuarterly-ADH.json
+++ b/tests/http/quoteSummary-balanceSheetHistoryQuarterly-ADH.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=balanceSheetHistoryQuarterly"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "8skf195g2nrr4"
+      ],
+      "x-yahoo-request-id": [
+        "8skf195g2nrr4"
+      ],
+      "x-request-id": [
+        "8a74d8d0-269b-4a95-ac80-51492e8b818b"
+      ],
+      "content-length": [
+        "161"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:27 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=balanceSheetHistoryQuarterly"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistoryQuarterly-AFRAF.json
+++ b/tests/http/quoteSummary-balanceSheetHistoryQuarterly-AFRAF.json
@@ -1,0 +1,664 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=balanceSheetHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "9mnhtc1g2nrr4"
+      ],
+      "x-yahoo-request-id": [
+        "9mnhtc1g2nrr4"
+      ],
+      "x-request-id": [
+        "0b4eaef0-b0a9-4891-9991-5156eab73a12"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:28 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 5917000000,
+                    "fmt": "5.92B",
+                    "longFmt": "5,917,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 443000000,
+                    "fmt": "443M",
+                    "longFmt": "443,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 1731000000,
+                    "fmt": "1.73B",
+                    "longFmt": "1,731,000,000"
+                  },
+                  "inventory": {
+                    "raw": 561000000,
+                    "fmt": "561M",
+                    "longFmt": "561,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 206000000,
+                    "fmt": "206M",
+                    "longFmt": "206,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 9012000000,
+                    "fmt": "9.01B",
+                    "longFmt": "9,012,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 1228000000,
+                    "fmt": "1.23B",
+                    "longFmt": "1,228,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 17333000000,
+                    "fmt": "17.33B",
+                    "longFmt": "17,333,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 216000000,
+                    "fmt": "216M",
+                    "longFmt": "216,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 1253000000,
+                    "fmt": "1.25B",
+                    "longFmt": "1,253,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 543000000,
+                    "fmt": "543M",
+                    "longFmt": "543,000,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 271000000,
+                    "fmt": "271M",
+                    "longFmt": "271,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 29585000000,
+                    "fmt": "29.59B",
+                    "longFmt": "29,585,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1555000000,
+                    "fmt": "1.55B",
+                    "longFmt": "1,555,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 1709000000,
+                    "fmt": "1.71B",
+                    "longFmt": "1,709,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 8136000000,
+                    "fmt": "8.14B",
+                    "longFmt": "8,136,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 7636000000,
+                    "fmt": "7.64B",
+                    "longFmt": "7,636,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 6372000000,
+                    "fmt": "6.37B",
+                    "longFmt": "6,372,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 9000000,
+                    "fmt": "9M",
+                    "longFmt": "9,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 14438000000,
+                    "fmt": "14.44B",
+                    "longFmt": "14,438,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 34258000000,
+                    "fmt": "34.26B",
+                    "longFmt": "34,258,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 429000000,
+                    "fmt": "429M",
+                    "longFmt": "429,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -9250000000,
+                    "fmt": "-9.25B",
+                    "longFmt": "-9,250,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 4139000000,
+                    "fmt": "4.14B",
+                    "longFmt": "4,139,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -9183000000,
+                    "fmt": "-9.18B",
+                    "longFmt": "-9,183,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -4682000000,
+                    "fmt": "-4.68B",
+                    "longFmt": "-4,682,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -6151000000,
+                    "fmt": "-6.15B",
+                    "longFmt": "-6,151,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "cash": {
+                    "raw": 4796000000,
+                    "fmt": "4.8B",
+                    "longFmt": "4,796,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 394000000,
+                    "fmt": "394M",
+                    "longFmt": "394,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 2042000000,
+                    "fmt": "2.04B",
+                    "longFmt": "2,042,000,000"
+                  },
+                  "inventory": {
+                    "raw": 647000000,
+                    "fmt": "647M",
+                    "longFmt": "647,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 246000000,
+                    "fmt": "246M",
+                    "longFmt": "246,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 8298000000,
+                    "fmt": "8.3B",
+                    "longFmt": "8,298,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 1338000000,
+                    "fmt": "1.34B",
+                    "longFmt": "1,338,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 17408000000,
+                    "fmt": "17.41B",
+                    "longFmt": "17,408,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 217000000,
+                    "fmt": "217M",
+                    "longFmt": "217,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 1282000000,
+                    "fmt": "1.28B",
+                    "longFmt": "1,282,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 767000000,
+                    "fmt": "767M",
+                    "longFmt": "767,000,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 282000000,
+                    "fmt": "282M",
+                    "longFmt": "282,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 29310000000,
+                    "fmt": "29.31B",
+                    "longFmt": "29,310,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1476000000,
+                    "fmt": "1.48B",
+                    "longFmt": "1,476,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 1295000000,
+                    "fmt": "1.29B",
+                    "longFmt": "1,295,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 8657000000,
+                    "fmt": "8.66B",
+                    "longFmt": "8,657,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 5292000000,
+                    "fmt": "5.29B",
+                    "longFmt": "5,292,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 6313000000,
+                    "fmt": "6.31B",
+                    "longFmt": "6,313,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 10000000,
+                    "fmt": "10M",
+                    "longFmt": "10,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 14291000000,
+                    "fmt": "14.29B",
+                    "longFmt": "14,291,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 31859000000,
+                    "fmt": "31.86B",
+                    "longFmt": "31,859,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 429000000,
+                    "fmt": "429M",
+                    "longFmt": "429,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -4343000000,
+                    "fmt": "-4.34B",
+                    "longFmt": "-4,343,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -3187000000,
+                    "fmt": "-3.19B",
+                    "longFmt": "-3,187,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 4139000000,
+                    "fmt": "4.14B",
+                    "longFmt": "4,139,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -3120000000,
+                    "fmt": "-3.12B",
+                    "longFmt": "-3,120,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -2962000000,
+                    "fmt": "-2.96B",
+                    "longFmt": "-2,962,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -4461000000,
+                    "fmt": "-4.46B",
+                    "longFmt": "-4,461,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "cash": {
+                    "raw": 5362000000,
+                    "fmt": "5.36B",
+                    "longFmt": "5,362,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 433000000,
+                    "fmt": "433M",
+                    "longFmt": "433,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 1565000000,
+                    "fmt": "1.56B",
+                    "longFmt": "1,565,000,000"
+                  },
+                  "inventory": {
+                    "raw": 691000000,
+                    "fmt": "691M",
+                    "longFmt": "691,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 1246000000,
+                    "fmt": "1.25B",
+                    "longFmt": "1,246,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 9297000000,
+                    "fmt": "9.3B",
+                    "longFmt": "9,297,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 1394000000,
+                    "fmt": "1.39B",
+                    "longFmt": "1,394,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 18161000000,
+                    "fmt": "18.16B",
+                    "longFmt": "18,161,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 218000000,
+                    "fmt": "218M",
+                    "longFmt": "218,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 1347000000,
+                    "fmt": "1.35B",
+                    "longFmt": "1,347,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 1362000000,
+                    "fmt": "1.36B",
+                    "longFmt": "1,362,000,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 325000000,
+                    "fmt": "325M",
+                    "longFmt": "325,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 31779000000,
+                    "fmt": "31.78B",
+                    "longFmt": "31,779,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 2056000000,
+                    "fmt": "2.06B",
+                    "longFmt": "2,056,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2575000000,
+                    "fmt": "2.58B",
+                    "longFmt": "2,575,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 9699000000,
+                    "fmt": "9.7B",
+                    "longFmt": "9,699,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 6730000000,
+                    "fmt": "6.73B",
+                    "longFmt": "6,730,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 6481000000,
+                    "fmt": "6.48B",
+                    "longFmt": "6,481,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 13000000,
+                    "fmt": "13M",
+                    "longFmt": "13,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 15305000000,
+                    "fmt": "15.3B",
+                    "longFmt": "15,305,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 31594000000,
+                    "fmt": "31.59B",
+                    "longFmt": "31,594,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 429000000,
+                    "fmt": "429M",
+                    "longFmt": "429,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -4799000000,
+                    "fmt": "-4.8B",
+                    "longFmt": "-4,799,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 4139000000,
+                    "fmt": "4.14B",
+                    "longFmt": "4,139,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -4732000000,
+                    "fmt": "-4.73B",
+                    "longFmt": "-4,732,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -231000000,
+                    "fmt": "-231M",
+                    "longFmt": "-231,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -1796000000,
+                    "fmt": "-1.8B",
+                    "longFmt": "-1,796,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 3715000000,
+                    "fmt": "3.71B",
+                    "longFmt": "3,715,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 50000000,
+                    "fmt": "50M",
+                    "longFmt": "50,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 2723000000,
+                    "fmt": "2.72B",
+                    "longFmt": "2,723,000,000"
+                  },
+                  "inventory": {
+                    "raw": 737000000,
+                    "fmt": "737M",
+                    "longFmt": "737,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 660000000,
+                    "fmt": "660M",
+                    "longFmt": "660,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 8539000000,
+                    "fmt": "8.54B",
+                    "longFmt": "8,539,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 969000000,
+                    "fmt": "969M",
+                    "longFmt": "969,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 18087000000,
+                    "fmt": "18.09B",
+                    "longFmt": "18,087,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 217000000,
+                    "fmt": "217M",
+                    "longFmt": "217,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 1305000000,
+                    "fmt": "1.3B",
+                    "longFmt": "1,305,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 1618000000,
+                    "fmt": "1.62B",
+                    "longFmt": "1,618,000,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 523000000,
+                    "fmt": "523M",
+                    "longFmt": "523,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 30735000000,
+                    "fmt": "30.73B",
+                    "longFmt": "30,735,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 2379000000,
+                    "fmt": "2.38B",
+                    "longFmt": "2,379,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 307000000,
+                    "fmt": "307M",
+                    "longFmt": "307,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 7332000000,
+                    "fmt": "7.33B",
+                    "longFmt": "7,332,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 3370000000,
+                    "fmt": "3.37B",
+                    "longFmt": "3,370,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 6330000000,
+                    "fmt": "6.33B",
+                    "longFmt": "6,330,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 15000000,
+                    "fmt": "15M",
+                    "longFmt": "15,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 12649000000,
+                    "fmt": "12.65B",
+                    "longFmt": "12,649,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 28436000000,
+                    "fmt": "28.44B",
+                    "longFmt": "28,436,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 429000000,
+                    "fmt": "429M",
+                    "longFmt": "429,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 360000000,
+                    "fmt": "360M",
+                    "longFmt": "360,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -3047000000,
+                    "fmt": "-3.05B",
+                    "longFmt": "-3,047,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 4139000000,
+                    "fmt": "4.14B",
+                    "longFmt": "4,139,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -2980000000,
+                    "fmt": "-2.98B",
+                    "longFmt": "-2,980,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1881000000,
+                    "fmt": "1.88B",
+                    "longFmt": "1,881,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 359000000,
+                    "fmt": "359M",
+                    "longFmt": "359,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistoryQuarterly-AMZN.json
+++ b/tests/http/quoteSummary-balanceSheetHistoryQuarterly-AMZN.json
@@ -1,0 +1,619 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=balanceSheetHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "eo18uspg2nrr4"
+      ],
+      "x-yahoo-request-id": [
+        "eo18uspg2nrr4"
+      ],
+      "x-request-id": [
+        "baa62489-1170-4e9e-a02e-9aeb7dd32a95"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:28 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "cash": {
+                    "raw": 42122000000,
+                    "fmt": "42.12B",
+                    "longFmt": "42,122,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 42274000000,
+                    "fmt": "42.27B",
+                    "longFmt": "42,274,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 24309000000,
+                    "fmt": "24.31B",
+                    "longFmt": "24,309,000,000"
+                  },
+                  "inventory": {
+                    "raw": 23795000000,
+                    "fmt": "23.8B",
+                    "longFmt": "23,795,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 233000000,
+                    "fmt": "233M",
+                    "longFmt": "233,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 132733000000,
+                    "fmt": "132.73B",
+                    "longFmt": "132,733,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 5700000000,
+                    "fmt": "5.7B",
+                    "longFmt": "5,700,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 150667000000,
+                    "fmt": "150.67B",
+                    "longFmt": "150,667,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 15017000000,
+                    "fmt": "15.02B",
+                    "longFmt": "15,017,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 4981000000,
+                    "fmt": "4.98B",
+                    "longFmt": "4,981,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 12097000000,
+                    "fmt": "12.1B",
+                    "longFmt": "12,097,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 321195000000,
+                    "fmt": "321.19B",
+                    "longFmt": "321,195,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 72539000000,
+                    "fmt": "72.54B",
+                    "longFmt": "72,539,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 1155000000,
+                    "fmt": "1.16B",
+                    "longFmt": "1,155,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 15267000000,
+                    "fmt": "15.27B",
+                    "longFmt": "15,267,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 31816000000,
+                    "fmt": "31.82B",
+                    "longFmt": "31,816,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 17017000000,
+                    "fmt": "17.02B",
+                    "longFmt": "17,017,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 126385000000,
+                    "fmt": "126.39B",
+                    "longFmt": "126,385,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 227791000000,
+                    "fmt": "227.79B",
+                    "longFmt": "227,791,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 52551000000,
+                    "fmt": "52.55B",
+                    "longFmt": "52,551,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -2017000000,
+                    "fmt": "-2.02B",
+                    "longFmt": "-2,017,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 42865000000,
+                    "fmt": "42.87B",
+                    "longFmt": "42,865,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -180000000,
+                    "fmt": "-180M",
+                    "longFmt": "-180,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 93404000000,
+                    "fmt": "93.4B",
+                    "longFmt": "93,404,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 73406000000,
+                    "fmt": "73.41B",
+                    "longFmt": "73,406,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 29930000000,
+                    "fmt": "29.93B",
+                    "longFmt": "29,930,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 38472000000,
+                    "fmt": "38.47B",
+                    "longFmt": "38,472,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 20593000000,
+                    "fmt": "20.59B",
+                    "longFmt": "20,593,000,000"
+                  },
+                  "inventory": {
+                    "raw": 23735000000,
+                    "fmt": "23.73B",
+                    "longFmt": "23,735,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 239000000,
+                    "fmt": "239M",
+                    "longFmt": "239,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 112969000000,
+                    "fmt": "112.97B",
+                    "longFmt": "112,969,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 4000000000,
+                    "fmt": "4B",
+                    "longFmt": "4,000,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 134100000000,
+                    "fmt": "134.1B",
+                    "longFmt": "134,100,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 14960000000,
+                    "fmt": "14.96B",
+                    "longFmt": "14,960,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 16150000000,
+                    "fmt": "16.15B",
+                    "longFmt": "16,150,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 282179000000,
+                    "fmt": "282.18B",
+                    "longFmt": "282,179,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 58334000000,
+                    "fmt": "58.33B",
+                    "longFmt": "58,334,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 155000000,
+                    "fmt": "155M",
+                    "longFmt": "155,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 9251000000,
+                    "fmt": "9.25B",
+                    "longFmt": "9,251,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 32929000000,
+                    "fmt": "32.93B",
+                    "longFmt": "32,929,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 15974000000,
+                    "fmt": "15.97B",
+                    "longFmt": "15,974,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 101912000000,
+                    "fmt": "101.91B",
+                    "longFmt": "101,912,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 199404000000,
+                    "fmt": "199.4B",
+                    "longFmt": "199,404,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 45329000000,
+                    "fmt": "45.33B",
+                    "longFmt": "45,329,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -2866000000,
+                    "fmt": "-2.87B",
+                    "longFmt": "-2,866,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 40307000000,
+                    "fmt": "40.31B",
+                    "longFmt": "40,307,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -1029000000,
+                    "fmt": "-1.03B",
+                    "longFmt": "-1,029,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 82775000000,
+                    "fmt": "82.78B",
+                    "longFmt": "82,775,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 67815000000,
+                    "fmt": "67.81B",
+                    "longFmt": "67,815,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "cash": {
+                    "raw": 37466000000,
+                    "fmt": "37.47B",
+                    "longFmt": "37,466,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 33925000000,
+                    "fmt": "33.92B",
+                    "longFmt": "33,925,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 19564000000,
+                    "fmt": "19.56B",
+                    "longFmt": "19,564,000,000"
+                  },
+                  "inventory": {
+                    "raw": 19599000000,
+                    "fmt": "19.6B",
+                    "longFmt": "19,599,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 354000000,
+                    "fmt": "354M",
+                    "longFmt": "354,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 110908000000,
+                    "fmt": "110.91B",
+                    "longFmt": "110,908,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2500000000,
+                    "fmt": "2.5B",
+                    "longFmt": "2,500,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 115054000000,
+                    "fmt": "115.05B",
+                    "longFmt": "115,054,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 14751000000,
+                    "fmt": "14.75B",
+                    "longFmt": "14,751,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 15101000000,
+                    "fmt": "15.1B",
+                    "longFmt": "15,101,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 258314000000,
+                    "fmt": "258.31B",
+                    "longFmt": "258,314,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 51036000000,
+                    "fmt": "51.04B",
+                    "longFmt": "51,036,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 1154000000,
+                    "fmt": "1.15B",
+                    "longFmt": "1,154,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 8997000000,
+                    "fmt": "9B",
+                    "longFmt": "8,997,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 33128000000,
+                    "fmt": "33.13B",
+                    "longFmt": "33,128,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 14764000000,
+                    "fmt": "14.76B",
+                    "longFmt": "14,764,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 93896000000,
+                    "fmt": "93.9B",
+                    "longFmt": "93,896,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 184586000000,
+                    "fmt": "184.59B",
+                    "longFmt": "184,586,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 38998000000,
+                    "fmt": "39B",
+                    "longFmt": "38,998,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -3292000000,
+                    "fmt": "-3.29B",
+                    "longFmt": "-3,292,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 38017000000,
+                    "fmt": "38.02B",
+                    "longFmt": "38,017,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -1455000000,
+                    "fmt": "-1.46B",
+                    "longFmt": "-1,455,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 73728000000,
+                    "fmt": "73.73B",
+                    "longFmt": "73,728,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 58977000000,
+                    "fmt": "58.98B",
+                    "longFmt": "58,977,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "cash": {
+                    "raw": 27201000000,
+                    "fmt": "27.2B",
+                    "longFmt": "27,201,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 22091000000,
+                    "fmt": "22.09B",
+                    "longFmt": "22,091,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 17836000000,
+                    "fmt": "17.84B",
+                    "longFmt": "17,836,000,000"
+                  },
+                  "inventory": {
+                    "raw": 18857000000,
+                    "fmt": "18.86B",
+                    "longFmt": "18,857,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 282000000,
+                    "fmt": "282M",
+                    "longFmt": "282,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 85985000000,
+                    "fmt": "85.98B",
+                    "longFmt": "85,985,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2028000000,
+                    "fmt": "2.03B",
+                    "longFmt": "2,028,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 104058000000,
+                    "fmt": "104.06B",
+                    "longFmt": "104,058,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 14739000000,
+                    "fmt": "14.74B",
+                    "longFmt": "14,739,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 16456000000,
+                    "fmt": "16.46B",
+                    "longFmt": "16,456,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 221238000000,
+                    "fmt": "221.24B",
+                    "longFmt": "221,238,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 40056000000,
+                    "fmt": "40.06B",
+                    "longFmt": "40,056,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 1311000000,
+                    "fmt": "1.31B",
+                    "longFmt": "1,311,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 8864000000,
+                    "fmt": "8.86B",
+                    "longFmt": "8,864,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 23437000000,
+                    "fmt": "23.44B",
+                    "longFmt": "23,437,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 12518000000,
+                    "fmt": "12.52B",
+                    "longFmt": "12,518,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 79711000000,
+                    "fmt": "79.71B",
+                    "longFmt": "79,711,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 155966000000,
+                    "fmt": "155.97B",
+                    "longFmt": "155,966,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 33755000000,
+                    "fmt": "33.76B",
+                    "longFmt": "33,755,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -3900000000,
+                    "fmt": "-3.9B",
+                    "longFmt": "-3,900,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 35412000000,
+                    "fmt": "35.41B",
+                    "longFmt": "35,412,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -2063000000,
+                    "fmt": "-2.06B",
+                    "longFmt": "-2,063,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 65272000000,
+                    "fmt": "65.27B",
+                    "longFmt": "65,272,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 50533000000,
+                    "fmt": "50.53B",
+                    "longFmt": "50,533,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistoryQuarterly-AZT.OL.json
+++ b/tests/http/quoteSummary-balanceSheetHistoryQuarterly-AZT.OL.json
@@ -1,0 +1,504 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=balanceSheetHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "fhahnipg2nrr4"
+      ],
+      "x-yahoo-request-id": [
+        "fhahnipg2nrr4"
+      ],
+      "x-request-id": [
+        "93518bfe-3470-42c1-92c7-8bcc2a65006a"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1366"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:28 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "cash": {
+                    "raw": 140178000,
+                    "fmt": "140.18M",
+                    "longFmt": "140,178,000"
+                  },
+                  "netReceivables": {
+                    "raw": 30705000,
+                    "fmt": "30.7M",
+                    "longFmt": "30,705,000"
+                  },
+                  "inventory": {
+                    "raw": 3889000,
+                    "fmt": "3.89M",
+                    "longFmt": "3,889,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 174772000,
+                    "fmt": "174.77M",
+                    "longFmt": "174,772,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 13573000,
+                    "fmt": "13.57M",
+                    "longFmt": "13,573,000"
+                  },
+                  "otherAssets": {
+                    "raw": 33402000,
+                    "fmt": "33.4M",
+                    "longFmt": "33,402,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 32978000,
+                    "fmt": "32.98M",
+                    "longFmt": "32,978,000"
+                  },
+                  "totalAssets": {
+                    "raw": 221747000,
+                    "fmt": "221.75M",
+                    "longFmt": "221,747,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 3456000,
+                    "fmt": "3.46M",
+                    "longFmt": "3,456,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 3721000,
+                    "fmt": "3.72M",
+                    "longFmt": "3,721,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 420000,
+                    "fmt": "420k",
+                    "longFmt": "420,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 3130000,
+                    "fmt": "3.13M",
+                    "longFmt": "3,130,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 14828000,
+                    "fmt": "14.83M",
+                    "longFmt": "14,828,000"
+                  },
+                  "totalLiab": {
+                    "raw": 24423000,
+                    "fmt": "24.42M",
+                    "longFmt": "24,423,000"
+                  },
+                  "commonStock": {
+                    "raw": 48335000,
+                    "fmt": "48.34M",
+                    "longFmt": "48,335,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -5180000,
+                    "fmt": "-5.18M",
+                    "longFmt": "-5,180,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 151039000,
+                    "fmt": "151.04M",
+                    "longFmt": "151,039,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 194194000,
+                    "fmt": "194.19M",
+                    "longFmt": "194,194,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 194194000,
+                    "fmt": "194.19M",
+                    "longFmt": "194,194,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 69660000,
+                    "fmt": "69.66M",
+                    "longFmt": "69,660,000"
+                  },
+                  "netReceivables": {
+                    "raw": 20754000,
+                    "fmt": "20.75M",
+                    "longFmt": "20,754,000"
+                  },
+                  "inventory": {
+                    "raw": 4876000,
+                    "fmt": "4.88M",
+                    "longFmt": "4,876,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 7640000,
+                    "fmt": "7.64M",
+                    "longFmt": "7,640,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 102930000,
+                    "fmt": "102.93M",
+                    "longFmt": "102,930,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 17051000,
+                    "fmt": "17.05M",
+                    "longFmt": "17,051,000"
+                  },
+                  "otherAssets": {
+                    "raw": 483000,
+                    "fmt": "483k",
+                    "longFmt": "483,000"
+                  },
+                  "totalAssets": {
+                    "raw": 120464000,
+                    "fmt": "120.46M",
+                    "longFmt": "120,464,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 10340000,
+                    "fmt": "10.34M",
+                    "longFmt": "10,340,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 7000,
+                    "fmt": "7k",
+                    "longFmt": "7,000"
+                  },
+                  "otherLiab": {
+                    "raw": 745000,
+                    "fmt": "745k",
+                    "longFmt": "745,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 484000,
+                    "fmt": "484k",
+                    "longFmt": "484,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 3039000,
+                    "fmt": "3.04M",
+                    "longFmt": "3,039,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 10347000,
+                    "fmt": "10.35M",
+                    "longFmt": "10,347,000"
+                  },
+                  "totalLiab": {
+                    "raw": 24835000,
+                    "fmt": "24.84M",
+                    "longFmt": "24,835,000"
+                  },
+                  "commonStock": {
+                    "raw": 48335000,
+                    "fmt": "48.34M",
+                    "longFmt": "48,335,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -106784000,
+                    "fmt": "-106.78M",
+                    "longFmt": "-106,784,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 151039000,
+                    "fmt": "151.04M",
+                    "longFmt": "151,039,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 92590000,
+                    "fmt": "92.59M",
+                    "longFmt": "92,590,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 92590000,
+                    "fmt": "92.59M",
+                    "longFmt": "92,590,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "cash": {
+                    "raw": 56109000,
+                    "fmt": "56.11M",
+                    "longFmt": "56,109,000"
+                  },
+                  "netReceivables": {
+                    "raw": 26660000,
+                    "fmt": "26.66M",
+                    "longFmt": "26,660,000"
+                  },
+                  "inventory": {
+                    "raw": 4439000,
+                    "fmt": "4.44M",
+                    "longFmt": "4,439,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 6961000,
+                    "fmt": "6.96M",
+                    "longFmt": "6,961,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 94169000,
+                    "fmt": "94.17M",
+                    "longFmt": "94,169,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 17887000,
+                    "fmt": "17.89M",
+                    "longFmt": "17,887,000"
+                  },
+                  "otherAssets": {
+                    "raw": 625000,
+                    "fmt": "625k",
+                    "longFmt": "625,000"
+                  },
+                  "totalAssets": {
+                    "raw": 112681000,
+                    "fmt": "112.68M",
+                    "longFmt": "112,681,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 4742000,
+                    "fmt": "4.74M",
+                    "longFmt": "4,742,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 3863000,
+                    "fmt": "3.86M",
+                    "longFmt": "3,863,000"
+                  },
+                  "otherLiab": {
+                    "raw": -1000,
+                    "fmt": "-1k",
+                    "longFmt": "-1,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 547000,
+                    "fmt": "547k",
+                    "longFmt": "547,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 2694000,
+                    "fmt": "2.69M",
+                    "longFmt": "2,694,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 12564000,
+                    "fmt": "12.56M",
+                    "longFmt": "12,564,000"
+                  },
+                  "totalLiab": {
+                    "raw": 26356000,
+                    "fmt": "26.36M",
+                    "longFmt": "26,356,000"
+                  },
+                  "commonStock": {
+                    "raw": 48335000,
+                    "fmt": "48.34M",
+                    "longFmt": "48,335,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -115743000,
+                    "fmt": "-115.74M",
+                    "longFmt": "-115,743,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 151039000,
+                    "fmt": "151.04M",
+                    "longFmt": "151,039,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 83631000,
+                    "fmt": "83.63M",
+                    "longFmt": "83,631,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 83631000,
+                    "fmt": "83.63M",
+                    "longFmt": "83,631,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "cash": {
+                    "raw": 35667000,
+                    "fmt": "35.67M",
+                    "longFmt": "35,667,000"
+                  },
+                  "netReceivables": {
+                    "raw": 23927000,
+                    "fmt": "23.93M",
+                    "longFmt": "23,927,000"
+                  },
+                  "inventory": {
+                    "raw": 4663000,
+                    "fmt": "4.66M",
+                    "longFmt": "4,663,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 8068000,
+                    "fmt": "8.07M",
+                    "longFmt": "8,068,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 72325000,
+                    "fmt": "72.33M",
+                    "longFmt": "72,325,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 18806000,
+                    "fmt": "18.81M",
+                    "longFmt": "18,806,000"
+                  },
+                  "otherAssets": {
+                    "raw": 612000,
+                    "fmt": "612k",
+                    "longFmt": "612,000"
+                  },
+                  "totalAssets": {
+                    "raw": 91743000,
+                    "fmt": "91.74M",
+                    "longFmt": "91,743,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 8206000,
+                    "fmt": "8.21M",
+                    "longFmt": "8,206,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 2640000,
+                    "fmt": "2.64M",
+                    "longFmt": "2,640,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 611000,
+                    "fmt": "611k",
+                    "longFmt": "611,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 1768000,
+                    "fmt": "1.77M",
+                    "longFmt": "1,768,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 17327000,
+                    "fmt": "17.33M",
+                    "longFmt": "17,327,000"
+                  },
+                  "totalLiab": {
+                    "raw": 31471000,
+                    "fmt": "31.47M",
+                    "longFmt": "31,471,000"
+                  },
+                  "commonStock": {
+                    "raw": 48335000,
+                    "fmt": "48.34M",
+                    "longFmt": "48,335,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -140870000,
+                    "fmt": "-140.87M",
+                    "longFmt": "-140,870,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 151039000,
+                    "fmt": "151.04M",
+                    "longFmt": "151,039,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 58504000,
+                    "fmt": "58.5M",
+                    "longFmt": "58,504,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 58504000,
+                    "fmt": "58.5M",
+                    "longFmt": "58,504,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistoryQuarterly-SIX.json
+++ b/tests/http/quoteSummary-balanceSheetHistoryQuarterly-SIX.json
@@ -1,0 +1,634 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=balanceSheetHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "0abe7itg2nuh7"
+      ],
+      "x-yahoo-request-id": [
+        "0abe7itg2nuh7"
+      ],
+      "x-request-id": [
+        "cd283d32-5f34-4844-818b-ad9f0156af83"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1898"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:23 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 213907000,
+                    "fmt": "213.91M",
+                    "longFmt": "213,907,000"
+                  },
+                  "netReceivables": {
+                    "raw": 48500000,
+                    "fmt": "48.5M",
+                    "longFmt": "48,500,000"
+                  },
+                  "inventory": {
+                    "raw": 43892000,
+                    "fmt": "43.89M",
+                    "longFmt": "43,892,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 381565000,
+                    "fmt": "381.56M",
+                    "longFmt": "381,565,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 1160000,
+                    "fmt": "1.16M",
+                    "longFmt": "1,160,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 1463694000,
+                    "fmt": "1.46B",
+                    "longFmt": "1,463,694,000"
+                  },
+                  "goodWill": {
+                    "raw": 659618000,
+                    "fmt": "659.62M",
+                    "longFmt": "659,618,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 344203000,
+                    "fmt": "344.2M",
+                    "longFmt": "344,203,000"
+                  },
+                  "otherAssets": {
+                    "raw": 14732000,
+                    "fmt": "14.73M",
+                    "longFmt": "14,732,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2864972000,
+                    "fmt": "2.86B",
+                    "longFmt": "2,864,972,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 36716000,
+                    "fmt": "36.72M",
+                    "longFmt": "36,716,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 9292000,
+                    "fmt": "9.29M",
+                    "longFmt": "9,292,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 198563000,
+                    "fmt": "198.56M",
+                    "longFmt": "198,563,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 2645353000,
+                    "fmt": "2.65B",
+                    "longFmt": "2,645,353,000"
+                  },
+                  "otherLiab": {
+                    "raw": 140883000,
+                    "fmt": "140.88M",
+                    "longFmt": "140,883,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 7568000,
+                    "fmt": "7.57M",
+                    "longFmt": "7,568,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 544020000,
+                    "fmt": "544.02M",
+                    "longFmt": "544,020,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 428356000,
+                    "fmt": "428.36M",
+                    "longFmt": "428,356,000"
+                  },
+                  "totalLiab": {
+                    "raw": 3397657000,
+                    "fmt": "3.4B",
+                    "longFmt": "3,397,657,000"
+                  },
+                  "commonStock": {
+                    "raw": 2124000,
+                    "fmt": "2.12M",
+                    "longFmt": "2,124,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -2067600000,
+                    "fmt": "-2.07B",
+                    "longFmt": "-2,067,600,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -97450000,
+                    "fmt": "-97.45M",
+                    "longFmt": "-97,450,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1086221000,
+                    "fmt": "1.09B",
+                    "longFmt": "1,086,221,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -97450000,
+                    "fmt": "-97.45M",
+                    "longFmt": "-97,450,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -1076705000,
+                    "fmt": "-1.08B",
+                    "longFmt": "-1,076,705,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -2080526000,
+                    "fmt": "-2.08B",
+                    "longFmt": "-2,080,526,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "cash": {
+                    "raw": 295956000,
+                    "fmt": "295.96M",
+                    "longFmt": "295,956,000"
+                  },
+                  "netReceivables": {
+                    "raw": 47003000,
+                    "fmt": "47M",
+                    "longFmt": "47,003,000"
+                  },
+                  "inventory": {
+                    "raw": 43456000,
+                    "fmt": "43.46M",
+                    "longFmt": "43,456,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 463175000,
+                    "fmt": "463.18M",
+                    "longFmt": "463,175,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 677000,
+                    "fmt": "677k",
+                    "longFmt": "677,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 1484772000,
+                    "fmt": "1.48B",
+                    "longFmt": "1,484,772,000"
+                  },
+                  "goodWill": {
+                    "raw": 659618000,
+                    "fmt": "659.62M",
+                    "longFmt": "659,618,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 344209000,
+                    "fmt": "344.21M",
+                    "longFmt": "344,209,000"
+                  },
+                  "otherAssets": {
+                    "raw": 16483000,
+                    "fmt": "16.48M",
+                    "longFmt": "16,483,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2968934000,
+                    "fmt": "2.97B",
+                    "longFmt": "2,968,934,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 27457000,
+                    "fmt": "27.46M",
+                    "longFmt": "27,457,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 8984000,
+                    "fmt": "8.98M",
+                    "longFmt": "8,984,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 182386000,
+                    "fmt": "182.39M",
+                    "longFmt": "182,386,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 2645017000,
+                    "fmt": "2.65B",
+                    "longFmt": "2,645,017,000"
+                  },
+                  "otherLiab": {
+                    "raw": 178437000,
+                    "fmt": "178.44M",
+                    "longFmt": "178,437,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 7451000,
+                    "fmt": "7.45M",
+                    "longFmt": "7,451,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 544020000,
+                    "fmt": "544.02M",
+                    "longFmt": "544,020,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 380385000,
+                    "fmt": "380.38M",
+                    "longFmt": "380,385,000"
+                  },
+                  "totalLiab": {
+                    "raw": 3395696000,
+                    "fmt": "3.4B",
+                    "longFmt": "3,395,696,000"
+                  },
+                  "commonStock": {
+                    "raw": 2119000,
+                    "fmt": "2.12M",
+                    "longFmt": "2,119,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -1951428000,
+                    "fmt": "-1.95B",
+                    "longFmt": "-1,951,428,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -99421000,
+                    "fmt": "-99.42M",
+                    "longFmt": "-99,421,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1077948000,
+                    "fmt": "1.08B",
+                    "longFmt": "1,077,948,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -99421000,
+                    "fmt": "-99.42M",
+                    "longFmt": "-99,421,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -970782000,
+                    "fmt": "-970.78M",
+                    "longFmt": "-970,782,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -1974609000,
+                    "fmt": "-1.97B",
+                    "longFmt": "-1,974,609,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "cash": {
+                    "raw": 22811000,
+                    "fmt": "22.81M",
+                    "longFmt": "22,811,000"
+                  },
+                  "netReceivables": {
+                    "raw": 71558000,
+                    "fmt": "71.56M",
+                    "longFmt": "71,558,000"
+                  },
+                  "inventory": {
+                    "raw": 42397000,
+                    "fmt": "42.4M",
+                    "longFmt": "42,397,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 216262000,
+                    "fmt": "216.26M",
+                    "longFmt": "216,262,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 1486193000,
+                    "fmt": "1.49B",
+                    "longFmt": "1,486,193,000"
+                  },
+                  "goodWill": {
+                    "raw": 659618000,
+                    "fmt": "659.62M",
+                    "longFmt": "659,618,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 344611000,
+                    "fmt": "344.61M",
+                    "longFmt": "344,611,000"
+                  },
+                  "otherAssets": {
+                    "raw": 13865000,
+                    "fmt": "13.87M",
+                    "longFmt": "13,865,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2720549000,
+                    "fmt": "2.72B",
+                    "longFmt": "2,720,549,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 48994000,
+                    "fmt": "48.99M",
+                    "longFmt": "48,994,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 15689000,
+                    "fmt": "15.69M",
+                    "longFmt": "15,689,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 149111000,
+                    "fmt": "149.11M",
+                    "longFmt": "149,111,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 2238589000,
+                    "fmt": "2.24B",
+                    "longFmt": "2,238,589,000"
+                  },
+                  "otherLiab": {
+                    "raw": 234481000,
+                    "fmt": "234.48M",
+                    "longFmt": "234,481,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 3413000,
+                    "fmt": "3.41M",
+                    "longFmt": "3,413,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 529276000,
+                    "fmt": "529.28M",
+                    "longFmt": "529,276,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 385005000,
+                    "fmt": "385M",
+                    "longFmt": "385,005,000"
+                  },
+                  "totalLiab": {
+                    "raw": 3044137000,
+                    "fmt": "3.04B",
+                    "longFmt": "3,044,137,000"
+                  },
+                  "commonStock": {
+                    "raw": 2116000,
+                    "fmt": "2.12M",
+                    "longFmt": "2,116,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -1815457000,
+                    "fmt": "-1.82B",
+                    "longFmt": "-1,815,457,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -110423000,
+                    "fmt": "-110.42M",
+                    "longFmt": "-110,423,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1070900000,
+                    "fmt": "1.07B",
+                    "longFmt": "1,070,900,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -110423000,
+                    "fmt": "-110.42M",
+                    "longFmt": "-110,423,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -852864000,
+                    "fmt": "-852.86M",
+                    "longFmt": "-852,864,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -1857093000,
+                    "fmt": "-1.86B",
+                    "longFmt": "-1,857,093,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 174179000,
+                    "fmt": "174.18M",
+                    "longFmt": "174,179,000"
+                  },
+                  "netReceivables": {
+                    "raw": 108679000,
+                    "fmt": "108.68M",
+                    "longFmt": "108,679,000"
+                  },
+                  "inventory": {
+                    "raw": 55851000,
+                    "fmt": "55.85M",
+                    "longFmt": "55,851,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 1800000,
+                    "fmt": "1.8M",
+                    "longFmt": "1,800,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 376240000,
+                    "fmt": "376.24M",
+                    "longFmt": "376,240,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 1440000,
+                    "fmt": "1.44M",
+                    "longFmt": "1,440,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 1485124000,
+                    "fmt": "1.49B",
+                    "longFmt": "1,485,124,000"
+                  },
+                  "goodWill": {
+                    "raw": 659618000,
+                    "fmt": "659.62M",
+                    "longFmt": "659,618,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 345212000,
+                    "fmt": "345.21M",
+                    "longFmt": "345,212,000"
+                  },
+                  "otherAssets": {
+                    "raw": 14906000,
+                    "fmt": "14.91M",
+                    "longFmt": "14,906,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2882540000,
+                    "fmt": "2.88B",
+                    "longFmt": "2,882,540,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 32904000,
+                    "fmt": "32.9M",
+                    "longFmt": "32,904,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 8788000,
+                    "fmt": "8.79M",
+                    "longFmt": "8,788,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 144040000,
+                    "fmt": "144.04M",
+                    "longFmt": "144,040,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 2269551000,
+                    "fmt": "2.27B",
+                    "longFmt": "2,269,551,000"
+                  },
+                  "otherLiab": {
+                    "raw": 271968000,
+                    "fmt": "271.97M",
+                    "longFmt": "271,968,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 3624000,
+                    "fmt": "3.62M",
+                    "longFmt": "3,624,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 529258000,
+                    "fmt": "529.26M",
+                    "longFmt": "529,258,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 339732000,
+                    "fmt": "339.73M",
+                    "longFmt": "339,732,000"
+                  },
+                  "totalLiab": {
+                    "raw": 3069400000,
+                    "fmt": "3.07B",
+                    "longFmt": "3,069,400,000"
+                  },
+                  "commonStock": {
+                    "raw": 2116000,
+                    "fmt": "2.12M",
+                    "longFmt": "2,116,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -1709747000,
+                    "fmt": "-1.71B",
+                    "longFmt": "-1,709,747,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -74710000,
+                    "fmt": "-74.71M",
+                    "longFmt": "-74,710,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1066223000,
+                    "fmt": "1.07B",
+                    "longFmt": "1,066,223,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -74710000,
+                    "fmt": "-74.71M",
+                    "longFmt": "-74,710,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -716118000,
+                    "fmt": "-716.12M",
+                    "longFmt": "-716,118,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -1720948000,
+                    "fmt": "-1.72B",
+                    "longFmt": "-1,720,948,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistoryQuarterly-WSKT.JK.json
+++ b/tests/http/quoteSummary-balanceSheetHistoryQuarterly-WSKT.JK.json
@@ -1,0 +1,674 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=balanceSheetHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "6j77onhg2nuh7"
+      ],
+      "x-yahoo-request-id": [
+        "6j77onhg2nuh7"
+      ],
+      "x-request-id": [
+        "ec601082-0290-451d-b457-c7e679c4e7e4"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:23 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 1196916435771,
+                    "fmt": "1.2T",
+                    "longFmt": "1,196,916,435,771"
+                  },
+                  "netReceivables": {
+                    "raw": 26928085920268,
+                    "fmt": "26.93T",
+                    "longFmt": "26,928,085,920,268"
+                  },
+                  "inventory": {
+                    "raw": 6263183669294,
+                    "fmt": "6.26T",
+                    "longFmt": "6,263,183,669,294"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 2796544135411,
+                    "fmt": "2.8T",
+                    "longFmt": "2,796,544,135,411"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 37537617902373,
+                    "fmt": "37.54T",
+                    "longFmt": "37,537,617,902,373"
+                  },
+                  "longTermInvestments": {
+                    "raw": 5190918736054,
+                    "fmt": "5.19T",
+                    "longFmt": "5,190,918,736,054"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 8628639628135,
+                    "fmt": "8.63T",
+                    "longFmt": "8,628,639,628,135"
+                  },
+                  "goodWill": {
+                    "raw": 1995908825753,
+                    "fmt": "2T",
+                    "longFmt": "1,995,908,825,753"
+                  },
+                  "intangibleAssets": {
+                    "raw": 60902303757246,
+                    "fmt": "60.9T",
+                    "longFmt": "60,902,303,757,246"
+                  },
+                  "otherAssets": {
+                    "raw": 1373033621408,
+                    "fmt": "1.37T",
+                    "longFmt": "1,373,033,621,408"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 1542424572,
+                    "fmt": "1.54B",
+                    "longFmt": "1,542,424,572"
+                  },
+                  "totalAssets": {
+                    "raw": 115628422470969,
+                    "fmt": "115.63T",
+                    "longFmt": "115,628,422,470,969"
+                  },
+                  "accountsPayable": {
+                    "raw": 11465814751576,
+                    "fmt": "11.47T",
+                    "longFmt": "11,465,814,751,576"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 3351983886623,
+                    "fmt": "3.35T",
+                    "longFmt": "3,351,983,886,623"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 2269165024494,
+                    "fmt": "2.27T",
+                    "longFmt": "2,269,165,024,494"
+                  },
+                  "longTermDebt": {
+                    "raw": 47297590750350,
+                    "fmt": "47.3T",
+                    "longFmt": "47,297,590,750,350"
+                  },
+                  "otherLiab": {
+                    "raw": 5696103647600,
+                    "fmt": "5.7T",
+                    "longFmt": "5,696,103,647,600"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 492605345220,
+                    "fmt": "492.61B",
+                    "longFmt": "492,605,345,220"
+                  },
+                  "minorityInterest": {
+                    "raw": 10421911999730,
+                    "fmt": "10.42T",
+                    "longFmt": "10,421,911,999,730"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 38791359723845,
+                    "fmt": "38.79T",
+                    "longFmt": "38,791,359,723,845"
+                  },
+                  "totalLiab": {
+                    "raw": 91861232033380,
+                    "fmt": "91.86T",
+                    "longFmt": "91,861,232,033,380"
+                  },
+                  "commonStock": {
+                    "raw": 1357395099999,
+                    "fmt": "1.36T",
+                    "longFmt": "1,357,395,099,999"
+                  },
+                  "retainedEarnings": {
+                    "raw": 5691130393923,
+                    "fmt": "5.69T",
+                    "longFmt": "5,691,130,393,923"
+                  },
+                  "treasuryStock": {
+                    "raw": 744726681500,
+                    "fmt": "744.73B",
+                    "longFmt": "744,726,681,500"
+                  },
+                  "capitalSurplus": {
+                    "raw": 5552026262437,
+                    "fmt": "5.55T",
+                    "longFmt": "5,552,026,262,437"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 744726681500,
+                    "fmt": "744.73B",
+                    "longFmt": "744,726,681,500"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 13345278437859,
+                    "fmt": "13.35T",
+                    "longFmt": "13,345,278,437,859"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -49552934145140,
+                    "fmt": "-49.55T",
+                    "longFmt": "-49,552,934,145,140"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "cash": {
+                    "raw": 1366299381863,
+                    "fmt": "1.37T",
+                    "longFmt": "1,366,299,381,863"
+                  },
+                  "netReceivables": {
+                    "raw": 26186958985246,
+                    "fmt": "26.19T",
+                    "longFmt": "26,186,958,985,246"
+                  },
+                  "inventory": {
+                    "raw": 6317148827173,
+                    "fmt": "6.32T",
+                    "longFmt": "6,317,148,827,173"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 2591061621433,
+                    "fmt": "2.59T",
+                    "longFmt": "2,591,061,621,433"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 37025926290746,
+                    "fmt": "37.03T",
+                    "longFmt": "37,025,926,290,746"
+                  },
+                  "longTermInvestments": {
+                    "raw": 5263732229721,
+                    "fmt": "5.26T",
+                    "longFmt": "5,263,732,229,721"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 8761422244907,
+                    "fmt": "8.76T",
+                    "longFmt": "8,761,422,244,907"
+                  },
+                  "goodWill": {
+                    "raw": 1995908825753,
+                    "fmt": "2T",
+                    "longFmt": "1,995,908,825,753"
+                  },
+                  "intangibleAssets": {
+                    "raw": 59221238536004,
+                    "fmt": "59.22T",
+                    "longFmt": "59,221,238,536,004"
+                  },
+                  "otherAssets": {
+                    "raw": 1803969074991,
+                    "fmt": "1.8T",
+                    "longFmt": "1,803,969,074,991"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 1542424572,
+                    "fmt": "1.54B",
+                    "longFmt": "1,542,424,572"
+                  },
+                  "totalAssets": {
+                    "raw": 114072197202122,
+                    "fmt": "114.07T",
+                    "longFmt": "114,072,197,202,122"
+                  },
+                  "accountsPayable": {
+                    "raw": 10804444033232,
+                    "fmt": "10.8T",
+                    "longFmt": "10,804,444,033,232"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 3351671053395,
+                    "fmt": "3.35T",
+                    "longFmt": "3,351,671,053,395"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 1694021208195,
+                    "fmt": "1.69T",
+                    "longFmt": "1,694,021,208,195"
+                  },
+                  "longTermDebt": {
+                    "raw": 45152950254070,
+                    "fmt": "45.15T",
+                    "longFmt": "45,152,950,254,070"
+                  },
+                  "otherLiab": {
+                    "raw": 6125619272650,
+                    "fmt": "6.13T",
+                    "longFmt": "6,125,619,272,650"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 897764063758,
+                    "fmt": "897.76B",
+                    "longFmt": "897,764,063,758"
+                  },
+                  "minorityInterest": {
+                    "raw": 10937396959806,
+                    "fmt": "10.94T",
+                    "longFmt": "10,937,396,959,806"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 36897628462130,
+                    "fmt": "36.9T",
+                    "longFmt": "36,897,628,462,130"
+                  },
+                  "totalLiab": {
+                    "raw": 88248305812373,
+                    "fmt": "88.25T",
+                    "longFmt": "88,248,305,812,373"
+                  },
+                  "commonStock": {
+                    "raw": 1357390259999,
+                    "fmt": "1.36T",
+                    "longFmt": "1,357,390,259,999"
+                  },
+                  "retainedEarnings": {
+                    "raw": 7233006294697,
+                    "fmt": "7.23T",
+                    "longFmt": "7,233,006,294,697"
+                  },
+                  "treasuryStock": {
+                    "raw": 744071612810,
+                    "fmt": "744.07B",
+                    "longFmt": "744,071,612,810"
+                  },
+                  "capitalSurplus": {
+                    "raw": 5552026262437,
+                    "fmt": "5.55T",
+                    "longFmt": "5,552,026,262,437"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 744071612810,
+                    "fmt": "744.07B",
+                    "longFmt": "744,071,612,810"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 14886494429943,
+                    "fmt": "14.89T",
+                    "longFmt": "14,886,494,429,943"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -46330652931814,
+                    "fmt": "-46.33T",
+                    "longFmt": "-46,330,652,931,814"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "cash": {
+                    "raw": 6095716333927,
+                    "fmt": "6.1T",
+                    "longFmt": "6,095,716,333,927"
+                  },
+                  "netReceivables": {
+                    "raw": 25496655733611,
+                    "fmt": "25.5T",
+                    "longFmt": "25,496,655,733,611"
+                  },
+                  "inventory": {
+                    "raw": 5906201926405,
+                    "fmt": "5.91T",
+                    "longFmt": "5,906,201,926,405"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 2718232886651,
+                    "fmt": "2.72T",
+                    "longFmt": "2,718,232,886,651"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 40574034824419,
+                    "fmt": "40.57T",
+                    "longFmt": "40,574,034,824,419"
+                  },
+                  "longTermInvestments": {
+                    "raw": 6156475861107,
+                    "fmt": "6.16T",
+                    "longFmt": "6,156,475,861,107"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 8783961962045,
+                    "fmt": "8.78T",
+                    "longFmt": "8,783,961,962,045"
+                  },
+                  "goodWill": {
+                    "raw": 1995908825753,
+                    "fmt": "2T",
+                    "longFmt": "1,995,908,825,753"
+                  },
+                  "intangibleAssets": {
+                    "raw": 57127719260218,
+                    "fmt": "57.13T",
+                    "longFmt": "57,127,719,260,218"
+                  },
+                  "otherAssets": {
+                    "raw": 1727761993991,
+                    "fmt": "1.73T",
+                    "longFmt": "1,727,761,993,991"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 1542424572,
+                    "fmt": "1.54B",
+                    "longFmt": "1,542,424,572"
+                  },
+                  "totalAssets": {
+                    "raw": 116365862727533,
+                    "fmt": "116.37T",
+                    "longFmt": "116,365,862,727,533"
+                  },
+                  "accountsPayable": {
+                    "raw": 11379107135168,
+                    "fmt": "11.38T",
+                    "longFmt": "11,379,107,135,168"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 3351360509549,
+                    "fmt": "3.35T",
+                    "longFmt": "3,351,360,509,549"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 3067343739436,
+                    "fmt": "3.07T",
+                    "longFmt": "3,067,343,739,436"
+                  },
+                  "longTermDebt": {
+                    "raw": 43518251267218,
+                    "fmt": "43.52T",
+                    "longFmt": "43,518,251,267,218"
+                  },
+                  "otherLiab": {
+                    "raw": 5400046297919,
+                    "fmt": "5.4T",
+                    "longFmt": "5,400,046,297,919"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 858452764306,
+                    "fmt": "858.45B",
+                    "longFmt": "858,452,764,306"
+                  },
+                  "minorityInterest": {
+                    "raw": 11203544702256,
+                    "fmt": "11.2T",
+                    "longFmt": "11,203,544,702,256"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 40110874635803,
+                    "fmt": "40.11T",
+                    "longFmt": "40,110,874,635,803"
+                  },
+                  "totalLiab": {
+                    "raw": 89095812601411,
+                    "fmt": "89.1T",
+                    "longFmt": "89,095,812,601,411"
+                  },
+                  "commonStock": {
+                    "raw": 1357390259999,
+                    "fmt": "1.36T",
+                    "longFmt": "1,357,390,259,999"
+                  },
+                  "retainedEarnings": {
+                    "raw": 8417704785780,
+                    "fmt": "8.42T",
+                    "longFmt": "8,417,704,785,780"
+                  },
+                  "treasuryStock": {
+                    "raw": 739384115650,
+                    "fmt": "739.38B",
+                    "longFmt": "739,384,115,650"
+                  },
+                  "capitalSurplus": {
+                    "raw": 5552026262437,
+                    "fmt": "5.55T",
+                    "longFmt": "5,552,026,262,437"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 739384115650,
+                    "fmt": "739.38B",
+                    "longFmt": "739,384,115,650"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 16066505423866,
+                    "fmt": "16.07T",
+                    "longFmt": "16,066,505,423,866"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -43057122662105,
+                    "fmt": "-43.06T",
+                    "longFmt": "-43,057,122,662,105"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 9258310028392,
+                    "fmt": "9.26T",
+                    "longFmt": "9,258,310,028,392"
+                  },
+                  "netReceivables": {
+                    "raw": 31735705540115,
+                    "fmt": "31.74T",
+                    "longFmt": "31,735,705,540,115"
+                  },
+                  "inventory": {
+                    "raw": 4470845549423,
+                    "fmt": "4.47T",
+                    "longFmt": "4,470,845,549,423"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 3395288657104,
+                    "fmt": "3.4T",
+                    "longFmt": "3,395,288,657,104"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 49037842886120,
+                    "fmt": "49.04T",
+                    "longFmt": "49,037,842,886,120"
+                  },
+                  "longTermInvestments": {
+                    "raw": 5831251114741,
+                    "fmt": "5.83T",
+                    "longFmt": "5,831,251,114,741"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 8663216063821,
+                    "fmt": "8.66T",
+                    "longFmt": "8,663,216,063,821"
+                  },
+                  "goodWill": {
+                    "raw": 1995908825753,
+                    "fmt": "2T",
+                    "longFmt": "1,995,908,825,753"
+                  },
+                  "intangibleAssets": {
+                    "raw": 55407004501205,
+                    "fmt": "55.41T",
+                    "longFmt": "55,407,004,501,205"
+                  },
+                  "otherAssets": {
+                    "raw": 1654035958931,
+                    "fmt": "1.65T",
+                    "longFmt": "1,654,035,958,931"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 1542424572,
+                    "fmt": "1.54B",
+                    "longFmt": "1,542,424,572"
+                  },
+                  "totalAssets": {
+                    "raw": 122589259350571,
+                    "fmt": "122.59T",
+                    "longFmt": "122,589,259,350,571"
+                  },
+                  "accountsPayable": {
+                    "raw": 11005539197920,
+                    "fmt": "11.01T",
+                    "longFmt": "11,005,539,197,920"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 4098002350931,
+                    "fmt": "4.1T",
+                    "longFmt": "4,098,002,350,931"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 4340597615238,
+                    "fmt": "4.34T",
+                    "longFmt": "4,340,597,615,238"
+                  },
+                  "longTermDebt": {
+                    "raw": 43894161654013,
+                    "fmt": "43.89T",
+                    "longFmt": "43,894,161,654,013"
+                  },
+                  "otherLiab": {
+                    "raw": 4553133367976,
+                    "fmt": "4.55T",
+                    "longFmt": "4,553,133,367,976"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 754641393913,
+                    "fmt": "754.64B",
+                    "longFmt": "754,641,393,913"
+                  },
+                  "minorityInterest": {
+                    "raw": 11236061197428,
+                    "fmt": "11.24T",
+                    "longFmt": "11,236,061,197,428"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 45023495139583,
+                    "fmt": "45.02T",
+                    "longFmt": "45,023,495,139,583"
+                  },
+                  "totalLiab": {
+                    "raw": 93470790161572,
+                    "fmt": "93.47T",
+                    "longFmt": "93,470,790,161,572"
+                  },
+                  "commonStock": {
+                    "raw": 1357390259999,
+                    "fmt": "1.36T",
+                    "longFmt": "1,357,390,259,999"
+                  },
+                  "retainedEarnings": {
+                    "raw": 10233409821327,
+                    "fmt": "10.23T",
+                    "longFmt": "10,233,409,821,327"
+                  },
+                  "treasuryStock": {
+                    "raw": 739581647808,
+                    "fmt": "739.58B",
+                    "longFmt": "739,581,647,808"
+                  },
+                  "capitalSurplus": {
+                    "raw": 5552026262437,
+                    "fmt": "5.55T",
+                    "longFmt": "5,552,026,262,437"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 739581647808,
+                    "fmt": "739.58B",
+                    "longFmt": "739,581,647,808"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 17882407991571,
+                    "fmt": "17.88T",
+                    "longFmt": "17,882,407,991,571"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -39520505335387,
+                    "fmt": "-39.52T",
+                    "longFmt": "-39,520,505,335,387"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-calendarEvents-ADH.json
+++ b/tests/http/quoteSummary-calendarEvents-ADH.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=calendarEvents"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "ftbqb0hg2nrr4"
+      ],
+      "x-yahoo-request-id": [
+        "ftbqb0hg2nrr4"
+      ],
+      "x-request-id": [
+        "46b054c7-2acb-4f5a-a425-ad395c020299"
+      ],
+      "content-length": [
+        "147"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:28 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=calendarEvents"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-calendarEvents-AFRAF.json
+++ b/tests/http/quoteSummary-calendarEvents-AFRAF.json
@@ -1,0 +1,86 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=calendarEvents"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "c9g3bblg2nrr4"
+      ],
+      "x-yahoo-request-id": [
+        "c9g3bblg2nrr4"
+      ],
+      "x-request-id": [
+        "65714481-ce87-4ab9-bb5e-b2e1dd1593bf"
+      ],
+      "content-length": [
+        "159"
+      ],
+      "x-envoy-upstream-service-time": [
+        "6"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:28 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": []
+              },
+              "exDividendDate": 1215993600,
+              "dividendDate": 1216252800
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-calendarEvents-AMZN.json
+++ b/tests/http/quoteSummary-calendarEvents-AMZN.json
@@ -1,0 +1,93 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=calendarEvents"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "ehjb241g2nrr4"
+      ],
+      "x-yahoo-request-id": [
+        "ehjb241g2nrr4"
+      ],
+      "x-request-id": [
+        "fbcf1103-5bb0-4471-ab37-c3162ddef0bb"
+      ],
+      "content-length": [
+        "271"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:28 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": [
+                  1619568000,
+                  1620000000
+                ],
+                "earningsAverage": 9.51,
+                "earningsLow": 6.41,
+                "earningsHigh": 12,
+                "revenueAverage": 104484000000,
+                "revenueLow": 100459000000,
+                "revenueHigh": 107474000000
+              }
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-calendarEvents-AZT.OL.json
+++ b/tests/http/quoteSummary-calendarEvents-AZT.OL.json
@@ -1,0 +1,86 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=calendarEvents"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "cb3lfi9g2nrr4"
+      ],
+      "x-yahoo-request-id": [
+        "cb3lfi9g2nrr4"
+      ],
+      "x-request-id": [
+        "b72491cf-b6df-4731-a52f-7eeef7144be7"
+      ],
+      "content-length": [
+        "115"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:28 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": [
+                  1611792000
+                ]
+              }
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-calendarEvents-SIX.json
+++ b/tests/http/quoteSummary-calendarEvents-SIX.json
@@ -1,0 +1,94 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=calendarEvents"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "1dtrkbdg2nuh8"
+      ],
+      "x-yahoo-request-id": [
+        "1dtrkbdg2nuh8"
+      ],
+      "x-request-id": [
+        "b0c438f1-33fd-47d3-ac2b-f55cc0dff038"
+      ],
+      "content-length": [
+        "305"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:23 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": [
+                  1614124800
+                ],
+                "earningsAverage": -0.89,
+                "earningsLow": -1.16,
+                "earningsHigh": 0.46,
+                "revenueAverage": 86590000,
+                "revenueLow": 71030000,
+                "revenueHigh": 146800000
+              },
+              "exDividendDate": 1583193600,
+              "dividendDate": 1583884800
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-calendarEvents-WSKT.JK.json
+++ b/tests/http/quoteSummary-calendarEvents-WSKT.JK.json
@@ -1,0 +1,85 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=calendarEvents"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "7gfvp4lg2nuh7"
+      ],
+      "x-yahoo-request-id": [
+        "7gfvp4lg2nuh7"
+      ],
+      "x-request-id": [
+        "a99fb35c-0ca1-4ba3-89d3-6c0aeb54acf7"
+      ],
+      "content-length": [
+        "133"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:23 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": []
+              },
+              "exDividendDate": 1592265600
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistory-ADH.json
+++ b/tests/http/quoteSummary-cashflowStatementHistory-ADH.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=cashflowStatementHistory"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "4mpngqlg2nrr5"
+      ],
+      "x-yahoo-request-id": [
+        "4mpngqlg2nrr5"
+      ],
+      "x-request-id": [
+        "47992672-a9d5-4577-8412-037582bf12e7"
+      ],
+      "content-length": [
+        "157"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:28 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=cashflowStatementHistory"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistory-AFRAF.json
+++ b/tests/http/quoteSummary-cashflowStatementHistory-AFRAF.json
@@ -1,0 +1,479 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=cashflowStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "efm2lihg2nrr5"
+      ],
+      "x-yahoo-request-id": [
+        "efm2lihg2nrr5"
+      ],
+      "x-request-id": [
+        "f7504566-e650-459a-858b-3aa07712faae"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1190"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:29 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 290000000,
+                    "fmt": "290M",
+                    "longFmt": "290,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 2941000000,
+                    "fmt": "2.94B",
+                    "longFmt": "2,941,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 529000000,
+                    "fmt": "529M",
+                    "longFmt": "529,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 61000000,
+                    "fmt": "61M",
+                    "longFmt": "61,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -133000000,
+                    "fmt": "-133M",
+                    "longFmt": "-133,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -93000000,
+                    "fmt": "-93M",
+                    "longFmt": "-93,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 300000000,
+                    "fmt": "300M",
+                    "longFmt": "300,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 3895000000,
+                    "fmt": "3.9B",
+                    "longFmt": "3,895,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -3372000000,
+                    "fmt": "-3.37B",
+                    "longFmt": "-3,372,000,000"
+                  },
+                  "investments": {
+                    "raw": -72000000,
+                    "fmt": "-72M",
+                    "longFmt": "-72,000,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 14000000,
+                    "fmt": "14M",
+                    "longFmt": "14,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -3318000000,
+                    "fmt": "-3.32B",
+                    "longFmt": "-3,318,000,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -26000000,
+                    "fmt": "-26M",
+                    "longFmt": "-26,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -475000000,
+                    "fmt": "-475M",
+                    "longFmt": "-475,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -447000000,
+                    "fmt": "-447M",
+                    "longFmt": "-447,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 1000000,
+                    "fmt": "1M",
+                    "longFmt": "1,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 131000000,
+                    "fmt": "131M",
+                    "longFmt": "131,000,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 54000000,
+                    "fmt": "54M",
+                    "longFmt": "54,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 420000000,
+                    "fmt": "420M",
+                    "longFmt": "420,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 2870000000,
+                    "fmt": "2.87B",
+                    "longFmt": "2,870,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 252000000,
+                    "fmt": "252M",
+                    "longFmt": "252,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -39000000,
+                    "fmt": "-39M",
+                    "longFmt": "-39,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 57000000,
+                    "fmt": "57M",
+                    "longFmt": "57,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -31000000,
+                    "fmt": "-31M",
+                    "longFmt": "-31,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 269000000,
+                    "fmt": "269M",
+                    "longFmt": "269,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 3798000000,
+                    "fmt": "3.8B",
+                    "longFmt": "3,798,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -2844000000,
+                    "fmt": "-2.84B",
+                    "longFmt": "-2,844,000,000"
+                  },
+                  "investments": {
+                    "raw": 4000000,
+                    "fmt": "4M",
+                    "longFmt": "4,000,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 6000000,
+                    "fmt": "6M",
+                    "longFmt": "6,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -2704000000,
+                    "fmt": "-2.7B",
+                    "longFmt": "-2,704,000,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -38000000,
+                    "fmt": "-38M",
+                    "longFmt": "-38,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -1939000000,
+                    "fmt": "-1.94B",
+                    "longFmt": "-1,939,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -2188000000,
+                    "fmt": "-2.19B",
+                    "longFmt": "-2,188,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 7000000,
+                    "fmt": "7M",
+                    "longFmt": "7,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": -1087000000,
+                    "fmt": "-1.09B",
+                    "longFmt": "-1,087,000,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 54000000,
+                    "fmt": "54M",
+                    "longFmt": "54,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 163000000,
+                    "fmt": "163M",
+                    "longFmt": "163,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 2756000000,
+                    "fmt": "2.76B",
+                    "longFmt": "2,756,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 889000000,
+                    "fmt": "889M",
+                    "longFmt": "889,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -331000000,
+                    "fmt": "-331M",
+                    "longFmt": "-331,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 68000000,
+                    "fmt": "68M",
+                    "longFmt": "68,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 549000000,
+                    "fmt": "549M",
+                    "longFmt": "549,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 4099000000,
+                    "fmt": "4.1B",
+                    "longFmt": "4,099,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -2562000000,
+                    "fmt": "-2.56B",
+                    "longFmt": "-2,562,000,000"
+                  },
+                  "investments": {
+                    "raw": -262000000,
+                    "fmt": "-262M",
+                    "longFmt": "-262,000,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 9000000,
+                    "fmt": "9M",
+                    "longFmt": "9,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -2692000000,
+                    "fmt": "-2.69B",
+                    "longFmt": "-2,692,000,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -38000000,
+                    "fmt": "-38M",
+                    "longFmt": "-38,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -1349000000,
+                    "fmt": "-1.35B",
+                    "longFmt": "-1,349,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -640000000,
+                    "fmt": "-640M",
+                    "longFmt": "-640,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -33000000,
+                    "fmt": "-33M",
+                    "longFmt": "-33,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 734000000,
+                    "fmt": "734M",
+                    "longFmt": "734,000,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 747000000,
+                    "fmt": "747M",
+                    "longFmt": "747,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 792000000,
+                    "fmt": "792M",
+                    "longFmt": "792,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 1571000000,
+                    "fmt": "1.57B",
+                    "longFmt": "1,571,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -191000000,
+                    "fmt": "-191M",
+                    "longFmt": "-191,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -104000000,
+                    "fmt": "-104M",
+                    "longFmt": "-104,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 23000000,
+                    "fmt": "23M",
+                    "longFmt": "23,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -61000000,
+                    "fmt": "-61M",
+                    "longFmt": "-61,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 209000000,
+                    "fmt": "209M",
+                    "longFmt": "209,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 2239000000,
+                    "fmt": "2.24B",
+                    "longFmt": "2,239,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -2072000000,
+                    "fmt": "-2.07B",
+                    "longFmt": "-2,072,000,000"
+                  },
+                  "investments": {
+                    "raw": 992000000,
+                    "fmt": "992M",
+                    "longFmt": "992,000,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 137000000,
+                    "fmt": "137M",
+                    "longFmt": "137,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -727000000,
+                    "fmt": "-727M",
+                    "longFmt": "-727,000,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -38000000,
+                    "fmt": "-38M",
+                    "longFmt": "-38,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -666000000,
+                    "fmt": "-666M",
+                    "longFmt": "-666,000,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 37000000,
+                    "fmt": "37M",
+                    "longFmt": "37,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -667000000,
+                    "fmt": "-667M",
+                    "longFmt": "-667,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -13000000,
+                    "fmt": "-13M",
+                    "longFmt": "-13,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 832000000,
+                    "fmt": "832M",
+                    "longFmt": "832,000,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 747000000,
+                    "fmt": "747M",
+                    "longFmt": "747,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistory-AMZN.json
+++ b/tests/http/quoteSummary-cashflowStatementHistory-AMZN.json
@@ -1,0 +1,424 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=cashflowStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "73ae32hg2nrr5"
+      ],
+      "x-yahoo-request-id": [
+        "73ae32hg2nrr5"
+      ],
+      "x-request-id": [
+        "dee5246f-5163-406f-ad24-44b5bf3efabd"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1204"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:29 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 21331000000,
+                    "fmt": "21.33B",
+                    "longFmt": "21,331,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 25251000000,
+                    "fmt": "25.25B",
+                    "longFmt": "25,251,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 6001000000,
+                    "fmt": "6B",
+                    "longFmt": "6,001,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -8169000000,
+                    "fmt": "-8.17B",
+                    "longFmt": "-8,169,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 18745000000,
+                    "fmt": "18.75B",
+                    "longFmt": "18,745,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -2849000000,
+                    "fmt": "-2.85B",
+                    "longFmt": "-2,849,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 5754000000,
+                    "fmt": "5.75B",
+                    "longFmt": "5,754,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 66064000000,
+                    "fmt": "66.06B",
+                    "longFmt": "66,064,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -40140000000,
+                    "fmt": "-40.14B",
+                    "longFmt": "-40,140,000,000"
+                  },
+                  "investments": {
+                    "raw": -22242000000,
+                    "fmt": "-22.24B",
+                    "longFmt": "-22,242,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -59611000000,
+                    "fmt": "-59.61B",
+                    "longFmt": "-59,611,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -1104000000,
+                    "fmt": "-1.1B",
+                    "longFmt": "-1,104,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -1104000000,
+                    "fmt": "-1.1B",
+                    "longFmt": "-1,104,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 618000000,
+                    "fmt": "618M",
+                    "longFmt": "618,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 5967000000,
+                    "fmt": "5.97B",
+                    "longFmt": "5,967,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 11588000000,
+                    "fmt": "11.59B",
+                    "longFmt": "11,588,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 21789000000,
+                    "fmt": "21.79B",
+                    "longFmt": "21,789,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 7575000000,
+                    "fmt": "7.58B",
+                    "longFmt": "7,575,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -7681000000,
+                    "fmt": "-7.68B",
+                    "longFmt": "-7,681,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 9904000000,
+                    "fmt": "9.9B",
+                    "longFmt": "9,904,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -3278000000,
+                    "fmt": "-3.28B",
+                    "longFmt": "-3,278,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -1383000000,
+                    "fmt": "-1.38B",
+                    "longFmt": "-1,383,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 38514000000,
+                    "fmt": "38.51B",
+                    "longFmt": "38,514,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -16861000000,
+                    "fmt": "-16.86B",
+                    "longFmt": "-16,861,000,000"
+                  },
+                  "investments": {
+                    "raw": -9131000000,
+                    "fmt": "-9.13B",
+                    "longFmt": "-9,131,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -24281000000,
+                    "fmt": "-24.28B",
+                    "longFmt": "-24,281,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -10066000000,
+                    "fmt": "-10.07B",
+                    "longFmt": "-10,066,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -10066000000,
+                    "fmt": "-10.07B",
+                    "longFmt": "-10,066,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 70000000,
+                    "fmt": "70M",
+                    "longFmt": "70,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 4237000000,
+                    "fmt": "4.24B",
+                    "longFmt": "4,237,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 10073000000,
+                    "fmt": "10.07B",
+                    "longFmt": "10,073,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 15341000000,
+                    "fmt": "15.34B",
+                    "longFmt": "15,341,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 6352000000,
+                    "fmt": "6.35B",
+                    "longFmt": "6,352,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -4615000000,
+                    "fmt": "-4.62B",
+                    "longFmt": "-4,615,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 4414000000,
+                    "fmt": "4.41B",
+                    "longFmt": "4,414,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -1314000000,
+                    "fmt": "-1.31B",
+                    "longFmt": "-1,314,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 472000000,
+                    "fmt": "472M",
+                    "longFmt": "472,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 30723000000,
+                    "fmt": "30.72B",
+                    "longFmt": "30,723,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -13427000000,
+                    "fmt": "-13.43B",
+                    "longFmt": "-13,427,000,000"
+                  },
+                  "investments": {
+                    "raw": 1140000000,
+                    "fmt": "1.14B",
+                    "longFmt": "1,140,000,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 2104000000,
+                    "fmt": "2.1B",
+                    "longFmt": "2,104,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -12369000000,
+                    "fmt": "-12.37B",
+                    "longFmt": "-12,369,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -7686000000,
+                    "fmt": "-7.69B",
+                    "longFmt": "-7,686,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -7686000000,
+                    "fmt": "-7.69B",
+                    "longFmt": "-7,686,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -351000000,
+                    "fmt": "-351M",
+                    "longFmt": "-351,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 10317000000,
+                    "fmt": "10.32B",
+                    "longFmt": "10,317,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 3033000000,
+                    "fmt": "3.03B",
+                    "longFmt": "3,033,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 11478000000,
+                    "fmt": "11.48B",
+                    "longFmt": "11,478,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 4096000000,
+                    "fmt": "4.1B",
+                    "longFmt": "4,096,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -4780000000,
+                    "fmt": "-4.78B",
+                    "longFmt": "-4,780,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 7838000000,
+                    "fmt": "7.84B",
+                    "longFmt": "7,838,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -3583000000,
+                    "fmt": "-3.58B",
+                    "longFmt": "-3,583,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 283000000,
+                    "fmt": "283M",
+                    "longFmt": "283,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 18365000000,
+                    "fmt": "18.36B",
+                    "longFmt": "18,365,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -11955000000,
+                    "fmt": "-11.96B",
+                    "longFmt": "-11,955,000,000"
+                  },
+                  "investments": {
+                    "raw": -3054000000,
+                    "fmt": "-3.05B",
+                    "longFmt": "-3,054,000,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 1897000000,
+                    "fmt": "1.9B",
+                    "longFmt": "1,897,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -27084000000,
+                    "fmt": "-27.08B",
+                    "longFmt": "-27,084,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 9928000000,
+                    "fmt": "9.93B",
+                    "longFmt": "9,928,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 9928000000,
+                    "fmt": "9.93B",
+                    "longFmt": "9,928,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 713000000,
+                    "fmt": "713M",
+                    "longFmt": "713,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 1922000000,
+                    "fmt": "1.92B",
+                    "longFmt": "1,922,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistory-AZT.OL.json
+++ b/tests/http/quoteSummary-cashflowStatementHistory-AZT.OL.json
@@ -1,0 +1,404 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=cashflowStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "2jch629g2nrr5"
+      ],
+      "x-yahoo-request-id": [
+        "2jch629g2nrr5"
+      ],
+      "x-request-id": [
+        "a757ba15-70b4-4ead-b455-2ec4b50a0fc6"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1067"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:29 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 84743000,
+                    "fmt": "84.74M",
+                    "longFmt": "84,743,000"
+                  },
+                  "depreciation": {
+                    "raw": 2385000,
+                    "fmt": "2.38M",
+                    "longFmt": "2,385,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -24629000,
+                    "fmt": "-24.63M",
+                    "longFmt": "-24,629,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -22715000,
+                    "fmt": "-22.71M",
+                    "longFmt": "-22,715,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 3098000,
+                    "fmt": "3.1M",
+                    "longFmt": "3,098,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -903000,
+                    "fmt": "-903k",
+                    "longFmt": "-903,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 42233000,
+                    "fmt": "42.23M",
+                    "longFmt": "42,233,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -1794000,
+                    "fmt": "-1.79M",
+                    "longFmt": "-1,794,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 10000,
+                    "fmt": "10k",
+                    "longFmt": "10,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -1784000,
+                    "fmt": "-1.78M",
+                    "longFmt": "-1,784,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -929000,
+                    "fmt": "-929k",
+                    "longFmt": "-929,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 69369000,
+                    "fmt": "69.37M",
+                    "longFmt": "69,369,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 68440000,
+                    "fmt": "68.44M",
+                    "longFmt": "68,440,000"
+                  },
+                  "changeInCash": {
+                    "raw": 108889000,
+                    "fmt": "108.89M",
+                    "longFmt": "108,889,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -6386000,
+                    "fmt": "-6.39M",
+                    "longFmt": "-6,386,000"
+                  },
+                  "depreciation": {
+                    "raw": 3928000,
+                    "fmt": "3.93M",
+                    "longFmt": "3,928,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 1176000,
+                    "fmt": "1.18M",
+                    "longFmt": "1,176,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 2299000,
+                    "fmt": "2.3M",
+                    "longFmt": "2,299,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 1054000,
+                    "fmt": "1.05M",
+                    "longFmt": "1,054,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 739000,
+                    "fmt": "739k",
+                    "longFmt": "739,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 3965000,
+                    "fmt": "3.96M",
+                    "longFmt": "3,965,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -688000,
+                    "fmt": "-688k",
+                    "longFmt": "-688,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 10000,
+                    "fmt": "10k",
+                    "longFmt": "10,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -1100000,
+                    "fmt": "-1.1M",
+                    "longFmt": "-1,100,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -2441000,
+                    "fmt": "-2.44M",
+                    "longFmt": "-2,441,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -797000,
+                    "fmt": "-797k",
+                    "longFmt": "-797,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -3238000,
+                    "fmt": "-3.24M",
+                    "longFmt": "-3,238,000"
+                  },
+                  "changeInCash": {
+                    "raw": -372000,
+                    "fmt": "-372k",
+                    "longFmt": "-372,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -14193000,
+                    "fmt": "-14.19M",
+                    "longFmt": "-14,193,000"
+                  },
+                  "depreciation": {
+                    "raw": 3699000,
+                    "fmt": "3.7M",
+                    "longFmt": "3,699,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 1888000,
+                    "fmt": "1.89M",
+                    "longFmt": "1,888,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -3282000,
+                    "fmt": "-3.28M",
+                    "longFmt": "-3,282,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -2766000,
+                    "fmt": "-2.77M",
+                    "longFmt": "-2,766,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -1549000,
+                    "fmt": "-1.55M",
+                    "longFmt": "-1,549,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -15192000,
+                    "fmt": "-15.19M",
+                    "longFmt": "-15,192,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -1269000,
+                    "fmt": "-1.27M",
+                    "longFmt": "-1,269,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 9000,
+                    "fmt": "9k",
+                    "longFmt": "9,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -2704000,
+                    "fmt": "-2.7M",
+                    "longFmt": "-2,704,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -2221000,
+                    "fmt": "-2.22M",
+                    "longFmt": "-2,221,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -865000,
+                    "fmt": "-865k",
+                    "longFmt": "-865,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 18965000,
+                    "fmt": "18.96M",
+                    "longFmt": "18,965,000"
+                  },
+                  "changeInCash": {
+                    "raw": 1069000,
+                    "fmt": "1.07M",
+                    "longFmt": "1,069,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 22051000,
+                    "fmt": "22.05M",
+                    "longFmt": "22,051,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -24938000,
+                    "fmt": "-24.94M",
+                    "longFmt": "-24,938,000"
+                  },
+                  "depreciation": {
+                    "raw": 1978000,
+                    "fmt": "1.98M",
+                    "longFmt": "1,978,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 1663000,
+                    "fmt": "1.66M",
+                    "longFmt": "1,663,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 2354000,
+                    "fmt": "2.35M",
+                    "longFmt": "2,354,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -877000,
+                    "fmt": "-877k",
+                    "longFmt": "-877,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -2236000,
+                    "fmt": "-2.24M",
+                    "longFmt": "-2,236,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -22056000,
+                    "fmt": "-22.06M",
+                    "longFmt": "-22,056,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -2629000,
+                    "fmt": "-2.63M",
+                    "longFmt": "-2,629,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 27000,
+                    "fmt": "27k",
+                    "longFmt": "27,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -5024000,
+                    "fmt": "-5.02M",
+                    "longFmt": "-5,024,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -2221000,
+                    "fmt": "-2.22M",
+                    "longFmt": "-2,221,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -865000,
+                    "fmt": "-865k",
+                    "longFmt": "-865,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 18965000,
+                    "fmt": "18.96M",
+                    "longFmt": "18,965,000"
+                  },
+                  "changeInCash": {
+                    "raw": -27079000,
+                    "fmt": "-27.08M",
+                    "longFmt": "-27,079,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 22051000,
+                    "fmt": "22.05M",
+                    "longFmt": "22,051,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistory-SIX.json
+++ b/tests/http/quoteSummary-cashflowStatementHistory-SIX.json
@@ -1,0 +1,494 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=cashflowStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "0uv5lodg2nuh8"
+      ],
+      "x-yahoo-request-id": [
+        "0uv5lodg2nuh8"
+      ],
+      "x-request-id": [
+        "7be44ed4-e53c-40eb-8cb0-6401bcb6437a"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1547"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:24 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 179065000,
+                    "fmt": "179.06M",
+                    "longFmt": "179,065,000"
+                  },
+                  "depreciation": {
+                    "raw": 118230000,
+                    "fmt": "118.23M",
+                    "longFmt": "118,230,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 60068000,
+                    "fmt": "60.07M",
+                    "longFmt": "60,068,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 7725000,
+                    "fmt": "7.72M",
+                    "longFmt": "7,725,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 62914000,
+                    "fmt": "62.91M",
+                    "longFmt": "62,914,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -14709000,
+                    "fmt": "-14.71M",
+                    "longFmt": "-14,709,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -6283000,
+                    "fmt": "-6.28M",
+                    "longFmt": "-6,283,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 410573000,
+                    "fmt": "410.57M",
+                    "longFmt": "410,573,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -143913000,
+                    "fmt": "-143.91M",
+                    "longFmt": "-143,913,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 3737000,
+                    "fmt": "3.74M",
+                    "longFmt": "3,737,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -139126000,
+                    "fmt": "-139.13M",
+                    "longFmt": "-139,126,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -278951000,
+                    "fmt": "-278.95M",
+                    "longFmt": "-278,951,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 167250000,
+                    "fmt": "167.25M",
+                    "longFmt": "167,250,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -50881000,
+                    "fmt": "-50.88M",
+                    "longFmt": "-50,881,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -143007000,
+                    "fmt": "-143.01M",
+                    "longFmt": "-143,007,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 1131000,
+                    "fmt": "1.13M",
+                    "longFmt": "1,131,000"
+                  },
+                  "changeInCash": {
+                    "raw": 129571000,
+                    "fmt": "129.57M",
+                    "longFmt": "129,571,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -52000,
+                    "fmt": "-52k",
+                    "longFmt": "-52,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 19627000,
+                    "fmt": "19.63M",
+                    "longFmt": "19,627,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 275996000,
+                    "fmt": "276M",
+                    "longFmt": "275,996,000"
+                  },
+                  "depreciation": {
+                    "raw": 115693000,
+                    "fmt": "115.69M",
+                    "longFmt": "115,693,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -4759000,
+                    "fmt": "-4.76M",
+                    "longFmt": "-4,759,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -39193000,
+                    "fmt": "-39.19M",
+                    "longFmt": "-39,193,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 59143000,
+                    "fmt": "59.14M",
+                    "longFmt": "59,143,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -3769000,
+                    "fmt": "-3.77M",
+                    "longFmt": "-3,769,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 6042000,
+                    "fmt": "6.04M",
+                    "longFmt": "6,042,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 413132000,
+                    "fmt": "413.13M",
+                    "longFmt": "413,132,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -135624000,
+                    "fmt": "-135.62M",
+                    "longFmt": "-135,624,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 2500000,
+                    "fmt": "2.5M",
+                    "longFmt": "2,500,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -152112000,
+                    "fmt": "-152.11M",
+                    "longFmt": "-152,112,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -267044000,
+                    "fmt": "-267.04M",
+                    "longFmt": "-267,044,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 82000000,
+                    "fmt": "82M",
+                    "longFmt": "82,000,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -41153000,
+                    "fmt": "-41.15M",
+                    "longFmt": "-41,153,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -293482000,
+                    "fmt": "-293.48M",
+                    "longFmt": "-293,482,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -426000,
+                    "fmt": "-426k",
+                    "longFmt": "-426,000"
+                  },
+                  "changeInCash": {
+                    "raw": -32888000,
+                    "fmt": "-32.89M",
+                    "longFmt": "-32,888,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -110990000,
+                    "fmt": "-110.99M",
+                    "longFmt": "-110,990,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 43705000,
+                    "fmt": "43.7M",
+                    "longFmt": "43,705,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 273816000,
+                    "fmt": "273.82M",
+                    "longFmt": "273,816,000"
+                  },
+                  "depreciation": {
+                    "raw": 111671000,
+                    "fmt": "111.67M",
+                    "longFmt": "111,671,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 61560000,
+                    "fmt": "61.56M",
+                    "longFmt": "61,560,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -3108000,
+                    "fmt": "-3.11M",
+                    "longFmt": "-3,108,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 3907000,
+                    "fmt": "3.91M",
+                    "longFmt": "3,907,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -1847000,
+                    "fmt": "-1.85M",
+                    "longFmt": "-1,847,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -4993000,
+                    "fmt": "-4.99M",
+                    "longFmt": "-4,993,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 445067000,
+                    "fmt": "445.07M",
+                    "longFmt": "445,067,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -135219000,
+                    "fmt": "-135.22M",
+                    "longFmt": "-135,219,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 4449000,
+                    "fmt": "4.45M",
+                    "longFmt": "4,449,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -130163000,
+                    "fmt": "-130.16M",
+                    "longFmt": "-130,163,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -227101000,
+                    "fmt": "-227.1M",
+                    "longFmt": "-227,101,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 363839000,
+                    "fmt": "363.84M",
+                    "longFmt": "363,839,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -76674000,
+                    "fmt": "-76.67M",
+                    "longFmt": "-76,674,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -376876000,
+                    "fmt": "-376.88M",
+                    "longFmt": "-376,876,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 2083000,
+                    "fmt": "2.08M",
+                    "longFmt": "2,083,000"
+                  },
+                  "changeInCash": {
+                    "raw": -59889000,
+                    "fmt": "-59.89M",
+                    "longFmt": "-59,889,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -499442000,
+                    "fmt": "-499.44M",
+                    "longFmt": "-499,442,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 62502000,
+                    "fmt": "62.5M",
+                    "longFmt": "62,502,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 118302000,
+                    "fmt": "118.3M",
+                    "longFmt": "118,302,000"
+                  },
+                  "depreciation": {
+                    "raw": 106893000,
+                    "fmt": "106.89M",
+                    "longFmt": "106,893,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 159104000,
+                    "fmt": "159.1M",
+                    "longFmt": "159,104,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -6157000,
+                    "fmt": "-6.16M",
+                    "longFmt": "-6,157,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 79420000,
+                    "fmt": "79.42M",
+                    "longFmt": "79,420,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -4948000,
+                    "fmt": "-4.95M",
+                    "longFmt": "-4,948,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 6118000,
+                    "fmt": "6.12M",
+                    "longFmt": "6,118,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 463235000,
+                    "fmt": "463.24M",
+                    "longFmt": "463,235,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -129258000,
+                    "fmt": "-129.26M",
+                    "longFmt": "-129,258,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -570000,
+                    "fmt": "-570k",
+                    "longFmt": "-570,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -127741000,
+                    "fmt": "-127.74M",
+                    "longFmt": "-127,741,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -220314000,
+                    "fmt": "-220.31M",
+                    "longFmt": "-220,314,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 147744000,
+                    "fmt": "147.74M",
+                    "longFmt": "147,744,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -44926000,
+                    "fmt": "-44.93M",
+                    "longFmt": "-44,926,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -292746000,
+                    "fmt": "-292.75M",
+                    "longFmt": "-292,746,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -5123000,
+                    "fmt": "-5.12M",
+                    "longFmt": "-5,123,000"
+                  },
+                  "changeInCash": {
+                    "raw": 37625000,
+                    "fmt": "37.62M",
+                    "longFmt": "37,625,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -211751000,
+                    "fmt": "-211.75M",
+                    "longFmt": "-211,751,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 36501000,
+                    "fmt": "36.5M",
+                    "longFmt": "36,501,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistory-WSKT.JK.json
+++ b/tests/http/quoteSummary-cashflowStatementHistory-WSKT.JK.json
@@ -1,0 +1,434 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=cashflowStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "3nj4selg2nuh8"
+      ],
+      "x-yahoo-request-id": [
+        "3nj4selg2nuh8"
+      ],
+      "x-request-id": [
+        "eaab9caa-61c0-48d4-a6b9-6254876bdbcc"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1841"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:23 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 938142364887,
+                    "fmt": "938.14B",
+                    "longFmt": "938,142,364,887"
+                  },
+                  "depreciation": {
+                    "raw": 717909241157,
+                    "fmt": "717.91B",
+                    "longFmt": "717,909,241,157"
+                  },
+                  "changeToNetincome": {
+                    "raw": 7358197834018,
+                    "fmt": "7.36T",
+                    "longFmt": "7,358,197,834,018"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 9014249440062,
+                    "fmt": "9.01T",
+                    "longFmt": "9,014,249,440,062"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -2742933949138,
+                    "fmt": "-2.74T",
+                    "longFmt": "-2,742,933,949,138"
+                  },
+                  "investments": {
+                    "raw": -1659684950790,
+                    "fmt": "-1.66T",
+                    "longFmt": "-1,659,684,950,790"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -32298146709,
+                    "fmt": "-32.3B",
+                    "longFmt": "-32,298,146,709"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -14924743305937,
+                    "fmt": "-14.92T",
+                    "longFmt": "-14,924,743,305,937"
+                  },
+                  "dividendsPaid": {
+                    "raw": -990709745083,
+                    "fmt": "-990.71B",
+                    "longFmt": "-990,709,745,083"
+                  },
+                  "netBorrowings": {
+                    "raw": 7782081216482,
+                    "fmt": "7.78T",
+                    "longFmt": "7,782,081,216,482"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -2456427184926,
+                    "fmt": "-2.46T",
+                    "longFmt": "-2,456,427,184,926"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 4334944286473,
+                    "fmt": "4.33T",
+                    "longFmt": "4,334,944,286,473"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -11818609407,
+                    "fmt": "-11.82B",
+                    "longFmt": "-11,818,609,407"
+                  },
+                  "changeInCash": {
+                    "raw": -1587368188809,
+                    "fmt": "-1.59T",
+                    "longFmt": "-1,587,368,188,809"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 3962838031865,
+                    "fmt": "3.96T",
+                    "longFmt": "3,962,838,031,865"
+                  },
+                  "depreciation": {
+                    "raw": 647085215580,
+                    "fmt": "647.09B",
+                    "longFmt": "647,085,215,580"
+                  },
+                  "changeToNetincome": {
+                    "raw": -598383168871,
+                    "fmt": "-598.38B",
+                    "longFmt": "-598,383,168,871"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 4011540078574,
+                    "fmt": "4.01T",
+                    "longFmt": "4,011,540,078,574"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -2962349807081,
+                    "fmt": "-2.96T",
+                    "longFmt": "-2,962,349,807,081"
+                  },
+                  "investments": {
+                    "raw": -4119777610204,
+                    "fmt": "-4.12T",
+                    "longFmt": "-4,119,777,610,204"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 698558079882,
+                    "fmt": "698.56B",
+                    "longFmt": "698,558,079,882"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -18768151650463,
+                    "fmt": "-18.77T",
+                    "longFmt": "-18,768,151,650,463"
+                  },
+                  "dividendsPaid": {
+                    "raw": -776342383468,
+                    "fmt": "-776.34B",
+                    "longFmt": "-776,342,383,468"
+                  },
+                  "netBorrowings": {
+                    "raw": 19973053792889,
+                    "fmt": "19.97T",
+                    "longFmt": "19,973,053,792,889"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 494371440036,
+                    "fmt": "494.37B",
+                    "longFmt": "494,371,440,036"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 19691082849457,
+                    "fmt": "19.69T",
+                    "longFmt": "19,691,082,849,457"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 11113410916,
+                    "fmt": "11.11B",
+                    "longFmt": "11,113,410,916"
+                  },
+                  "changeInCash": {
+                    "raw": 4756715630454,
+                    "fmt": "4.76T",
+                    "longFmt": "4,756,715,630,454"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 3881711917338,
+                    "fmt": "3.88T",
+                    "longFmt": "3,881,711,917,338"
+                  },
+                  "depreciation": {
+                    "raw": 600374669280,
+                    "fmt": "600.37B",
+                    "longFmt": "600,374,669,280"
+                  },
+                  "changeToNetincome": {
+                    "raw": -10441649022077,
+                    "fmt": "-10.44T",
+                    "longFmt": "-10,441,649,022,077"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -5959562435459,
+                    "fmt": "-5.96T",
+                    "longFmt": "-5,959,562,435,459"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -2434808757933,
+                    "fmt": "-2.43T",
+                    "longFmt": "-2,434,808,757,933"
+                  },
+                  "investments": {
+                    "raw": 1534441645590,
+                    "fmt": "1.53T",
+                    "longFmt": "1,534,441,645,590"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 698558079882,
+                    "fmt": "698.56B",
+                    "longFmt": "698,558,079,882"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -19238718205754,
+                    "fmt": "-19.24T",
+                    "longFmt": "-19,238,718,205,754"
+                  },
+                  "dividendsPaid": {
+                    "raw": -513978185018,
+                    "fmt": "-513.98B",
+                    "longFmt": "-513,978,185,018"
+                  },
+                  "netBorrowings": {
+                    "raw": 18512110501373,
+                    "fmt": "18.51T",
+                    "longFmt": "18,512,110,501,373"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 3212308760319,
+                    "fmt": "3.21T",
+                    "longFmt": "3,212,308,760,319"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 20630919145126,
+                    "fmt": "20.63T",
+                    "longFmt": "20,630,919,145,126"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 327579903,
+                    "fmt": "327.58M",
+                    "longFmt": "327,579,903"
+                  },
+                  "changeInCash": {
+                    "raw": -4567033916184,
+                    "fmt": "-4.57T",
+                    "longFmt": "-4,567,033,916,184"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -579682828561,
+                    "fmt": "-579.68B",
+                    "longFmt": "-579,682,828,561"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 160897013,
+                    "fmt": "160.9M",
+                    "longFmt": "160,897,013"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 1713260616725,
+                    "fmt": "1.71T",
+                    "longFmt": "1,713,260,616,725"
+                  },
+                  "depreciation": {
+                    "raw": 251144952664,
+                    "fmt": "251.14B",
+                    "longFmt": "251,144,952,664"
+                  },
+                  "changeToNetincome": {
+                    "raw": -9726819344592,
+                    "fmt": "-9.73T",
+                    "longFmt": "-9,726,819,344,592"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -7762413775203,
+                    "fmt": "-7.76T",
+                    "longFmt": "-7,762,413,775,203"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -611419778706,
+                    "fmt": "-611.42B",
+                    "longFmt": "-611,419,778,706"
+                  },
+                  "investments": {
+                    "raw": -3467889128716,
+                    "fmt": "-3.47T",
+                    "longFmt": "-3,467,889,128,716"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 100000000000,
+                    "fmt": "100B",
+                    "longFmt": "100,000,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -9552720853199,
+                    "fmt": "-9.55T",
+                    "longFmt": "-9,552,720,853,199"
+                  },
+                  "dividendsPaid": {
+                    "raw": -209547624362,
+                    "fmt": "-209.55B",
+                    "longFmt": "-209,547,624,362"
+                  },
+                  "netBorrowings": {
+                    "raw": 17227212829448,
+                    "fmt": "17.23T",
+                    "longFmt": "17,227,212,829,448"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 5440911757064,
+                    "fmt": "5.44T",
+                    "longFmt": "5,440,911,757,064"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 22459333440495,
+                    "fmt": "22.46T",
+                    "longFmt": "22,459,333,440,495"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 609611060,
+                    "fmt": "609.61M",
+                    "longFmt": "609,611,060"
+                  },
+                  "changeInCash": {
+                    "raw": 5144808423153,
+                    "fmt": "5.14T",
+                    "longFmt": "5,144,808,423,153"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -579682828561,
+                    "fmt": "-579.68B",
+                    "longFmt": "-579,682,828,561"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 756478345,
+                    "fmt": "756.48M",
+                    "longFmt": "756,478,345"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-ADH.json
+++ b/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-ADH.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=cashflowStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "1n6b0b5g2nrr5"
+      ],
+      "x-yahoo-request-id": [
+        "1n6b0b5g2nrr5"
+      ],
+      "x-request-id": [
+        "d4399611-4582-420a-97ba-d034c321edd4"
+      ],
+      "content-length": [
+        "166"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:29 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=cashflowStatementHistoryQuarterly"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-AFRAF.json
+++ b/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-AFRAF.json
@@ -1,0 +1,424 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=cashflowStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "ej8b5slg2nrr5"
+      ],
+      "x-yahoo-request-id": [
+        "ej8b5slg2nrr5"
+      ],
+      "x-request-id": [
+        "ce113007-a8d0-4301-9711-0bf4cd3eb378"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1045"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:29 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": -1665000000,
+                    "fmt": "-1.67B",
+                    "longFmt": "-1,665,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 638000000,
+                    "fmt": "638M",
+                    "longFmt": "638,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 295000000,
+                    "fmt": "295M",
+                    "longFmt": "295,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 120000000,
+                    "fmt": "120M",
+                    "longFmt": "120,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -730000000,
+                    "fmt": "-730M",
+                    "longFmt": "-730,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 75000000,
+                    "fmt": "75M",
+                    "longFmt": "75,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 658000000,
+                    "fmt": "658M",
+                    "longFmt": "658,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -609000000,
+                    "fmt": "-609M",
+                    "longFmt": "-609,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -370000000,
+                    "fmt": "-370M",
+                    "longFmt": "-370,000,000"
+                  },
+                  "investments": {
+                    "raw": -6000000,
+                    "fmt": "-6M",
+                    "longFmt": "-6,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -367000000,
+                    "fmt": "-367M",
+                    "longFmt": "-367,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 2121000000,
+                    "fmt": "2.12B",
+                    "longFmt": "2,121,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 2121000000,
+                    "fmt": "2.12B",
+                    "longFmt": "2,121,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -22000000,
+                    "fmt": "-22M",
+                    "longFmt": "-22,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 1123000000,
+                    "fmt": "1.12B",
+                    "longFmt": "1,123,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "netIncome": {
+                    "raw": -2612000000,
+                    "fmt": "-2.61B",
+                    "longFmt": "-2,612,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 670000000,
+                    "fmt": "670M",
+                    "longFmt": "670,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 776000000,
+                    "fmt": "776M",
+                    "longFmt": "776,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 107000000,
+                    "fmt": "107M",
+                    "longFmt": "107,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -188000000,
+                    "fmt": "-188M",
+                    "longFmt": "-188,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 37000000,
+                    "fmt": "37M",
+                    "longFmt": "37,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 125000000,
+                    "fmt": "125M",
+                    "longFmt": "125,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -1085000000,
+                    "fmt": "-1.08B",
+                    "longFmt": "-1,085,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -415000000,
+                    "fmt": "-415M",
+                    "longFmt": "-415,000,000"
+                  },
+                  "investments": {
+                    "raw": -3000000,
+                    "fmt": "-3M",
+                    "longFmt": "-3,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -256000000,
+                    "fmt": "-256M",
+                    "longFmt": "-256,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 791000000,
+                    "fmt": "791M",
+                    "longFmt": "791,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 791000000,
+                    "fmt": "791M",
+                    "longFmt": "791,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -14000000,
+                    "fmt": "-14M",
+                    "longFmt": "-14,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": -564000000,
+                    "fmt": "-564M",
+                    "longFmt": "-564,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "netIncome": {
+                    "raw": -1801000000,
+                    "fmt": "-1.8B",
+                    "longFmt": "-1,801,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 743000000,
+                    "fmt": "743M",
+                    "longFmt": "743,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 878000000,
+                    "fmt": "878M",
+                    "longFmt": "878,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 596000000,
+                    "fmt": "596M",
+                    "longFmt": "596,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -309000000,
+                    "fmt": "-309M",
+                    "longFmt": "-309,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 22000000,
+                    "fmt": "22M",
+                    "longFmt": "22,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 153000000,
+                    "fmt": "153M",
+                    "longFmt": "153,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 282000000,
+                    "fmt": "282M",
+                    "longFmt": "282,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -869000000,
+                    "fmt": "-869M",
+                    "longFmt": "-869,000,000"
+                  },
+                  "investments": {
+                    "raw": -3000000,
+                    "fmt": "-3M",
+                    "longFmt": "-3,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -503000000,
+                    "fmt": "-503M",
+                    "longFmt": "-503,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 1870000000,
+                    "fmt": "1.87B",
+                    "longFmt": "1,870,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 1870000000,
+                    "fmt": "1.87B",
+                    "longFmt": "1,870,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -3000000,
+                    "fmt": "-3M",
+                    "longFmt": "-3,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 1646000000,
+                    "fmt": "1.65B",
+                    "longFmt": "1,646,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 164000000,
+                    "fmt": "164M",
+                    "longFmt": "164,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 820000000,
+                    "fmt": "820M",
+                    "longFmt": "820,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -170000000,
+                    "fmt": "-170M",
+                    "longFmt": "-170,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 208000000,
+                    "fmt": "208M",
+                    "longFmt": "208,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -175000000,
+                    "fmt": "-175M",
+                    "longFmt": "-175,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -10000000,
+                    "fmt": "-10M",
+                    "longFmt": "-10,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 40000000,
+                    "fmt": "40M",
+                    "longFmt": "40,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 877000000,
+                    "fmt": "877M",
+                    "longFmt": "877,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -1134000000,
+                    "fmt": "-1.13B",
+                    "longFmt": "-1,134,000,000"
+                  },
+                  "investments": {
+                    "raw": -63000000,
+                    "fmt": "-63M",
+                    "longFmt": "-63,000,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 4000000,
+                    "fmt": "4M",
+                    "longFmt": "4,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -1172000000,
+                    "fmt": "-1.17B",
+                    "longFmt": "-1,172,000,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -25000000,
+                    "fmt": "-25M",
+                    "longFmt": "-25,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -54000000,
+                    "fmt": "-54M",
+                    "longFmt": "-54,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -79000000,
+                    "fmt": "-79M",
+                    "longFmt": "-79,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -8000000,
+                    "fmt": "-8M",
+                    "longFmt": "-8,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": -382000000,
+                    "fmt": "-382M",
+                    "longFmt": "-382,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-AMZN.json
+++ b/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-AMZN.json
@@ -1,0 +1,414 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=cashflowStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "3u803s1g2nrr5"
+      ],
+      "x-yahoo-request-id": [
+        "3u803s1g2nrr5"
+      ],
+      "x-request-id": [
+        "079779c3-4d82-4e04-9d36-5d2d391293f6"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1154"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:29 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 7222000000,
+                    "fmt": "7.22B",
+                    "longFmt": "7,222,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 7618000000,
+                    "fmt": "7.62B",
+                    "longFmt": "7,618,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -888000000,
+                    "fmt": "-888M",
+                    "longFmt": "-888,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -4561000000,
+                    "fmt": "-4.56B",
+                    "longFmt": "-4,561,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 13582000000,
+                    "fmt": "13.58B",
+                    "longFmt": "13,582,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 329000000,
+                    "fmt": "329M",
+                    "longFmt": "329,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 7129000000,
+                    "fmt": "7.13B",
+                    "longFmt": "7,129,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 30431000000,
+                    "fmt": "30.43B",
+                    "longFmt": "30,431,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -14823000000,
+                    "fmt": "-14.82B",
+                    "longFmt": "-14,823,000,000"
+                  },
+                  "investments": {
+                    "raw": -3463000000,
+                    "fmt": "-3.46B",
+                    "longFmt": "-3,463,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -17037000000,
+                    "fmt": "-17.04B",
+                    "longFmt": "-17,037,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -1816000000,
+                    "fmt": "-1.82B",
+                    "longFmt": "-1,816,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -1816000000,
+                    "fmt": "-1.82B",
+                    "longFmt": "-1,816,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 597000000,
+                    "fmt": "597M",
+                    "longFmt": "597,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 12175000000,
+                    "fmt": "12.18B",
+                    "longFmt": "12,175,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 6331000000,
+                    "fmt": "6.33B",
+                    "longFmt": "6,331,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 6523000000,
+                    "fmt": "6.52B",
+                    "longFmt": "6,523,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 1599000000,
+                    "fmt": "1.6B",
+                    "longFmt": "1,599,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -2016000000,
+                    "fmt": "-2.02B",
+                    "longFmt": "-2,016,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 3736000000,
+                    "fmt": "3.74B",
+                    "longFmt": "3,736,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -3899000000,
+                    "fmt": "-3.9B",
+                    "longFmt": "-3,899,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -310000000,
+                    "fmt": "-310M",
+                    "longFmt": "-310,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 11964000000,
+                    "fmt": "11.96B",
+                    "longFmt": "11,964,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -11063000000,
+                    "fmt": "-11.06B",
+                    "longFmt": "-11,063,000,000"
+                  },
+                  "investments": {
+                    "raw": -4333000000,
+                    "fmt": "-4.33B",
+                    "longFmt": "-4,333,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -15876000000,
+                    "fmt": "-15.88B",
+                    "longFmt": "-15,876,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -4105000000,
+                    "fmt": "-4.11B",
+                    "longFmt": "-4,105,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -4105000000,
+                    "fmt": "-4.11B",
+                    "longFmt": "-4,105,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 377000000,
+                    "fmt": "377M",
+                    "longFmt": "377,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": -7640000000,
+                    "fmt": "-7.64B",
+                    "longFmt": "-7,640,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "netIncome": {
+                    "raw": 5243000000,
+                    "fmt": "5.24B",
+                    "longFmt": "5,243,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 5748000000,
+                    "fmt": "5.75B",
+                    "longFmt": "5,748,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 2579000000,
+                    "fmt": "2.58B",
+                    "longFmt": "2,579,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -2854000000,
+                    "fmt": "-2.85B",
+                    "longFmt": "-2,854,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 8863000000,
+                    "fmt": "8.86B",
+                    "longFmt": "8,863,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -672000000,
+                    "fmt": "-672M",
+                    "longFmt": "-672,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 1699000000,
+                    "fmt": "1.7B",
+                    "longFmt": "1,699,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 20606000000,
+                    "fmt": "20.61B",
+                    "longFmt": "20,606,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -7459000000,
+                    "fmt": "-7.46B",
+                    "longFmt": "-7,459,000,000"
+                  },
+                  "investments": {
+                    "raw": -11071000000,
+                    "fmt": "-11.07B",
+                    "longFmt": "-11,071,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -17804000000,
+                    "fmt": "-17.8B",
+                    "longFmt": "-17,804,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 7408000000,
+                    "fmt": "7.41B",
+                    "longFmt": "7,408,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 7408000000,
+                    "fmt": "7.41B",
+                    "longFmt": "7,408,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 127000000,
+                    "fmt": "127M",
+                    "longFmt": "127,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 10337000000,
+                    "fmt": "10.34B",
+                    "longFmt": "10,337,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "netIncome": {
+                    "raw": 2535000000,
+                    "fmt": "2.54B",
+                    "longFmt": "2,535,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 5362000000,
+                    "fmt": "5.36B",
+                    "longFmt": "5,362,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 2711000000,
+                    "fmt": "2.71B",
+                    "longFmt": "2,711,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 1262000000,
+                    "fmt": "1.26B",
+                    "longFmt": "1,262,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -7437000000,
+                    "fmt": "-7.44B",
+                    "longFmt": "-7,437,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 1392000000,
+                    "fmt": "1.39B",
+                    "longFmt": "1,392,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -2761000000,
+                    "fmt": "-2.76B",
+                    "longFmt": "-2,761,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 3064000000,
+                    "fmt": "3.06B",
+                    "longFmt": "3,064,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -6795000000,
+                    "fmt": "-6.79B",
+                    "longFmt": "-6,795,000,000"
+                  },
+                  "investments": {
+                    "raw": -3375000000,
+                    "fmt": "-3.38B",
+                    "longFmt": "-3,375,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -8894000000,
+                    "fmt": "-8.89B",
+                    "longFmt": "-8,894,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -2591000000,
+                    "fmt": "-2.59B",
+                    "longFmt": "-2,591,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -2591000000,
+                    "fmt": "-2.59B",
+                    "longFmt": "-2,591,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -484000000,
+                    "fmt": "-484M",
+                    "longFmt": "-484,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": -8905000000,
+                    "fmt": "-8.9B",
+                    "longFmt": "-8,905,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-AZT.OL.json
+++ b/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-AZT.OL.json
@@ -1,0 +1,394 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=cashflowStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "351ekn9g2nrr5"
+      ],
+      "x-yahoo-request-id": [
+        "351ekn9g2nrr5"
+      ],
+      "x-request-id": [
+        "fee9d0e7-f40e-4422-b334-ddb3965c1d81"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "996"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:29 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 36243000,
+                    "fmt": "36.24M",
+                    "longFmt": "36,243,000"
+                  },
+                  "depreciation": {
+                    "raw": 607000,
+                    "fmt": "607k",
+                    "longFmt": "607,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -14107000,
+                    "fmt": "-14.11M",
+                    "longFmt": "-14,107,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -16534000,
+                    "fmt": "-16.53M",
+                    "longFmt": "-16,534,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 7238000,
+                    "fmt": "7.24M",
+                    "longFmt": "7,238,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -444000,
+                    "fmt": "-444k",
+                    "longFmt": "-444,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 13054000,
+                    "fmt": "13.05M",
+                    "longFmt": "13,054,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -619000,
+                    "fmt": "-619k",
+                    "longFmt": "-619,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 9000,
+                    "fmt": "9k",
+                    "longFmt": "9,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -610000,
+                    "fmt": "-610k",
+                    "longFmt": "-610,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -2047000,
+                    "fmt": "-2.05M",
+                    "longFmt": "-2,047,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 69842000,
+                    "fmt": "69.84M",
+                    "longFmt": "69,842,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 67795000,
+                    "fmt": "67.8M",
+                    "longFmt": "67,795,000"
+                  },
+                  "changeInCash": {
+                    "raw": 80239000,
+                    "fmt": "80.24M",
+                    "longFmt": "80,239,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 9093000,
+                    "fmt": "9.09M",
+                    "longFmt": "9,093,000"
+                  },
+                  "depreciation": {
+                    "raw": 892000,
+                    "fmt": "892k",
+                    "longFmt": "892,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 390000,
+                    "fmt": "390k",
+                    "longFmt": "390,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 5880000,
+                    "fmt": "5.88M",
+                    "longFmt": "5,880,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -1997000,
+                    "fmt": "-2M",
+                    "longFmt": "-1,997,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -337000,
+                    "fmt": "-337k",
+                    "longFmt": "-337,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 13984000,
+                    "fmt": "13.98M",
+                    "longFmt": "13,984,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -57000,
+                    "fmt": "-57k",
+                    "longFmt": "-57,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 85000,
+                    "fmt": "85k",
+                    "longFmt": "85,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 28000,
+                    "fmt": "28k",
+                    "longFmt": "28,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -2047000,
+                    "fmt": "-2.05M",
+                    "longFmt": "-2,047,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -461000,
+                    "fmt": "-461k",
+                    "longFmt": "-461,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -461000,
+                    "fmt": "-461k",
+                    "longFmt": "-461,000"
+                  },
+                  "changeInCash": {
+                    "raw": 13551000,
+                    "fmt": "13.55M",
+                    "longFmt": "13,551,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "netIncome": {
+                    "raw": 25688000,
+                    "fmt": "25.69M",
+                    "longFmt": "25,688,000"
+                  },
+                  "depreciation": {
+                    "raw": 888000,
+                    "fmt": "888k",
+                    "longFmt": "888,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 540000,
+                    "fmt": "540k",
+                    "longFmt": "540,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -1993000,
+                    "fmt": "-1.99M",
+                    "longFmt": "-1,993,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -4762000,
+                    "fmt": "-4.76M",
+                    "longFmt": "-4,762,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 590000,
+                    "fmt": "590k",
+                    "longFmt": "590,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 21014000,
+                    "fmt": "21.01M",
+                    "longFmt": "21,014,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -53000,
+                    "fmt": "-53k",
+                    "longFmt": "-53,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -78000,
+                    "fmt": "-78k",
+                    "longFmt": "-78,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -131000,
+                    "fmt": "-131k",
+                    "longFmt": "-131,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -2047000,
+                    "fmt": "-2.05M",
+                    "longFmt": "-2,047,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -442000,
+                    "fmt": "-442k",
+                    "longFmt": "-442,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -442000,
+                    "fmt": "-442k",
+                    "longFmt": "-442,000"
+                  },
+                  "changeInCash": {
+                    "raw": 20442000,
+                    "fmt": "20.44M",
+                    "longFmt": "20,442,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "netIncome": {
+                    "raw": 13744000,
+                    "fmt": "13.74M",
+                    "longFmt": "13,744,000"
+                  },
+                  "depreciation": {
+                    "raw": 896000,
+                    "fmt": "896k",
+                    "longFmt": "896,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 238000,
+                    "fmt": "238k",
+                    "longFmt": "238,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -9992000,
+                    "fmt": "-9.99M",
+                    "longFmt": "-9,992,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 305000,
+                    "fmt": "305k",
+                    "longFmt": "305,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 635000,
+                    "fmt": "635k",
+                    "longFmt": "635,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 5889000,
+                    "fmt": "5.89M",
+                    "longFmt": "5,889,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -1066000,
+                    "fmt": "-1.07M",
+                    "longFmt": "-1,066,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -78000,
+                    "fmt": "-78k",
+                    "longFmt": "-78,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -1066000,
+                    "fmt": "-1.07M",
+                    "longFmt": "-1,066,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -268000,
+                    "fmt": "-268k",
+                    "longFmt": "-268,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -177000,
+                    "fmt": "-177k",
+                    "longFmt": "-177,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -445000,
+                    "fmt": "-445k",
+                    "longFmt": "-445,000"
+                  },
+                  "changeInCash": {
+                    "raw": 4378000,
+                    "fmt": "4.38M",
+                    "longFmt": "4,378,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-SIX.json
+++ b/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-SIX.json
@@ -1,0 +1,489 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=cashflowStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "9qe4jdlg2nuh8"
+      ],
+      "x-yahoo-request-id": [
+        "9qe4jdlg2nuh8"
+      ],
+      "x-request-id": [
+        "5b7b04ff-2e6c-4b48-b613-8a08ee430309"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1443"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:24 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": -116172000,
+                    "fmt": "-116.17M",
+                    "longFmt": "-116,172,000"
+                  },
+                  "depreciation": {
+                    "raw": 28785000,
+                    "fmt": "28.79M",
+                    "longFmt": "28,785,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 38108000,
+                    "fmt": "38.11M",
+                    "longFmt": "38,108,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -1195000,
+                    "fmt": "-1.2M",
+                    "longFmt": "-1,195,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -6578000,
+                    "fmt": "-6.58M",
+                    "longFmt": "-6,578,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 1413000,
+                    "fmt": "1.41M",
+                    "longFmt": "1,413,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 10287000,
+                    "fmt": "10.29M",
+                    "longFmt": "10,287,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -43261000,
+                    "fmt": "-43.26M",
+                    "longFmt": "-43,261,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -17337000,
+                    "fmt": "-17.34M",
+                    "longFmt": "-17,337,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -17337000,
+                    "fmt": "-17.34M",
+                    "longFmt": "-17,337,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -1079000,
+                    "fmt": "-1.08M",
+                    "longFmt": "-1,079,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -212000,
+                    "fmt": "-212k",
+                    "longFmt": "-212,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -21453000,
+                    "fmt": "-21.45M",
+                    "longFmt": "-21,453,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -22373000,
+                    "fmt": "-22.37M",
+                    "longFmt": "-22,373,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 922000,
+                    "fmt": "922k",
+                    "longFmt": "922,000"
+                  },
+                  "changeInCash": {
+                    "raw": -82049000,
+                    "fmt": "-82.05M",
+                    "longFmt": "-82,049,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -48000,
+                    "fmt": "-48k",
+                    "longFmt": "-48,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 419000,
+                    "fmt": "419k",
+                    "longFmt": "419,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "netIncome": {
+                    "raw": -136894000,
+                    "fmt": "-136.89M",
+                    "longFmt": "-136,894,000"
+                  },
+                  "depreciation": {
+                    "raw": 29434000,
+                    "fmt": "29.43M",
+                    "longFmt": "29,434,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 31517000,
+                    "fmt": "31.52M",
+                    "longFmt": "31,517,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 24825000,
+                    "fmt": "24.82M",
+                    "longFmt": "24,825,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -18362000,
+                    "fmt": "-18.36M",
+                    "longFmt": "-18,362,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 2002000,
+                    "fmt": "2M",
+                    "longFmt": "2,002,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 15551000,
+                    "fmt": "15.55M",
+                    "longFmt": "15,551,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -50316000,
+                    "fmt": "-50.32M",
+                    "longFmt": "-50,316,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -22165000,
+                    "fmt": "-22.16M",
+                    "longFmt": "-22,165,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 472000,
+                    "fmt": "472k",
+                    "longFmt": "472,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -21693000,
+                    "fmt": "-21.69M",
+                    "longFmt": "-21,693,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -51000,
+                    "fmt": "-51k",
+                    "longFmt": "-51,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 369816000,
+                    "fmt": "369.82M",
+                    "longFmt": "369,816,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -26438000,
+                    "fmt": "-26.44M",
+                    "longFmt": "-26,438,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 344358000,
+                    "fmt": "344.36M",
+                    "longFmt": "344,358,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 796000,
+                    "fmt": "796k",
+                    "longFmt": "796,000"
+                  },
+                  "changeInCash": {
+                    "raw": 273145000,
+                    "fmt": "273.14M",
+                    "longFmt": "273,145,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -48000,
+                    "fmt": "-48k",
+                    "longFmt": "-48,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 1031000,
+                    "fmt": "1.03M",
+                    "longFmt": "1,031,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "netIncome": {
+                    "raw": -84546000,
+                    "fmt": "-84.55M",
+                    "longFmt": "-84,546,000"
+                  },
+                  "depreciation": {
+                    "raw": 30664000,
+                    "fmt": "30.66M",
+                    "longFmt": "30,664,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 7165000,
+                    "fmt": "7.17M",
+                    "longFmt": "7,165,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 35159000,
+                    "fmt": "35.16M",
+                    "longFmt": "35,159,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -20025000,
+                    "fmt": "-20.02M",
+                    "longFmt": "-20,025,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -30794000,
+                    "fmt": "-30.79M",
+                    "longFmt": "-30,794,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 1134000,
+                    "fmt": "1.13M",
+                    "longFmt": "1,134,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -60387000,
+                    "fmt": "-60.39M",
+                    "longFmt": "-60,387,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -53458000,
+                    "fmt": "-53.46M",
+                    "longFmt": "-53,458,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 2042000,
+                    "fmt": "2.04M",
+                    "longFmt": "2,042,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -51416000,
+                    "fmt": "-51.42M",
+                    "longFmt": "-51,416,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -21367000,
+                    "fmt": "-21.37M",
+                    "longFmt": "-21,367,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -12510000,
+                    "fmt": "-12.51M",
+                    "longFmt": "-12,510,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -26438000,
+                    "fmt": "-26.44M",
+                    "longFmt": "-26,438,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -33462000,
+                    "fmt": "-33.46M",
+                    "longFmt": "-33,462,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -6103000,
+                    "fmt": "-6.1M",
+                    "longFmt": "-6,103,000"
+                  },
+                  "changeInCash": {
+                    "raw": -151368000,
+                    "fmt": "-151.37M",
+                    "longFmt": "-151,368,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -6000,
+                    "fmt": "-6k",
+                    "longFmt": "-6,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 421000,
+                    "fmt": "421k",
+                    "longFmt": "421,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -11155000,
+                    "fmt": "-11.15M",
+                    "longFmt": "-11,155,000"
+                  },
+                  "depreciation": {
+                    "raw": 29197000,
+                    "fmt": "29.2M",
+                    "longFmt": "29,197,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -2300000,
+                    "fmt": "-2.3M",
+                    "longFmt": "-2,300,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 90786000,
+                    "fmt": "90.79M",
+                    "longFmt": "90,786,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -50305000,
+                    "fmt": "-50.3M",
+                    "longFmt": "-50,305,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 4479000,
+                    "fmt": "4.48M",
+                    "longFmt": "4,479,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 8146000,
+                    "fmt": "8.15M",
+                    "longFmt": "8,146,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 69708000,
+                    "fmt": "69.71M",
+                    "longFmt": "69,708,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -20251000,
+                    "fmt": "-20.25M",
+                    "longFmt": "-20,251,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 2100000,
+                    "fmt": "2.1M",
+                    "longFmt": "2,100,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -17125000,
+                    "fmt": "-17.12M",
+                    "longFmt": "-17,125,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -70211000,
+                    "fmt": "-70.21M",
+                    "longFmt": "-70,211,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -2000000,
+                    "fmt": "-2M",
+                    "longFmt": "-2,000,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -21361000,
+                    "fmt": "-21.36M",
+                    "longFmt": "-21,361,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -91336000,
+                    "fmt": "-91.34M",
+                    "longFmt": "-91,336,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 1135000,
+                    "fmt": "1.14M",
+                    "longFmt": "1,135,000"
+                  },
+                  "changeInCash": {
+                    "raw": -37618000,
+                    "fmt": "-37.62M",
+                    "longFmt": "-37,618,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -6000,
+                    "fmt": "-6k",
+                    "longFmt": "-6,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 2236000,
+                    "fmt": "2.24M",
+                    "longFmt": "2,236,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-WSKT.JK.json
+++ b/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-WSKT.JK.json
@@ -1,0 +1,414 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=cashflowStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "5kbsau5g2nuh8"
+      ],
+      "x-yahoo-request-id": [
+        "5kbsau5g2nuh8"
+      ],
+      "x-request-id": [
+        "0b4a6b08-2b04-47f8-b916-50841b2470c6"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1702"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:24 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": -1541875900774,
+                    "fmt": "-1.54T",
+                    "longFmt": "-1,541,875,900,774"
+                  },
+                  "depreciation": {
+                    "raw": 231091569531,
+                    "fmt": "231.09B",
+                    "longFmt": "231,091,569,531"
+                  },
+                  "changeToNetincome": {
+                    "raw": -81314580296,
+                    "fmt": "-81.31B",
+                    "longFmt": "-81,314,580,296"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -1392098911539,
+                    "fmt": "-1.39T",
+                    "longFmt": "-1,392,098,911,539"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -302225459186,
+                    "fmt": "-302.23B",
+                    "longFmt": "-302,225,459,186"
+                  },
+                  "investments": {
+                    "raw": -62161137293,
+                    "fmt": "-62.16B",
+                    "longFmt": "-62,161,137,293"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 1127172556007,
+                    "fmt": "1.13T",
+                    "longFmt": "1,127,172,556,007"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -827619194480,
+                    "fmt": "-827.62B",
+                    "longFmt": "-827,619,194,480"
+                  },
+                  "dividendsPaid": {
+                    "raw": -45317667578,
+                    "fmt": "-45.32B",
+                    "longFmt": "-45,317,667,578"
+                  },
+                  "netBorrowings": {
+                    "raw": 2837577322870,
+                    "fmt": "2.84T",
+                    "longFmt": "2,837,577,322,870"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -760265508940,
+                    "fmt": "-760.27B",
+                    "longFmt": "-760,265,508,940"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 2031994146352,
+                    "fmt": "2.03T",
+                    "longFmt": "2,031,994,146,352"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 18341013574,
+                    "fmt": "18.34B",
+                    "longFmt": "18,341,013,574"
+                  },
+                  "changeInCash": {
+                    "raw": -169382946093,
+                    "fmt": "-169.38B",
+                    "longFmt": "-169,382,946,093"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "netIncome": {
+                    "raw": -1137790988612,
+                    "fmt": "-1.14T",
+                    "longFmt": "-1,137,790,988,612"
+                  },
+                  "depreciation": {
+                    "raw": 223004624316,
+                    "fmt": "223B",
+                    "longFmt": "223,004,624,316"
+                  },
+                  "changeToNetincome": {
+                    "raw": -192337207128,
+                    "fmt": "-192.34B",
+                    "longFmt": "-192,337,207,128"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -1107123571424,
+                    "fmt": "-1.11T",
+                    "longFmt": "-1,107,123,571,424"
+                  },
+                  "capitalExpenditures": {
+                    "raw": 69155856242,
+                    "fmt": "69.16B",
+                    "longFmt": "69,155,856,242"
+                  },
+                  "investments": {
+                    "raw": 1322690801657,
+                    "fmt": "1.32T",
+                    "longFmt": "1,322,690,801,657"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -248093352584,
+                    "fmt": "-248.09B",
+                    "longFmt": "-248,093,352,584"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -1405024004580,
+                    "fmt": "-1.41T",
+                    "longFmt": "-1,405,024,004,580"
+                  },
+                  "dividendsPaid": {
+                    "raw": -45317667578,
+                    "fmt": "-45.32B",
+                    "longFmt": "-45,317,667,578"
+                  },
+                  "netBorrowings": {
+                    "raw": 384478651233,
+                    "fmt": "384.48B",
+                    "longFmt": "384,478,651,233"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -2581555857971,
+                    "fmt": "-2.58T",
+                    "longFmt": "-2,581,555,857,971"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -2197077206738,
+                    "fmt": "-2.2T",
+                    "longFmt": "-2,197,077,206,738"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -20192169322,
+                    "fmt": "-20.19B",
+                    "longFmt": "-20,192,169,322"
+                  },
+                  "changeInCash": {
+                    "raw": -4729416952064,
+                    "fmt": "-4.73T",
+                    "longFmt": "-4,729,416,952,064"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "netIncome": {
+                    "raw": 42696350655,
+                    "fmt": "42.7B",
+                    "longFmt": "42,696,350,655"
+                  },
+                  "depreciation": {
+                    "raw": 385127294046,
+                    "fmt": "385.13B",
+                    "longFmt": "385,127,294,046"
+                  },
+                  "changeToNetincome": {
+                    "raw": 2378732914830,
+                    "fmt": "2.38T",
+                    "longFmt": "2,378,732,914,830"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 2806556559531,
+                    "fmt": "2.81T",
+                    "longFmt": "2,806,556,559,531"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -634768146204,
+                    "fmt": "-634.77B",
+                    "longFmt": "-634,768,146,204"
+                  },
+                  "investments": {
+                    "raw": 1648320186286,
+                    "fmt": "1.65T",
+                    "longFmt": "1,648,320,186,286"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -2905468528,
+                    "fmt": "-2.91B",
+                    "longFmt": "-2,905,468,528"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -494127049424,
+                    "fmt": "-494.13B",
+                    "longFmt": "-494,127,049,424"
+                  },
+                  "dividendsPaid": {
+                    "raw": -45317667578,
+                    "fmt": "-45.32B",
+                    "longFmt": "-45,317,667,578"
+                  },
+                  "netBorrowings": {
+                    "raw": -5095472197442,
+                    "fmt": "-5.1T",
+                    "longFmt": "-5,095,472,197,442"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -398405755081,
+                    "fmt": "-398.41B",
+                    "longFmt": "-398,405,755,081"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -5493877952523,
+                    "fmt": "-5.49T",
+                    "longFmt": "-5,493,877,952,523"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 18854747951,
+                    "fmt": "18.85B",
+                    "longFmt": "18,854,747,951"
+                  },
+                  "changeInCash": {
+                    "raw": -3162593694465,
+                    "fmt": "-3.16T",
+                    "longFmt": "-3,162,593,694,465"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -212188468091,
+                    "fmt": "-212.19B",
+                    "longFmt": "-212,188,468,091"
+                  },
+                  "depreciation": {
+                    "raw": 250963763494,
+                    "fmt": "250.96B",
+                    "longFmt": "250,963,763,494"
+                  },
+                  "changeToNetincome": {
+                    "raw": 13851278449112,
+                    "fmt": "13.85T",
+                    "longFmt": "13,851,278,449,112"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 13890053744515,
+                    "fmt": "13.89T",
+                    "longFmt": "13,890,053,744,515"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -855007643428,
+                    "fmt": "-855.01B",
+                    "longFmt": "-855,007,643,428"
+                  },
+                  "investments": {
+                    "raw": -2394544824643,
+                    "fmt": "-2.39T",
+                    "longFmt": "-2,394,544,824,643"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -30109245841,
+                    "fmt": "-30.11B",
+                    "longFmt": "-30,109,245,841"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -1456372203453,
+                    "fmt": "-1.46T",
+                    "longFmt": "-1,456,372,203,453"
+                  },
+                  "dividendsPaid": {
+                    "raw": -196260589054,
+                    "fmt": "-196.26B",
+                    "longFmt": "-196,260,589,054"
+                  },
+                  "netBorrowings": {
+                    "raw": -3812577734424,
+                    "fmt": "-3.81T",
+                    "longFmt": "-3,812,577,734,424"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -2660696919498,
+                    "fmt": "-2.66T",
+                    "longFmt": "-2,660,696,919,498"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -6669535242976,
+                    "fmt": "-6.67T",
+                    "longFmt": "-6,669,535,242,976"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -1890326095,
+                    "fmt": "-1.89B",
+                    "longFmt": "-1,890,326,095"
+                  },
+                  "changeInCash": {
+                    "raw": 5762255971991,
+                    "fmt": "5.76T",
+                    "longFmt": "5,762,255,971,991"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-defaultKeyStatistics-ADH.json
+++ b/tests/http/quoteSummary-defaultKeyStatistics-ADH.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=defaultKeyStatistics"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "46ce5s9g2nrr6"
+      ],
+      "x-yahoo-request-id": [
+        "46ce5s9g2nrr6"
+      ],
+      "x-request-id": [
+        "bffb863e-17de-4269-b08b-f35f6958a2f4"
+      ],
+      "content-length": [
+        "153"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:30 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=defaultKeyStatistics"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-defaultKeyStatistics-AFRAF.json
+++ b/tests/http/quoteSummary-defaultKeyStatistics-AFRAF.json
@@ -1,0 +1,106 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=defaultKeyStatistics"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "f3viuudg2nrr6"
+      ],
+      "x-yahoo-request-id": [
+        "f3viuudg2nrr6"
+      ],
+      "x-request-id": [
+        "b4d551c8-7078-494c-a880-217d63176b1c"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "414"
+      ],
+      "x-envoy-upstream-service-time": [
+        "8"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:30 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": 2564594688,
+              "profitMargins": -0.38606,
+              "floatShares": 215079742,
+              "sharesOutstanding": 427432000,
+              "heldPercentInsiders": 0.49626,
+              "heldPercentInstitutions": 0.12174,
+              "beta": 2.112234,
+              "category": null,
+              "bookValue": 8.847,
+              "priceToBook": 0.6668927,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1577750400,
+              "nextFiscalYearEnd": 1640908800,
+              "mostRecentQuarter": 1601424000,
+              "trailingEps": -1.903,
+              "lastSplitFactor": null,
+              "52WeekChange": -0.4520548,
+              "SandP52WeekChange": 0.1675049,
+              "lastDividendValue": 0.58,
+              "lastDividendDate": 1215993600
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-defaultKeyStatistics-AMZN.json
+++ b/tests/http/quoteSummary-defaultKeyStatistics-AMZN.json
@@ -1,0 +1,119 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=defaultKeyStatistics"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "ebta5tlg2nrr6"
+      ],
+      "x-yahoo-request-id": [
+        "ebta5tlg2nrr6"
+      ],
+      "x-request-id": [
+        "20eb3bcd-6f19-4cc7-954d-f5c87c08fb3c"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "575"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:29 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": 1667372154880,
+              "forwardPE": 49.344,
+              "profitMargins": 0.05525,
+              "floatShares": 429329229,
+              "sharesOutstanding": 500889984,
+              "sharesShort": 3315887,
+              "sharesShortPriorMonth": 3293474,
+              "sharesShortPreviousMonthDate": 1609372800,
+              "dateShortInterest": 1611878400,
+              "sharesPercentSharesOut": 0.0066000004,
+              "heldPercentInsiders": 0.14556,
+              "heldPercentInstitutions": 0.58663,
+              "shortRatio": 0.88,
+              "shortPercentOfFloat": 0.0077,
+              "beta": 1.143009,
+              "category": null,
+              "bookValue": 185.694,
+              "priceToBook": 17.66025,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1609372800,
+              "nextFiscalYearEnd": 1672444800,
+              "mostRecentQuarter": 1609372800,
+              "earningsQuarterlyGrowth": 1.21,
+              "netIncomeToCommon": 21330999296,
+              "trailingEps": 41.83,
+              "forwardEps": 66.46,
+              "pegRatio": 1.71,
+              "lastSplitFactor": "2:1",
+              "lastSplitDate": 936230400,
+              "enterpriseToRevenue": 4.319,
+              "enterpriseToEbitda": 34.629,
+              "52WeekChange": 0.5205064,
+              "SandP52WeekChange": 0.1675049
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-defaultKeyStatistics-AZT.OL.json
+++ b/tests/http/quoteSummary-defaultKeyStatistics-AZT.OL.json
@@ -1,0 +1,107 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=defaultKeyStatistics"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "76ggva1g2nrr6"
+      ],
+      "x-yahoo-request-id": [
+        "76ggva1g2nrr6"
+      ],
+      "x-request-id": [
+        "c70e8787-578a-4b4c-98c2-9f33b771ddc4"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "430"
+      ],
+      "x-envoy-upstream-service-time": [
+        "9"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:30 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": 3226973184,
+              "profitMargins": 0.86629,
+              "floatShares": 30973342,
+              "sharesOutstanding": 48334700,
+              "heldPercentInsiders": 0.23488002,
+              "heldPercentInstitutions": 0.13869001,
+              "beta": 1.681382,
+              "category": null,
+              "bookValue": 4.018,
+              "priceToBook": 17.471378,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1609372800,
+              "nextFiscalYearEnd": 1672444800,
+              "mostRecentQuarter": 1609372800,
+              "earningsQuarterlyGrowth": 31.74,
+              "netIncomeToCommon": 75387000,
+              "trailingEps": 1.72,
+              "lastSplitFactor": null,
+              "enterpriseToRevenue": 32.988,
+              "enterpriseToEbitda": 74.31,
+              "SandP52WeekChange": 0.1675049
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-defaultKeyStatistics-SIX.json
+++ b/tests/http/quoteSummary-defaultKeyStatistics-SIX.json
@@ -1,0 +1,119 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=defaultKeyStatistics"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "3ftmsb9g2nuh8"
+      ],
+      "x-yahoo-request-id": [
+        "3ftmsb9g2nuh8"
+      ],
+      "x-request-id": [
+        "de02062e-70c3-4ea9-8a02-58bc33322559"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "589"
+      ],
+      "x-envoy-upstream-service-time": [
+        "6"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:24 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": 6570519040,
+              "forwardPE": -36.733944,
+              "profitMargins": -0.68524003,
+              "floatShares": 71662870,
+              "sharesOutstanding": 84977104,
+              "sharesShort": 6440294,
+              "sharesShortPriorMonth": 8135637,
+              "sharesShortPreviousMonthDate": 1609372800,
+              "dateShortInterest": 1611878400,
+              "sharesPercentSharesOut": 0.0758,
+              "heldPercentInsiders": 0.07217,
+              "heldPercentInstitutions": 0.83259004,
+              "shortRatio": 4.05,
+              "shortPercentOfFloat": 0.084300004,
+              "beta": 2.497331,
+              "category": null,
+              "bookValue": -12.674,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1577750400,
+              "nextFiscalYearEnd": 1640908800,
+              "mostRecentQuarter": 1601424000,
+              "netIncomeToCommon": -348767008,
+              "trailingEps": -4.118,
+              "forwardEps": -1.09,
+              "pegRatio": 0.52,
+              "lastSplitFactor": "2:1",
+              "lastSplitDate": 1372291200,
+              "enterpriseToRevenue": 12.909,
+              "enterpriseToEbitda": -66.208,
+              "52WeekChange": 0.036699772,
+              "SandP52WeekChange": 0.1675049,
+              "lastDividendValue": 0.25,
+              "lastDividendDate": 1583193600
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-defaultKeyStatistics-WSKT.JK.json
+++ b/tests/http/quoteSummary-defaultKeyStatistics-WSKT.JK.json
@@ -1,0 +1,110 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=defaultKeyStatistics"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "0a3is0hg2nuh8"
+      ],
+      "x-yahoo-request-id": [
+        "0a3is0hg2nuh8"
+      ],
+      "x-request-id": [
+        "7e02aaad-cf02-4598-87de-283592174ced"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "480"
+      ],
+      "x-envoy-upstream-service-time": [
+        "6"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:24 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": 100142262779904,
+              "profitMargins": -0.13495,
+              "floatShares": 4608627844,
+              "sharesOutstanding": 13573900288,
+              "heldPercentInsiders": 0.71228,
+              "heldPercentInstitutions": 0.108,
+              "beta": 2.181707,
+              "category": null,
+              "bookValue": 983.154,
+              "priceToBook": 1.6325011,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1577750400,
+              "nextFiscalYearEnd": 1640908800,
+              "mostRecentQuarter": 1601424000,
+              "netIncomeToCommon": -2849158987776,
+              "trailingEps": -209.899,
+              "forwardEps": 234.26,
+              "lastSplitFactor": null,
+              "enterpriseToRevenue": 4.743,
+              "enterpriseToEbitda": 90.033,
+              "52WeekChange": 0.37610614,
+              "SandP52WeekChange": 0.1675049,
+              "lastDividendValue": 3.4557,
+              "lastDividendDate": 1592265600
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earnings-ADH.json
+++ b/tests/http/quoteSummary-earnings-ADH.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=earnings"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "6d2dtslg2nrr6"
+      ],
+      "x-yahoo-request-id": [
+        "6d2dtslg2nrr6"
+      ],
+      "x-request-id": [
+        "eb975ce8-b70c-444e-a2e2-1e82c983afbe"
+      ],
+      "content-length": [
+        "141"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:30 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=earnings"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earnings-AFRAF.json
+++ b/tests/http/quoteSummary-earnings-AFRAF.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=earnings"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "dc1hr4hg2nrr6"
+      ],
+      "x-yahoo-request-id": [
+        "dc1hr4hg2nrr6"
+      ],
+      "x-request-id": [
+        "8f9b1b46-52bc-4c02-9804-e4943cf92bd2"
+      ],
+      "content-length": [
+        "141"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:30 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=earnings"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earnings-AMZN.json
+++ b/tests/http/quoteSummary-earnings-AMZN.json
@@ -1,0 +1,162 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=earnings"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "034a4hhg2nrr6"
+      ],
+      "x-yahoo-request-id": [
+        "034a4hhg2nrr6"
+      ],
+      "x-request-id": [
+        "d52d02b5-0e73-47ac-8f50-9cec37912923"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "379"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:30 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [
+                  {
+                    "date": "1Q2020",
+                    "actual": 5.01,
+                    "estimate": 6.25
+                  },
+                  {
+                    "date": "2Q2020",
+                    "actual": 10.3,
+                    "estimate": 1.46
+                  },
+                  {
+                    "date": "3Q2020",
+                    "actual": 12.37,
+                    "estimate": 7.41
+                  },
+                  {
+                    "date": "4Q2020",
+                    "actual": 14.09,
+                    "estimate": 7.23
+                  }
+                ],
+                "currentQuarterEstimate": 9.51,
+                "currentQuarterEstimateDate": "1Q",
+                "currentQuarterEstimateYear": 2021,
+                "earningsDate": [
+                  1619568000,
+                  1620000000
+                ]
+              },
+              "financialsChart": {
+                "yearly": [
+                  {
+                    "date": 2017,
+                    "revenue": 177866000000,
+                    "earnings": 3033000000
+                  },
+                  {
+                    "date": 2018,
+                    "revenue": 232887000000,
+                    "earnings": 10073000000
+                  },
+                  {
+                    "date": 2019,
+                    "revenue": 280522000000,
+                    "earnings": 11588000000
+                  },
+                  {
+                    "date": 2020,
+                    "revenue": 386064000000,
+                    "earnings": 21331000000
+                  }
+                ],
+                "quarterly": [
+                  {
+                    "date": "1Q2020",
+                    "revenue": 75452000000,
+                    "earnings": 2535000000
+                  },
+                  {
+                    "date": "2Q2020",
+                    "revenue": 88912000000,
+                    "earnings": 5243000000
+                  },
+                  {
+                    "date": "3Q2020",
+                    "revenue": 96145000000,
+                    "earnings": 6331000000
+                  },
+                  {
+                    "date": "4Q2020",
+                    "revenue": 125555000000,
+                    "earnings": 7222000000
+                  }
+                ]
+              },
+              "financialCurrency": "USD"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earnings-AZT.OL.json
+++ b/tests/http/quoteSummary-earnings-AZT.OL.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=earnings"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "7l1ccbpg2nrr7"
+      ],
+      "x-yahoo-request-id": [
+        "7l1ccbpg2nrr7"
+      ],
+      "x-request-id": [
+        "22edc7bd-7af8-402b-b3ee-9e4cd188c4ce"
+      ],
+      "content-length": [
+        "141"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:30 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=earnings"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earnings-SIX.json
+++ b/tests/http/quoteSummary-earnings-SIX.json
@@ -1,0 +1,161 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=earnings"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "351l4c9g2nuh9"
+      ],
+      "x-yahoo-request-id": [
+        "351l4c9g2nuh9"
+      ],
+      "x-request-id": [
+        "06da5f6f-cba6-4ff8-a16a-37d661a09494"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "376"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:24 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [
+                  {
+                    "date": "4Q2019",
+                    "actual": -0.13,
+                    "estimate": 0.14
+                  },
+                  {
+                    "date": "1Q2020",
+                    "actual": -1,
+                    "estimate": -1.06
+                  },
+                  {
+                    "date": "2Q2020",
+                    "actual": -1.62,
+                    "estimate": -1.01
+                  },
+                  {
+                    "date": "3Q2020",
+                    "actual": -1.37,
+                    "estimate": -1
+                  }
+                ],
+                "currentQuarterEstimate": -0.89,
+                "currentQuarterEstimateDate": "4Q",
+                "currentQuarterEstimateYear": 2020,
+                "earningsDate": [
+                  1614124800
+                ]
+              },
+              "financialsChart": {
+                "yearly": [
+                  {
+                    "date": 2016,
+                    "revenue": 1319398000,
+                    "earnings": 118302000
+                  },
+                  {
+                    "date": 2017,
+                    "revenue": 1359074000,
+                    "earnings": 273816000
+                  },
+                  {
+                    "date": 2018,
+                    "revenue": 1463707000,
+                    "earnings": 275996000
+                  },
+                  {
+                    "date": 2019,
+                    "revenue": 1487583000,
+                    "earnings": 179065000
+                  }
+                ],
+                "quarterly": [
+                  {
+                    "date": "4Q2019",
+                    "revenue": 261000000,
+                    "earnings": -11155000
+                  },
+                  {
+                    "date": "1Q2020",
+                    "revenue": 102503000,
+                    "earnings": -84546000
+                  },
+                  {
+                    "date": "2Q2020",
+                    "revenue": 19143000,
+                    "earnings": -136894000
+                  },
+                  {
+                    "date": "3Q2020",
+                    "revenue": 126327000,
+                    "earnings": -116172000
+                  }
+                ]
+              },
+              "financialCurrency": "USD"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earnings-WSKT.JK.json
+++ b/tests/http/quoteSummary-earnings-WSKT.JK.json
@@ -1,0 +1,135 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=earnings"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "9mqmt45g2nuh8"
+      ],
+      "x-yahoo-request-id": [
+        "9mqmt45g2nuh8"
+      ],
+      "x-request-id": [
+        "f2eacba7-131b-42c5-9ed3-ec4acf4dafdc"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "349"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:24 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "2"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [],
+                "earningsDate": []
+              },
+              "financialsChart": {
+                "yearly": [
+                  {
+                    "date": 2016,
+                    "revenue": 23788322626347,
+                    "earnings": 1713260616725
+                  },
+                  {
+                    "date": 2017,
+                    "revenue": 45212897632604,
+                    "earnings": 3881711917338
+                  },
+                  {
+                    "date": 2018,
+                    "revenue": 48788950838822,
+                    "earnings": 3962838031865
+                  },
+                  {
+                    "date": 2019,
+                    "revenue": 31387389629869,
+                    "earnings": 938142364887
+                  }
+                ],
+                "quarterly": [
+                  {
+                    "date": "4Q2019",
+                    "revenue": 9372493217765,
+                    "earnings": -212188468091
+                  },
+                  {
+                    "date": "1Q2020",
+                    "revenue": 4169887433590,
+                    "earnings": 42696350655
+                  },
+                  {
+                    "date": "2Q2020",
+                    "revenue": 3867906986507,
+                    "earnings": -1137790988612
+                  },
+                  {
+                    "date": "3Q2020",
+                    "revenue": 3702444815840,
+                    "earnings": -1541875900774
+                  }
+                ]
+              },
+              "financialCurrency": "IDR"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsHistory-ADH.json
+++ b/tests/http/quoteSummary-earningsHistory-ADH.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=earningsHistory"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "1h1m0rlg2nrr7"
+      ],
+      "x-yahoo-request-id": [
+        "1h1m0rlg2nrr7"
+      ],
+      "x-request-id": [
+        "820cdb1c-65b6-4ef3-b61a-ff5055bd8a47"
+      ],
+      "content-length": [
+        "148"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:30 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=earningsHistory"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsHistory-AFRAF.json
+++ b/tests/http/quoteSummary-earningsHistory-AFRAF.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=earningsHistory"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "9aligthg2nrr7"
+      ],
+      "x-yahoo-request-id": [
+        "9aligthg2nrr7"
+      ],
+      "x-request-id": [
+        "574e206f-13ac-47b1-b94c-b91d079db829"
+      ],
+      "content-length": [
+        "148"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:31 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=earningsHistory"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsHistory-AMZN.json
+++ b/tests/http/quoteSummary-earningsHistory-AMZN.json
@@ -1,0 +1,182 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=earningsHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "5eq4vu5g2nrr7"
+      ],
+      "x-yahoo-request-id": [
+        "5eq4vu5g2nrr7"
+      ],
+      "x-request-id": [
+        "8754250e-99f9-478b-b44f-0613834aa526"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "365"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:31 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 5.01,
+                    "fmt": "5.01"
+                  },
+                  "epsEstimate": {
+                    "raw": 6.25,
+                    "fmt": "6.25"
+                  },
+                  "epsDifference": {
+                    "raw": -1.24,
+                    "fmt": "-1.24"
+                  },
+                  "surprisePercent": {
+                    "raw": -0.198,
+                    "fmt": "-19.80%"
+                  },
+                  "quarter": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 10.3,
+                    "fmt": "10.3"
+                  },
+                  "epsEstimate": {
+                    "raw": 1.46,
+                    "fmt": "1.46"
+                  },
+                  "epsDifference": {
+                    "raw": 8.84,
+                    "fmt": "8.84"
+                  },
+                  "surprisePercent": {
+                    "raw": 6.055,
+                    "fmt": "605.50%"
+                  },
+                  "quarter": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 12.37,
+                    "fmt": "12.37"
+                  },
+                  "epsEstimate": {
+                    "raw": 7.41,
+                    "fmt": "7.41"
+                  },
+                  "epsDifference": {
+                    "raw": 4.96,
+                    "fmt": "4.96"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.669,
+                    "fmt": "66.90%"
+                  },
+                  "quarter": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 14.09,
+                    "fmt": "14.09"
+                  },
+                  "epsEstimate": {
+                    "raw": 7.23,
+                    "fmt": "7.23"
+                  },
+                  "epsDifference": {
+                    "raw": 6.86,
+                    "fmt": "6.86"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.949,
+                    "fmt": "94.90%"
+                  },
+                  "quarter": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsHistory-AZT.OL.json
+++ b/tests/http/quoteSummary-earningsHistory-AZT.OL.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=earningsHistory"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "87bb91lg2nrr7"
+      ],
+      "x-yahoo-request-id": [
+        "87bb91lg2nrr7"
+      ],
+      "x-request-id": [
+        "61823a08-94c8-4c7e-8643-0846de707cc8"
+      ],
+      "content-length": [
+        "148"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:31 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=earningsHistory"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsHistory-SIX.json
+++ b/tests/http/quoteSummary-earningsHistory-SIX.json
@@ -1,0 +1,182 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=earningsHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "5neumi5g2nuh9"
+      ],
+      "x-yahoo-request-id": [
+        "5neumi5g2nuh9"
+      ],
+      "x-request-id": [
+        "542f9f51-25bf-47f3-9379-9acbfb80bb31"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "368"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:25 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": -0.13,
+                    "fmt": "-0.13"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.14,
+                    "fmt": "0.14"
+                  },
+                  "epsDifference": {
+                    "raw": -0.27,
+                    "fmt": "-0.27"
+                  },
+                  "surprisePercent": {
+                    "raw": -1.9289999,
+                    "fmt": "-192.90%"
+                  },
+                  "quarter": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": -1,
+                    "fmt": "-1"
+                  },
+                  "epsEstimate": {
+                    "raw": -1.06,
+                    "fmt": "-1.06"
+                  },
+                  "epsDifference": {
+                    "raw": 0.06,
+                    "fmt": "0.06"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.056999996,
+                    "fmt": "5.70%"
+                  },
+                  "quarter": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": -1.62,
+                    "fmt": "-1.62"
+                  },
+                  "epsEstimate": {
+                    "raw": -1.01,
+                    "fmt": "-1.01"
+                  },
+                  "epsDifference": {
+                    "raw": -0.61,
+                    "fmt": "-0.61"
+                  },
+                  "surprisePercent": {
+                    "raw": -0.60400003,
+                    "fmt": "-60.40%"
+                  },
+                  "quarter": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": -1.37,
+                    "fmt": "-1.37"
+                  },
+                  "epsEstimate": {
+                    "raw": -1,
+                    "fmt": "-1"
+                  },
+                  "epsDifference": {
+                    "raw": -0.37,
+                    "fmt": "-0.37"
+                  },
+                  "surprisePercent": {
+                    "raw": -0.37,
+                    "fmt": "-37.00%"
+                  },
+                  "quarter": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsHistory-WSKT.JK.json
+++ b/tests/http/quoteSummary-earningsHistory-WSKT.JK.json
@@ -1,0 +1,122 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=earningsHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "6obiut5g2nuh9"
+      ],
+      "x-yahoo-request-id": [
+        "6obiut5g2nuh9"
+      ],
+      "x-request-id": [
+        "a33df891-80dd-40c0-8d11-405e0d13ced5"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "176"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:24 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsTrend-ADH.json
+++ b/tests/http/quoteSummary-earningsTrend-ADH.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=earningsTrend"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "d3nq63pg2nrr7"
+      ],
+      "x-yahoo-request-id": [
+        "d3nq63pg2nrr7"
+      ],
+      "x-request-id": [
+        "caf45867-8315-4260-b3b9-d7d227eddda7"
+      ],
+      "content-length": [
+        "146"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:31 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=earningsTrend"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsTrend-AFRAF.json
+++ b/tests/http/quoteSummary-earningsTrend-AFRAF.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=earningsTrend"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "dliv8rlg2nrr7"
+      ],
+      "x-yahoo-request-id": [
+        "dliv8rlg2nrr7"
+      ],
+      "x-request-id": [
+        "553717e7-1130-4077-bc7a-9c0faa7813eb"
+      ],
+      "content-length": [
+        "146"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:31 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=earningsTrend"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsTrend-AMZN.json
+++ b/tests/http/quoteSummary-earningsTrend-AMZN.json
@@ -1,0 +1,590 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=earningsTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "4m1k3qtg2nrr7"
+      ],
+      "x-yahoo-request-id": [
+        "4m1k3qtg2nrr7"
+      ],
+      "x-request-id": [
+        "731a7d10-ec94-42b9-a4a8-151b89a5b288"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1130"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:31 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": "2021-03-31",
+                  "growth": {
+                    "raw": 0.898,
+                    "fmt": "89.80%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 9.51,
+                      "fmt": "9.51"
+                    },
+                    "low": {
+                      "raw": 6.41,
+                      "fmt": "6.41"
+                    },
+                    "high": {
+                      "raw": 12,
+                      "fmt": "12"
+                    },
+                    "yearAgoEps": {
+                      "raw": 5.01,
+                      "fmt": "5.01"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 36,
+                      "fmt": "36",
+                      "longFmt": "36"
+                    },
+                    "growth": {
+                      "raw": 0.898,
+                      "fmt": "89.80%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 104484000000,
+                      "fmt": "104.48B",
+                      "longFmt": "104,484,000,000"
+                    },
+                    "low": {
+                      "raw": 100459000000,
+                      "fmt": "100.46B",
+                      "longFmt": "100,459,000,000"
+                    },
+                    "high": {
+                      "raw": 107474000000,
+                      "fmt": "107.47B",
+                      "longFmt": "107,474,000,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 36,
+                      "fmt": "36",
+                      "longFmt": "36"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 75452000000,
+                      "fmt": "75.45B",
+                      "longFmt": "75,452,000,000"
+                    },
+                    "growth": {
+                      "raw": 0.385,
+                      "fmt": "38.50%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 9.51,
+                      "fmt": "9.51"
+                    },
+                    "7daysAgo": {
+                      "raw": 9.51,
+                      "fmt": "9.51"
+                    },
+                    "30daysAgo": {
+                      "raw": 9.1,
+                      "fmt": "9.1"
+                    },
+                    "60daysAgo": {
+                      "raw": 9.2,
+                      "fmt": "9.2"
+                    },
+                    "90daysAgo": {
+                      "raw": 9.2,
+                      "fmt": "9.2"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "upLast30days": {
+                      "raw": 21,
+                      "fmt": "21",
+                      "longFmt": "21"
+                    },
+                    "downLast30days": {
+                      "raw": 3,
+                      "fmt": "3",
+                      "longFmt": "3"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": "2021-06-30",
+                  "growth": {
+                    "raw": 0.062,
+                    "fmt": "6.20%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 10.94,
+                      "fmt": "10.94"
+                    },
+                    "low": {
+                      "raw": 5.21,
+                      "fmt": "5.21"
+                    },
+                    "high": {
+                      "raw": 13.09,
+                      "fmt": "13.09"
+                    },
+                    "yearAgoEps": {
+                      "raw": 10.3,
+                      "fmt": "10.3"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 35,
+                      "fmt": "35",
+                      "longFmt": "35"
+                    },
+                    "growth": {
+                      "raw": 0.062,
+                      "fmt": "6.20%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 107902000000,
+                      "fmt": "107.9B",
+                      "longFmt": "107,902,000,000"
+                    },
+                    "low": {
+                      "raw": 99044000000,
+                      "fmt": "99.04B",
+                      "longFmt": "99,044,000,000"
+                    },
+                    "high": {
+                      "raw": 120590000000,
+                      "fmt": "120.59B",
+                      "longFmt": "120,590,000,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 35,
+                      "fmt": "35",
+                      "longFmt": "35"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 88912000000,
+                      "fmt": "88.91B",
+                      "longFmt": "88,912,000,000"
+                    },
+                    "growth": {
+                      "raw": 0.214,
+                      "fmt": "21.40%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 10.94,
+                      "fmt": "10.94"
+                    },
+                    "7daysAgo": {
+                      "raw": 10.91,
+                      "fmt": "10.91"
+                    },
+                    "30daysAgo": {
+                      "raw": 10.91,
+                      "fmt": "10.91"
+                    },
+                    "60daysAgo": {
+                      "raw": 10.83,
+                      "fmt": "10.83"
+                    },
+                    "90daysAgo": {
+                      "raw": 10.83,
+                      "fmt": "10.83"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 2,
+                      "fmt": "2",
+                      "longFmt": "2"
+                    },
+                    "upLast30days": {
+                      "raw": 21,
+                      "fmt": "21",
+                      "longFmt": "21"
+                    },
+                    "downLast30days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": "2021-12-31",
+                  "growth": {
+                    "raw": 0.14,
+                    "fmt": "14.00%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 47.68,
+                      "fmt": "47.68"
+                    },
+                    "low": {
+                      "raw": 31.49,
+                      "fmt": "31.49"
+                    },
+                    "high": {
+                      "raw": 63.63,
+                      "fmt": "63.63"
+                    },
+                    "yearAgoEps": {
+                      "raw": 41.83,
+                      "fmt": "41.83"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 44,
+                      "fmt": "44",
+                      "longFmt": "44"
+                    },
+                    "growth": {
+                      "raw": 0.14,
+                      "fmt": "14.00%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 474121000000,
+                      "fmt": "474.12B",
+                      "longFmt": "474,121,000,000"
+                    },
+                    "low": {
+                      "raw": 439134000000,
+                      "fmt": "439.13B",
+                      "longFmt": "439,134,000,000"
+                    },
+                    "high": {
+                      "raw": 511167000000,
+                      "fmt": "511.17B",
+                      "longFmt": "511,167,000,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 42,
+                      "fmt": "42",
+                      "longFmt": "42"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 386064000000,
+                      "fmt": "386.06B",
+                      "longFmt": "386,064,000,000"
+                    },
+                    "growth": {
+                      "raw": 0.22799999,
+                      "fmt": "22.80%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 47.68,
+                      "fmt": "47.68"
+                    },
+                    "7daysAgo": {
+                      "raw": 47.65,
+                      "fmt": "47.65"
+                    },
+                    "30daysAgo": {
+                      "raw": 45.47,
+                      "fmt": "45.47"
+                    },
+                    "60daysAgo": {
+                      "raw": 45.38,
+                      "fmt": "45.38"
+                    },
+                    "90daysAgo": {
+                      "raw": 45.84,
+                      "fmt": "45.84"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 4,
+                      "fmt": "4",
+                      "longFmt": "4"
+                    },
+                    "upLast30days": {
+                      "raw": 32,
+                      "fmt": "32",
+                      "longFmt": "32"
+                    },
+                    "downLast30days": {
+                      "raw": 3,
+                      "fmt": "3",
+                      "longFmt": "3"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": "2022-12-31",
+                  "growth": {
+                    "raw": 0.39400002,
+                    "fmt": "39.40%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 66.46,
+                      "fmt": "66.46"
+                    },
+                    "low": {
+                      "raw": 36.71,
+                      "fmt": "36.71"
+                    },
+                    "high": {
+                      "raw": 91.52,
+                      "fmt": "91.52"
+                    },
+                    "yearAgoEps": {
+                      "raw": 47.68,
+                      "fmt": "47.68"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 43,
+                      "fmt": "43",
+                      "longFmt": "43"
+                    },
+                    "growth": {
+                      "raw": 0.39400002,
+                      "fmt": "39.40%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 557143000000,
+                      "fmt": "557.14B",
+                      "longFmt": "557,143,000,000"
+                    },
+                    "low": {
+                      "raw": 505681000000,
+                      "fmt": "505.68B",
+                      "longFmt": "505,681,000,000"
+                    },
+                    "high": {
+                      "raw": 613468000000,
+                      "fmt": "613.47B",
+                      "longFmt": "613,468,000,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 41,
+                      "fmt": "41",
+                      "longFmt": "41"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 474121000000,
+                      "fmt": "474.12B",
+                      "longFmt": "474,121,000,000"
+                    },
+                    "growth": {
+                      "raw": 0.175,
+                      "fmt": "17.50%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 66.46,
+                      "fmt": "66.46"
+                    },
+                    "7daysAgo": {
+                      "raw": 66.48,
+                      "fmt": "66.48"
+                    },
+                    "30daysAgo": {
+                      "raw": 64.73,
+                      "fmt": "64.73"
+                    },
+                    "60daysAgo": {
+                      "raw": 64.62,
+                      "fmt": "64.62"
+                    },
+                    "90daysAgo": {
+                      "raw": 65.45,
+                      "fmt": "65.45"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "upLast30days": {
+                      "raw": 24,
+                      "fmt": "24",
+                      "longFmt": "24"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": 0.38369998,
+                    "fmt": "38.37%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": 1.00597,
+                    "fmt": "100.60%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsTrend-AZT.OL.json
+++ b/tests/http/quoteSummary-earningsTrend-AZT.OL.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=earningsTrend"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "dpf92g1g2nrr8"
+      ],
+      "x-yahoo-request-id": [
+        "dpf92g1g2nrr8"
+      ],
+      "x-request-id": [
+        "832f2c74-5508-4563-8c79-691525f34153"
+      ],
+      "content-length": [
+        "146"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:31 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=earningsTrend"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsTrend-SIX.json
+++ b/tests/http/quoteSummary-earningsTrend-SIX.json
@@ -1,0 +1,590 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=earningsTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "du0fig5g2nuh9"
+      ],
+      "x-yahoo-request-id": [
+        "du0fig5g2nuh9"
+      ],
+      "x-request-id": [
+        "086f755e-c062-4152-bb39-8d936ef57990"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1027"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:25 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": "2020-12-31",
+                  "growth": {
+                    "raw": -5.8459997,
+                    "fmt": "-584.60%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": -0.89,
+                      "fmt": "-0.89"
+                    },
+                    "low": {
+                      "raw": -1.16,
+                      "fmt": "-1.16"
+                    },
+                    "high": {
+                      "raw": 0.46,
+                      "fmt": "0.46"
+                    },
+                    "yearAgoEps": {
+                      "raw": -0.13,
+                      "fmt": "-0.13"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 12,
+                      "fmt": "12",
+                      "longFmt": "12"
+                    },
+                    "growth": {
+                      "raw": -5.8459997,
+                      "fmt": "-584.60%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 86590000,
+                      "fmt": "86.59M",
+                      "longFmt": "86,590,000"
+                    },
+                    "low": {
+                      "raw": 71030000,
+                      "fmt": "71.03M",
+                      "longFmt": "71,030,000"
+                    },
+                    "high": {
+                      "raw": 146800000,
+                      "fmt": "146.8M",
+                      "longFmt": "146,800,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 13,
+                      "fmt": "13",
+                      "longFmt": "13"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 261000000,
+                      "fmt": "261M",
+                      "longFmt": "261,000,000"
+                    },
+                    "growth": {
+                      "raw": -0.66800004,
+                      "fmt": "-66.80%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": -0.89,
+                      "fmt": "-0.89"
+                    },
+                    "7daysAgo": {
+                      "raw": -0.9,
+                      "fmt": "-0.9"
+                    },
+                    "30daysAgo": {
+                      "raw": -0.9,
+                      "fmt": "-0.9"
+                    },
+                    "60daysAgo": {
+                      "raw": -0.91,
+                      "fmt": "-0.91"
+                    },
+                    "90daysAgo": {
+                      "raw": -0.91,
+                      "fmt": "-0.91"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "upLast30days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": "2021-03-31",
+                  "growth": {
+                    "raw": -0.08,
+                    "fmt": "-8.00%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": -1.08,
+                      "fmt": "-1.08"
+                    },
+                    "low": {
+                      "raw": -1.29,
+                      "fmt": "-1.29"
+                    },
+                    "high": {
+                      "raw": -0.85,
+                      "fmt": "-0.85"
+                    },
+                    "yearAgoEps": {
+                      "raw": -1,
+                      "fmt": "-1"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 8,
+                      "fmt": "8",
+                      "longFmt": "8"
+                    },
+                    "growth": {
+                      "raw": -0.08,
+                      "fmt": "-8.00%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 58110000,
+                      "fmt": "58.11M",
+                      "longFmt": "58,110,000"
+                    },
+                    "low": {
+                      "raw": 30100000,
+                      "fmt": "30.1M",
+                      "longFmt": "30,100,000"
+                    },
+                    "high": {
+                      "raw": 86280000,
+                      "fmt": "86.28M",
+                      "longFmt": "86,280,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 8,
+                      "fmt": "8",
+                      "longFmt": "8"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 102503000,
+                      "fmt": "102.5M",
+                      "longFmt": "102,503,000"
+                    },
+                    "growth": {
+                      "raw": -0.433,
+                      "fmt": "-43.30%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": -1.08,
+                      "fmt": "-1.08"
+                    },
+                    "7daysAgo": {
+                      "raw": -1.08,
+                      "fmt": "-1.08"
+                    },
+                    "30daysAgo": {
+                      "raw": -1.06,
+                      "fmt": "-1.06"
+                    },
+                    "60daysAgo": {
+                      "raw": -1.05,
+                      "fmt": "-1.05"
+                    },
+                    "90daysAgo": {
+                      "raw": -1.06,
+                      "fmt": "-1.06"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": "2020-12-31",
+                  "growth": {
+                    "raw": -3.299,
+                    "fmt": "-329.90%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": -4.85,
+                      "fmt": "-4.85"
+                    },
+                    "low": {
+                      "raw": -5.11,
+                      "fmt": "-5.11"
+                    },
+                    "high": {
+                      "raw": -3.52,
+                      "fmt": "-3.52"
+                    },
+                    "yearAgoEps": {
+                      "raw": 2.11,
+                      "fmt": "2.11"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 11,
+                      "fmt": "11",
+                      "longFmt": "11"
+                    },
+                    "growth": {
+                      "raw": -3.299,
+                      "fmt": "-329.90%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 334690000,
+                      "fmt": "334.69M",
+                      "longFmt": "334,690,000"
+                    },
+                    "low": {
+                      "raw": 319000000,
+                      "fmt": "319M",
+                      "longFmt": "319,000,000"
+                    },
+                    "high": {
+                      "raw": 394700000,
+                      "fmt": "394.7M",
+                      "longFmt": "394,700,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 13,
+                      "fmt": "13",
+                      "longFmt": "13"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 1487580000,
+                      "fmt": "1.49B",
+                      "longFmt": "1,487,580,000"
+                    },
+                    "growth": {
+                      "raw": -0.775,
+                      "fmt": "-77.50%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": -4.85,
+                      "fmt": "-4.85"
+                    },
+                    "7daysAgo": {
+                      "raw": -4.86,
+                      "fmt": "-4.86"
+                    },
+                    "30daysAgo": {
+                      "raw": -4.86,
+                      "fmt": "-4.86"
+                    },
+                    "60daysAgo": {
+                      "raw": -4.87,
+                      "fmt": "-4.87"
+                    },
+                    "90daysAgo": {
+                      "raw": -4.87,
+                      "fmt": "-4.87"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "upLast30days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": "2021-12-31",
+                  "growth": {
+                    "raw": 0.775,
+                    "fmt": "77.50%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": -1.09,
+                      "fmt": "-1.09"
+                    },
+                    "low": {
+                      "raw": -3.13,
+                      "fmt": "-3.13"
+                    },
+                    "high": {
+                      "raw": -0.08,
+                      "fmt": "-0.08"
+                    },
+                    "yearAgoEps": {
+                      "raw": -4.85,
+                      "fmt": "-4.85"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 12,
+                      "fmt": "12",
+                      "longFmt": "12"
+                    },
+                    "growth": {
+                      "raw": 0.775,
+                      "fmt": "77.50%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 920010000,
+                      "fmt": "920.01M",
+                      "longFmt": "920,010,000"
+                    },
+                    "low": {
+                      "raw": 733600000,
+                      "fmt": "733.6M",
+                      "longFmt": "733,600,000"
+                    },
+                    "high": {
+                      "raw": 1049270000,
+                      "fmt": "1.05B",
+                      "longFmt": "1,049,270,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 13,
+                      "fmt": "13",
+                      "longFmt": "13"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 334690000,
+                      "fmt": "334.69M",
+                      "longFmt": "334,690,000"
+                    },
+                    "growth": {
+                      "raw": 1.749,
+                      "fmt": "174.90%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": -1.09,
+                      "fmt": "-1.09"
+                    },
+                    "7daysAgo": {
+                      "raw": -1.1,
+                      "fmt": "-1.1"
+                    },
+                    "30daysAgo": {
+                      "raw": -1.1,
+                      "fmt": "-1.1"
+                    },
+                    "60daysAgo": {
+                      "raw": -1.09,
+                      "fmt": "-1.09"
+                    },
+                    "90daysAgo": {
+                      "raw": -1.16,
+                      "fmt": "-1.16"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "upLast30days": {
+                      "raw": 2,
+                      "fmt": "2",
+                      "longFmt": "2"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": -0.1496,
+                    "fmt": "-14.96%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": 0.2564,
+                    "fmt": "25.64%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsTrend-WSKT.JK.json
+++ b/tests/http/quoteSummary-earningsTrend-WSKT.JK.json
@@ -1,0 +1,523 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=earningsTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "0828t6pg2nuh9"
+      ],
+      "x-yahoo-request-id": [
+        "0828t6pg2nuh9"
+      ],
+      "x-request-id": [
+        "f681d824-ad44-4692-b752-4b15c0c9b3e6"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "407"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:25 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": -0.1325,
+                    "fmt": "-13.25%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-financialData-ADH.json
+++ b/tests/http/quoteSummary-financialData-ADH.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=financialData"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "8l1m9hhg2nrr8"
+      ],
+      "x-yahoo-request-id": [
+        "8l1m9hhg2nrr8"
+      ],
+      "x-request-id": [
+        "e6d7fa7f-ce1d-44fa-9414-c0418875eed9"
+      ],
+      "content-length": [
+        "146"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:31 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=financialData"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-financialData-AFRAF.json
+++ b/tests/http/quoteSummary-financialData-AFRAF.json
@@ -1,0 +1,93 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=financialData"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "5p5h3hdg2nrr8"
+      ],
+      "x-yahoo-request-id": [
+        "5p5h3hdg2nrr8"
+      ],
+      "x-request-id": [
+        "fb9f499f-a772-49e9-bff5-dd5d258192c4"
+      ],
+      "content-length": [
+        "359"
+      ],
+      "x-envoy-upstream-service-time": [
+        "75"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:31 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 5.9,
+              "recommendationKey": "none",
+              "quickRatio": 0.56,
+              "currentRatio": 0.624,
+              "returnOnAssets": -0.07041,
+              "grossProfits": 5916000000,
+              "revenueGrowth": -0.668,
+              "grossMargins": 0.05006,
+              "ebitdaMargins": -0.12091,
+              "operatingMargins": 0,
+              "profitMargins": -0.38606,
+              "financialCurrency": "EUR"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-financialData-AMZN.json
+++ b/tests/http/quoteSummary-financialData-AMZN.json
@@ -1,0 +1,113 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=financialData"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "26oh8cpg2nrr8"
+      ],
+      "x-yahoo-request-id": [
+        "26oh8cpg2nrr8"
+      ],
+      "x-request-id": [
+        "fcba55d4-74bb-4f82-a8b8-665e28a47af2"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "471"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:32 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 3279.4023,
+              "targetHighPrice": 5200,
+              "targetLowPrice": 3048,
+              "targetMeanPrice": 4002.71,
+              "targetMedianPrice": 4000,
+              "recommendationMean": 1.7,
+              "recommendationKey": "buy",
+              "numberOfAnalystOpinions": 45,
+              "totalCash": 84395999232,
+              "totalCashPerShare": 167.597,
+              "ebitda": 48149999616,
+              "totalDebt": 101229002752,
+              "quickRatio": 0.86,
+              "currentRatio": 1.05,
+              "totalRevenue": 386063990784,
+              "debtToEquity": 108.377,
+              "revenuePerShare": 772.128,
+              "returnOnAssets": 0.05238,
+              "returnOnEquity": 0.27442,
+              "grossProfits": 152757000000,
+              "freeCashflow": 36638498816,
+              "operatingCashflow": 66063998976,
+              "earningsGrowth": 1.166,
+              "revenueGrowth": 0.436,
+              "grossMargins": 0.39568,
+              "ebitdaMargins": 0.12472,
+              "operatingMargins": 0.059310004,
+              "profitMargins": 0.05525,
+              "financialCurrency": "USD"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-financialData-AZT.OL.json
+++ b/tests/http/quoteSummary-financialData-AZT.OL.json
@@ -1,0 +1,107 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=financialData"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "4blhbi9g2nrr8"
+      ],
+      "x-yahoo-request-id": [
+        "4blhbi9g2nrr8"
+      ],
+      "x-request-id": [
+        "7f276e8f-3d55-40e2-a9c0-1d65eb29eb14"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "378"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:32 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 70.2,
+              "recommendationKey": "none",
+              "totalCash": 140178000,
+              "totalCashPerShare": 2.9,
+              "ebitda": 43426000,
+              "totalDebt": 9595000,
+              "quickRatio": 11.524,
+              "currentRatio": 11.787,
+              "totalRevenue": 97823000,
+              "debtToEquity": 4.862,
+              "revenuePerShare": 2.02,
+              "returnOnAssets": 0.17869,
+              "returnOnEquity": 0.61842996,
+              "grossProfits": 96692000,
+              "freeCashflow": 20620624,
+              "operatingCashflow": 42233000,
+              "earningsGrowth": 30.218,
+              "revenueGrowth": -0.061,
+              "grossMargins": 0.98844004,
+              "ebitdaMargins": 0.44392,
+              "operatingMargins": 0.43745,
+              "profitMargins": 0.86629,
+              "financialCurrency": "NOK"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-financialData-SIX.json
+++ b/tests/http/quoteSummary-financialData-SIX.json
@@ -1,0 +1,110 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=financialData"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "5aj0tclg2nuh9"
+      ],
+      "x-yahoo-request-id": [
+        "5aj0tclg2nuh9"
+      ],
+      "x-request-id": [
+        "f0e56360-5bfc-4669-a961-ae4a2d8a47c4"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "422"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:25 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "2"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 40.04,
+              "targetHighPrice": 50,
+              "targetLowPrice": 17,
+              "targetMeanPrice": 32.91,
+              "targetMedianPrice": 32,
+              "recommendationMean": 2.2,
+              "recommendationKey": "buy",
+              "numberOfAnalystOpinions": 11,
+              "totalCash": 214651008,
+              "totalCashPerShare": 2.526,
+              "ebitda": -99240000,
+              "totalDebt": 2856513024,
+              "quickRatio": 0.614,
+              "currentRatio": 0.891,
+              "totalRevenue": 508972992,
+              "revenuePerShare": 6.01,
+              "returnOnAssets": -0.04615,
+              "grossProfits": 787282000,
+              "freeCashflow": -58257500,
+              "operatingCashflow": -84256000,
+              "revenueGrowth": -0.797,
+              "grossMargins": 0.18232,
+              "ebitdaMargins": -0.19498,
+              "operatingMargins": -0.42698002,
+              "profitMargins": -0.68524003,
+              "financialCurrency": "USD"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-financialData-WSKT.JK.json
+++ b/tests/http/quoteSummary-financialData-WSKT.JK.json
@@ -1,0 +1,111 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=financialData"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "9v0abdhg2nuh9"
+      ],
+      "x-yahoo-request-id": [
+        "9v0abdhg2nuh9"
+      ],
+      "x-request-id": [
+        "27440d19-197f-4f29-8922-c2062f9c74e0"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "465"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:25 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 1605,
+              "targetHighPrice": 3600,
+              "targetLowPrice": 1650,
+              "targetMeanPrice": 2471.4,
+              "targetMedianPrice": 2310,
+              "recommendationKey": "none",
+              "numberOfAnalystOpinions": 11,
+              "totalCash": 1196916473856,
+              "totalCashPerShare": 88.177,
+              "ebitda": 1112281972736,
+              "totalDebt": 69063208337408,
+              "quickRatio": 0.638,
+              "currentRatio": 0.968,
+              "totalRevenue": 21112731729920,
+              "debtToEquity": 290.582,
+              "revenuePerShare": 1555.387,
+              "returnOnAssets": 0.00093999994,
+              "returnOnEquity": -0.13034001,
+              "grossProfits": 5604642763405,
+              "freeCashflow": 18182632898560,
+              "operatingCashflow": 10596487528448,
+              "revenueGrowth": -0.487,
+              "grossMargins": 0.10501,
+              "ebitdaMargins": 0.05268,
+              "operatingMargins": 0.00897,
+              "profitMargins": -0.13495,
+              "financialCurrency": "IDR"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-fundOwnership-ADH.json
+++ b/tests/http/quoteSummary-fundOwnership-ADH.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=fundOwnership"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "40rdke9g2nrr8"
+      ],
+      "x-yahoo-request-id": [
+        "40rdke9g2nrr8"
+      ],
+      "x-request-id": [
+        "585ef79a-205d-4db0-b0a6-2fb79e42f4e6"
+      ],
+      "content-length": [
+        "146"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:32 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=fundOwnership"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-fundOwnership-AFRAF.json
+++ b/tests/http/quoteSummary-fundOwnership-AFRAF.json
@@ -1,0 +1,306 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=fundOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "927q62tg2nrr8"
+      ],
+      "x-yahoo-request-id": [
+        "927q62tg2nrr8"
+      ],
+      "x-request-id": [
+        "bfdf7c15-22eb-4524-aabe-237644ec64f2"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "858"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:32 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "2"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "ETF Series Solutions-U.S. Global Jets ETF",
+                  "pctHeld": {
+                    "raw": 0.0091,
+                    "fmt": "0.91%"
+                  },
+                  "position": {
+                    "raw": 3904347,
+                    "fmt": "3.9M",
+                    "longFmt": "3,904,347"
+                  },
+                  "value": {
+                    "raw": 13743301,
+                    "fmt": "13.74M",
+                    "longFmt": "13,743,301"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1604102400,
+                    "fmt": "2020-10-31"
+                  },
+                  "organization": "Vanguard International Stock Index-Total Intl Stock Indx",
+                  "pctHeld": {
+                    "raw": 0.0069999998,
+                    "fmt": "0.70%"
+                  },
+                  "position": {
+                    "raw": 2982812,
+                    "fmt": "2.98M",
+                    "longFmt": "2,982,812"
+                  },
+                  "value": {
+                    "raw": 9753795,
+                    "fmt": "9.75M",
+                    "longFmt": "9,753,795"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Causeway International Value Fund",
+                  "pctHeld": {
+                    "raw": 0.0039,
+                    "fmt": "0.39%"
+                  },
+                  "position": {
+                    "raw": 1674686,
+                    "fmt": "1.67M",
+                    "longFmt": "1,674,686"
+                  },
+                  "value": {
+                    "raw": 5894894,
+                    "fmt": "5.89M",
+                    "longFmt": "5,894,894"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1604102400,
+                    "fmt": "2020-10-31"
+                  },
+                  "organization": "DFA Continental Small Company Series",
+                  "pctHeld": {
+                    "raw": 0.0029,
+                    "fmt": "0.29%"
+                  },
+                  "position": {
+                    "raw": 1233305,
+                    "fmt": "1.23M",
+                    "longFmt": "1,233,305"
+                  },
+                  "value": {
+                    "raw": 4032907,
+                    "fmt": "4.03M",
+                    "longFmt": "4,032,907"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Tax Managed Fund-Vanguard Developed Markets Index Fund",
+                  "pctHeld": {
+                    "raw": 0.0029,
+                    "fmt": "0.29%"
+                  },
+                  "position": {
+                    "raw": 1232316,
+                    "fmt": "1.23M",
+                    "longFmt": "1,232,316"
+                  },
+                  "value": {
+                    "raw": 4337752,
+                    "fmt": "4.34M",
+                    "longFmt": "4,337,752"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "iShares Core MSCI EAFE ETF",
+                  "pctHeld": {
+                    "raw": 0.0022,
+                    "fmt": "0.22%"
+                  },
+                  "position": {
+                    "raw": 963129,
+                    "fmt": "963.13k",
+                    "longFmt": "963,129"
+                  },
+                  "value": {
+                    "raw": 5875086,
+                    "fmt": "5.88M",
+                    "longFmt": "5,875,086"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1604102400,
+                    "fmt": "2020-10-31"
+                  },
+                  "organization": "DFA International Core Equity Portfolio",
+                  "pctHeld": {
+                    "raw": 0.0019,
+                    "fmt": "0.19%"
+                  },
+                  "position": {
+                    "raw": 803774,
+                    "fmt": "803.77k",
+                    "longFmt": "803,774"
+                  },
+                  "value": {
+                    "raw": 2628340,
+                    "fmt": "2.63M",
+                    "longFmt": "2,628,340"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "iShares MSCI EAFE Small Cap ETF",
+                  "pctHeld": {
+                    "raw": 0.0018000001,
+                    "fmt": "0.18%"
+                  },
+                  "position": {
+                    "raw": 752367,
+                    "fmt": "752.37k",
+                    "longFmt": "752,367"
+                  },
+                  "value": {
+                    "raw": 4589438,
+                    "fmt": "4.59M",
+                    "longFmt": "4,589,438"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "PIMCO Equity Series-PIMCO RAE International Fd",
+                  "pctHeld": {
+                    "raw": 0.0017,
+                    "fmt": "0.17%"
+                  },
+                  "position": {
+                    "raw": 741343,
+                    "fmt": "741.34k",
+                    "longFmt": "741,343"
+                  },
+                  "value": {
+                    "raw": 2609527,
+                    "fmt": "2.61M",
+                    "longFmt": "2,609,527"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1604102400,
+                    "fmt": "2020-10-31"
+                  },
+                  "organization": "Domini Impact International Equity Fund",
+                  "pctHeld": {
+                    "raw": 0.0017,
+                    "fmt": "0.17%"
+                  },
+                  "position": {
+                    "raw": 725639,
+                    "fmt": "725.64k",
+                    "longFmt": "725,639"
+                  },
+                  "value": {
+                    "raw": 2372839,
+                    "fmt": "2.37M",
+                    "longFmt": "2,372,839"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-fundOwnership-AMZN.json
+++ b/tests/http/quoteSummary-fundOwnership-AMZN.json
@@ -1,0 +1,306 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=fundOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "2k4pu4tg2nrr9"
+      ],
+      "x-yahoo-request-id": [
+        "2k4pu4tg2nrr9"
+      ],
+      "x-request-id": [
+        "418a4a88-70c0-4b42-8def-7fcda6e291d8"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "852"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:32 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Total Stock Market Index Fund",
+                  "pctHeld": {
+                    "raw": 0.023699999,
+                    "fmt": "2.37%"
+                  },
+                  "position": {
+                    "raw": 11939563,
+                    "fmt": "11.94M",
+                    "longFmt": "11,939,563"
+                  },
+                  "value": {
+                    "raw": 37594460204,
+                    "fmt": "37.59B",
+                    "longFmt": "37,594,460,204"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard 500 Index Fund",
+                  "pctHeld": {
+                    "raw": 0.0173,
+                    "fmt": "1.73%"
+                  },
+                  "position": {
+                    "raw": 8734062,
+                    "fmt": "8.73M",
+                    "longFmt": "8,734,062"
+                  },
+                  "value": {
+                    "raw": 27501203041,
+                    "fmt": "27.5B",
+                    "longFmt": "27,501,203,041"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "SPDR S&P 500 ETF Trust",
+                  "pctHeld": {
+                    "raw": 0.0089,
+                    "fmt": "0.89%"
+                  },
+                  "position": {
+                    "raw": 4477608,
+                    "fmt": "4.48M",
+                    "longFmt": "4,477,608"
+                  },
+                  "value": {
+                    "raw": 14583255823,
+                    "fmt": "14.58B",
+                    "longFmt": "14,583,255,823"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Invesco ETF Tr-Invesco QQQ Tr, Series 1 ETF",
+                  "pctHeld": {
+                    "raw": 0.0082,
+                    "fmt": "0.82%"
+                  },
+                  "position": {
+                    "raw": 4143104,
+                    "fmt": "4.14M",
+                    "longFmt": "4,143,104"
+                  },
+                  "value": {
+                    "raw": 13493799710,
+                    "fmt": "13.49B",
+                    "longFmt": "13,493,799,710"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Fidelity 500 Index Fund",
+                  "pctHeld": {
+                    "raw": 0.0077,
+                    "fmt": "0.77%"
+                  },
+                  "position": {
+                    "raw": 3860193,
+                    "fmt": "3.86M",
+                    "longFmt": "3,860,193"
+                  },
+                  "value": {
+                    "raw": 12572378387,
+                    "fmt": "12.57B",
+                    "longFmt": "12,572,378,387"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Fidelity Contrafund Inc",
+                  "pctHeld": {
+                    "raw": 0.0075,
+                    "fmt": "0.75%"
+                  },
+                  "position": {
+                    "raw": 3781672,
+                    "fmt": "3.78M",
+                    "longFmt": "3,781,672"
+                  },
+                  "value": {
+                    "raw": 12316640986,
+                    "fmt": "12.32B",
+                    "longFmt": "12,316,640,986"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Growth Fund Of America Inc",
+                  "pctHeld": {
+                    "raw": 0.0074,
+                    "fmt": "0.74%"
+                  },
+                  "position": {
+                    "raw": 3709684,
+                    "fmt": "3.71M",
+                    "longFmt": "3,709,684"
+                  },
+                  "value": {
+                    "raw": 12082181110,
+                    "fmt": "12.08B",
+                    "longFmt": "12,082,181,110"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Institutional Index Fund-Institutional Index Fund",
+                  "pctHeld": {
+                    "raw": 0.0073,
+                    "fmt": "0.73%"
+                  },
+                  "position": {
+                    "raw": 3654026,
+                    "fmt": "3.65M",
+                    "longFmt": "3,654,026"
+                  },
+                  "value": {
+                    "raw": 11505541286,
+                    "fmt": "11.51B",
+                    "longFmt": "11,505,541,286"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Growth Index Fund",
+                  "pctHeld": {
+                    "raw": 0.0067000003,
+                    "fmt": "0.67%"
+                  },
+                  "position": {
+                    "raw": 3372922,
+                    "fmt": "3.37M",
+                    "longFmt": "3,372,922"
+                  },
+                  "value": {
+                    "raw": 10620420689,
+                    "fmt": "10.62B",
+                    "longFmt": "10,620,420,689"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Price (T.Rowe) Blue Chip Growth Fund Inc.",
+                  "pctHeld": {
+                    "raw": 0.0066000004,
+                    "fmt": "0.66%"
+                  },
+                  "position": {
+                    "raw": 3301177,
+                    "fmt": "3.3M",
+                    "longFmt": "3,301,177"
+                  },
+                  "value": {
+                    "raw": 10751702406,
+                    "fmt": "10.75B",
+                    "longFmt": "10,751,702,406"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-fundOwnership-AZT.OL.json
+++ b/tests/http/quoteSummary-fundOwnership-AZT.OL.json
@@ -1,0 +1,240 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=fundOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "d19jqa1g2nrr9"
+      ],
+      "x-yahoo-request-id": [
+        "d19jqa1g2nrr9"
+      ],
+      "x-request-id": [
+        "29d7b103-7a47-42a5-95d8-43b6548fd226"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "676"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:33 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1606694400,
+                    "fmt": "2020-11-30"
+                  },
+                  "organization": "USAA Mutual Fd Tr-International Fd",
+                  "pctHeld": {
+                    "raw": 0.0013,
+                    "fmt": "0.13%"
+                  },
+                  "position": {
+                    "raw": 64177,
+                    "fmt": "64.18k",
+                    "longFmt": "64,177"
+                  },
+                  "value": {
+                    "raw": 4325529,
+                    "fmt": "4.33M",
+                    "longFmt": "4,325,529"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "SPDR Portfolio Developed World ex-US ETF",
+                  "pctHeld": {
+                    "raw": 0.001,
+                    "fmt": "0.10%"
+                  },
+                  "position": {
+                    "raw": 48642,
+                    "fmt": "48.64k",
+                    "longFmt": "48,642"
+                  },
+                  "value": {
+                    "raw": 3093631,
+                    "fmt": "3.09M",
+                    "longFmt": "3,093,631"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "SPDR (R) Idx Shares-SPDR (R) S&P (R) International Small Cap ETF",
+                  "pctHeld": {
+                    "raw": 0.0004,
+                    "fmt": "0.04%"
+                  },
+                  "position": {
+                    "raw": 20200,
+                    "fmt": "20.2k",
+                    "longFmt": "20,200"
+                  },
+                  "value": {
+                    "raw": 1284720,
+                    "fmt": "1.28M",
+                    "longFmt": "1,284,720"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1604102400,
+                    "fmt": "2020-10-31"
+                  },
+                  "organization": "DFA Investment Dimensions-DFA International Small Cap Growth Port",
+                  "pctHeld": {
+                    "raw": 0.0002,
+                    "fmt": "0.02%"
+                  },
+                  "position": {
+                    "raw": 11505,
+                    "fmt": "11.51k",
+                    "longFmt": "11,505"
+                  },
+                  "value": {
+                    "raw": 687999,
+                    "fmt": "688k",
+                    "longFmt": "687,999"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Wilshire Mutual Funds, Inc.-International Equity Fund",
+                  "pctHeld": {
+                    "raw": 0.0001,
+                    "fmt": "0.01%"
+                  },
+                  "position": {
+                    "raw": 7230,
+                    "fmt": "7.23k",
+                    "longFmt": "7,230"
+                  },
+                  "value": {
+                    "raw": 469950,
+                    "fmt": "469.95k",
+                    "longFmt": "469,950"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1604102400,
+                    "fmt": "2020-10-31"
+                  },
+                  "organization": "DFA Continental Small Company Series",
+                  "pctHeld": {
+                    "raw": 0.0001,
+                    "fmt": "0.01%"
+                  },
+                  "position": {
+                    "raw": 3238,
+                    "fmt": "3.24k",
+                    "longFmt": "3,238"
+                  },
+                  "value": {
+                    "raw": 193632,
+                    "fmt": "193.63k",
+                    "longFmt": "193,632"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Avantis International Equity ETF",
+                  "pctHeld": {
+                    "raw": 0.0001,
+                    "fmt": "0.01%"
+                  },
+                  "position": {
+                    "raw": 2740,
+                    "fmt": "2.74k",
+                    "longFmt": "2,740"
+                  },
+                  "value": {
+                    "raw": 174264,
+                    "fmt": "174.26k",
+                    "longFmt": "174,264"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-fundOwnership-SIX.json
+++ b/tests/http/quoteSummary-fundOwnership-SIX.json
@@ -1,0 +1,306 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=fundOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "4j9g0nhg2nuha"
+      ],
+      "x-yahoo-request-id": [
+        "4j9g0nhg2nuha"
+      ],
+      "x-request-id": [
+        "a8f715c5-f2d8-4ca2-a624-3aa7fb6ac005"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "855"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:26 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Smallcap World Fund",
+                  "pctHeld": {
+                    "raw": 0.0493,
+                    "fmt": "4.93%"
+                  },
+                  "position": {
+                    "raw": 4193532,
+                    "fmt": "4.19M",
+                    "longFmt": "4,193,532"
+                  },
+                  "value": {
+                    "raw": 142999441,
+                    "fmt": "143M",
+                    "longFmt": "142,999,441"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Total Stock Market Index Fund",
+                  "pctHeld": {
+                    "raw": 0.026700001,
+                    "fmt": "2.67%"
+                  },
+                  "position": {
+                    "raw": 2267214,
+                    "fmt": "2.27M",
+                    "longFmt": "2,267,214"
+                  },
+                  "value": {
+                    "raw": 46024444,
+                    "fmt": "46.02M",
+                    "longFmt": "46,024,444"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "iShares Core S&P Midcap ETF",
+                  "pctHeld": {
+                    "raw": 0.0232,
+                    "fmt": "2.32%"
+                  },
+                  "position": {
+                    "raw": 1967613,
+                    "fmt": "1.97M",
+                    "longFmt": "1,967,613"
+                  },
+                  "value": {
+                    "raw": 67095603,
+                    "fmt": "67.1M",
+                    "longFmt": "67,095,603"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Small-Cap Index Fund",
+                  "pctHeld": {
+                    "raw": 0.0221,
+                    "fmt": "2.21%"
+                  },
+                  "position": {
+                    "raw": 1879894,
+                    "fmt": "1.88M",
+                    "longFmt": "1,879,894"
+                  },
+                  "value": {
+                    "raw": 38161848,
+                    "fmt": "38.16M",
+                    "longFmt": "38,161,848"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Small-Cap Growth Index Fund",
+                  "pctHeld": {
+                    "raw": 0.014099999,
+                    "fmt": "1.41%"
+                  },
+                  "position": {
+                    "raw": 1200964,
+                    "fmt": "1.2M",
+                    "longFmt": "1,200,964"
+                  },
+                  "value": {
+                    "raw": 24379569,
+                    "fmt": "24.38M",
+                    "longFmt": "24,379,569"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Extended Market Index Fund",
+                  "pctHeld": {
+                    "raw": 0.0117,
+                    "fmt": "1.17%"
+                  },
+                  "position": {
+                    "raw": 990391,
+                    "fmt": "990.39k",
+                    "longFmt": "990,391"
+                  },
+                  "value": {
+                    "raw": 20104937,
+                    "fmt": "20.1M",
+                    "longFmt": "20,104,937"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "MFS Series Trust XI-MFS Mid Cap Value Fund",
+                  "pctHeld": {
+                    "raw": 0.0084,
+                    "fmt": "0.84%"
+                  },
+                  "position": {
+                    "raw": 714956,
+                    "fmt": "714.96k",
+                    "longFmt": "714,956"
+                  },
+                  "value": {
+                    "raw": 14513606,
+                    "fmt": "14.51M",
+                    "longFmt": "14,513,606"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "SPDR S&P Mid Cap 400 ETF Trust",
+                  "pctHeld": {
+                    "raw": 0.0077,
+                    "fmt": "0.77%"
+                  },
+                  "position": {
+                    "raw": 652225,
+                    "fmt": "652.23k",
+                    "longFmt": "652,225"
+                  },
+                  "value": {
+                    "raw": 22240872,
+                    "fmt": "22.24M",
+                    "longFmt": "22,240,872"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Price (T.Rowe) QM U.S. Small Cap Growth Equity Fd",
+                  "pctHeld": {
+                    "raw": 0.0073,
+                    "fmt": "0.73%"
+                  },
+                  "position": {
+                    "raw": 617800,
+                    "fmt": "617.8k",
+                    "longFmt": "617,800"
+                  },
+                  "value": {
+                    "raw": 21066980,
+                    "fmt": "21.07M",
+                    "longFmt": "21,066,980"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1606694400,
+                    "fmt": "2020-11-30"
+                  },
+                  "organization": "MFS Series Trust XIII-MFS New Discovery Value Fund",
+                  "pctHeld": {
+                    "raw": 0.0070999996,
+                    "fmt": "0.71%"
+                  },
+                  "position": {
+                    "raw": 601122,
+                    "fmt": "601.12k",
+                    "longFmt": "601,122"
+                  },
+                  "value": {
+                    "raw": 18472479,
+                    "fmt": "18.47M",
+                    "longFmt": "18,472,479"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-fundOwnership-WSKT.JK.json
+++ b/tests/http/quoteSummary-fundOwnership-WSKT.JK.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=fundOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "fu1h589g2nuha"
+      ],
+      "x-yahoo-request-id": [
+        "fu1h589g2nuha"
+      ],
+      "x-request-id": [
+        "3bfbeb0a-d111-4d9b-92d4-35b474c4401e"
+      ],
+      "content-length": [
+        "92"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:25 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistory-ADH.json
+++ b/tests/http/quoteSummary-incomeStatementHistory-ADH.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=incomeStatementHistory"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "3jtin7pg2nrr9"
+      ],
+      "x-yahoo-request-id": [
+        "3jtin7pg2nrr9"
+      ],
+      "x-request-id": [
+        "aebf2d0a-fba4-42d8-817b-54d43b29baf7"
+      ],
+      "content-length": [
+        "155"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:33 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=incomeStatementHistory"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistory-AFRAF.json
+++ b/tests/http/quoteSummary-incomeStatementHistory-AFRAF.json
@@ -1,0 +1,466 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=incomeStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "8spks69g2nrr9"
+      ],
+      "x-yahoo-request-id": [
+        "8spks69g2nrr9"
+      ],
+      "x-request-id": [
+        "5f995b9b-73d8-49ef-9456-9ad38e834fcb"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1173"
+      ],
+      "x-envoy-upstream-service-time": [
+        "5"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:33 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 27189000000,
+                    "fmt": "27.19B",
+                    "longFmt": "27,189,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 21273000000,
+                    "fmt": "21.27B",
+                    "longFmt": "21,273,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 5916000000,
+                    "fmt": "5.92B",
+                    "longFmt": "5,916,000,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 1029000000,
+                    "fmt": "1.03B",
+                    "longFmt": "1,029,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 774000000,
+                    "fmt": "774M",
+                    "longFmt": "774,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 26063000000,
+                    "fmt": "26.06B",
+                    "longFmt": "26,063,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 1126000000,
+                    "fmt": "1.13B",
+                    "longFmt": "1,126,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -757000000,
+                    "fmt": "-757M",
+                    "longFmt": "-757,000,000"
+                  },
+                  "ebit": {
+                    "raw": 1126000000,
+                    "fmt": "1.13B",
+                    "longFmt": "1,126,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -385000000,
+                    "fmt": "-385M",
+                    "longFmt": "-385,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 369000000,
+                    "fmt": "369M",
+                    "longFmt": "369,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 76000000,
+                    "fmt": "76M",
+                    "longFmt": "76,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 15000000,
+                    "fmt": "15M",
+                    "longFmt": "15,000,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 293000000,
+                    "fmt": "293M",
+                    "longFmt": "293,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 290000000,
+                    "fmt": "290M",
+                    "longFmt": "290,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 273000000,
+                    "fmt": "273M",
+                    "longFmt": "273,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 26227000000,
+                    "fmt": "26.23B",
+                    "longFmt": "26,227,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 20053000000,
+                    "fmt": "20.05B",
+                    "longFmt": "20,053,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 6174000000,
+                    "fmt": "6.17B",
+                    "longFmt": "6,174,000,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 1034000000,
+                    "fmt": "1.03B",
+                    "longFmt": "1,034,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 774000000,
+                    "fmt": "774M",
+                    "longFmt": "774,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 24749000000,
+                    "fmt": "24.75B",
+                    "longFmt": "24,749,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 1478000000,
+                    "fmt": "1.48B",
+                    "longFmt": "1,478,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -832000000,
+                    "fmt": "-832M",
+                    "longFmt": "-832,000,000"
+                  },
+                  "ebit": {
+                    "raw": 1478000000,
+                    "fmt": "1.48B",
+                    "longFmt": "1,478,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -417000000,
+                    "fmt": "-417M",
+                    "longFmt": "-417,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 646000000,
+                    "fmt": "646M",
+                    "longFmt": "646,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 224000000,
+                    "fmt": "224M",
+                    "longFmt": "224,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 12000000,
+                    "fmt": "12M",
+                    "longFmt": "12,000,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 422000000,
+                    "fmt": "422M",
+                    "longFmt": "422,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 420000000,
+                    "fmt": "420M",
+                    "longFmt": "420,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 395000000,
+                    "fmt": "395M",
+                    "longFmt": "395,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 25867000000,
+                    "fmt": "25.87B",
+                    "longFmt": "25,867,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 19411000000,
+                    "fmt": "19.41B",
+                    "longFmt": "19,411,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 6456000000,
+                    "fmt": "6.46B",
+                    "longFmt": "6,456,000,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 935000000,
+                    "fmt": "935M",
+                    "longFmt": "935,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 660000000,
+                    "fmt": "660M",
+                    "longFmt": "660,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 23846000000,
+                    "fmt": "23.85B",
+                    "longFmt": "23,846,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 2021000000,
+                    "fmt": "2.02B",
+                    "longFmt": "2,021,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -1871000000,
+                    "fmt": "-1.87B",
+                    "longFmt": "-1,871,000,000"
+                  },
+                  "ebit": {
+                    "raw": 2021000000,
+                    "fmt": "2.02B",
+                    "longFmt": "2,021,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -519000000,
+                    "fmt": "-519M",
+                    "longFmt": "-519,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 150000000,
+                    "fmt": "150M",
+                    "longFmt": "150,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -21000000,
+                    "fmt": "-21M",
+                    "longFmt": "-21,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 12000000,
+                    "fmt": "12M",
+                    "longFmt": "12,000,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 171000000,
+                    "fmt": "171M",
+                    "longFmt": "171,000,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -8000000,
+                    "fmt": "-8M",
+                    "longFmt": "-8,000,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 163000000,
+                    "fmt": "163M",
+                    "longFmt": "163,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 138000000,
+                    "fmt": "138M",
+                    "longFmt": "138,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 24846000000,
+                    "fmt": "24.85B",
+                    "longFmt": "24,846,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 19947000000,
+                    "fmt": "19.95B",
+                    "longFmt": "19,947,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 4899000000,
+                    "fmt": "4.9B",
+                    "longFmt": "4,899,000,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 905000000,
+                    "fmt": "905M",
+                    "longFmt": "905,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 1346000000,
+                    "fmt": "1.35B",
+                    "longFmt": "1,346,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 23863000000,
+                    "fmt": "23.86B",
+                    "longFmt": "23,863,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 983000000,
+                    "fmt": "983M",
+                    "longFmt": "983,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -167000000,
+                    "fmt": "-167M",
+                    "longFmt": "-167,000,000"
+                  },
+                  "ebit": {
+                    "raw": 983000000,
+                    "fmt": "983M",
+                    "longFmt": "983,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -229000000,
+                    "fmt": "-229M",
+                    "longFmt": "-229,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 816000000,
+                    "fmt": "816M",
+                    "longFmt": "816,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 294000000,
+                    "fmt": "294M",
+                    "longFmt": "294,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 12000000,
+                    "fmt": "12M",
+                    "longFmt": "12,000,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 522000000,
+                    "fmt": "522M",
+                    "longFmt": "522,000,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": 270000000,
+                    "fmt": "270M",
+                    "longFmt": "270,000,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 792000000,
+                    "fmt": "792M",
+                    "longFmt": "792,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 767000000,
+                    "fmt": "767M",
+                    "longFmt": "767,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistory-AMZN.json
+++ b/tests/http/quoteSummary-incomeStatementHistory-AMZN.json
@@ -1,0 +1,458 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=incomeStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "6d8dvitg2nrr9"
+      ],
+      "x-yahoo-request-id": [
+        "6d8dvitg2nrr9"
+      ],
+      "x-request-id": [
+        "1efeba15-9b12-4768-9abc-6b635ba4812f"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1259"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:33 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 386064000000,
+                    "fmt": "386.06B",
+                    "longFmt": "386,064,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 233307000000,
+                    "fmt": "233.31B",
+                    "longFmt": "233,307,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 152757000000,
+                    "fmt": "152.76B",
+                    "longFmt": "152,757,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 42740000000,
+                    "fmt": "42.74B",
+                    "longFmt": "42,740,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 87193000000,
+                    "fmt": "87.19B",
+                    "longFmt": "87,193,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": -75000000,
+                    "fmt": "-75M",
+                    "longFmt": "-75,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 363165000000,
+                    "fmt": "363.17B",
+                    "longFmt": "363,165,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 22899000000,
+                    "fmt": "22.9B",
+                    "longFmt": "22,899,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 1295000000,
+                    "fmt": "1.29B",
+                    "longFmt": "1,295,000,000"
+                  },
+                  "ebit": {
+                    "raw": 22899000000,
+                    "fmt": "22.9B",
+                    "longFmt": "22,899,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -1647000000,
+                    "fmt": "-1.65B",
+                    "longFmt": "-1,647,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 24194000000,
+                    "fmt": "24.19B",
+                    "longFmt": "24,194,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 2863000000,
+                    "fmt": "2.86B",
+                    "longFmt": "2,863,000,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 21331000000,
+                    "fmt": "21.33B",
+                    "longFmt": "21,331,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 21331000000,
+                    "fmt": "21.33B",
+                    "longFmt": "21,331,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 21331000000,
+                    "fmt": "21.33B",
+                    "longFmt": "21,331,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 280522000000,
+                    "fmt": "280.52B",
+                    "longFmt": "280,522,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 165536000000,
+                    "fmt": "165.54B",
+                    "longFmt": "165,536,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 114986000000,
+                    "fmt": "114.99B",
+                    "longFmt": "114,986,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 35931000000,
+                    "fmt": "35.93B",
+                    "longFmt": "35,931,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 64313000000,
+                    "fmt": "64.31B",
+                    "longFmt": "64,313,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 338000000,
+                    "fmt": "338M",
+                    "longFmt": "338,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 266118000000,
+                    "fmt": "266.12B",
+                    "longFmt": "266,118,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 14404000000,
+                    "fmt": "14.4B",
+                    "longFmt": "14,404,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -442000000,
+                    "fmt": "-442M",
+                    "longFmt": "-442,000,000"
+                  },
+                  "ebit": {
+                    "raw": 14404000000,
+                    "fmt": "14.4B",
+                    "longFmt": "14,404,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -1600000000,
+                    "fmt": "-1.6B",
+                    "longFmt": "-1,600,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 13962000000,
+                    "fmt": "13.96B",
+                    "longFmt": "13,962,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 2374000000,
+                    "fmt": "2.37B",
+                    "longFmt": "2,374,000,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 11588000000,
+                    "fmt": "11.59B",
+                    "longFmt": "11,588,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 11588000000,
+                    "fmt": "11.59B",
+                    "longFmt": "11,588,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 11588000000,
+                    "fmt": "11.59B",
+                    "longFmt": "11,588,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 232887000000,
+                    "fmt": "232.89B",
+                    "longFmt": "232,887,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 139156000000,
+                    "fmt": "139.16B",
+                    "longFmt": "139,156,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 93731000000,
+                    "fmt": "93.73B",
+                    "longFmt": "93,731,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 28837000000,
+                    "fmt": "28.84B",
+                    "longFmt": "28,837,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 52177000000,
+                    "fmt": "52.18B",
+                    "longFmt": "52,177,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 296000000,
+                    "fmt": "296M",
+                    "longFmt": "296,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 220466000000,
+                    "fmt": "220.47B",
+                    "longFmt": "220,466,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 12421000000,
+                    "fmt": "12.42B",
+                    "longFmt": "12,421,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -1151000000,
+                    "fmt": "-1.15B",
+                    "longFmt": "-1,151,000,000"
+                  },
+                  "ebit": {
+                    "raw": 12421000000,
+                    "fmt": "12.42B",
+                    "longFmt": "12,421,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -1417000000,
+                    "fmt": "-1.42B",
+                    "longFmt": "-1,417,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 11270000000,
+                    "fmt": "11.27B",
+                    "longFmt": "11,270,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 1197000000,
+                    "fmt": "1.2B",
+                    "longFmt": "1,197,000,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 10073000000,
+                    "fmt": "10.07B",
+                    "longFmt": "10,073,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 10073000000,
+                    "fmt": "10.07B",
+                    "longFmt": "10,073,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 10073000000,
+                    "fmt": "10.07B",
+                    "longFmt": "10,073,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 177866000000,
+                    "fmt": "177.87B",
+                    "longFmt": "177,866,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 111934000000,
+                    "fmt": "111.93B",
+                    "longFmt": "111,934,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 65932000000,
+                    "fmt": "65.93B",
+                    "longFmt": "65,932,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 22620000000,
+                    "fmt": "22.62B",
+                    "longFmt": "22,620,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 38992000000,
+                    "fmt": "38.99B",
+                    "longFmt": "38,992,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 214000000,
+                    "fmt": "214M",
+                    "longFmt": "214,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 173760000000,
+                    "fmt": "173.76B",
+                    "longFmt": "173,760,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 4106000000,
+                    "fmt": "4.11B",
+                    "longFmt": "4,106,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -304000000,
+                    "fmt": "-304M",
+                    "longFmt": "-304,000,000"
+                  },
+                  "ebit": {
+                    "raw": 4106000000,
+                    "fmt": "4.11B",
+                    "longFmt": "4,106,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -848000000,
+                    "fmt": "-848M",
+                    "longFmt": "-848,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 3802000000,
+                    "fmt": "3.8B",
+                    "longFmt": "3,802,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 769000000,
+                    "fmt": "769M",
+                    "longFmt": "769,000,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 3033000000,
+                    "fmt": "3.03B",
+                    "longFmt": "3,033,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 3033000000,
+                    "fmt": "3.03B",
+                    "longFmt": "3,033,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 3033000000,
+                    "fmt": "3.03B",
+                    "longFmt": "3,033,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistory-AZT.OL.json
+++ b/tests/http/quoteSummary-incomeStatementHistory-AZT.OL.json
@@ -1,0 +1,474 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=incomeStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "aeuonvlg2nrr9"
+      ],
+      "x-yahoo-request-id": [
+        "aeuonvlg2nrr9"
+      ],
+      "x-request-id": [
+        "1ef936d7-90f0-454a-8ad3-11d61530e09e"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1221"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:33 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 97823000,
+                    "fmt": "97.82M",
+                    "longFmt": "97,823,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 1131000,
+                    "fmt": "1.13M",
+                    "longFmt": "1,131,000"
+                  },
+                  "grossProfit": {
+                    "raw": 96692000,
+                    "fmt": "96.69M",
+                    "longFmt": "96,692,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 34564000,
+                    "fmt": "34.56M",
+                    "longFmt": "34,564,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 16696000,
+                    "fmt": "16.7M",
+                    "longFmt": "16,696,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 55030000,
+                    "fmt": "55.03M",
+                    "longFmt": "55,030,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 42793000,
+                    "fmt": "42.79M",
+                    "longFmt": "42,793,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -384000,
+                    "fmt": "-384k",
+                    "longFmt": "-384,000"
+                  },
+                  "ebit": {
+                    "raw": 42793000,
+                    "fmt": "42.79M",
+                    "longFmt": "42,793,000"
+                  },
+                  "interestExpense": {
+                    "raw": -384000,
+                    "fmt": "-384k",
+                    "longFmt": "-384,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 42409000,
+                    "fmt": "42.41M",
+                    "longFmt": "42,409,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -32978000,
+                    "fmt": "-32.98M",
+                    "longFmt": "-32,978,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 3130000,
+                    "fmt": "3.13M",
+                    "longFmt": "3,130,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 75387000,
+                    "fmt": "75.39M",
+                    "longFmt": "75,387,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": 9356000,
+                    "fmt": "9.36M",
+                    "longFmt": "9,356,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 84743000,
+                    "fmt": "84.74M",
+                    "longFmt": "84,743,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 84743000,
+                    "fmt": "84.74M",
+                    "longFmt": "84,743,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 84395000,
+                    "fmt": "84.39M",
+                    "longFmt": "84,395,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 18900000,
+                    "fmt": "18.9M",
+                    "longFmt": "18,900,000"
+                  },
+                  "grossProfit": {
+                    "raw": 65495000,
+                    "fmt": "65.5M",
+                    "longFmt": "65,495,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 49768000,
+                    "fmt": "49.77M",
+                    "longFmt": "49,768,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 16399000,
+                    "fmt": "16.4M",
+                    "longFmt": "16,399,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 90150000,
+                    "fmt": "90.15M",
+                    "longFmt": "90,150,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -5755000,
+                    "fmt": "-5.75M",
+                    "longFmt": "-5,755,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -171000,
+                    "fmt": "-171k",
+                    "longFmt": "-171,000"
+                  },
+                  "ebit": {
+                    "raw": -5755000,
+                    "fmt": "-5.75M",
+                    "longFmt": "-5,755,000"
+                  },
+                  "interestExpense": {
+                    "raw": -797000,
+                    "fmt": "-797k",
+                    "longFmt": "-797,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -5926000,
+                    "fmt": "-5.93M",
+                    "longFmt": "-5,926,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "minorityInterest": {
+                    "raw": 1336000,
+                    "fmt": "1.34M",
+                    "longFmt": "1,336,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -5926000,
+                    "fmt": "-5.93M",
+                    "longFmt": "-5,926,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": 9356000,
+                    "fmt": "9.36M",
+                    "longFmt": "9,356,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -6386000,
+                    "fmt": "-6.39M",
+                    "longFmt": "-6,386,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -6386000,
+                    "fmt": "-6.39M",
+                    "longFmt": "-6,386,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 72817000,
+                    "fmt": "72.82M",
+                    "longFmt": "72,817,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 19366000,
+                    "fmt": "19.37M",
+                    "longFmt": "19,366,000"
+                  },
+                  "grossProfit": {
+                    "raw": 53451000,
+                    "fmt": "53.45M",
+                    "longFmt": "53,451,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 45906000,
+                    "fmt": "45.91M",
+                    "longFmt": "45,906,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 16342000,
+                    "fmt": "16.34M",
+                    "longFmt": "16,342,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 86323000,
+                    "fmt": "86.32M",
+                    "longFmt": "86,323,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -13506000,
+                    "fmt": "-13.51M",
+                    "longFmt": "-13,506,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -526000,
+                    "fmt": "-526k",
+                    "longFmt": "-526,000"
+                  },
+                  "ebit": {
+                    "raw": -13506000,
+                    "fmt": "-13.51M",
+                    "longFmt": "-13,506,000"
+                  },
+                  "interestExpense": {
+                    "raw": -865000,
+                    "fmt": "-865k",
+                    "longFmt": "-865,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -14032000,
+                    "fmt": "-14.03M",
+                    "longFmt": "-14,032,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "minorityInterest": {
+                    "raw": 876000,
+                    "fmt": "876k",
+                    "longFmt": "876,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -14032000,
+                    "fmt": "-14.03M",
+                    "longFmt": "-14,032,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": 9356000,
+                    "fmt": "9.36M",
+                    "longFmt": "9,356,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -14193000,
+                    "fmt": "-14.19M",
+                    "longFmt": "-14,193,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -14193000,
+                    "fmt": "-14.19M",
+                    "longFmt": "-14,193,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 72758000,
+                    "fmt": "72.76M",
+                    "longFmt": "72,758,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 21927000,
+                    "fmt": "21.93M",
+                    "longFmt": "21,927,000"
+                  },
+                  "grossProfit": {
+                    "raw": 50831000,
+                    "fmt": "50.83M",
+                    "longFmt": "50,831,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 51965000,
+                    "fmt": "51.97M",
+                    "longFmt": "51,965,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 21803000,
+                    "fmt": "21.8M",
+                    "longFmt": "21,803,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 97673000,
+                    "fmt": "97.67M",
+                    "longFmt": "97,673,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -24915000,
+                    "fmt": "-24.91M",
+                    "longFmt": "-24,915,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 112000,
+                    "fmt": "112k",
+                    "longFmt": "112,000"
+                  },
+                  "ebit": {
+                    "raw": -24915000,
+                    "fmt": "-24.91M",
+                    "longFmt": "-24,915,000"
+                  },
+                  "interestExpense": {
+                    "raw": -695000,
+                    "fmt": "-695k",
+                    "longFmt": "-695,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -24803000,
+                    "fmt": "-24.8M",
+                    "longFmt": "-24,803,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "minorityInterest": {
+                    "raw": 715000,
+                    "fmt": "715k",
+                    "longFmt": "715,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -24803000,
+                    "fmt": "-24.8M",
+                    "longFmt": "-24,803,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": 9356000,
+                    "fmt": "9.36M",
+                    "longFmt": "9,356,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -24938000,
+                    "fmt": "-24.94M",
+                    "longFmt": "-24,938,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -24938000,
+                    "fmt": "-24.94M",
+                    "longFmt": "-24,938,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistory-SIX.json
+++ b/tests/http/quoteSummary-incomeStatementHistory-SIX.json
@@ -1,0 +1,442 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=incomeStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "9vmlktdg2nuha"
+      ],
+      "x-yahoo-request-id": [
+        "9vmlktdg2nuha"
+      ],
+      "x-request-id": [
+        "a55b15a7-d521-4f36-8cda-a53a6f798674"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1317"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:26 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 1487583000,
+                    "fmt": "1.49B",
+                    "longFmt": "1,487,583,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 700301000,
+                    "fmt": "700.3M",
+                    "longFmt": "700,301,000"
+                  },
+                  "grossProfit": {
+                    "raw": 787282000,
+                    "fmt": "787.28M",
+                    "longFmt": "787,282,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 232802000,
+                    "fmt": "232.8M",
+                    "longFmt": "232,802,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 1051333000,
+                    "fmt": "1.05B",
+                    "longFmt": "1,051,333,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 436250000,
+                    "fmt": "436.25M",
+                    "longFmt": "436,250,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -124490000,
+                    "fmt": "-124.49M",
+                    "longFmt": "-124,490,000"
+                  },
+                  "ebit": {
+                    "raw": 436250000,
+                    "fmt": "436.25M",
+                    "longFmt": "436,250,000"
+                  },
+                  "interestExpense": {
+                    "raw": -114703000,
+                    "fmt": "-114.7M",
+                    "longFmt": "-114,703,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 311760000,
+                    "fmt": "311.76M",
+                    "longFmt": "311,760,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 91942000,
+                    "fmt": "91.94M",
+                    "longFmt": "91,942,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 529258000,
+                    "fmt": "529.26M",
+                    "longFmt": "529,258,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 219818000,
+                    "fmt": "219.82M",
+                    "longFmt": "219,818,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 179065000,
+                    "fmt": "179.06M",
+                    "longFmt": "179,065,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 179065000,
+                    "fmt": "179.06M",
+                    "longFmt": "179,065,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 1463707000,
+                    "fmt": "1.46B",
+                    "longFmt": "1,463,707,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 667227000,
+                    "fmt": "667.23M",
+                    "longFmt": "667,227,000"
+                  },
+                  "grossProfit": {
+                    "raw": 796480000,
+                    "fmt": "796.48M",
+                    "longFmt": "796,480,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 156299000,
+                    "fmt": "156.3M",
+                    "longFmt": "156,299,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 939219000,
+                    "fmt": "939.22M",
+                    "longFmt": "939,219,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 524488000,
+                    "fmt": "524.49M",
+                    "longFmt": "524,488,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -112630000,
+                    "fmt": "-112.63M",
+                    "longFmt": "-112,630,000"
+                  },
+                  "ebit": {
+                    "raw": 524488000,
+                    "fmt": "524.49M",
+                    "longFmt": "524,488,000"
+                  },
+                  "interestExpense": {
+                    "raw": -108034000,
+                    "fmt": "-108.03M",
+                    "longFmt": "-108,034,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 411858000,
+                    "fmt": "411.86M",
+                    "longFmt": "411,858,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 95855000,
+                    "fmt": "95.86M",
+                    "longFmt": "95,855,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 525271000,
+                    "fmt": "525.27M",
+                    "longFmt": "525,271,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 316003000,
+                    "fmt": "316M",
+                    "longFmt": "316,003,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 275996000,
+                    "fmt": "276M",
+                    "longFmt": "275,996,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 275996000,
+                    "fmt": "276M",
+                    "longFmt": "275,996,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 1359074000,
+                    "fmt": "1.36B",
+                    "longFmt": "1,359,074,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 622247000,
+                    "fmt": "622.25M",
+                    "longFmt": "622,247,000"
+                  },
+                  "grossProfit": {
+                    "raw": 736827000,
+                    "fmt": "736.83M",
+                    "longFmt": "736,827,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 155748000,
+                    "fmt": "155.75M",
+                    "longFmt": "155,748,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 889666000,
+                    "fmt": "889.67M",
+                    "longFmt": "889,666,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 469408000,
+                    "fmt": "469.41M",
+                    "longFmt": "469,408,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -140356000,
+                    "fmt": "-140.36M",
+                    "longFmt": "-140,356,000"
+                  },
+                  "ebit": {
+                    "raw": 469408000,
+                    "fmt": "469.41M",
+                    "longFmt": "469,408,000"
+                  },
+                  "interestExpense": {
+                    "raw": -99766000,
+                    "fmt": "-99.77M",
+                    "longFmt": "-99,766,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 329052000,
+                    "fmt": "329.05M",
+                    "longFmt": "329,052,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 16026000,
+                    "fmt": "16.03M",
+                    "longFmt": "16,026,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 494431000,
+                    "fmt": "494.43M",
+                    "longFmt": "494,431,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 313026000,
+                    "fmt": "313.03M",
+                    "longFmt": "313,026,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 273816000,
+                    "fmt": "273.82M",
+                    "longFmt": "273,816,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 273816000,
+                    "fmt": "273.82M",
+                    "longFmt": "273,816,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 1319398000,
+                    "fmt": "1.32B",
+                    "longFmt": "1,319,398,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 599695000,
+                    "fmt": "599.7M",
+                    "longFmt": "599,695,000"
+                  },
+                  "grossProfit": {
+                    "raw": 719703000,
+                    "fmt": "719.7M",
+                    "longFmt": "719,703,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 291085000,
+                    "fmt": "291.08M",
+                    "longFmt": "291,085,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 997673000,
+                    "fmt": "997.67M",
+                    "longFmt": "997,673,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 321725000,
+                    "fmt": "321.73M",
+                    "longFmt": "321,725,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -88459000,
+                    "fmt": "-88.46M",
+                    "longFmt": "-88,459,000"
+                  },
+                  "ebit": {
+                    "raw": 321725000,
+                    "fmt": "321.73M",
+                    "longFmt": "321,725,000"
+                  },
+                  "interestExpense": {
+                    "raw": -82377000,
+                    "fmt": "-82.38M",
+                    "longFmt": "-82,377,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 233266000,
+                    "fmt": "233.27M",
+                    "longFmt": "233,266,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 76539000,
+                    "fmt": "76.54M",
+                    "longFmt": "76,539,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 485876000,
+                    "fmt": "485.88M",
+                    "longFmt": "485,876,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 156727000,
+                    "fmt": "156.73M",
+                    "longFmt": "156,727,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 118302000,
+                    "fmt": "118.3M",
+                    "longFmt": "118,302,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 118302000,
+                    "fmt": "118.3M",
+                    "longFmt": "118,302,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistory-WSKT.JK.json
+++ b/tests/http/quoteSummary-incomeStatementHistory-WSKT.JK.json
@@ -1,0 +1,458 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=incomeStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "267b7kpg2nuha"
+      ],
+      "x-yahoo-request-id": [
+        "267b7kpg2nuha"
+      ],
+      "x-request-id": [
+        "258b1a20-93d2-424f-a677-762254ee355f"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1902"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:26 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 31387389629869,
+                    "fmt": "31.39T",
+                    "longFmt": "31,387,389,629,869"
+                  },
+                  "costOfRevenue": {
+                    "raw": 25782746866464,
+                    "fmt": "25.78T",
+                    "longFmt": "25,782,746,866,464"
+                  },
+                  "grossProfit": {
+                    "raw": 5604642763405,
+                    "fmt": "5.6T",
+                    "longFmt": "5,604,642,763,405"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 1371547283663,
+                    "fmt": "1.37T",
+                    "longFmt": "1,371,547,283,663"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 197802480370,
+                    "fmt": "197.8B",
+                    "longFmt": "197,802,480,370"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 27352096630497,
+                    "fmt": "27.35T",
+                    "longFmt": "27,352,096,630,497"
+                  },
+                  "operatingIncome": {
+                    "raw": 4035292999372,
+                    "fmt": "4.04T",
+                    "longFmt": "4,035,292,999,372"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -2000225656219,
+                    "fmt": "-2T",
+                    "longFmt": "-2,000,225,656,219"
+                  },
+                  "ebit": {
+                    "raw": 4035292999372,
+                    "fmt": "4.04T",
+                    "longFmt": "4,035,292,999,372"
+                  },
+                  "interestExpense": {
+                    "raw": -3620533969507,
+                    "fmt": "-3.62T",
+                    "longFmt": "-3,620,533,969,507"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 2035067343153,
+                    "fmt": "2.04T",
+                    "longFmt": "2,035,067,343,153"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 1006168975262,
+                    "fmt": "1.01T",
+                    "longFmt": "1,006,168,975,262"
+                  },
+                  "minorityInterest": {
+                    "raw": 11236061197428,
+                    "fmt": "11.24T",
+                    "longFmt": "11,236,061,197,428"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 1028898367891,
+                    "fmt": "1.03T",
+                    "longFmt": "1,028,898,367,891"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 938142364887,
+                    "fmt": "938.14B",
+                    "longFmt": "938,142,364,887"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 938142364887,
+                    "fmt": "938.14B",
+                    "longFmt": "938,142,364,887"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 48788950838822,
+                    "fmt": "48.79T",
+                    "longFmt": "48,788,950,838,822"
+                  },
+                  "costOfRevenue": {
+                    "raw": 39926332089924,
+                    "fmt": "39.93T",
+                    "longFmt": "39,926,332,089,924"
+                  },
+                  "grossProfit": {
+                    "raw": 8862618748898,
+                    "fmt": "8.86T",
+                    "longFmt": "8,862,618,748,898"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 1667745969535,
+                    "fmt": "1.67T",
+                    "longFmt": "1,667,745,969,535"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 423475576187,
+                    "fmt": "423.48B",
+                    "longFmt": "423,475,576,187"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 42017553635646,
+                    "fmt": "42.02T",
+                    "longFmt": "42,017,553,635,646"
+                  },
+                  "operatingIncome": {
+                    "raw": 6771397203176,
+                    "fmt": "6.77T",
+                    "longFmt": "6,771,397,203,176"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 254560670874,
+                    "fmt": "254.56B",
+                    "longFmt": "254,560,670,874"
+                  },
+                  "ebit": {
+                    "raw": 6771397203176,
+                    "fmt": "6.77T",
+                    "longFmt": "6,771,397,203,176"
+                  },
+                  "interestExpense": {
+                    "raw": -2459241670378,
+                    "fmt": "-2.46T",
+                    "longFmt": "-2,459,241,670,378"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 7025957874050,
+                    "fmt": "7.03T",
+                    "longFmt": "7,025,957,874,050"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 2406390168497,
+                    "fmt": "2.41T",
+                    "longFmt": "2,406,390,168,497"
+                  },
+                  "minorityInterest": {
+                    "raw": 10886002685490,
+                    "fmt": "10.89T",
+                    "longFmt": "10,886,002,685,490"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 4619567705553,
+                    "fmt": "4.62T",
+                    "longFmt": "4,619,567,705,553"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 3962838031865,
+                    "fmt": "3.96T",
+                    "longFmt": "3,962,838,031,865"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 3962838031865,
+                    "fmt": "3.96T",
+                    "longFmt": "3,962,838,031,865"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 45212897632604,
+                    "fmt": "45.21T",
+                    "longFmt": "45,212,897,632,604"
+                  },
+                  "costOfRevenue": {
+                    "raw": 35749365206806,
+                    "fmt": "35.75T",
+                    "longFmt": "35,749,365,206,806"
+                  },
+                  "grossProfit": {
+                    "raw": 9463532425798,
+                    "fmt": "9.46T",
+                    "longFmt": "9,463,532,425,798"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 2103899171263,
+                    "fmt": "2.1T",
+                    "longFmt": "2,103,899,171,263"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 170448268152,
+                    "fmt": "170.45B",
+                    "longFmt": "170,448,268,152"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 38023712646221,
+                    "fmt": "38.02T",
+                    "longFmt": "38,023,712,646,221"
+                  },
+                  "operatingIncome": {
+                    "raw": 7189184986383,
+                    "fmt": "7.19T",
+                    "longFmt": "7,189,184,986,383"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -1133897951258,
+                    "fmt": "-1.13T",
+                    "longFmt": "-1,133,897,951,258"
+                  },
+                  "ebit": {
+                    "raw": 7189184986383,
+                    "fmt": "7.19T",
+                    "longFmt": "7,189,184,986,383"
+                  },
+                  "interestExpense": {
+                    "raw": -1932084162136,
+                    "fmt": "-1.93T",
+                    "longFmt": "-1,932,084,162,136"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 6055287035125,
+                    "fmt": "6.06T",
+                    "longFmt": "6,055,287,035,125"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 1853714544371,
+                    "fmt": "1.85T",
+                    "longFmt": "1,853,714,544,371"
+                  },
+                  "minorityInterest": {
+                    "raw": 8748386520139,
+                    "fmt": "8.75T",
+                    "longFmt": "8,748,386,520,139"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 4201572490754,
+                    "fmt": "4.2T",
+                    "longFmt": "4,201,572,490,754"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 3881711917338,
+                    "fmt": "3.88T",
+                    "longFmt": "3,881,711,917,338"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 3881711917338,
+                    "fmt": "3.88T",
+                    "longFmt": "3,881,711,917,338"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 23788322626347,
+                    "fmt": "23.79T",
+                    "longFmt": "23,788,322,626,347"
+                  },
+                  "costOfRevenue": {
+                    "raw": 19820484367904,
+                    "fmt": "19.82T",
+                    "longFmt": "19,820,484,367,904"
+                  },
+                  "grossProfit": {
+                    "raw": 3967838258443,
+                    "fmt": "3.97T",
+                    "longFmt": "3,967,838,258,443"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 788282594058,
+                    "fmt": "788.28B",
+                    "longFmt": "788,282,594,058"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 43695297650,
+                    "fmt": "43.7B",
+                    "longFmt": "43,695,297,650"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 20652462259612,
+                    "fmt": "20.65T",
+                    "longFmt": "20,652,462,259,612"
+                  },
+                  "operatingIncome": {
+                    "raw": 3135860366735,
+                    "fmt": "3.14T",
+                    "longFmt": "3,135,860,366,735"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -655966823303,
+                    "fmt": "-655.97B",
+                    "longFmt": "-655,966,823,303"
+                  },
+                  "ebit": {
+                    "raw": 3135860366735,
+                    "fmt": "3.14T",
+                    "longFmt": "3,135,860,366,735"
+                  },
+                  "interestExpense": {
+                    "raw": -982835623286,
+                    "fmt": "-982.84B",
+                    "longFmt": "-982,835,623,286"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 2479893543432,
+                    "fmt": "2.48T",
+                    "longFmt": "2,479,893,543,432"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 666824926648,
+                    "fmt": "666.82B",
+                    "longFmt": "666,824,926,648"
+                  },
+                  "minorityInterest": {
+                    "raw": 5703665307835,
+                    "fmt": "5.7T",
+                    "longFmt": "5,703,665,307,835"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 1813068616784,
+                    "fmt": "1.81T",
+                    "longFmt": "1,813,068,616,784"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 1713260616725,
+                    "fmt": "1.71T",
+                    "longFmt": "1,713,260,616,725"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 1713260616725,
+                    "fmt": "1.71T",
+                    "longFmt": "1,713,260,616,725"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistoryQuarterly-ADH.json
+++ b/tests/http/quoteSummary-incomeStatementHistoryQuarterly-ADH.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=incomeStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "8ni9fkpg2nrr9"
+      ],
+      "x-yahoo-request-id": [
+        "8ni9fkpg2nrr9"
+      ],
+      "x-request-id": [
+        "b6f47677-46a7-4373-9db7-2a51b25101dc"
+      ],
+      "content-length": [
+        "164"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:33 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=incomeStatementHistoryQuarterly"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistoryQuarterly-AFRAF.json
+++ b/tests/http/quoteSummary-incomeStatementHistoryQuarterly-AFRAF.json
@@ -1,0 +1,458 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=incomeStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "8hgip35g2nrra"
+      ],
+      "x-yahoo-request-id": [
+        "8hgip35g2nrra"
+      ],
+      "x-request-id": [
+        "5c9d7b4e-23f6-4ad3-ba89-a3176a56a23d"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1140"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:33 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 2524000000,
+                    "fmt": "2.52B",
+                    "longFmt": "2,524,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 2708000000,
+                    "fmt": "2.71B",
+                    "longFmt": "2,708,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": -184000000,
+                    "fmt": "-184M",
+                    "longFmt": "-184,000,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 61000000,
+                    "fmt": "61M",
+                    "longFmt": "61,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 204000000,
+                    "fmt": "204M",
+                    "longFmt": "204,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 3577000000,
+                    "fmt": "3.58B",
+                    "longFmt": "3,577,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -1053000000,
+                    "fmt": "-1.05B",
+                    "longFmt": "-1,053,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -624000000,
+                    "fmt": "-624M",
+                    "longFmt": "-624,000,000"
+                  },
+                  "ebit": {
+                    "raw": -1053000000,
+                    "fmt": "-1.05B",
+                    "longFmt": "-1,053,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -108000000,
+                    "fmt": "-108M",
+                    "longFmt": "-108,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -1677000000,
+                    "fmt": "-1.68B",
+                    "longFmt": "-1,677,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -12000000,
+                    "fmt": "-12M",
+                    "longFmt": "-12,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 9000000,
+                    "fmt": "9M",
+                    "longFmt": "9,000,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -1665000000,
+                    "fmt": "-1.67B",
+                    "longFmt": "-1,665,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -1665000000,
+                    "fmt": "-1.67B",
+                    "longFmt": "-1,665,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -1656000000,
+                    "fmt": "-1.66B",
+                    "longFmt": "-1,656,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 1181000000,
+                    "fmt": "1.18B",
+                    "longFmt": "1,181,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 1737000000,
+                    "fmt": "1.74B",
+                    "longFmt": "1,737,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": -556000000,
+                    "fmt": "-556M",
+                    "longFmt": "-556,000,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 36000000,
+                    "fmt": "36M",
+                    "longFmt": "36,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 210000000,
+                    "fmt": "210M",
+                    "longFmt": "210,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 2757000000,
+                    "fmt": "2.76B",
+                    "longFmt": "2,757,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -1576000000,
+                    "fmt": "-1.58B",
+                    "longFmt": "-1,576,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -957000000,
+                    "fmt": "-957M",
+                    "longFmt": "-957,000,000"
+                  },
+                  "ebit": {
+                    "raw": -1576000000,
+                    "fmt": "-1.58B",
+                    "longFmt": "-1,576,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -99000000,
+                    "fmt": "-99M",
+                    "longFmt": "-99,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -2533000000,
+                    "fmt": "-2.53B",
+                    "longFmt": "-2,533,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 81000000,
+                    "fmt": "81M",
+                    "longFmt": "81,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 10000000,
+                    "fmt": "10M",
+                    "longFmt": "10,000,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -2614000000,
+                    "fmt": "-2.61B",
+                    "longFmt": "-2,614,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -2612000000,
+                    "fmt": "-2.61B",
+                    "longFmt": "-2,612,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -2621000000,
+                    "fmt": "-2.62B",
+                    "longFmt": "-2,621,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 5020000000,
+                    "fmt": "5.02B",
+                    "longFmt": "5,020,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 4714000000,
+                    "fmt": "4.71B",
+                    "longFmt": "4,714,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 306000000,
+                    "fmt": "306M",
+                    "longFmt": "306,000,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 194000000,
+                    "fmt": "194M",
+                    "longFmt": "194,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 215000000,
+                    "fmt": "215M",
+                    "longFmt": "215,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 5877000000,
+                    "fmt": "5.88B",
+                    "longFmt": "5,877,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -857000000,
+                    "fmt": "-857M",
+                    "longFmt": "-857,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -773000000,
+                    "fmt": "-773M",
+                    "longFmt": "-773,000,000"
+                  },
+                  "ebit": {
+                    "raw": -857000000,
+                    "fmt": "-857M",
+                    "longFmt": "-857,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -89000000,
+                    "fmt": "-89M",
+                    "longFmt": "-89,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -1630000000,
+                    "fmt": "-1.63B",
+                    "longFmt": "-1,630,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 173000000,
+                    "fmt": "173M",
+                    "longFmt": "173,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 13000000,
+                    "fmt": "13M",
+                    "longFmt": "13,000,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -1803000000,
+                    "fmt": "-1.8B",
+                    "longFmt": "-1,803,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -1801000000,
+                    "fmt": "-1.8B",
+                    "longFmt": "-1,801,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -1801000000,
+                    "fmt": "-1.8B",
+                    "longFmt": "-1,801,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 6457000000,
+                    "fmt": "6.46B",
+                    "longFmt": "6,457,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 5266000000,
+                    "fmt": "5.27B",
+                    "longFmt": "5,266,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 1191000000,
+                    "fmt": "1.19B",
+                    "longFmt": "1,191,000,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 246000000,
+                    "fmt": "246M",
+                    "longFmt": "246,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 17000000,
+                    "fmt": "17M",
+                    "longFmt": "17,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 6295000000,
+                    "fmt": "6.29B",
+                    "longFmt": "6,295,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 162000000,
+                    "fmt": "162M",
+                    "longFmt": "162,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -57000000,
+                    "fmt": "-57M",
+                    "longFmt": "-57,000,000"
+                  },
+                  "ebit": {
+                    "raw": 162000000,
+                    "fmt": "162M",
+                    "longFmt": "162,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -74000000,
+                    "fmt": "-74M",
+                    "longFmt": "-74,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 105000000,
+                    "fmt": "105M",
+                    "longFmt": "105,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -60000000,
+                    "fmt": "-60M",
+                    "longFmt": "-60,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 15000000,
+                    "fmt": "15M",
+                    "longFmt": "15,000,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 165000000,
+                    "fmt": "165M",
+                    "longFmt": "165,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 164000000,
+                    "fmt": "164M",
+                    "longFmt": "164,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 159000000,
+                    "fmt": "159M",
+                    "longFmt": "159,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistoryQuarterly-AMZN.json
+++ b/tests/http/quoteSummary-incomeStatementHistoryQuarterly-AMZN.json
@@ -1,0 +1,458 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=incomeStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "46u93jdg2nrra"
+      ],
+      "x-yahoo-request-id": [
+        "46u93jdg2nrra"
+      ],
+      "x-request-id": [
+        "1969ee5e-c3c5-4416-aa43-654651ba0928"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1210"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:33 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 125555000000,
+                    "fmt": "125.56B",
+                    "longFmt": "125,555,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 79284000000,
+                    "fmt": "79.28B",
+                    "longFmt": "79,284,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 46271000000,
+                    "fmt": "46.27B",
+                    "longFmt": "46,271,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 16466000000,
+                    "fmt": "16.47B",
+                    "longFmt": "16,466,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 23428000000,
+                    "fmt": "23.43B",
+                    "longFmt": "23,428,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": -496000000,
+                    "fmt": "-496M",
+                    "longFmt": "-496,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 118682000000,
+                    "fmt": "118.68B",
+                    "longFmt": "118,682,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 6873000000,
+                    "fmt": "6.87B",
+                    "longFmt": "6,873,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 914000000,
+                    "fmt": "914M",
+                    "longFmt": "914,000,000"
+                  },
+                  "ebit": {
+                    "raw": 6873000000,
+                    "fmt": "6.87B",
+                    "longFmt": "6,873,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -414000000,
+                    "fmt": "-414M",
+                    "longFmt": "-414,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 7787000000,
+                    "fmt": "7.79B",
+                    "longFmt": "7,787,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 565000000,
+                    "fmt": "565M",
+                    "longFmt": "565,000,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 7222000000,
+                    "fmt": "7.22B",
+                    "longFmt": "7,222,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 7222000000,
+                    "fmt": "7.22B",
+                    "longFmt": "7,222,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 7222000000,
+                    "fmt": "7.22B",
+                    "longFmt": "7,222,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 96145000000,
+                    "fmt": "96.14B",
+                    "longFmt": "96,145,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 57106000000,
+                    "fmt": "57.11B",
+                    "longFmt": "57,106,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 39039000000,
+                    "fmt": "39.04B",
+                    "longFmt": "39,039,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 9334000000,
+                    "fmt": "9.33B",
+                    "longFmt": "9,334,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 23449000000,
+                    "fmt": "23.45B",
+                    "longFmt": "23,449,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 62000000,
+                    "fmt": "62M",
+                    "longFmt": "62,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 89951000000,
+                    "fmt": "89.95B",
+                    "longFmt": "89,951,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 6194000000,
+                    "fmt": "6.19B",
+                    "longFmt": "6,194,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 706000000,
+                    "fmt": "706M",
+                    "longFmt": "706,000,000"
+                  },
+                  "ebit": {
+                    "raw": 6194000000,
+                    "fmt": "6.19B",
+                    "longFmt": "6,194,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -428000000,
+                    "fmt": "-428M",
+                    "longFmt": "-428,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 6900000000,
+                    "fmt": "6.9B",
+                    "longFmt": "6,900,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 569000000,
+                    "fmt": "569M",
+                    "longFmt": "569,000,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 6331000000,
+                    "fmt": "6.33B",
+                    "longFmt": "6,331,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 6331000000,
+                    "fmt": "6.33B",
+                    "longFmt": "6,331,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 6331000000,
+                    "fmt": "6.33B",
+                    "longFmt": "6,331,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 88912000000,
+                    "fmt": "88.91B",
+                    "longFmt": "88,912,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 52660000000,
+                    "fmt": "52.66B",
+                    "longFmt": "52,660,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 36252000000,
+                    "fmt": "36.25B",
+                    "longFmt": "36,252,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 8945000000,
+                    "fmt": "8.95B",
+                    "longFmt": "8,945,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 21174000000,
+                    "fmt": "21.17B",
+                    "longFmt": "21,174,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 290000000,
+                    "fmt": "290M",
+                    "longFmt": "290,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 83069000000,
+                    "fmt": "83.07B",
+                    "longFmt": "83,069,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 5843000000,
+                    "fmt": "5.84B",
+                    "longFmt": "5,843,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 384000000,
+                    "fmt": "384M",
+                    "longFmt": "384,000,000"
+                  },
+                  "ebit": {
+                    "raw": 5843000000,
+                    "fmt": "5.84B",
+                    "longFmt": "5,843,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -403000000,
+                    "fmt": "-403M",
+                    "longFmt": "-403,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 6227000000,
+                    "fmt": "6.23B",
+                    "longFmt": "6,227,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 984000000,
+                    "fmt": "984M",
+                    "longFmt": "984,000,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 5243000000,
+                    "fmt": "5.24B",
+                    "longFmt": "5,243,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 5243000000,
+                    "fmt": "5.24B",
+                    "longFmt": "5,243,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 5243000000,
+                    "fmt": "5.24B",
+                    "longFmt": "5,243,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 75452000000,
+                    "fmt": "75.45B",
+                    "longFmt": "75,452,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 44257000000,
+                    "fmt": "44.26B",
+                    "longFmt": "44,257,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 31195000000,
+                    "fmt": "31.2B",
+                    "longFmt": "31,195,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 9325000000,
+                    "fmt": "9.32B",
+                    "longFmt": "9,325,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 17811000000,
+                    "fmt": "17.81B",
+                    "longFmt": "17,811,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 70000000,
+                    "fmt": "70M",
+                    "longFmt": "70,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 71463000000,
+                    "fmt": "71.46B",
+                    "longFmt": "71,463,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 3989000000,
+                    "fmt": "3.99B",
+                    "longFmt": "3,989,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -741000000,
+                    "fmt": "-741M",
+                    "longFmt": "-741,000,000"
+                  },
+                  "ebit": {
+                    "raw": 3989000000,
+                    "fmt": "3.99B",
+                    "longFmt": "3,989,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -402000000,
+                    "fmt": "-402M",
+                    "longFmt": "-402,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 3279000000,
+                    "fmt": "3.28B",
+                    "longFmt": "3,279,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 744000000,
+                    "fmt": "744M",
+                    "longFmt": "744,000,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 2535000000,
+                    "fmt": "2.54B",
+                    "longFmt": "2,535,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 2535000000,
+                    "fmt": "2.54B",
+                    "longFmt": "2,535,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 2535000000,
+                    "fmt": "2.54B",
+                    "longFmt": "2,535,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistoryQuarterly-AZT.OL.json
+++ b/tests/http/quoteSummary-incomeStatementHistoryQuarterly-AZT.OL.json
@@ -1,0 +1,474 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=incomeStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "0gr7pqhg2nrra"
+      ],
+      "x-yahoo-request-id": [
+        "0gr7pqhg2nrra"
+      ],
+      "x-request-id": [
+        "76d51419-5423-4602-a475-bac508726491"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1166"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:33 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 24013000,
+                    "fmt": "24.01M",
+                    "longFmt": "24,013,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 582000,
+                    "fmt": "582k",
+                    "longFmt": "582,000"
+                  },
+                  "grossProfit": {
+                    "raw": 23431000,
+                    "fmt": "23.43M",
+                    "longFmt": "23,431,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 9835000,
+                    "fmt": "9.84M",
+                    "longFmt": "9,835,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 6757000,
+                    "fmt": "6.76M",
+                    "longFmt": "6,757,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 17832000,
+                    "fmt": "17.83M",
+                    "longFmt": "17,832,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 6181000,
+                    "fmt": "6.18M",
+                    "longFmt": "6,181,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -641000,
+                    "fmt": "-641k",
+                    "longFmt": "-641,000"
+                  },
+                  "ebit": {
+                    "raw": 6181000,
+                    "fmt": "6.18M",
+                    "longFmt": "6,181,000"
+                  },
+                  "interestExpense": {
+                    "raw": -642000,
+                    "fmt": "-642k",
+                    "longFmt": "-642,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 5540000,
+                    "fmt": "5.54M",
+                    "longFmt": "5,540,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -32978000,
+                    "fmt": "-32.98M",
+                    "longFmt": "-32,978,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 3130000,
+                    "fmt": "3.13M",
+                    "longFmt": "3,130,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 38518000,
+                    "fmt": "38.52M",
+                    "longFmt": "38,518,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -2275000,
+                    "fmt": "-2.27M",
+                    "longFmt": "-2,275,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 36243000,
+                    "fmt": "36.24M",
+                    "longFmt": "36,243,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 36243000,
+                    "fmt": "36.24M",
+                    "longFmt": "36,243,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 31550000,
+                    "fmt": "31.55M",
+                    "longFmt": "31,550,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 4736000,
+                    "fmt": "4.74M",
+                    "longFmt": "4,736,000"
+                  },
+                  "grossProfit": {
+                    "raw": 26814000,
+                    "fmt": "26.81M",
+                    "longFmt": "26,814,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 12050000,
+                    "fmt": "12.05M",
+                    "longFmt": "12,050,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 4663000,
+                    "fmt": "4.66M",
+                    "longFmt": "4,663,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 22404000,
+                    "fmt": "22.4M",
+                    "longFmt": "22,404,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 9146000,
+                    "fmt": "9.15M",
+                    "longFmt": "9,146,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -53000,
+                    "fmt": "-53k",
+                    "longFmt": "-53,000"
+                  },
+                  "ebit": {
+                    "raw": 9146000,
+                    "fmt": "9.15M",
+                    "longFmt": "9,146,000"
+                  },
+                  "interestExpense": {
+                    "raw": -51000,
+                    "fmt": "-51k",
+                    "longFmt": "-51,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 9093000,
+                    "fmt": "9.09M",
+                    "longFmt": "9,093,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "minorityInterest": {
+                    "raw": 3039000,
+                    "fmt": "3.04M",
+                    "longFmt": "3,039,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 9093000,
+                    "fmt": "9.09M",
+                    "longFmt": "9,093,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -2275000,
+                    "fmt": "-2.27M",
+                    "longFmt": "-2,275,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 9093000,
+                    "fmt": "9.09M",
+                    "longFmt": "9,093,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 9093000,
+                    "fmt": "9.09M",
+                    "longFmt": "9,093,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 44872000,
+                    "fmt": "44.87M",
+                    "longFmt": "44,872,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 4310000,
+                    "fmt": "4.31M",
+                    "longFmt": "4,310,000"
+                  },
+                  "grossProfit": {
+                    "raw": 40562000,
+                    "fmt": "40.56M",
+                    "longFmt": "40,562,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 7546000,
+                    "fmt": "7.55M",
+                    "longFmt": "7,546,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 5799000,
+                    "fmt": "5.8M",
+                    "longFmt": "5,799,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 18606000,
+                    "fmt": "18.61M",
+                    "longFmt": "18,606,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 26266000,
+                    "fmt": "26.27M",
+                    "longFmt": "26,266,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -578000,
+                    "fmt": "-578k",
+                    "longFmt": "-578,000"
+                  },
+                  "ebit": {
+                    "raw": 26266000,
+                    "fmt": "26.27M",
+                    "longFmt": "26,266,000"
+                  },
+                  "interestExpense": {
+                    "raw": -578000,
+                    "fmt": "-578k",
+                    "longFmt": "-578,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 25688000,
+                    "fmt": "25.69M",
+                    "longFmt": "25,688,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "minorityInterest": {
+                    "raw": 2694000,
+                    "fmt": "2.69M",
+                    "longFmt": "2,694,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 25688000,
+                    "fmt": "25.69M",
+                    "longFmt": "25,688,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -2275000,
+                    "fmt": "-2.27M",
+                    "longFmt": "-2,275,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 25688000,
+                    "fmt": "25.69M",
+                    "longFmt": "25,688,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 25688000,
+                    "fmt": "25.69M",
+                    "longFmt": "25,688,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 35550000,
+                    "fmt": "35.55M",
+                    "longFmt": "35,550,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 8105000,
+                    "fmt": "8.11M",
+                    "longFmt": "8,105,000"
+                  },
+                  "grossProfit": {
+                    "raw": 27445000,
+                    "fmt": "27.45M",
+                    "longFmt": "27,445,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 9903000,
+                    "fmt": "9.9M",
+                    "longFmt": "9,903,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 3782000,
+                    "fmt": "3.78M",
+                    "longFmt": "3,782,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 22749000,
+                    "fmt": "22.75M",
+                    "longFmt": "22,749,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 12801000,
+                    "fmt": "12.8M",
+                    "longFmt": "12,801,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 943000,
+                    "fmt": "943k",
+                    "longFmt": "943,000"
+                  },
+                  "ebit": {
+                    "raw": 12801000,
+                    "fmt": "12.8M",
+                    "longFmt": "12,801,000"
+                  },
+                  "interestExpense": {
+                    "raw": -578000,
+                    "fmt": "-578k",
+                    "longFmt": "-578,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 13744000,
+                    "fmt": "13.74M",
+                    "longFmt": "13,744,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "minorityInterest": {
+                    "raw": 1768000,
+                    "fmt": "1.77M",
+                    "longFmt": "1,768,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 13744000,
+                    "fmt": "13.74M",
+                    "longFmt": "13,744,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -2275000,
+                    "fmt": "-2.27M",
+                    "longFmt": "-2,275,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 13744000,
+                    "fmt": "13.74M",
+                    "longFmt": "13,744,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 13744000,
+                    "fmt": "13.74M",
+                    "longFmt": "13,744,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistoryQuarterly-SIX.json
+++ b/tests/http/quoteSummary-incomeStatementHistoryQuarterly-SIX.json
@@ -1,0 +1,442 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=incomeStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "1uk3r79g2nuha"
+      ],
+      "x-yahoo-request-id": [
+        "1uk3r79g2nuha"
+      ],
+      "x-request-id": [
+        "5070e13b-c260-4df5-bd88-66203f1682df"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1282"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:26 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 126327000,
+                    "fmt": "126.33M",
+                    "longFmt": "126,327,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 125621000,
+                    "fmt": "125.62M",
+                    "longFmt": "125,621,000"
+                  },
+                  "grossProfit": {
+                    "raw": 706000,
+                    "fmt": "706k",
+                    "longFmt": "706,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 41765000,
+                    "fmt": "41.77M",
+                    "longFmt": "41,765,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 196171000,
+                    "fmt": "196.17M",
+                    "longFmt": "196,171,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -69844000,
+                    "fmt": "-69.84M",
+                    "longFmt": "-69,844,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -61927000,
+                    "fmt": "-61.93M",
+                    "longFmt": "-61,927,000"
+                  },
+                  "ebit": {
+                    "raw": -69844000,
+                    "fmt": "-69.84M",
+                    "longFmt": "-69,844,000"
+                  },
+                  "interestExpense": {
+                    "raw": -38500000,
+                    "fmt": "-38.5M",
+                    "longFmt": "-38,500,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -131771000,
+                    "fmt": "-131.77M",
+                    "longFmt": "-131,771,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -36243000,
+                    "fmt": "-36.24M",
+                    "longFmt": "-36,243,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 544020000,
+                    "fmt": "544.02M",
+                    "longFmt": "544,020,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -95528000,
+                    "fmt": "-95.53M",
+                    "longFmt": "-95,528,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -116172000,
+                    "fmt": "-116.17M",
+                    "longFmt": "-116,172,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -116172000,
+                    "fmt": "-116.17M",
+                    "longFmt": "-116,172,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 19143000,
+                    "fmt": "19.14M",
+                    "longFmt": "19,143,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 63780000,
+                    "fmt": "63.78M",
+                    "longFmt": "63,780,000"
+                  },
+                  "grossProfit": {
+                    "raw": -44637000,
+                    "fmt": "-44.64M",
+                    "longFmt": "-44,637,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 36941000,
+                    "fmt": "36.94M",
+                    "longFmt": "36,941,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 130155000,
+                    "fmt": "130.16M",
+                    "longFmt": "130,155,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -111012000,
+                    "fmt": "-111.01M",
+                    "longFmt": "-111,012,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -60899000,
+                    "fmt": "-60.9M",
+                    "longFmt": "-60,899,000"
+                  },
+                  "ebit": {
+                    "raw": -111012000,
+                    "fmt": "-111.01M",
+                    "longFmt": "-111,012,000"
+                  },
+                  "interestExpense": {
+                    "raw": -51248000,
+                    "fmt": "-51.25M",
+                    "longFmt": "-51,248,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -171911000,
+                    "fmt": "-171.91M",
+                    "longFmt": "-171,911,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -55661000,
+                    "fmt": "-55.66M",
+                    "longFmt": "-55,661,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 544020000,
+                    "fmt": "544.02M",
+                    "longFmt": "544,020,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -116250000,
+                    "fmt": "-116.25M",
+                    "longFmt": "-116,250,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -136894000,
+                    "fmt": "-136.89M",
+                    "longFmt": "-136,894,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -136894000,
+                    "fmt": "-136.89M",
+                    "longFmt": "-136,894,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 102503000,
+                    "fmt": "102.5M",
+                    "longFmt": "102,503,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 112158000,
+                    "fmt": "112.16M",
+                    "longFmt": "112,158,000"
+                  },
+                  "grossProfit": {
+                    "raw": -9655000,
+                    "fmt": "-9.65M",
+                    "longFmt": "-9,655,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 36660000,
+                    "fmt": "36.66M",
+                    "longFmt": "36,660,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 179482000,
+                    "fmt": "179.48M",
+                    "longFmt": "179,482,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -76979000,
+                    "fmt": "-76.98M",
+                    "longFmt": "-76,979,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -29616000,
+                    "fmt": "-29.62M",
+                    "longFmt": "-29,616,000"
+                  },
+                  "ebit": {
+                    "raw": -76979000,
+                    "fmt": "-76.98M",
+                    "longFmt": "-76,979,000"
+                  },
+                  "interestExpense": {
+                    "raw": -27486000,
+                    "fmt": "-27.49M",
+                    "longFmt": "-27,486,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -106595000,
+                    "fmt": "-106.59M",
+                    "longFmt": "-106,595,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -22049000,
+                    "fmt": "-22.05M",
+                    "longFmt": "-22,049,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 529276000,
+                    "fmt": "529.28M",
+                    "longFmt": "529,276,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -84546000,
+                    "fmt": "-84.55M",
+                    "longFmt": "-84,546,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -84546000,
+                    "fmt": "-84.55M",
+                    "longFmt": "-84,546,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -84546000,
+                    "fmt": "-84.55M",
+                    "longFmt": "-84,546,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 261000000,
+                    "fmt": "261M",
+                    "longFmt": "261,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 136219000,
+                    "fmt": "136.22M",
+                    "longFmt": "136,219,000"
+                  },
+                  "grossProfit": {
+                    "raw": 124781000,
+                    "fmt": "124.78M",
+                    "longFmt": "124,781,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 55069000,
+                    "fmt": "55.07M",
+                    "longFmt": "55,069,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 220485000,
+                    "fmt": "220.49M",
+                    "longFmt": "220,485,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 40515000,
+                    "fmt": "40.52M",
+                    "longFmt": "40,515,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -30372000,
+                    "fmt": "-30.37M",
+                    "longFmt": "-30,372,000"
+                  },
+                  "ebit": {
+                    "raw": 40515000,
+                    "fmt": "40.52M",
+                    "longFmt": "40,515,000"
+                  },
+                  "interestExpense": {
+                    "raw": -27738000,
+                    "fmt": "-27.74M",
+                    "longFmt": "-27,738,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 10143000,
+                    "fmt": "10.14M",
+                    "longFmt": "10,143,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 21298000,
+                    "fmt": "21.3M",
+                    "longFmt": "21,298,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 529258000,
+                    "fmt": "529.26M",
+                    "longFmt": "529,258,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -11155000,
+                    "fmt": "-11.15M",
+                    "longFmt": "-11,155,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -11155000,
+                    "fmt": "-11.15M",
+                    "longFmt": "-11,155,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -11155000,
+                    "fmt": "-11.15M",
+                    "longFmt": "-11,155,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistoryQuarterly-WSKT.JK.json
+++ b/tests/http/quoteSummary-incomeStatementHistoryQuarterly-WSKT.JK.json
@@ -1,0 +1,458 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=incomeStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "a98qq99g2nuha"
+      ],
+      "x-yahoo-request-id": [
+        "a98qq99g2nuha"
+      ],
+      "x-request-id": [
+        "6821a13a-a599-4572-a16b-63e39b2ece66"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1880"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:26 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 3702444815840,
+                    "fmt": "3.7T",
+                    "longFmt": "3,702,444,815,840"
+                  },
+                  "costOfRevenue": {
+                    "raw": 4000156906933,
+                    "fmt": "4T",
+                    "longFmt": "4,000,156,906,933"
+                  },
+                  "grossProfit": {
+                    "raw": -297712091093,
+                    "fmt": "-297.71B",
+                    "longFmt": "-297,712,091,093"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 250353444864,
+                    "fmt": "250.35B",
+                    "longFmt": "250,353,444,864"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 512412339527,
+                    "fmt": "512.41B",
+                    "longFmt": "512,412,339,527"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 4762922691324,
+                    "fmt": "4.76T",
+                    "longFmt": "4,762,922,691,324"
+                  },
+                  "operatingIncome": {
+                    "raw": -1060477875484,
+                    "fmt": "-1.06T",
+                    "longFmt": "-1,060,477,875,484"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -915830264077,
+                    "fmt": "-915.83B",
+                    "longFmt": "-915,830,264,077"
+                  },
+                  "ebit": {
+                    "raw": -1060477875484,
+                    "fmt": "-1.06T",
+                    "longFmt": "-1,060,477,875,484"
+                  },
+                  "interestExpense": {
+                    "raw": -1081591970173,
+                    "fmt": "-1.08T",
+                    "longFmt": "-1,081,591,970,173"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -1976308139561,
+                    "fmt": "-1.98T",
+                    "longFmt": "-1,976,308,139,561"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 81052721385,
+                    "fmt": "81.05B",
+                    "longFmt": "81,052,721,385"
+                  },
+                  "minorityInterest": {
+                    "raw": 10421911999730,
+                    "fmt": "10.42T",
+                    "longFmt": "10,421,911,999,730"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -2057360860946,
+                    "fmt": "-2.06T",
+                    "longFmt": "-2,057,360,860,946"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -1541875900774,
+                    "fmt": "-1.54T",
+                    "longFmt": "-1,541,875,900,774"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -1541875900774,
+                    "fmt": "-1.54T",
+                    "longFmt": "-1,541,875,900,774"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 3867906986507,
+                    "fmt": "3.87T",
+                    "longFmt": "3,867,906,986,507"
+                  },
+                  "costOfRevenue": {
+                    "raw": 3638479716687,
+                    "fmt": "3.64T",
+                    "longFmt": "3,638,479,716,687"
+                  },
+                  "grossProfit": {
+                    "raw": 229427269820,
+                    "fmt": "229.43B",
+                    "longFmt": "229,427,269,820"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 277196426825,
+                    "fmt": "277.2B",
+                    "longFmt": "277,196,426,825"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 19838121455,
+                    "fmt": "19.84B",
+                    "longFmt": "19,838,121,455"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 3935514264967,
+                    "fmt": "3.94T",
+                    "longFmt": "3,935,514,264,967"
+                  },
+                  "operatingIncome": {
+                    "raw": -67607278460,
+                    "fmt": "-67.61B",
+                    "longFmt": "-67,607,278,460"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -1190849027335,
+                    "fmt": "-1.19T",
+                    "longFmt": "-1,190,849,027,335"
+                  },
+                  "ebit": {
+                    "raw": -67607278460,
+                    "fmt": "-67.61B",
+                    "longFmt": "-67,607,278,460"
+                  },
+                  "interestExpense": {
+                    "raw": -1224736795485,
+                    "fmt": "-1.22T",
+                    "longFmt": "-1,224,736,795,485"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -1258456305795,
+                    "fmt": "-1.26T",
+                    "longFmt": "-1,258,456,305,795"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 73975034586,
+                    "fmt": "73.98B",
+                    "longFmt": "73,975,034,586"
+                  },
+                  "minorityInterest": {
+                    "raw": 10937396959806,
+                    "fmt": "10.94T",
+                    "longFmt": "10,937,396,959,806"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -1332431340381,
+                    "fmt": "-1.33T",
+                    "longFmt": "-1,332,431,340,381"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -1137790988612,
+                    "fmt": "-1.14T",
+                    "longFmt": "-1,137,790,988,612"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -1137790988612,
+                    "fmt": "-1.14T",
+                    "longFmt": "-1,137,790,988,612"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 4169887433590,
+                    "fmt": "4.17T",
+                    "longFmt": "4,169,887,433,590"
+                  },
+                  "costOfRevenue": {
+                    "raw": 3332972919201,
+                    "fmt": "3.33T",
+                    "longFmt": "3,332,972,919,201"
+                  },
+                  "grossProfit": {
+                    "raw": 836914514389,
+                    "fmt": "836.91B",
+                    "longFmt": "836,914,514,389"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 210954179587,
+                    "fmt": "210.95B",
+                    "longFmt": "210,954,179,587"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 24092664799,
+                    "fmt": "24.09B",
+                    "longFmt": "24,092,664,799"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 3568019763587,
+                    "fmt": "3.57T",
+                    "longFmt": "3,568,019,763,587"
+                  },
+                  "operatingIncome": {
+                    "raw": 601867670003,
+                    "fmt": "601.87B",
+                    "longFmt": "601,867,670,003"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -486212050524,
+                    "fmt": "-486.21B",
+                    "longFmt": "-486,212,050,524"
+                  },
+                  "ebit": {
+                    "raw": 601867670003,
+                    "fmt": "601.87B",
+                    "longFmt": "601,867,670,003"
+                  },
+                  "interestExpense": {
+                    "raw": -701040339582,
+                    "fmt": "-701.04B",
+                    "longFmt": "-701,040,339,582"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 115655619479,
+                    "fmt": "115.66B",
+                    "longFmt": "115,655,619,479"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 105475763996,
+                    "fmt": "105.48B",
+                    "longFmt": "105,475,763,996"
+                  },
+                  "minorityInterest": {
+                    "raw": 11203544702256,
+                    "fmt": "11.2T",
+                    "longFmt": "11,203,544,702,256"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 10179855483,
+                    "fmt": "10.18B",
+                    "longFmt": "10,179,855,483"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 42696350655,
+                    "fmt": "42.7B",
+                    "longFmt": "42,696,350,655"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 42696350655,
+                    "fmt": "42.7B",
+                    "longFmt": "42,696,350,655"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 9372493217765,
+                    "fmt": "9.37T",
+                    "longFmt": "9,372,493,217,765"
+                  },
+                  "costOfRevenue": {
+                    "raw": 7924139656299,
+                    "fmt": "7.92T",
+                    "longFmt": "7,924,139,656,299"
+                  },
+                  "grossProfit": {
+                    "raw": 1448353561466,
+                    "fmt": "1.45T",
+                    "longFmt": "1,448,353,561,466"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 596747885424,
+                    "fmt": "596.75B",
+                    "longFmt": "596,747,885,424"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 135923296923,
+                    "fmt": "135.92B",
+                    "longFmt": "135,923,296,923"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 8656810838646,
+                    "fmt": "8.66T",
+                    "longFmt": "8,656,810,838,646"
+                  },
+                  "operatingIncome": {
+                    "raw": 715682379119,
+                    "fmt": "715.68B",
+                    "longFmt": "715,682,379,119"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -460554709593,
+                    "fmt": "-460.55B",
+                    "longFmt": "-460,554,709,593"
+                  },
+                  "ebit": {
+                    "raw": 715682379119,
+                    "fmt": "715.68B",
+                    "longFmt": "715,682,379,119"
+                  },
+                  "interestExpense": {
+                    "raw": -1031364328349,
+                    "fmt": "-1.03T",
+                    "longFmt": "-1,031,364,328,349"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 255127669526,
+                    "fmt": "255.13B",
+                    "longFmt": "255,127,669,526"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 329179388870,
+                    "fmt": "329.18B",
+                    "longFmt": "329,179,388,870"
+                  },
+                  "minorityInterest": {
+                    "raw": 11236061197428,
+                    "fmt": "11.24T",
+                    "longFmt": "11,236,061,197,428"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -74051719344,
+                    "fmt": "-74.05B",
+                    "longFmt": "-74,051,719,344"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -212188468091,
+                    "fmt": "-212.19B",
+                    "longFmt": "-212,188,468,091"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -212188468091,
+                    "fmt": "-212.19B",
+                    "longFmt": "-212,188,468,091"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-indexTrend-ADH.json
+++ b/tests/http/quoteSummary-indexTrend-ADH.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=indexTrend"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "fbmm679g2nrra"
+      ],
+      "x-yahoo-request-id": [
+        "fbmm679g2nrra"
+      ],
+      "x-request-id": [
+        "cde66467-fa6d-4646-996b-e76c8b84e0c9"
+      ],
+      "content-length": [
+        "143"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:33 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=indexTrend"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-indexTrend-AFRAF.json
+++ b/tests/http/quoteSummary-indexTrend-AFRAF.json
@@ -1,0 +1,109 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=indexTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "2fr8eehg2nrra"
+      ],
+      "x-yahoo-request-id": [
+        "2fr8eehg2nrra"
+      ],
+      "x-request-id": [
+        "7c178e85-757e-48ae-b7fd-0dfd5e1ac522"
+      ],
+      "content-length": [
+        "321"
+      ],
+      "x-envoy-upstream-service-time": [
+        "8"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:34 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 6.26429,
+              "pegRatio": 0.655216,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.258
+                },
+                {
+                  "period": "+1q",
+                  "growth": 0.97400004
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.144
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.158
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0820068
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-indexTrend-AMZN.json
+++ b/tests/http/quoteSummary-indexTrend-AMZN.json
@@ -1,0 +1,109 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=indexTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "c6fm7l5g2nrra"
+      ],
+      "x-yahoo-request-id": [
+        "c6fm7l5g2nrra"
+      ],
+      "x-request-id": [
+        "6a458413-ae62-44d3-bc1e-9707838ad6e9"
+      ],
+      "content-length": [
+        "321"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:34 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 6.26429,
+              "pegRatio": 0.655216,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.258
+                },
+                {
+                  "period": "+1q",
+                  "growth": 0.97400004
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.144
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.158
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0820068
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-indexTrend-AZT.OL.json
+++ b/tests/http/quoteSummary-indexTrend-AZT.OL.json
@@ -1,0 +1,109 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=indexTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "9mujnq5g2nrra"
+      ],
+      "x-yahoo-request-id": [
+        "9mujnq5g2nrra"
+      ],
+      "x-request-id": [
+        "4898e6a9-decc-9a4e-aa83-a4103a160d88"
+      ],
+      "content-length": [
+        "321"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:34 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 6.26429,
+              "pegRatio": 0.655216,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.258
+                },
+                {
+                  "period": "+1q",
+                  "growth": 0.97400004
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.144
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.158
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0820068
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-indexTrend-SIX.json
+++ b/tests/http/quoteSummary-indexTrend-SIX.json
@@ -1,0 +1,109 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=indexTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "ee05oilg2nuhb"
+      ],
+      "x-yahoo-request-id": [
+        "ee05oilg2nuhb"
+      ],
+      "x-request-id": [
+        "bb3bef19-06ec-463a-9053-8c136f1f9561"
+      ],
+      "content-length": [
+        "321"
+      ],
+      "x-envoy-upstream-service-time": [
+        "5"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:26 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 6.26429,
+              "pegRatio": 0.655216,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.258
+                },
+                {
+                  "period": "+1q",
+                  "growth": 0.97400004
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.144
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.158
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0820068
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-indexTrend-WSKT.JK.json
+++ b/tests/http/quoteSummary-indexTrend-WSKT.JK.json
@@ -1,0 +1,109 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=indexTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "850k1rlg2nuhb"
+      ],
+      "x-yahoo-request-id": [
+        "850k1rlg2nuhb"
+      ],
+      "x-request-id": [
+        "16ebc083-707e-4bd2-b7fc-752a38d72fbf"
+      ],
+      "content-length": [
+        "321"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:26 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 6.26429,
+              "pegRatio": 0.655216,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.258
+                },
+                {
+                  "period": "+1q",
+                  "growth": 0.97400004
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.144
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.158
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0820068
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-industryTrend-ADH.json
+++ b/tests/http/quoteSummary-industryTrend-ADH.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=industryTrend"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "3q3erfpg2nrra"
+      ],
+      "x-yahoo-request-id": [
+        "3q3erfpg2nrra"
+      ],
+      "x-request-id": [
+        "54435e85-d500-49b8-9692-f5434765cf10"
+      ],
+      "content-length": [
+        "146"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:34 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=industryTrend"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-industryTrend-AFRAF.json
+++ b/tests/http/quoteSummary-industryTrend-AFRAF.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=industryTrend"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "ar89245g2nrrb"
+      ],
+      "x-yahoo-request-id": [
+        "ar89245g2nrrb"
+      ],
+      "x-request-id": [
+        "1f6d8dc1-3644-41ac-8c0a-df984500e39c"
+      ],
+      "content-length": [
+        "146"
+      ],
+      "x-envoy-upstream-service-time": [
+        "6"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:34 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=industryTrend"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-industryTrend-AMZN.json
+++ b/tests/http/quoteSummary-industryTrend-AMZN.json
@@ -1,0 +1,83 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=industryTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "38ujmshg2nrrb"
+      ],
+      "x-yahoo-request-id": [
+        "38ujmshg2nrrb"
+      ],
+      "x-request-id": [
+        "8ea6fe01-5882-478f-9e41-5a99874c23e9"
+      ],
+      "content-length": [
+        "102"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:34 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-industryTrend-AZT.OL.json
+++ b/tests/http/quoteSummary-industryTrend-AZT.OL.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=industryTrend"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "4duj90hg2nrrb"
+      ],
+      "x-yahoo-request-id": [
+        "4duj90hg2nrrb"
+      ],
+      "x-request-id": [
+        "a1653907-b170-4841-8d32-78749271596b"
+      ],
+      "content-length": [
+        "146"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:35 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=industryTrend"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-industryTrend-SIX.json
+++ b/tests/http/quoteSummary-industryTrend-SIX.json
@@ -1,0 +1,83 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=industryTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "f0ci2qtg2nuhb"
+      ],
+      "x-yahoo-request-id": [
+        "f0ci2qtg2nuhb"
+      ],
+      "x-request-id": [
+        "13663235-774a-4322-b970-8d9ffc25d99f"
+      ],
+      "content-length": [
+        "102"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:27 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-industryTrend-WSKT.JK.json
+++ b/tests/http/quoteSummary-industryTrend-WSKT.JK.json
@@ -1,0 +1,83 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=industryTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "3if7g4hg2nuhb"
+      ],
+      "x-yahoo-request-id": [
+        "3if7g4hg2nuhb"
+      ],
+      "x-request-id": [
+        "cc922ebb-5474-4c3d-a301-76bf9cc958ff"
+      ],
+      "content-length": [
+        "102"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:27 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderHolders-ADH.json
+++ b/tests/http/quoteSummary-insiderHolders-ADH.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=insiderHolders"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "eoj0m1dg2nrrb"
+      ],
+      "x-yahoo-request-id": [
+        "eoj0m1dg2nrrb"
+      ],
+      "x-request-id": [
+        "a1fd296e-86cd-4d3a-be05-2b50ecc03377"
+      ],
+      "content-length": [
+        "147"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:35 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=insiderHolders"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderHolders-AFRAF.json
+++ b/tests/http/quoteSummary-insiderHolders-AFRAF.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=insiderHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "b1mv05tg2nrrb"
+      ],
+      "x-yahoo-request-id": [
+        "b1mv05tg2nrrb"
+      ],
+      "x-request-id": [
+        "9910974a-fd91-481a-accc-ec3579a129f9"
+      ],
+      "content-length": [
+        "87"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:35 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "insiderHolders": {
+              "holders": [],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderHolders-AMZN.json
+++ b/tests/http/quoteSummary-insiderHolders-AMZN.json
@@ -1,0 +1,286 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=insiderHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "81dtg1pg2nrrb"
+      ],
+      "x-yahoo-request-id": [
+        "81dtg1pg2nrrb"
+      ],
+      "x-request-id": [
+        "9667c49f-0785-401b-aea9-1a4dd4eacfe0"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "713"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:35 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "insiderHolders": {
+              "holders": [
+                {
+                  "maxAge": 1,
+                  "name": "BEZOS JEFFREY P",
+                  "relation": "Chief Executive Officer",
+                  "url": "",
+                  "transactionDescription": "Stock Gift",
+                  "latestTransDate": {
+                    "raw": 1606867200,
+                    "fmt": "2020-12-02"
+                  },
+                  "positionDirect": {
+                    "raw": 53220600,
+                    "fmt": "53.22M",
+                    "longFmt": "53,220,600"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1606867200,
+                    "fmt": "2020-12-02"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "HUTTENLOCHER DANIEL P",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1605830400,
+                    "fmt": "2020-11-20"
+                  },
+                  "positionDirect": {
+                    "raw": 950,
+                    "fmt": "950",
+                    "longFmt": "950"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605830400,
+                    "fmt": "2020-11-20"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "JASSY ANDREW R",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  },
+                  "positionDirect": {
+                    "raw": 84782,
+                    "fmt": "84.78k",
+                    "longFmt": "84,782"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "MCGRATH JUDITH A",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1612396800,
+                    "fmt": "2021-02-04"
+                  },
+                  "positionDirect": {
+                    "raw": 1984,
+                    "fmt": "1.98k",
+                    "longFmt": "1,984"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1612396800,
+                    "fmt": "2021-02-04"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "OLSAVSKY BRIAN T.",
+                  "relation": "Chief Financial Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  },
+                  "positionDirect": {
+                    "raw": 1571,
+                    "fmt": "1.57k",
+                    "longFmt": "1,571"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "REYNOLDS SHELLEY L",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  },
+                  "positionDirect": {
+                    "raw": 6122,
+                    "fmt": "6.12k",
+                    "longFmt": "6,122"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "RUBINSTEIN JONATHAN J",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1609804800,
+                    "fmt": "2021-01-05"
+                  },
+                  "positionDirect": {
+                    "raw": 6758,
+                    "fmt": "6.76k",
+                    "longFmt": "6,758"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1609804800,
+                    "fmt": "2021-01-05"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "STONESIFER PATRICIA Q",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "positionDirect": {
+                    "raw": 1967,
+                    "fmt": "1.97k",
+                    "longFmt": "1,967"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "WILKE JEFFREY A",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Stock Gift",
+                  "latestTransDate": {
+                    "raw": 1609286400,
+                    "fmt": "2020-12-30"
+                  },
+                  "positionIndirect": {
+                    "raw": 20110,
+                    "fmt": "20.11k",
+                    "longFmt": "20,110"
+                  },
+                  "positionIndirectDate": {
+                    "raw": 1609286400,
+                    "fmt": "2020-12-30"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "ZAPOLSKY DAVID",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  },
+                  "positionDirect": {
+                    "raw": 3605,
+                    "fmt": "3.6k",
+                    "longFmt": "3,605"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  }
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderHolders-AZT.OL.json
+++ b/tests/http/quoteSummary-insiderHolders-AZT.OL.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=insiderHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "fga405lg2nrrb"
+      ],
+      "x-yahoo-request-id": [
+        "fga405lg2nrrb"
+      ],
+      "x-request-id": [
+        "facc7c9a-8978-44f4-b230-8f72e0390796"
+      ],
+      "content-length": [
+        "87"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:35 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "insiderHolders": {
+              "holders": [],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderHolders-SIX.json
+++ b/tests/http/quoteSummary-insiderHolders-SIX.json
@@ -1,0 +1,286 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=insiderHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "3adm2mpg2nuhb"
+      ],
+      "x-yahoo-request-id": [
+        "3adm2mpg2nuhb"
+      ],
+      "x-request-id": [
+        "06a2fffb-c1ec-4e8f-a6d3-e5eae0523796"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "652"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:27 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "insiderHolders": {
+              "holders": [
+                {
+                  "maxAge": 1,
+                  "name": "ASLIN CATHERINE",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1601596800,
+                    "fmt": "2020-10-02"
+                  },
+                  "positionDirect": {
+                    "raw": 42610,
+                    "fmt": "42.61k",
+                    "longFmt": "42,610"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1601596800,
+                    "fmt": "2020-10-02"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "BALDANZA BASIL BEN",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  },
+                  "positionDirect": {
+                    "raw": 11957,
+                    "fmt": "11.96k",
+                    "longFmt": "11,957"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "BASSOUL SELIM A",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  },
+                  "positionDirect": {
+                    "raw": 30050,
+                    "fmt": "30.05k",
+                    "longFmt": "30,050"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "BRACEY ESI EGGLESTON",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  },
+                  "positionDirect": {
+                    "raw": 7984,
+                    "fmt": "7.98k",
+                    "longFmt": "7,984"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "BROOKS WILSON TAYLOR",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1599177600,
+                    "fmt": "2020-09-04"
+                  },
+                  "positionDirect": {
+                    "raw": 13319,
+                    "fmt": "13.32k",
+                    "longFmt": "13,319"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1599177600,
+                    "fmt": "2020-09-04"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "KREJSA NANCY A.",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  },
+                  "positionDirect": {
+                    "raw": 167259,
+                    "fmt": "167.26k",
+                    "longFmt": "167,259"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "PETIT BRETT",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1601596800,
+                    "fmt": "2020-10-02"
+                  },
+                  "positionDirect": {
+                    "raw": 191762,
+                    "fmt": "191.76k",
+                    "longFmt": "191,762"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1601596800,
+                    "fmt": "2020-10-02"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "ROEDEL RICHARD W",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  },
+                  "positionDirect": {
+                    "raw": 92669,
+                    "fmt": "92.67k",
+                    "longFmt": "92,669"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "RUSS LEONARD A",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1593648000,
+                    "fmt": "2020-07-02"
+                  },
+                  "positionDirect": {
+                    "raw": 96584,
+                    "fmt": "96.58k",
+                    "longFmt": "96,584"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1593648000,
+                    "fmt": "2020-07-02"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "SPANOS MICHAEL",
+                  "relation": "Chief Executive Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1606089600,
+                    "fmt": "2020-11-23"
+                  },
+                  "positionDirect": {
+                    "raw": 385572,
+                    "fmt": "385.57k",
+                    "longFmt": "385,572"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1606089600,
+                    "fmt": "2020-11-23"
+                  }
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderHolders-WSKT.JK.json
+++ b/tests/http/quoteSummary-insiderHolders-WSKT.JK.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=insiderHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "eoekvk1g2nuhb"
+      ],
+      "x-yahoo-request-id": [
+        "eoekvk1g2nuhb"
+      ],
+      "x-request-id": [
+        "f6c55fa6-59bc-4bff-b6dd-a5af82f81b7c"
+      ],
+      "content-length": [
+        "87"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:27 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "insiderHolders": {
+              "holders": [],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderTransactions-ADH.json
+++ b/tests/http/quoteSummary-insiderTransactions-ADH.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=insiderTransactions"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "ap28ot1g2nrrb"
+      ],
+      "x-yahoo-request-id": [
+        "ap28ot1g2nrrb"
+      ],
+      "x-request-id": [
+        "25d023d6-739c-4ffd-a952-6d46f8625bf3"
+      ],
+      "content-length": [
+        "152"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:35 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=insiderTransactions"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderTransactions-AFRAF.json
+++ b/tests/http/quoteSummary-insiderTransactions-AFRAF.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=insiderTransactions"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "deebvd5g2nrrc"
+      ],
+      "x-yahoo-request-id": [
+        "deebvd5g2nrrc"
+      ],
+      "x-request-id": [
+        "8e51724d-fe86-4679-a601-778107cf8453"
+      ],
+      "content-length": [
+        "152"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:35 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=insiderTransactions"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderTransactions-AMZN.json
+++ b/tests/http/quoteSummary-insiderTransactions-AMZN.json
@@ -1,0 +1,3331 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=insiderTransactions"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "fs56rrpg2nrrc"
+      ],
+      "x-yahoo-request-id": [
+        "fs56rrpg2nrrc"
+      ],
+      "x-request-id": [
+        "617a5de2-239a-4db0-ac2c-76bb25b17f4c"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "5"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:36 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "insiderTransactions": {
+              "transactions": [
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 340,
+                    "fmt": "340",
+                    "longFmt": "340"
+                  },
+                  "value": {
+                    "raw": 1131639,
+                    "fmt": "1.13M",
+                    "longFmt": "1,131,639"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3328.35 per share.",
+                  "filerName": "MCGRATH JUDITH A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1612396800,
+                    "fmt": "2021-02-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 314,
+                    "fmt": "314",
+                    "longFmt": "314"
+                  },
+                  "value": {
+                    "raw": 994127,
+                    "fmt": "994.13k",
+                    "longFmt": "994,127"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3166.01 per share.",
+                  "filerName": "RUBINSTEIN JONATHAN J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1609804800,
+                    "fmt": "2021-01-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1510,
+                    "fmt": "1.51k",
+                    "longFmt": "1,510"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1609286400,
+                    "fmt": "2020-12-30"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 31421,
+                    "fmt": "31.42k",
+                    "longFmt": "31,421"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606867200,
+                    "fmt": "2020-12-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 832,
+                    "fmt": "832",
+                    "longFmt": "832"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606780800,
+                    "fmt": "2020-12-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2000,
+                    "fmt": "2k",
+                    "longFmt": "2,000"
+                  },
+                  "value": {
+                    "raw": 6401175,
+                    "fmt": "6.4M",
+                    "longFmt": "6,401,175"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3161.66 - 3242.78 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606780800,
+                    "fmt": "2020-12-01"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 368,
+                    "fmt": "368",
+                    "longFmt": "368"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606176000,
+                    "fmt": "2020-11-24"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1899,
+                    "fmt": "1.9k",
+                    "longFmt": "1,899"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606089600,
+                    "fmt": "2020-11-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 750,
+                    "fmt": "750",
+                    "longFmt": "750"
+                  },
+                  "value": {
+                    "raw": 2318360,
+                    "fmt": "2.32M",
+                    "longFmt": "2,318,360"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3070.30 - 3100.76 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606089600,
+                    "fmt": "2020-11-23"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 172,
+                    "fmt": "172",
+                    "longFmt": "172"
+                  },
+                  "value": {
+                    "raw": 535744,
+                    "fmt": "535.74k",
+                    "longFmt": "535,744"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3100.53 - 3132.71 per share.",
+                  "filerName": "HUTTENLOCHER DANIEL P",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605830400,
+                    "fmt": "2020-11-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 220825,
+                    "fmt": "220.82k",
+                    "longFmt": "220,825"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1200,
+                    "fmt": "1.2k",
+                    "longFmt": "1,200"
+                  },
+                  "value": {
+                    "raw": 3737229,
+                    "fmt": "3.74M",
+                    "longFmt": "3,737,229"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3101.32 - 3126.09 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1099,
+                    "fmt": "1.1k",
+                    "longFmt": "1,099"
+                  },
+                  "value": {
+                    "raw": 3391096,
+                    "fmt": "3.39M",
+                    "longFmt": "3,391,096"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3085.62 per share.",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 293,
+                    "fmt": "293",
+                    "longFmt": "293"
+                  },
+                  "value": {
+                    "raw": 904087,
+                    "fmt": "904.09k",
+                    "longFmt": "904,087"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3085.62 per share.",
+                  "filerName": "REYNOLDS SHELLEY L",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1238,
+                    "fmt": "1.24k",
+                    "longFmt": "1,238"
+                  },
+                  "value": {
+                    "raw": 3819998,
+                    "fmt": "3.82M",
+                    "longFmt": "3,819,998"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3085.62 per share.",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1377,
+                    "fmt": "1.38k",
+                    "longFmt": "1,377"
+                  },
+                  "value": {
+                    "raw": 4248899,
+                    "fmt": "4.25M",
+                    "longFmt": "4,248,899"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3085.62 per share.",
+                  "filerName": "OLSAVSKY BRIAN T.",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 172,
+                    "fmt": "172",
+                    "longFmt": "172"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "STONESIFER PATRICIA Q",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 172,
+                    "fmt": "172",
+                    "longFmt": "172"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "RUBINSTEIN JONATHAN J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 172,
+                    "fmt": "172",
+                    "longFmt": "172"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "RYDER THOMAS O",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2791,
+                    "fmt": "2.79k",
+                    "longFmt": "2,791"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6550,
+                    "fmt": "6.55k",
+                    "longFmt": "6,550"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D/I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2791,
+                    "fmt": "2.79k",
+                    "longFmt": "2,791"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 293,
+                    "fmt": "293",
+                    "longFmt": "293"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "REYNOLDS SHELLEY L",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1377,
+                    "fmt": "1.38k",
+                    "longFmt": "1,377"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 172,
+                    "fmt": "172",
+                    "longFmt": "172"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "HUTTENLOCHER DANIEL P",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1377,
+                    "fmt": "1.38k",
+                    "longFmt": "1,377"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "OLSAVSKY BRIAN T.",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 550,
+                    "fmt": "550",
+                    "longFmt": "550"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "STONESIFER PATRICIA Q",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604620800,
+                    "fmt": "2020-11-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 600,
+                    "fmt": "600",
+                    "longFmt": "600"
+                  },
+                  "value": {
+                    "raw": 1982172,
+                    "fmt": "1.98M",
+                    "longFmt": "1,982,172"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3303.62 per share.",
+                  "filerName": "STONESIFER PATRICIA Q",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604620800,
+                    "fmt": "2020-11-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 309,
+                    "fmt": "309",
+                    "longFmt": "309"
+                  },
+                  "value": {
+                    "raw": 1025871,
+                    "fmt": "1.03M",
+                    "longFmt": "1,025,871"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3319.97 per share.",
+                  "filerName": "RUBINSTEIN JONATHAN J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604534400,
+                    "fmt": "2020-11-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 100809,
+                    "fmt": "100.81k",
+                    "longFmt": "100,809"
+                  },
+                  "value": {
+                    "raw": 305318709,
+                    "fmt": "305.32M",
+                    "longFmt": "305,318,709"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2983.37 - 3079.05 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604361600,
+                    "fmt": "2020-11-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 72076,
+                    "fmt": "72.08k",
+                    "longFmt": "72,076"
+                  },
+                  "value": {
+                    "raw": 218241914,
+                    "fmt": "218.24M",
+                    "longFmt": "218,241,914"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3001.24 - 3043.19 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604361600,
+                    "fmt": "2020-11-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 352307,
+                    "fmt": "352.31k",
+                    "longFmt": "352,307"
+                  },
+                  "value": {
+                    "raw": 1077105854,
+                    "fmt": "1.08B",
+                    "longFmt": "1,077,105,854"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3044.30 - 3073.15 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604361600,
+                    "fmt": "2020-11-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 460,
+                    "fmt": "460",
+                    "longFmt": "460"
+                  },
+                  "value": {
+                    "raw": 1414472,
+                    "fmt": "1.41M",
+                    "longFmt": "1,414,472"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3074.94 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604361600,
+                    "fmt": "2020-11-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 156352,
+                    "fmt": "156.35k",
+                    "longFmt": "156,352"
+                  },
+                  "value": {
+                    "raw": 464489563,
+                    "fmt": "464.49M",
+                    "longFmt": "464,489,563"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2951.01 - 2983.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604275200,
+                    "fmt": "2020-11-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 240060,
+                    "fmt": "240.06k",
+                    "longFmt": "240,060"
+                  },
+                  "value": {
+                    "raw": 719601001,
+                    "fmt": "719.6M",
+                    "longFmt": "719,601,001"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2984.03 - 3014.75 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604275200,
+                    "fmt": "2020-11-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 77936,
+                    "fmt": "77.94k",
+                    "longFmt": "77,936"
+                  },
+                  "value": {
+                    "raw": 236668949,
+                    "fmt": "236.67M",
+                    "longFmt": "236,668,949"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3016.10 - 3052.95 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604275200,
+                    "fmt": "2020-11-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 329,
+                    "fmt": "329",
+                    "longFmt": "329"
+                  },
+                  "value": {
+                    "raw": 1007312,
+                    "fmt": "1.01M",
+                    "longFmt": "1,007,312"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3061.74 per share.",
+                  "filerName": "RUBINSTEIN JONATHAN J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604275200,
+                    "fmt": "2020-11-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1709,
+                    "fmt": "1.71k",
+                    "longFmt": "1,709"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604275200,
+                    "fmt": "2020-11-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2000,
+                    "fmt": "2k",
+                    "longFmt": "2,000"
+                  },
+                  "value": {
+                    "raw": 6022793,
+                    "fmt": "6.02M",
+                    "longFmt": "6,022,793"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3000.60 - 3064.97 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604275200,
+                    "fmt": "2020-11-02"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6945,
+                    "fmt": "6.95k",
+                    "longFmt": "6,945"
+                  },
+                  "value": {
+                    "raw": 21263784,
+                    "fmt": "21.26M",
+                    "longFmt": "21,263,784"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3061.74 per share.",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604275200,
+                    "fmt": "2020-11-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1100,
+                    "fmt": "1.1k",
+                    "longFmt": "1,100"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1603065600,
+                    "fmt": "2020-10-19"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1100,
+                    "fmt": "1.1k",
+                    "longFmt": "1,100"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1599696000,
+                    "fmt": "2020-09-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 360,
+                    "fmt": "360",
+                    "longFmt": "360"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598918400,
+                    "fmt": "2020-09-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3518,
+                    "fmt": "3.52k",
+                    "longFmt": "3,518"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598572800,
+                    "fmt": "2020-08-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7548,
+                    "fmt": "7.55k",
+                    "longFmt": "7,548"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598313600,
+                    "fmt": "2020-08-25"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 750,
+                    "fmt": "750",
+                    "longFmt": "750"
+                  },
+                  "value": {
+                    "raw": 2478209,
+                    "fmt": "2.48M",
+                    "longFmt": "2,478,209"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3286.82 - 3323.27 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598227200,
+                    "fmt": "2020-08-24"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1200,
+                    "fmt": "1.2k",
+                    "longFmt": "1,200"
+                  },
+                  "value": {
+                    "raw": 3809017,
+                    "fmt": "3.81M",
+                    "longFmt": "3,809,017"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3155.09 - 3190.23 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597622400,
+                    "fmt": "2020-08-17"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1099,
+                    "fmt": "1.1k",
+                    "longFmt": "1,099"
+                  },
+                  "value": {
+                    "raw": 3487259,
+                    "fmt": "3.49M",
+                    "longFmt": "3,487,259"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3173.12 per share.",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597622400,
+                    "fmt": "2020-08-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 292,
+                    "fmt": "292",
+                    "longFmt": "292"
+                  },
+                  "value": {
+                    "raw": 926551,
+                    "fmt": "926.55k",
+                    "longFmt": "926,551"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3173.12 per share.",
+                  "filerName": "REYNOLDS SHELLEY L",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597622400,
+                    "fmt": "2020-08-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1238,
+                    "fmt": "1.24k",
+                    "longFmt": "1,238"
+                  },
+                  "value": {
+                    "raw": 3928323,
+                    "fmt": "3.93M",
+                    "longFmt": "3,928,323"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3173.12 per share.",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597622400,
+                    "fmt": "2020-08-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 304,
+                    "fmt": "304",
+                    "longFmt": "304"
+                  },
+                  "value": {
+                    "raw": 964628,
+                    "fmt": "964.63k",
+                    "longFmt": "964,628"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3173.12 per share.",
+                  "filerName": "MCGRATH JUDITH A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597622400,
+                    "fmt": "2020-08-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1377,
+                    "fmt": "1.38k",
+                    "longFmt": "1,377"
+                  },
+                  "value": {
+                    "raw": 4369386,
+                    "fmt": "4.37M",
+                    "longFmt": "4,369,386"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3173.12 per share.",
+                  "filerName": "OLSAVSKY BRIAN T.",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597622400,
+                    "fmt": "2020-08-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2941,
+                    "fmt": "2.94k",
+                    "longFmt": "2,941"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597363200,
+                    "fmt": "2020-08-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2791,
+                    "fmt": "2.79k",
+                    "longFmt": "2,791"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597363200,
+                    "fmt": "2020-08-14"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2791,
+                    "fmt": "2.79k",
+                    "longFmt": "2,791"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597363200,
+                    "fmt": "2020-08-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 292,
+                    "fmt": "292",
+                    "longFmt": "292"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "REYNOLDS SHELLEY L",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597363200,
+                    "fmt": "2020-08-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1377,
+                    "fmt": "1.38k",
+                    "longFmt": "1,377"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597363200,
+                    "fmt": "2020-08-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 304,
+                    "fmt": "304",
+                    "longFmt": "304"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "MCGRATH JUDITH A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597363200,
+                    "fmt": "2020-08-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1377,
+                    "fmt": "1.38k",
+                    "longFmt": "1,377"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "OLSAVSKY BRIAN T.",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597363200,
+                    "fmt": "2020-08-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 550,
+                    "fmt": "550",
+                    "longFmt": "550"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "STONESIFER PATRICIA Q",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596672000,
+                    "fmt": "2020-08-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 600,
+                    "fmt": "600",
+                    "longFmt": "600"
+                  },
+                  "value": {
+                    "raw": 1916616,
+                    "fmt": "1.92M",
+                    "longFmt": "1,916,616"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3194.36 per share.",
+                  "filerName": "STONESIFER PATRICIA Q",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596672000,
+                    "fmt": "2020-08-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 154394,
+                    "fmt": "154.39k",
+                    "longFmt": "154,394"
+                  },
+                  "value": {
+                    "raw": 485072931,
+                    "fmt": "485.07M",
+                    "longFmt": "485,072,931"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3102.85 - 3183.27 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596499200,
+                    "fmt": "2020-08-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 293614,
+                    "fmt": "293.61k",
+                    "longFmt": "293,614"
+                  },
+                  "value": {
+                    "raw": 916281263,
+                    "fmt": "916.28M",
+                    "longFmt": "916,281,263"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3108.33 - 3137.11 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596499200,
+                    "fmt": "2020-08-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 97654,
+                    "fmt": "97.65k",
+                    "longFmt": "97,654"
+                  },
+                  "value": {
+                    "raw": 307619184,
+                    "fmt": "307.62M",
+                    "longFmt": "307,619,184"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3138.51 - 3167.15 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596499200,
+                    "fmt": "2020-08-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 454338,
+                    "fmt": "454.34k",
+                    "longFmt": "454,338"
+                  },
+                  "value": {
+                    "raw": 1420090247,
+                    "fmt": "1.42B",
+                    "longFmt": "1,420,090,247"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3106.29 - 3137.51 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596412800,
+                    "fmt": "2020-08-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6945,
+                    "fmt": "6.95k",
+                    "longFmt": "6,945"
+                  },
+                  "value": {
+                    "raw": 22108644,
+                    "fmt": "22.11M",
+                    "longFmt": "22,108,644"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3183.39 per share.",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596412800,
+                    "fmt": "2020-08-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2602,
+                    "fmt": "2.6k",
+                    "longFmt": "2,602"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 750,
+                    "fmt": "750",
+                    "longFmt": "750"
+                  },
+                  "value": {
+                    "raw": 1832372,
+                    "fmt": "1.83M",
+                    "longFmt": "1,832,372"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2434.48 - 2451.35 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1590105600,
+                    "fmt": "2020-05-22"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4300,
+                    "fmt": "4.3k",
+                    "longFmt": "4,300"
+                  },
+                  "value": {
+                    "raw": 10742038,
+                    "fmt": "10.74M",
+                    "longFmt": "10,742,038"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2496.22 - 2499.01 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589932800,
+                    "fmt": "2020-05-20"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 183,
+                    "fmt": "183",
+                    "longFmt": "183"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "NOOYI INDRA K",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589500800,
+                    "fmt": "2020-05-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 347,
+                    "fmt": "347",
+                    "longFmt": "347"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589500800,
+                    "fmt": "2020-05-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1200,
+                    "fmt": "1.2k",
+                    "longFmt": "1,200"
+                  },
+                  "value": {
+                    "raw": 2859399,
+                    "fmt": "2.86M",
+                    "longFmt": "2,859,399"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2361.61 - 2409.00 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589500800,
+                    "fmt": "2020-05-15"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2791,
+                    "fmt": "2.79k",
+                    "longFmt": "2,791"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589500800,
+                    "fmt": "2020-05-15"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1099,
+                    "fmt": "1.1k",
+                    "longFmt": "1,099"
+                  },
+                  "value": {
+                    "raw": 2608079,
+                    "fmt": "2.61M",
+                    "longFmt": "2,608,079"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2372.34 - 2374.34 per share.",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589500800,
+                    "fmt": "2020-05-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2791,
+                    "fmt": "2.79k",
+                    "longFmt": "2,791"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589500800,
+                    "fmt": "2020-05-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 292,
+                    "fmt": "292",
+                    "longFmt": "292"
+                  },
+                  "value": {
+                    "raw": 693307,
+                    "fmt": "693.31k",
+                    "longFmt": "693,307"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2374.34 per share.",
+                  "filerName": "REYNOLDS SHELLEY L",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589500800,
+                    "fmt": "2020-05-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 292,
+                    "fmt": "292",
+                    "longFmt": "292"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "REYNOLDS SHELLEY L",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589500800,
+                    "fmt": "2020-05-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 424,
+                    "fmt": "424",
+                    "longFmt": "424"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589500800,
+                    "fmt": "2020-05-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1238,
+                    "fmt": "1.24k",
+                    "longFmt": "1,238"
+                  },
+                  "value": {
+                    "raw": 2935467,
+                    "fmt": "2.94M",
+                    "longFmt": "2,935,467"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2362.98 - 2376.05 per share.",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589500800,
+                    "fmt": "2020-05-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1376,
+                    "fmt": "1.38k",
+                    "longFmt": "1,376"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589500800,
+                    "fmt": "2020-05-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1376,
+                    "fmt": "1.38k",
+                    "longFmt": "1,376"
+                  },
+                  "value": {
+                    "raw": 3267092,
+                    "fmt": "3.27M",
+                    "longFmt": "3,267,092"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2374.34 per share.",
+                  "filerName": "OLSAVSKY BRIAN T.",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589500800,
+                    "fmt": "2020-05-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1376,
+                    "fmt": "1.38k",
+                    "longFmt": "1,376"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "OLSAVSKY BRIAN T.",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589500800,
+                    "fmt": "2020-05-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 550,
+                    "fmt": "550",
+                    "longFmt": "550"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "STONESIFER PATRICIA Q",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2200,
+                    "fmt": "2.2k",
+                    "longFmt": "2,200"
+                  },
+                  "value": {
+                    "raw": 5124768,
+                    "fmt": "5.12M",
+                    "longFmt": "5,124,768"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2329.44 per share.",
+                  "filerName": "STONESIFER PATRICIA Q",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3957,
+                    "fmt": "3.96k",
+                    "longFmt": "3,957"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 437,
+                    "fmt": "437",
+                    "longFmt": "437"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "RUBINSTEIN JONATHAN J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588550400,
+                    "fmt": "2020-05-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6945,
+                    "fmt": "6.95k",
+                    "longFmt": "6,945"
+                  },
+                  "value": {
+                    "raw": 15671392,
+                    "fmt": "15.67M",
+                    "longFmt": "15,671,392"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2256.50 per share.",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588550400,
+                    "fmt": "2020-05-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 352,
+                    "fmt": "352",
+                    "longFmt": "352"
+                  },
+                  "value": {
+                    "raw": 809668,
+                    "fmt": "809.67k",
+                    "longFmt": "809,668"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2300.00 - 2301.61 per share.",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1586908800,
+                    "fmt": "2020-04-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 52967,
+                    "fmt": "52.97k",
+                    "longFmt": "52,967"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1585872000,
+                    "fmt": "2020-04-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 524,
+                    "fmt": "524",
+                    "longFmt": "524"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1583107200,
+                    "fmt": "2020-03-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2049,
+                    "fmt": "2.05k",
+                    "longFmt": "2,049"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582502400,
+                    "fmt": "2020-02-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1000,
+                    "fmt": "1k",
+                    "longFmt": "1,000"
+                  },
+                  "value": {
+                    "raw": 2103212,
+                    "fmt": "2.1M",
+                    "longFmt": "2,103,212"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2093.64 - 2118.80 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582243200,
+                    "fmt": "2020-02-21"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3475,
+                    "fmt": "3.48k",
+                    "longFmt": "3,475"
+                  },
+                  "value": {
+                    "raw": 7471245,
+                    "fmt": "7.47M",
+                    "longFmt": "7,471,245"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2134.47 - 2164.88 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581984000,
+                    "fmt": "2020-02-18"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3178,
+                    "fmt": "3.18k",
+                    "longFmt": "3,178"
+                  },
+                  "value": {
+                    "raw": 6814364,
+                    "fmt": "6.81M",
+                    "longFmt": "6,814,364"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2142.60 - 2145.60 per share.",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581984000,
+                    "fmt": "2020-02-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3573,
+                    "fmt": "3.57k",
+                    "longFmt": "3,573"
+                  },
+                  "value": {
+                    "raw": 7652608,
+                    "fmt": "7.65M",
+                    "longFmt": "7,652,608"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2125.35 - 2147.76 per share.",
+                  "filerName": "BLACKBURN JEFFREY M",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581984000,
+                    "fmt": "2020-02-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 380,
+                    "fmt": "380",
+                    "longFmt": "380"
+                  },
+                  "value": {
+                    "raw": 811354,
+                    "fmt": "811.35k",
+                    "longFmt": "811,354"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2126.00 - 2144.05 per share.",
+                  "filerName": "REYNOLDS SHELLEY L",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581984000,
+                    "fmt": "2020-02-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1685,
+                    "fmt": "1.69k",
+                    "longFmt": "1,685"
+                  },
+                  "value": {
+                    "raw": 3601156,
+                    "fmt": "3.6M",
+                    "longFmt": "3,601,156"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2125.02 - 2147.45 per share.",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581984000,
+                    "fmt": "2020-02-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1765,
+                    "fmt": "1.76k",
+                    "longFmt": "1,765"
+                  },
+                  "value": {
+                    "raw": 3750660,
+                    "fmt": "3.75M",
+                    "longFmt": "3,750,660"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2125.02 per share.",
+                  "filerName": "OLSAVSKY BRIAN T.",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581984000,
+                    "fmt": "2020-02-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 190,
+                    "fmt": "190",
+                    "longFmt": "190"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "WEEKS WENDELL P.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581638400,
+                    "fmt": "2020-02-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8073,
+                    "fmt": "8.07k",
+                    "longFmt": "8,073"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581638400,
+                    "fmt": "2020-02-14"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 207,
+                    "fmt": "207",
+                    "longFmt": "207"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "GORELICK JAMIE S. J.D.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581638400,
+                    "fmt": "2020-02-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 190,
+                    "fmt": "190",
+                    "longFmt": "190"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "BREWER ROSALIND G",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581638400,
+                    "fmt": "2020-02-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8073,
+                    "fmt": "8.07k",
+                    "longFmt": "8,073"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581638400,
+                    "fmt": "2020-02-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3573,
+                    "fmt": "3.57k",
+                    "longFmt": "3,573"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "BLACKBURN JEFFREY M",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581638400,
+                    "fmt": "2020-02-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 380,
+                    "fmt": "380",
+                    "longFmt": "380"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "REYNOLDS SHELLEY L",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581638400,
+                    "fmt": "2020-02-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1765,
+                    "fmt": "1.76k",
+                    "longFmt": "1,765"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581638400,
+                    "fmt": "2020-02-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1765,
+                    "fmt": "1.76k",
+                    "longFmt": "1,765"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "OLSAVSKY BRIAN T.",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581638400,
+                    "fmt": "2020-02-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 250,
+                    "fmt": "250",
+                    "longFmt": "250"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GORELICK JAMIE S. J.D.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581033600,
+                    "fmt": "2020-02-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 283632,
+                    "fmt": "283.63k",
+                    "longFmt": "283,632"
+                  },
+                  "value": {
+                    "raw": 579803224,
+                    "fmt": "579.8M",
+                    "longFmt": "579,803,224"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2026.49 - 2056.18 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580947200,
+                    "fmt": "2020-02-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 486226,
+                    "fmt": "486.23k",
+                    "longFmt": "486,226"
+                  },
+                  "value": {
+                    "raw": 987950131,
+                    "fmt": "987.95M",
+                    "longFmt": "987,950,131"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2016.94 - 2041.54 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580860800,
+                    "fmt": "2020-02-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 324686,
+                    "fmt": "324.69k",
+                    "longFmt": "324,686"
+                  },
+                  "value": {
+                    "raw": 666158144,
+                    "fmt": "666.16M",
+                    "longFmt": "666,158,144"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2042.42 - 2070.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580860800,
+                    "fmt": "2020-02-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 229981,
+                    "fmt": "229.98k",
+                    "longFmt": "229,981"
+                  },
+                  "value": {
+                    "raw": 465004659,
+                    "fmt": "465M",
+                    "longFmt": "465,004,659"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2004.85 - 2053.62 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580688000,
+                    "fmt": "2020-02-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 364684,
+                    "fmt": "364.68k",
+                    "longFmt": "364,684"
+                  },
+                  "value": {
+                    "raw": 742649707,
+                    "fmt": "742.65M",
+                    "longFmt": "742,649,707"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2028.19 - 2048.42 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580688000,
+                    "fmt": "2020-02-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 200,
+                    "fmt": "200",
+                    "longFmt": "200"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580688000,
+                    "fmt": "2020-02-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6945,
+                    "fmt": "6.95k",
+                    "longFmt": "6,945"
+                  },
+                  "value": {
+                    "raw": 14025906,
+                    "fmt": "14.03M",
+                    "longFmt": "14,025,906"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2011.77 - 2025.69 per share.",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580688000,
+                    "fmt": "2020-02-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 310791,
+                    "fmt": "310.79k",
+                    "longFmt": "310,791"
+                  },
+                  "value": {
+                    "raw": 629448719,
+                    "fmt": "629.45M",
+                    "longFmt": "629,448,719"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 2003.15 - 2042.47 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580428800,
+                    "fmt": "2020-01-31"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 705,
+                    "fmt": "705",
+                    "longFmt": "705"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580428800,
+                    "fmt": "2020-01-31"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3700,
+                    "fmt": "3.7k",
+                    "longFmt": "3,700"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1577404800,
+                    "fmt": "2019-12-27"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 200,
+                    "fmt": "200",
+                    "longFmt": "200"
+                  },
+                  "value": {
+                    "raw": 373067,
+                    "fmt": "373.07k",
+                    "longFmt": "373,067"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1862.03 - 1868.64 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1577318400,
+                    "fmt": "2019-12-26"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 281,
+                    "fmt": "281",
+                    "longFmt": "281"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "RYDER THOMAS O",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1575244800,
+                    "fmt": "2019-12-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 56702,
+                    "fmt": "56.7k",
+                    "longFmt": "56,702"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1574294400,
+                    "fmt": "2019-11-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1000,
+                    "fmt": "1k",
+                    "longFmt": "1,000"
+                  },
+                  "value": {
+                    "raw": 1748043,
+                    "fmt": "1.75M",
+                    "longFmt": "1,748,043"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1736.51 - 1760.18 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1574208000,
+                    "fmt": "2019-11-20"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 359,
+                    "fmt": "359",
+                    "longFmt": "359"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "STONESIFER PATRICIA Q",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 359,
+                    "fmt": "359",
+                    "longFmt": "359"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "RUBINSTEIN JONATHAN J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 359,
+                    "fmt": "359",
+                    "longFmt": "359"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "RYDER THOMAS O",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3475,
+                    "fmt": "3.48k",
+                    "longFmt": "3,475"
+                  },
+                  "value": {
+                    "raw": 6065867,
+                    "fmt": "6.07M",
+                    "longFmt": "6,065,867"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1733.00 - 1751.48 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8073,
+                    "fmt": "8.07k",
+                    "longFmt": "8,073"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3230,
+                    "fmt": "3.23k",
+                    "longFmt": "3,230"
+                  },
+                  "value": {
+                    "raw": 5659554,
+                    "fmt": "5.66M",
+                    "longFmt": "5,659,554"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1745.90 - 1759.86 per share.",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8073,
+                    "fmt": "8.07k",
+                    "longFmt": "8,073"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3573,
+                    "fmt": "3.57k",
+                    "longFmt": "3,573"
+                  },
+                  "value": {
+                    "raw": 6260717,
+                    "fmt": "6.26M",
+                    "longFmt": "6,260,717"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1745.64 - 1759.97 per share.",
+                  "filerName": "BLACKBURN JEFFREY M",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3573,
+                    "fmt": "3.57k",
+                    "longFmt": "3,573"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "BLACKBURN JEFFREY M",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 379,
+                    "fmt": "379",
+                    "longFmt": "379"
+                  },
+                  "value": {
+                    "raw": 663499,
+                    "fmt": "663.5k",
+                    "longFmt": "663,499"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1745.46 - 1760.82 per share.",
+                  "filerName": "REYNOLDS SHELLEY L",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 379,
+                    "fmt": "379",
+                    "longFmt": "379"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "REYNOLDS SHELLEY L",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 222,
+                    "fmt": "222",
+                    "longFmt": "222"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 880,
+                    "fmt": "880",
+                    "longFmt": "880"
+                  },
+                  "value": {
+                    "raw": 1540567,
+                    "fmt": "1.54M",
+                    "longFmt": "1,540,567"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1746.20 - 1759.34 per share.",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1765,
+                    "fmt": "1.76k",
+                    "longFmt": "1,765"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "ZAPOLSKY DAVID",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 377,
+                    "fmt": "377",
+                    "longFmt": "377"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "HUTTENLOCHER DANIEL P",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1265,
+                    "fmt": "1.26k",
+                    "longFmt": "1,265"
+                  },
+                  "value": {
+                    "raw": 2226463,
+                    "fmt": "2.23M",
+                    "longFmt": "2,226,463"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1760.05 per share.",
+                  "filerName": "OLSAVSKY BRIAN T.",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1765,
+                    "fmt": "1.76k",
+                    "longFmt": "1,765"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "OLSAVSKY BRIAN T.",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2441,
+                    "fmt": "2.44k",
+                    "longFmt": "2,441"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BEZOS JEFFREY P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573603200,
+                    "fmt": "2019-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 304,
+                    "fmt": "304",
+                    "longFmt": "304"
+                  },
+                  "value": {
+                    "raw": 531973,
+                    "fmt": "531.97k",
+                    "longFmt": "531,973"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1749.91 per share.",
+                  "filerName": "MCGRATH JUDITH A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1572220800,
+                    "fmt": "2019-10-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2800,
+                    "fmt": "2.8k",
+                    "longFmt": "2,800"
+                  },
+                  "value": {
+                    "raw": 5173031,
+                    "fmt": "5.17M",
+                    "longFmt": "5,173,031"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1846.48 - 1852.01 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1568246400,
+                    "fmt": "2019-09-12"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2500,
+                    "fmt": "2.5k",
+                    "longFmt": "2,500"
+                  },
+                  "value": {
+                    "raw": 4480255,
+                    "fmt": "4.48M",
+                    "longFmt": "4,480,255"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1781.94 - 1799.81 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1567468800,
+                    "fmt": "2019-09-03"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7144,
+                    "fmt": "7.14k",
+                    "longFmt": "7,144"
+                  },
+                  "value": {
+                    "raw": 12797740,
+                    "fmt": "12.8M",
+                    "longFmt": "12,797,740"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1778.15 - 1797.60 per share.",
+                  "filerName": "BLACKBURN JEFFREY M",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1567036800,
+                    "fmt": "2019-08-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2500,
+                    "fmt": "2.5k",
+                    "longFmt": "2,500"
+                  },
+                  "value": {
+                    "raw": 4397582,
+                    "fmt": "4.4M",
+                    "longFmt": "4,397,582"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1749.92 - 1766.52 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1566777600,
+                    "fmt": "2019-08-26"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 277,
+                    "fmt": "277",
+                    "longFmt": "277"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "RUBINSTEIN JONATHAN J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1566259200,
+                    "fmt": "2019-08-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1000,
+                    "fmt": "1k",
+                    "longFmt": "1,000"
+                  },
+                  "value": {
+                    "raw": 1809204,
+                    "fmt": "1.81M",
+                    "longFmt": "1,809,204"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1804.48 - 1813.28 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1566259200,
+                    "fmt": "2019-08-20"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3475,
+                    "fmt": "3.48k",
+                    "longFmt": "3,475"
+                  },
+                  "value": {
+                    "raw": 6164625,
+                    "fmt": "6.16M",
+                    "longFmt": "6,164,625"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1765.07 - 1780.13 per share.",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1565827200,
+                    "fmt": "2019-08-15"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8072,
+                    "fmt": "8.07k",
+                    "longFmt": "8,072"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "WILKE JEFFREY A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1565827200,
+                    "fmt": "2019-08-15"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3230,
+                    "fmt": "3.23k",
+                    "longFmt": "3,230"
+                  },
+                  "value": {
+                    "raw": 5734363,
+                    "fmt": "5.73M",
+                    "longFmt": "5,734,363"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 1768.36 - 1787.05 per share.",
+                  "filerName": "JASSY ANDREW R",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1565827200,
+                    "fmt": "2019-08-15"
+                  },
+                  "ownership": "D"
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderTransactions-AZT.OL.json
+++ b/tests/http/quoteSummary-insiderTransactions-AZT.OL.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=insiderTransactions"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "ecunku5g2nrrc"
+      ],
+      "x-yahoo-request-id": [
+        "ecunku5g2nrrc"
+      ],
+      "x-request-id": [
+        "1c2b5f4a-54e9-4c59-8e81-e08fdc3a6841"
+      ],
+      "content-length": [
+        "152"
+      ],
+      "x-envoy-upstream-service-time": [
+        "5"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:35 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=insiderTransactions"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderTransactions-SIX.json
+++ b/tests/http/quoteSummary-insiderTransactions-SIX.json
@@ -1,0 +1,3536 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=insiderTransactions"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "coeftstg2nuhc"
+      ],
+      "x-yahoo-request-id": [
+        "coeftstg2nuhc"
+      ],
+      "x-request-id": [
+        "f9f8928b-056c-4f4d-a788-c72e0a02dd4f"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:27 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "insiderTransactions": {
+              "transactions": [
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1102,
+                    "fmt": "1.1k",
+                    "longFmt": "1,102"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BALDANZA BASIL BEN",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1973,
+                    "fmt": "1.97k",
+                    "longFmt": "1,973"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BASSOUL SELIM A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 603,
+                    "fmt": "603",
+                    "longFmt": "603"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROEDEL RICHARD W",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2041,
+                    "fmt": "2.04k",
+                    "longFmt": "2,041"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "KREJSA NANCY A.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1008,
+                    "fmt": "1.01k",
+                    "longFmt": "1,008"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BRACEY ESI EGGLESTON",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611878400,
+                    "fmt": "2021-01-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 13677,
+                    "fmt": "13.68k",
+                    "longFmt": "13,677"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "ROEDEL RICHARD W",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1609200000,
+                    "fmt": "2020-12-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 902,
+                    "fmt": "902",
+                    "longFmt": "902"
+                  },
+                  "value": {
+                    "raw": 27977,
+                    "fmt": "27.98k",
+                    "longFmt": "27,977"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 31.02 per share.",
+                  "filerName": "SPANOS MICHAEL",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606089600,
+                    "fmt": "2020-11-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3505,
+                    "fmt": "3.5k",
+                    "longFmt": "3,505"
+                  },
+                  "value": {
+                    "raw": 103993,
+                    "fmt": "103.99k",
+                    "longFmt": "103,993"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 29.67 per share.",
+                  "filerName": "SPANOS MICHAEL",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3900,
+                    "fmt": "3.9k",
+                    "longFmt": "3,900"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SPANOS MICHAEL",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 25000,
+                    "fmt": "25k",
+                    "longFmt": "25,000"
+                  },
+                  "value": {
+                    "raw": 725750,
+                    "fmt": "725.75k",
+                    "longFmt": "725,750"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 29.03 per share.",
+                  "filerName": "KREJSA NANCY A.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604966400,
+                    "fmt": "2020-11-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5700,
+                    "fmt": "5.7k",
+                    "longFmt": "5,700"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "KREJSA NANCY A.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604275200,
+                    "fmt": "2020-11-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4470,
+                    "fmt": "4.47k",
+                    "longFmt": "4,470"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1601596800,
+                    "fmt": "2020-10-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5004,
+                    "fmt": "5k",
+                    "longFmt": "5,004"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1601596800,
+                    "fmt": "2020-10-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1730,
+                    "fmt": "1.73k",
+                    "longFmt": "1,730"
+                  },
+                  "value": {
+                    "raw": 36814,
+                    "fmt": "36.81k",
+                    "longFmt": "36,814"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 21.28 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1599177600,
+                    "fmt": "2020-09-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 444,
+                    "fmt": "444",
+                    "longFmt": "444"
+                  },
+                  "value": {
+                    "raw": 9448,
+                    "fmt": "9.45k",
+                    "longFmt": "9,448"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 21.28 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1599177600,
+                    "fmt": "2020-09-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3459,
+                    "fmt": "3.46k",
+                    "longFmt": "3,459"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598572800,
+                    "fmt": "2020-08-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3459,
+                    "fmt": "3.46k",
+                    "longFmt": "3,459"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598572800,
+                    "fmt": "2020-08-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1109,
+                    "fmt": "1.11k",
+                    "longFmt": "1,109"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598572800,
+                    "fmt": "2020-08-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 147,
+                    "fmt": "147",
+                    "longFmt": "147"
+                  },
+                  "value": {
+                    "raw": 3087,
+                    "fmt": "3.09k",
+                    "longFmt": "3,087"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 21.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598486400,
+                    "fmt": "2020-08-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 117,
+                    "fmt": "117",
+                    "longFmt": "117"
+                  },
+                  "value": {
+                    "raw": 2457,
+                    "fmt": "2.46k",
+                    "longFmt": "2,457"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 21.00 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598486400,
+                    "fmt": "2020-08-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1956,
+                    "fmt": "1.96k",
+                    "longFmt": "1,956"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598227200,
+                    "fmt": "2020-08-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 293,
+                    "fmt": "293",
+                    "longFmt": "293"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598227200,
+                    "fmt": "2020-08-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 293,
+                    "fmt": "293",
+                    "longFmt": "293"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598227200,
+                    "fmt": "2020-08-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6976,
+                    "fmt": "6.98k",
+                    "longFmt": "6,976"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BRACEY ESI EGGLESTON",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596585600,
+                    "fmt": "2020-08-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 329,
+                    "fmt": "329",
+                    "longFmt": "329"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RUSS LEONARD A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1593648000,
+                    "fmt": "2020-07-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 90590,
+                    "fmt": "90.59k",
+                    "longFmt": "90,590"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "REDDY SANDEEP",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1593561600,
+                    "fmt": "2020-07-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1011,
+                    "fmt": "1.01k",
+                    "longFmt": "1,011"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "ROEDEL RICHARD W",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589155200,
+                    "fmt": "2020-05-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2970,
+                    "fmt": "2.97k",
+                    "longFmt": "2,970"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "ROEDEL RICHARD W",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588809600,
+                    "fmt": "2020-05-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8417,
+                    "fmt": "8.42k",
+                    "longFmt": "8,417"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BALDANZA BASIL BEN",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8417,
+                    "fmt": "8.42k",
+                    "longFmt": "8,417"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BASSOUL SELIM A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 19324,
+                    "fmt": "19.32k",
+                    "longFmt": "19,324"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROEDEL RICHARD W",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8417,
+                    "fmt": "8.42k",
+                    "longFmt": "8,417"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CELLAR KURT MATTHEW",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 22658,
+                    "fmt": "22.66k",
+                    "longFmt": "22,658"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 22658,
+                    "fmt": "22.66k",
+                    "longFmt": "22,658"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RUSS LEONARD A",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 42083,
+                    "fmt": "42.08k",
+                    "longFmt": "42,083"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DOERRE LAURA W.",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8417,
+                    "fmt": "8.42k",
+                    "longFmt": "8,417"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "KREJSA NANCY A.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 315623,
+                    "fmt": "315.62k",
+                    "longFmt": "315,623"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SPANOS MICHAEL",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 22658,
+                    "fmt": "22.66k",
+                    "longFmt": "22,658"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10621,
+                    "fmt": "10.62k",
+                    "longFmt": "10,621"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588723200,
+                    "fmt": "2020-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6135,
+                    "fmt": "6.13k",
+                    "longFmt": "6,135"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RUSS LEONARD A",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1585699200,
+                    "fmt": "2020-04-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 31546,
+                    "fmt": "31.55k",
+                    "longFmt": "31,546"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DOERRE LAURA W.",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1583712000,
+                    "fmt": "2020-03-09"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 800,
+                    "fmt": "800",
+                    "longFmt": "800"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BALDANZA BASIL BEN",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582502400,
+                    "fmt": "2020-02-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 800,
+                    "fmt": "800",
+                    "longFmt": "800"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BASSOUL SELIM A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582502400,
+                    "fmt": "2020-02-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5360,
+                    "fmt": "5.36k",
+                    "longFmt": "5,360"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582070400,
+                    "fmt": "2020-02-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 297,
+                    "fmt": "297",
+                    "longFmt": "297"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BALK LANCE C",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581033600,
+                    "fmt": "2020-02-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 297,
+                    "fmt": "297",
+                    "longFmt": "297"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581033600,
+                    "fmt": "2020-02-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 297,
+                    "fmt": "297",
+                    "longFmt": "297"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581033600,
+                    "fmt": "2020-02-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 178,
+                    "fmt": "178",
+                    "longFmt": "178"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581033600,
+                    "fmt": "2020-02-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 169,
+                    "fmt": "169",
+                    "longFmt": "169"
+                  },
+                  "value": {
+                    "raw": 7512,
+                    "fmt": "7.51k",
+                    "longFmt": "7,512"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 44.45 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1578355200,
+                    "fmt": "2020-01-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 338,
+                    "fmt": "338",
+                    "longFmt": "338"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1578009600,
+                    "fmt": "2020-01-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10000,
+                    "fmt": "10k",
+                    "longFmt": "10,000"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BALK LANCE C",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1575504000,
+                    "fmt": "2019-12-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1011,
+                    "fmt": "1.01k",
+                    "longFmt": "1,011"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROEDEL RICHARD W",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1574035200,
+                    "fmt": "2019-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 48282,
+                    "fmt": "48.28k",
+                    "longFmt": "48,282"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Former",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1574035200,
+                    "fmt": "2019-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 43431,
+                    "fmt": "43.43k",
+                    "longFmt": "43,431"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SPANOS MICHAEL",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1574035200,
+                    "fmt": "2019-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 85,
+                    "fmt": "85",
+                    "longFmt": "85"
+                  },
+                  "value": {
+                    "raw": 4954,
+                    "fmt": "4.95k",
+                    "longFmt": "4,954"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 58.28 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1567555200,
+                    "fmt": "2019-09-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 990,
+                    "fmt": "990",
+                    "longFmt": "990"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BALK LANCE C",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1567123200,
+                    "fmt": "2019-08-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 990,
+                    "fmt": "990",
+                    "longFmt": "990"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1567123200,
+                    "fmt": "2019-08-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 791,
+                    "fmt": "791",
+                    "longFmt": "791"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1567123200,
+                    "fmt": "2019-08-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 791,
+                    "fmt": "791",
+                    "longFmt": "791"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1567123200,
+                    "fmt": "2019-08-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 213,
+                    "fmt": "213",
+                    "longFmt": "213"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1567123200,
+                    "fmt": "2019-08-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 468,
+                    "fmt": "468",
+                    "longFmt": "468"
+                  },
+                  "value": {
+                    "raw": 27603,
+                    "fmt": "27.6k",
+                    "longFmt": "27,603"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 58.98 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1566864000,
+                    "fmt": "2019-08-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 90,
+                    "fmt": "90",
+                    "longFmt": "90"
+                  },
+                  "value": {
+                    "raw": 5308,
+                    "fmt": "5.31k",
+                    "longFmt": "5,308"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 58.98 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1566864000,
+                    "fmt": "2019-08-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1500,
+                    "fmt": "1.5k",
+                    "longFmt": "1,500"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BALK LANCE C",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1566518400,
+                    "fmt": "2019-08-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 935,
+                    "fmt": "935",
+                    "longFmt": "935"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1566518400,
+                    "fmt": "2019-08-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1500,
+                    "fmt": "1.5k",
+                    "longFmt": "1,500"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1566518400,
+                    "fmt": "2019-08-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 224,
+                    "fmt": "224",
+                    "longFmt": "224"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1566518400,
+                    "fmt": "2019-08-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 224,
+                    "fmt": "224",
+                    "longFmt": "224"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1566518400,
+                    "fmt": "2019-08-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2800,
+                    "fmt": "2.8k",
+                    "longFmt": "2,800"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "KREJSA NANCY A.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1566345600,
+                    "fmt": "2019-08-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 14378,
+                    "fmt": "14.38k",
+                    "longFmt": "14,378"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1563408000,
+                    "fmt": "2019-07-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2520,
+                    "fmt": "2.52k",
+                    "longFmt": "2,520"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "ROEDEL RICHARD W",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1557273600,
+                    "fmt": "2019-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4965,
+                    "fmt": "4.96k",
+                    "longFmt": "4,965"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROEDEL RICHARD W",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556668800,
+                    "fmt": "2019-05-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2970,
+                    "fmt": "2.97k",
+                    "longFmt": "2,970"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CELLAR KURT MATTHEW",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556668800,
+                    "fmt": "2019-05-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2970,
+                    "fmt": "2.97k",
+                    "longFmt": "2,970"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "OWENS STEPHEN D",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556668800,
+                    "fmt": "2019-05-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3666,
+                    "fmt": "3.67k",
+                    "longFmt": "3,666"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "LUTHER JON L",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556668800,
+                    "fmt": "2019-05-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4269,
+                    "fmt": "4.27k",
+                    "longFmt": "4,269"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "NABI USMAN S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556668800,
+                    "fmt": "2019-05-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2970,
+                    "fmt": "2.97k",
+                    "longFmt": "2,970"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "KREJSA NANCY A.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556668800,
+                    "fmt": "2019-05-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2865,
+                    "fmt": "2.87k",
+                    "longFmt": "2,865"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1551657600,
+                    "fmt": "2019-03-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 286,
+                    "fmt": "286",
+                    "longFmt": "286"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1551657600,
+                    "fmt": "2019-03-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1275,
+                    "fmt": "1.27k",
+                    "longFmt": "1,275"
+                  },
+                  "value": {
+                    "raw": 72012,
+                    "fmt": "72.01k",
+                    "longFmt": "72,012"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 56.48 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550793600,
+                    "fmt": "2019-02-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 20439,
+                    "fmt": "20.44k",
+                    "longFmt": "20,439"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550707200,
+                    "fmt": "2019-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 112500,
+                    "fmt": "112.5k",
+                    "longFmt": "112,500"
+                  },
+                  "value": {
+                    "raw": 5591250,
+                    "fmt": "5.59M",
+                    "longFmt": "5,591,250"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 47.60 - 51.38 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550534400,
+                    "fmt": "2019-02-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2550,
+                    "fmt": "2.55k",
+                    "longFmt": "2,550"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550534400,
+                    "fmt": "2019-02-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 114,
+                    "fmt": "114",
+                    "longFmt": "114"
+                  },
+                  "value": {
+                    "raw": 7233,
+                    "fmt": "7.23k",
+                    "longFmt": "7,233"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 63.45 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550016000,
+                    "fmt": "2019-02-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 114,
+                    "fmt": "114",
+                    "longFmt": "114"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BALK LANCE C",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1549584000,
+                    "fmt": "2019-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 114,
+                    "fmt": "114",
+                    "longFmt": "114"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1549584000,
+                    "fmt": "2019-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 114,
+                    "fmt": "114",
+                    "longFmt": "114"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1549584000,
+                    "fmt": "2019-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 68,
+                    "fmt": "68",
+                    "longFmt": "68"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1549584000,
+                    "fmt": "2019-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 27750,
+                    "fmt": "27.75k",
+                    "longFmt": "27,750"
+                  },
+                  "value": {
+                    "raw": 1748250,
+                    "fmt": "1.75M",
+                    "longFmt": "1,748,250"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 63.00 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1547596800,
+                    "fmt": "2019-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 27750,
+                    "fmt": "27.75k",
+                    "longFmt": "27,750"
+                  },
+                  "value": {
+                    "raw": 1073722,
+                    "fmt": "1.07M",
+                    "longFmt": "1,073,722"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 34.49 - 42.34 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1547596800,
+                    "fmt": "2019-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 325,
+                    "fmt": "325",
+                    "longFmt": "325"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "KREJSA NANCY A.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1547164800,
+                    "fmt": "2019-01-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 174,
+                    "fmt": "174",
+                    "longFmt": "174"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1546473600,
+                    "fmt": "2019-01-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1860,
+                    "fmt": "1.86k",
+                    "longFmt": "1,860"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "KREJSA NANCY A.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1544400000,
+                    "fmt": "2018-12-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 69,
+                    "fmt": "69",
+                    "longFmt": "69"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BALK LANCE C",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1536537600,
+                    "fmt": "2018-09-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 69,
+                    "fmt": "69",
+                    "longFmt": "69"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1536537600,
+                    "fmt": "2018-09-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10768,
+                    "fmt": "10.77k",
+                    "longFmt": "10,768"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "CELLAR KURT MATTHEW",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1536537600,
+                    "fmt": "2018-09-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 55,
+                    "fmt": "55",
+                    "longFmt": "55"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1536537600,
+                    "fmt": "2018-09-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 55,
+                    "fmt": "55",
+                    "longFmt": "55"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1536537600,
+                    "fmt": "2018-09-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8,
+                    "fmt": "8",
+                    "longFmt": "8"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1536537600,
+                    "fmt": "2018-09-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10,
+                    "fmt": "10",
+                    "longFmt": "10"
+                  },
+                  "value": {
+                    "raw": 686,
+                    "fmt": "686",
+                    "longFmt": "686"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 68.60 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1536192000,
+                    "fmt": "2018-09-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 277,
+                    "fmt": "277",
+                    "longFmt": "277"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BALK LANCE C",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535587200,
+                    "fmt": "2018-08-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 277,
+                    "fmt": "277",
+                    "longFmt": "277"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535587200,
+                    "fmt": "2018-08-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 222,
+                    "fmt": "222",
+                    "longFmt": "222"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535587200,
+                    "fmt": "2018-08-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 222,
+                    "fmt": "222",
+                    "longFmt": "222"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535587200,
+                    "fmt": "2018-08-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 33,
+                    "fmt": "33",
+                    "longFmt": "33"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535587200,
+                    "fmt": "2018-08-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 62500,
+                    "fmt": "62.5k",
+                    "longFmt": "62,500"
+                  },
+                  "value": {
+                    "raw": 2346250,
+                    "fmt": "2.35M",
+                    "longFmt": "2,346,250"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 37.54 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535414400,
+                    "fmt": "2018-08-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 449,
+                    "fmt": "449",
+                    "longFmt": "449"
+                  },
+                  "value": {
+                    "raw": 29279,
+                    "fmt": "29.28k",
+                    "longFmt": "29,279"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 65.21 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535414400,
+                    "fmt": "2018-08-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 50,
+                    "fmt": "50",
+                    "longFmt": "50"
+                  },
+                  "value": {
+                    "raw": 3260,
+                    "fmt": "3.26k",
+                    "longFmt": "3,260"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 65.21 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535414400,
+                    "fmt": "2018-08-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2425,
+                    "fmt": "2.42k",
+                    "longFmt": "2,425"
+                  },
+                  "value": {
+                    "raw": 162111,
+                    "fmt": "162.11k",
+                    "longFmt": "162,111"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 66.85 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535328000,
+                    "fmt": "2018-08-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3000,
+                    "fmt": "3k",
+                    "longFmt": "3,000"
+                  },
+                  "value": {
+                    "raw": 103470,
+                    "fmt": "103.47k",
+                    "longFmt": "103,470"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 34.49 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535328000,
+                    "fmt": "2018-08-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1973,
+                    "fmt": "1.97k",
+                    "longFmt": "1,973"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BALK LANCE C",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535068800,
+                    "fmt": "2018-08-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9109,
+                    "fmt": "9.11k",
+                    "longFmt": "9,109"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535068800,
+                    "fmt": "2018-08-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 898,
+                    "fmt": "898",
+                    "longFmt": "898"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535068800,
+                    "fmt": "2018-08-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1790,
+                    "fmt": "1.79k",
+                    "longFmt": "1,790"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535068800,
+                    "fmt": "2018-08-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 258,
+                    "fmt": "258",
+                    "longFmt": "258"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535068800,
+                    "fmt": "2018-08-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 167,
+                    "fmt": "167",
+                    "longFmt": "167"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BROOKS WILSON TAYLOR",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1535068800,
+                    "fmt": "2018-08-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5191,
+                    "fmt": "5.19k",
+                    "longFmt": "5,191"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1531872000,
+                    "fmt": "2018-07-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 125000,
+                    "fmt": "125k",
+                    "longFmt": "125,000"
+                  },
+                  "value": {
+                    "raw": 7126250,
+                    "fmt": "7.13M",
+                    "longFmt": "7,126,250"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 57.01 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1531872000,
+                    "fmt": "2018-07-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9062,
+                    "fmt": "9.06k",
+                    "longFmt": "9,062"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "BALK LANCE C",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1529452800,
+                    "fmt": "2018-06-20"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 35815,
+                    "fmt": "35.81k",
+                    "longFmt": "35,815"
+                  },
+                  "value": {
+                    "raw": 2597693,
+                    "fmt": "2.6M",
+                    "longFmt": "2,597,693"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 72.50 - 72.53 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1529452800,
+                    "fmt": "2018-06-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 64185,
+                    "fmt": "64.19k",
+                    "longFmt": "64,185"
+                  },
+                  "value": {
+                    "raw": 4657311,
+                    "fmt": "4.66M",
+                    "longFmt": "4,657,311"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 72.49 - 72.57 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1529020800,
+                    "fmt": "2018-06-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 100000,
+                    "fmt": "100k",
+                    "longFmt": "100,000"
+                  },
+                  "value": {
+                    "raw": 7014783,
+                    "fmt": "7.01M",
+                    "longFmt": "7,014,783"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 70.09 - 70.16 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "President",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1528416000,
+                    "fmt": "2018-06-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2429,
+                    "fmt": "2.43k",
+                    "longFmt": "2,429"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "ROEDEL RICHARD W",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1526515200,
+                    "fmt": "2018-05-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4065,
+                    "fmt": "4.07k",
+                    "longFmt": "4,065"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROEDEL RICHARD W",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525219200,
+                    "fmt": "2018-05-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2520,
+                    "fmt": "2.52k",
+                    "longFmt": "2,520"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CELLAR KURT MATTHEW",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525219200,
+                    "fmt": "2018-05-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2520,
+                    "fmt": "2.52k",
+                    "longFmt": "2,520"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "OWENS STEPHEN D",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525219200,
+                    "fmt": "2018-05-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4065,
+                    "fmt": "4.07k",
+                    "longFmt": "4,065"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "LUTHER JON L",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525219200,
+                    "fmt": "2018-05-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2520,
+                    "fmt": "2.52k",
+                    "longFmt": "2,520"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "NABI USMAN S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525219200,
+                    "fmt": "2018-05-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2520,
+                    "fmt": "2.52k",
+                    "longFmt": "2,520"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "KREJSA NANCY A.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525219200,
+                    "fmt": "2018-05-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1809,
+                    "fmt": "1.81k",
+                    "longFmt": "1,809"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1520208000,
+                    "fmt": "2018-03-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 226,
+                    "fmt": "226",
+                    "longFmt": "226"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1520208000,
+                    "fmt": "2018-03-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 100000,
+                    "fmt": "100k",
+                    "longFmt": "100,000"
+                  },
+                  "value": {
+                    "raw": 6566645,
+                    "fmt": "6.57M",
+                    "longFmt": "6,566,645"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 65.49 - 66.40 per share.",
+                  "filerName": "BALK LANCE C",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519689600,
+                    "fmt": "2018-02-27"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5166,
+                    "fmt": "5.17k",
+                    "longFmt": "5,166"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519603200,
+                    "fmt": "2018-02-26"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 597,
+                    "fmt": "597",
+                    "longFmt": "597"
+                  },
+                  "value": {
+                    "raw": 39742,
+                    "fmt": "39.74k",
+                    "longFmt": "39,742"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 66.57 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519171200,
+                    "fmt": "2018-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 150000,
+                    "fmt": "150k",
+                    "longFmt": "150,000"
+                  },
+                  "value": {
+                    "raw": 7092000,
+                    "fmt": "7.09M",
+                    "longFmt": "7,092,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 40.02 - 51.38 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519084800,
+                    "fmt": "2018-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 13653,
+                    "fmt": "13.65k",
+                    "longFmt": "13,653"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518998400,
+                    "fmt": "2018-02-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1194,
+                    "fmt": "1.19k",
+                    "longFmt": "1,194"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518998400,
+                    "fmt": "2018-02-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 26,
+                    "fmt": "26",
+                    "longFmt": "26"
+                  },
+                  "value": {
+                    "raw": 1703,
+                    "fmt": "1.7k",
+                    "longFmt": "1,703"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 65.51 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518480000,
+                    "fmt": "2018-02-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 24,
+                    "fmt": "24",
+                    "longFmt": "24"
+                  },
+                  "value": {
+                    "raw": 1572,
+                    "fmt": "1.57k",
+                    "longFmt": "1,572"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 65.51 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518480000,
+                    "fmt": "2018-02-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 51,
+                    "fmt": "51",
+                    "longFmt": "51"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BALK LANCE C",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518048000,
+                    "fmt": "2018-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 51,
+                    "fmt": "51",
+                    "longFmt": "51"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BARBER MARSHALL WILLIAM",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518048000,
+                    "fmt": "2018-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 51,
+                    "fmt": "51",
+                    "longFmt": "51"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETIT BRETT",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518048000,
+                    "fmt": "2018-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 20,
+                    "fmt": "20",
+                    "longFmt": "20"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CENTOLA MARIO L",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518048000,
+                    "fmt": "2018-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 30,
+                    "fmt": "30",
+                    "longFmt": "30"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518048000,
+                    "fmt": "2018-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 54,
+                    "fmt": "54",
+                    "longFmt": "54"
+                  },
+                  "value": {
+                    "raw": 3578,
+                    "fmt": "3.58k",
+                    "longFmt": "3,578"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 66.26 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1515456000,
+                    "fmt": "2018-01-09"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 30976,
+                    "fmt": "30.98k",
+                    "longFmt": "30,976"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1514937600,
+                    "fmt": "2018-01-03"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 30976,
+                    "fmt": "30.98k",
+                    "longFmt": "30,976"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1514937600,
+                    "fmt": "2018-01-03"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 67,
+                    "fmt": "67",
+                    "longFmt": "67"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ASLIN CATHERINE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1514937600,
+                    "fmt": "2018-01-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 77310,
+                    "fmt": "77.31k",
+                    "longFmt": "77,310"
+                  },
+                  "value": {
+                    "raw": 5220312,
+                    "fmt": "5.22M",
+                    "longFmt": "5,220,312"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 67.52 - 67.53 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1513900800,
+                    "fmt": "2017-12-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 800,
+                    "fmt": "800",
+                    "longFmt": "800"
+                  },
+                  "value": {
+                    "raw": 53880,
+                    "fmt": "53.88k",
+                    "longFmt": "53,880"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 67.35 per share.",
+                  "filerName": "KREJSA NANCY A.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1513814400,
+                    "fmt": "2017-12-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 42690,
+                    "fmt": "42.69k",
+                    "longFmt": "42,690"
+                  },
+                  "value": {
+                    "raw": 2883983,
+                    "fmt": "2.88M",
+                    "longFmt": "2,883,983"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 67.56 per share.",
+                  "filerName": "REID-ANDERSON JAMES W P",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1513641600,
+                    "fmt": "2017-12-19"
+                  },
+                  "ownership": "D"
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderTransactions-WSKT.JK.json
+++ b/tests/http/quoteSummary-insiderTransactions-WSKT.JK.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=insiderTransactions"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "cu9ln1pg2nuhb"
+      ],
+      "x-yahoo-request-id": [
+        "cu9ln1pg2nuhb"
+      ],
+      "x-request-id": [
+        "2c8e5d05-0cea-45f3-8900-31ef33bf5ac6"
+      ],
+      "content-length": [
+        "152"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:27 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=insiderTransactions"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-institutionOwnership-ADH.json
+++ b/tests/http/quoteSummary-institutionOwnership-ADH.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=institutionOwnership"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "2stdmrlg2nrrc"
+      ],
+      "x-yahoo-request-id": [
+        "2stdmrlg2nrrc"
+      ],
+      "x-request-id": [
+        "2317750b-8791-47e1-8708-917771b8d8e4"
+      ],
+      "content-length": [
+        "153"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:36 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=institutionOwnership"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-institutionOwnership-AFRAF.json
+++ b/tests/http/quoteSummary-institutionOwnership-AFRAF.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=institutionOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "38ba8cpg2nrrc"
+      ],
+      "x-yahoo-request-id": [
+        "38ba8cpg2nrrc"
+      ],
+      "x-request-id": [
+        "426daf75-fb42-4af6-99ae-46972713b4a1"
+      ],
+      "content-length": [
+        "99"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:36 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-institutionOwnership-AMZN.json
+++ b/tests/http/quoteSummary-institutionOwnership-AMZN.json
@@ -1,0 +1,306 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=institutionOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "al8bp5dg2nrrc"
+      ],
+      "x-yahoo-request-id": [
+        "al8bp5dg2nrrc"
+      ],
+      "x-request-id": [
+        "d04e9fe5-3156-4aa7-a20f-b9745049cccf"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "893"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:36 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Group, Inc. (The)",
+                  "pctHeld": {
+                    "raw": 0.0651,
+                    "fmt": "6.51%"
+                  },
+                  "position": {
+                    "raw": 32783886,
+                    "fmt": "32.78M",
+                    "longFmt": "32,783,886"
+                  },
+                  "value": {
+                    "raw": 103227605364,
+                    "fmt": "103.23B",
+                    "longFmt": "103,227,605,364"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Blackrock Inc.",
+                  "pctHeld": {
+                    "raw": 0.0547,
+                    "fmt": "5.47%"
+                  },
+                  "position": {
+                    "raw": 27524749,
+                    "fmt": "27.52M",
+                    "longFmt": "27,524,749"
+                  },
+                  "value": {
+                    "raw": 89646180760,
+                    "fmt": "89.65B",
+                    "longFmt": "89,646,180,760"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "State Street Corporation",
+                  "pctHeld": {
+                    "raw": 0.0325,
+                    "fmt": "3.25%"
+                  },
+                  "position": {
+                    "raw": 16344982,
+                    "fmt": "16.34M",
+                    "longFmt": "16,344,982"
+                  },
+                  "value": {
+                    "raw": 51465935172,
+                    "fmt": "51.47B",
+                    "longFmt": "51,465,935,172"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Price (T.Rowe) Associates Inc",
+                  "pctHeld": {
+                    "raw": 0.0312,
+                    "fmt": "3.12%"
+                  },
+                  "position": {
+                    "raw": 15700902,
+                    "fmt": "15.7M",
+                    "longFmt": "15,700,902"
+                  },
+                  "value": {
+                    "raw": 49437901154,
+                    "fmt": "49.44B",
+                    "longFmt": "49,437,901,154"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "FMR, LLC",
+                  "pctHeld": {
+                    "raw": 0.0307,
+                    "fmt": "3.07%"
+                  },
+                  "position": {
+                    "raw": 15472297,
+                    "fmt": "15.47M",
+                    "longFmt": "15,472,297"
+                  },
+                  "value": {
+                    "raw": 50392188268,
+                    "fmt": "50.39B",
+                    "longFmt": "50,392,188,268"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Geode Capital Management, LLC",
+                  "pctHeld": {
+                    "raw": 0.0127,
+                    "fmt": "1.27%"
+                  },
+                  "position": {
+                    "raw": 6398830,
+                    "fmt": "6.4M",
+                    "longFmt": "6,398,830"
+                  },
+                  "value": {
+                    "raw": 20148187985,
+                    "fmt": "20.15B",
+                    "longFmt": "20,148,187,985"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Northern Trust Corporation",
+                  "pctHeld": {
+                    "raw": 0.01,
+                    "fmt": "1.00%"
+                  },
+                  "position": {
+                    "raw": 5016332,
+                    "fmt": "5.02M",
+                    "longFmt": "5,016,332"
+                  },
+                  "value": {
+                    "raw": 15795075058,
+                    "fmt": "15.8B",
+                    "longFmt": "15,795,075,058"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Morgan Stanley",
+                  "pctHeld": {
+                    "raw": 0.0097,
+                    "fmt": "0.97%"
+                  },
+                  "position": {
+                    "raw": 4875392,
+                    "fmt": "4.88M",
+                    "longFmt": "4,875,392"
+                  },
+                  "value": {
+                    "raw": 15351293052,
+                    "fmt": "15.35B",
+                    "longFmt": "15,351,293,052"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Capital Research Global Investors",
+                  "pctHeld": {
+                    "raw": 0.008,
+                    "fmt": "0.80%"
+                  },
+                  "position": {
+                    "raw": 4017791,
+                    "fmt": "4.02M",
+                    "longFmt": "4,017,791"
+                  },
+                  "value": {
+                    "raw": 12650939055,
+                    "fmt": "12.65B",
+                    "longFmt": "12,650,939,055"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Bank Of New York Mellon Corporation",
+                  "pctHeld": {
+                    "raw": 0.007900001,
+                    "fmt": "0.79%"
+                  },
+                  "position": {
+                    "raw": 3983095,
+                    "fmt": "3.98M",
+                    "longFmt": "3,983,095"
+                  },
+                  "value": {
+                    "raw": 12972661598,
+                    "fmt": "12.97B",
+                    "longFmt": "12,972,661,598"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-institutionOwnership-AZT.OL.json
+++ b/tests/http/quoteSummary-institutionOwnership-AZT.OL.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=institutionOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "0mu8fctg2nrrc"
+      ],
+      "x-yahoo-request-id": [
+        "0mu8fctg2nrrc"
+      ],
+      "x-request-id": [
+        "5a083243-99ab-49df-a162-e10dfd16109d"
+      ],
+      "content-length": [
+        "99"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:36 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-institutionOwnership-SIX.json
+++ b/tests/http/quoteSummary-institutionOwnership-SIX.json
@@ -1,0 +1,306 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=institutionOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "4bejtedg2nuhc"
+      ],
+      "x-yahoo-request-id": [
+        "4bejtedg2nuhc"
+      ],
+      "x-request-id": [
+        "f6314f1b-1c93-484c-8249-9362142a5624"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "844"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:27 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "H Partners Management, LLC",
+                  "pctHeld": {
+                    "raw": 0.091800004,
+                    "fmt": "9.18%"
+                  },
+                  "position": {
+                    "raw": 7800000,
+                    "fmt": "7.8M",
+                    "longFmt": "7,800,000"
+                  },
+                  "value": {
+                    "raw": 158340000,
+                    "fmt": "158.34M",
+                    "longFmt": "158,340,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Group, Inc. (The)",
+                  "pctHeld": {
+                    "raw": 0.081999995,
+                    "fmt": "8.20%"
+                  },
+                  "position": {
+                    "raw": 6965424,
+                    "fmt": "6.97M",
+                    "longFmt": "6,965,424"
+                  },
+                  "value": {
+                    "raw": 141398107,
+                    "fmt": "141.4M",
+                    "longFmt": "141,398,107"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Blackrock Inc.",
+                  "pctHeld": {
+                    "raw": 0.0779,
+                    "fmt": "7.79%"
+                  },
+                  "position": {
+                    "raw": 6615731,
+                    "fmt": "6.62M",
+                    "longFmt": "6,615,731"
+                  },
+                  "value": {
+                    "raw": 225596427,
+                    "fmt": "225.6M",
+                    "longFmt": "225,596,427"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Thunderbird Partners LLP",
+                  "pctHeld": {
+                    "raw": 0.0319,
+                    "fmt": "3.19%"
+                  },
+                  "position": {
+                    "raw": 2708443,
+                    "fmt": "2.71M",
+                    "longFmt": "2,708,443"
+                  },
+                  "value": {
+                    "raw": 54981392,
+                    "fmt": "54.98M",
+                    "longFmt": "54,981,392"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Kohlberg Kravis Roberts & Co. L.P.",
+                  "pctHeld": {
+                    "raw": 0.028800001,
+                    "fmt": "2.88%"
+                  },
+                  "position": {
+                    "raw": 2446441,
+                    "fmt": "2.45M",
+                    "longFmt": "2,446,441"
+                  },
+                  "value": {
+                    "raw": 49662752,
+                    "fmt": "49.66M",
+                    "longFmt": "49,662,752"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Capital International Investors",
+                  "pctHeld": {
+                    "raw": 0.0286,
+                    "fmt": "2.86%"
+                  },
+                  "position": {
+                    "raw": 2429784,
+                    "fmt": "2.43M",
+                    "longFmt": "2,429,784"
+                  },
+                  "value": {
+                    "raw": 49324615,
+                    "fmt": "49.32M",
+                    "longFmt": "49,324,615"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Samlyn Capital, LLC",
+                  "pctHeld": {
+                    "raw": 0.0249,
+                    "fmt": "2.49%"
+                  },
+                  "position": {
+                    "raw": 2111952,
+                    "fmt": "2.11M",
+                    "longFmt": "2,111,952"
+                  },
+                  "value": {
+                    "raw": 42872625,
+                    "fmt": "42.87M",
+                    "longFmt": "42,872,625"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Massachusetts Financial Services Co.",
+                  "pctHeld": {
+                    "raw": 0.023,
+                    "fmt": "2.30%"
+                  },
+                  "position": {
+                    "raw": 1953622,
+                    "fmt": "1.95M",
+                    "longFmt": "1,953,622"
+                  },
+                  "value": {
+                    "raw": 39658526,
+                    "fmt": "39.66M",
+                    "longFmt": "39,658,526"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Jericho Capital Asset Management, LP",
+                  "pctHeld": {
+                    "raw": 0.0225,
+                    "fmt": "2.25%"
+                  },
+                  "position": {
+                    "raw": 1912578,
+                    "fmt": "1.91M",
+                    "longFmt": "1,912,578"
+                  },
+                  "value": {
+                    "raw": 38825333,
+                    "fmt": "38.83M",
+                    "longFmt": "38,825,333"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "State Street Corporation",
+                  "pctHeld": {
+                    "raw": 0.0221,
+                    "fmt": "2.21%"
+                  },
+                  "position": {
+                    "raw": 1878913,
+                    "fmt": "1.88M",
+                    "longFmt": "1,878,913"
+                  },
+                  "value": {
+                    "raw": 38141933,
+                    "fmt": "38.14M",
+                    "longFmt": "38,141,933"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-institutionOwnership-WSKT.JK.json
+++ b/tests/http/quoteSummary-institutionOwnership-WSKT.JK.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=institutionOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "6vjb4d9g2nuhc"
+      ],
+      "x-yahoo-request-id": [
+        "6vjb4d9g2nuhc"
+      ],
+      "x-request-id": [
+        "cf09e371-be1e-4cf8-b102-2f265bc0885e"
+      ],
+      "content-length": [
+        "99"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:27 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorDirectHolders-ADH.json
+++ b/tests/http/quoteSummary-majorDirectHolders-ADH.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=majorDirectHolders"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "98neaitg2nrrc"
+      ],
+      "x-yahoo-request-id": [
+        "98neaitg2nrrc"
+      ],
+      "x-request-id": [
+        "85d79e4a-a624-40df-8d41-f77c14b7cf7a"
+      ],
+      "content-length": [
+        "151"
+      ],
+      "x-envoy-upstream-service-time": [
+        "5"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:36 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "2"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=majorDirectHolders"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorDirectHolders-AFRAF.json
+++ b/tests/http/quoteSummary-majorDirectHolders-AFRAF.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=majorDirectHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "6ia0o29g2nrrd"
+      ],
+      "x-yahoo-request-id": [
+        "6ia0o29g2nrrd"
+      ],
+      "x-request-id": [
+        "896a54f4-97a6-48e0-ac9a-c8d7dac357c0"
+      ],
+      "content-length": [
+        "91"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:36 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorDirectHolders-AMZN.json
+++ b/tests/http/quoteSummary-majorDirectHolders-AMZN.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=majorDirectHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "867da7lg2nrrd"
+      ],
+      "x-yahoo-request-id": [
+        "867da7lg2nrrd"
+      ],
+      "x-request-id": [
+        "bc385169-2d99-4f6c-9eb4-09de37541678"
+      ],
+      "content-length": [
+        "91"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:36 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorDirectHolders-AZT.OL.json
+++ b/tests/http/quoteSummary-majorDirectHolders-AZT.OL.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=majorDirectHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "d0d7totg2nrrd"
+      ],
+      "x-yahoo-request-id": [
+        "d0d7totg2nrrd"
+      ],
+      "x-request-id": [
+        "2b73c35a-1882-4931-9a82-c8d4534030c8"
+      ],
+      "content-length": [
+        "91"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:37 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorDirectHolders-SIX.json
+++ b/tests/http/quoteSummary-majorDirectHolders-SIX.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=majorDirectHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "d5vrq45g2nuhc"
+      ],
+      "x-yahoo-request-id": [
+        "d5vrq45g2nuhc"
+      ],
+      "x-request-id": [
+        "6ba8349f-a508-4fb6-97e0-6684a29a64c2"
+      ],
+      "content-length": [
+        "91"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:28 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorDirectHolders-WSKT.JK.json
+++ b/tests/http/quoteSummary-majorDirectHolders-WSKT.JK.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=majorDirectHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "1jhpfuhg2nuhc"
+      ],
+      "x-yahoo-request-id": [
+        "1jhpfuhg2nuhc"
+      ],
+      "x-request-id": [
+        "f7efe5e5-2e97-47b1-9616-f888d2256228"
+      ],
+      "content-length": [
+        "91"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:28 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorHoldersBreakdown-ADH.json
+++ b/tests/http/quoteSummary-majorHoldersBreakdown-ADH.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=majorHoldersBreakdown"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "cadrk55g2nrrd"
+      ],
+      "x-yahoo-request-id": [
+        "cadrk55g2nrrd"
+      ],
+      "x-request-id": [
+        "1760507f-b260-44d7-9d0a-4b2ded4a64b1"
+      ],
+      "content-length": [
+        "154"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:37 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=majorHoldersBreakdown"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorHoldersBreakdown-AFRAF.json
+++ b/tests/http/quoteSummary-majorHoldersBreakdown-AFRAF.json
@@ -1,0 +1,85 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=majorHoldersBreakdown"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "98h4e0hg2nrrd"
+      ],
+      "x-yahoo-request-id": [
+        "98h4e0hg2nrrd"
+      ],
+      "x-request-id": [
+        "328ac0d1-dc2f-4d61-acf0-bbb1591647e5"
+      ],
+      "content-length": [
+        "207"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:37 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.49626,
+              "institutionsPercentHeld": 0.12174,
+              "institutionsFloatPercentHeld": 0.24167,
+              "institutionsCount": 99
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorHoldersBreakdown-AMZN.json
+++ b/tests/http/quoteSummary-majorHoldersBreakdown-AMZN.json
@@ -1,0 +1,85 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=majorHoldersBreakdown"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "8fs39rhg2nrrd"
+      ],
+      "x-yahoo-request-id": [
+        "8fs39rhg2nrrd"
+      ],
+      "x-request-id": [
+        "ae97396e-8983-486d-8032-c16abb547781"
+      ],
+      "content-length": [
+        "209"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:37 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.14556,
+              "institutionsPercentHeld": 0.58663,
+              "institutionsFloatPercentHeld": 0.68657,
+              "institutionsCount": 4408
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorHoldersBreakdown-AZT.OL.json
+++ b/tests/http/quoteSummary-majorHoldersBreakdown-AZT.OL.json
@@ -1,0 +1,85 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=majorHoldersBreakdown"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "dadsgvhg2nrrd"
+      ],
+      "x-yahoo-request-id": [
+        "dadsgvhg2nrrd"
+      ],
+      "x-request-id": [
+        "162a19f8-37fe-4cce-a0d5-39eacb47c1b7"
+      ],
+      "content-length": [
+        "213"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:37 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.23488002,
+              "institutionsPercentHeld": 0.13869001,
+              "institutionsFloatPercentHeld": 0.18127,
+              "institutionsCount": 12
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorHoldersBreakdown-SIX.json
+++ b/tests/http/quoteSummary-majorHoldersBreakdown-SIX.json
@@ -1,0 +1,85 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=majorHoldersBreakdown"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "bs63s11g2nuhc"
+      ],
+      "x-yahoo-request-id": [
+        "bs63s11g2nuhc"
+      ],
+      "x-request-id": [
+        "c1ae1a4e-1907-484e-8805-7ac68d656cff"
+      ],
+      "content-length": [
+        "211"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:28 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.07217,
+              "institutionsPercentHeld": 0.83259004,
+              "institutionsFloatPercentHeld": 0.89735,
+              "institutionsCount": 350
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorHoldersBreakdown-WSKT.JK.json
+++ b/tests/http/quoteSummary-majorHoldersBreakdown-WSKT.JK.json
@@ -1,0 +1,85 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=majorHoldersBreakdown"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "6tvn5rlg2nuhc"
+      ],
+      "x-yahoo-request-id": [
+        "6tvn5rlg2nuhc"
+      ],
+      "x-request-id": [
+        "cb539874-8130-4768-a28b-ba6e4dce81f1"
+      ],
+      "content-length": [
+        "205"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:28 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.71228,
+              "institutionsPercentHeld": 0.108,
+              "institutionsFloatPercentHeld": 0.37535,
+              "institutionsCount": 34
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-netSharePurchaseActivity-ADH.json
+++ b/tests/http/quoteSummary-netSharePurchaseActivity-ADH.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=netSharePurchaseActivity"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "31sb4ghg2nrre"
+      ],
+      "x-yahoo-request-id": [
+        "31sb4ghg2nrre"
+      ],
+      "x-request-id": [
+        "a8779e61-a919-42db-9f12-769eac9fe60d"
+      ],
+      "content-length": [
+        "157"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:37 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=netSharePurchaseActivity"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-netSharePurchaseActivity-AFRAF.json
+++ b/tests/http/quoteSummary-netSharePurchaseActivity-AFRAF.json
@@ -1,0 +1,89 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=netSharePurchaseActivity"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "91689c1g2nrre"
+      ],
+      "x-yahoo-request-id": [
+        "91689c1g2nrre"
+      ],
+      "x-request-id": [
+        "29ce6c09-70b3-4672-990a-42e249041835"
+      ],
+      "content-length": [
+        "247"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:37 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 0,
+              "buyInfoShares": 0,
+              "sellInfoCount": 0,
+              "netInfoCount": 0,
+              "netInfoShares": 0,
+              "netPercentInsiderShares": 0,
+              "totalInsiderShares": 212117616
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-netSharePurchaseActivity-AMZN.json
+++ b/tests/http/quoteSummary-netSharePurchaseActivity-AMZN.json
@@ -1,0 +1,92 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=netSharePurchaseActivity"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "9r49is9g2nrre"
+      ],
+      "x-yahoo-request-id": [
+        "9r49is9g2nrre"
+      ],
+      "x-request-id": [
+        "baed74ef-d76f-46d0-91a7-53d3f0c2ae8b"
+      ],
+      "content-length": [
+        "359"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:37 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 32,
+              "buyInfoShares": 300580,
+              "buyPercentInsiderShares": 0.004,
+              "sellInfoCount": 29,
+              "sellInfoShares": 1025226,
+              "sellPercentInsiderShares": 0.0139999995,
+              "netInfoCount": 61,
+              "netInfoShares": -724646,
+              "netPercentInsiderShares": -0.01,
+              "totalInsiderShares": 73298880
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-netSharePurchaseActivity-AZT.OL.json
+++ b/tests/http/quoteSummary-netSharePurchaseActivity-AZT.OL.json
@@ -1,0 +1,89 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=netSharePurchaseActivity"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "7p3f5cdg2nrre"
+      ],
+      "x-yahoo-request-id": [
+        "7p3f5cdg2nrre"
+      ],
+      "x-request-id": [
+        "39a4ace1-e660-42ef-a6f6-4b52c63370ce"
+      ],
+      "content-length": [
+        "246"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:38 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 0,
+              "buyInfoShares": 0,
+              "sellInfoCount": 0,
+              "netInfoCount": 0,
+              "netInfoShares": 0,
+              "netPercentInsiderShares": 0,
+              "totalInsiderShares": 11352848
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-netSharePurchaseActivity-SIX.json
+++ b/tests/http/quoteSummary-netSharePurchaseActivity-SIX.json
@@ -1,0 +1,92 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=netSharePurchaseActivity"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "5kuegc5g2nuhd"
+      ],
+      "x-yahoo-request-id": [
+        "5kuegc5g2nuhd"
+      ],
+      "x-request-id": [
+        "b04919da-8f27-4304-abca-30e96b92f50b"
+      ],
+      "content-length": [
+        "345"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:28 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 17,
+              "buyInfoShares": 50871,
+              "buyPercentInsiderShares": 0.008,
+              "sellInfoCount": 7,
+              "sellInfoShares": 31845,
+              "sellPercentInsiderShares": 0.005,
+              "netInfoCount": 24,
+              "netInfoShares": 19026,
+              "netPercentInsiderShares": 0.003,
+              "totalInsiderShares": 6132795
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-netSharePurchaseActivity-WSKT.JK.json
+++ b/tests/http/quoteSummary-netSharePurchaseActivity-WSKT.JK.json
@@ -1,0 +1,89 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=netSharePurchaseActivity"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "4vc6m1tg2nuhd"
+      ],
+      "x-yahoo-request-id": [
+        "4vc6m1tg2nuhd"
+      ],
+      "x-request-id": [
+        "1663b187-31c0-492a-9b2e-6f70cd6a3200"
+      ],
+      "content-length": [
+        "248"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:28 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 0,
+              "buyInfoShares": 0,
+              "sellInfoCount": 0,
+              "netInfoCount": 0,
+              "netInfoShares": 0,
+              "netPercentInsiderShares": 0,
+              "totalInsiderShares": 9668453376
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-price-ADH.json
+++ b/tests/http/quoteSummary-price-ADH.json
@@ -1,0 +1,97 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=price"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "16pcnn9g2nrre"
+      ],
+      "x-yahoo-request-id": [
+        "16pcnn9g2nrre"
+      ],
+      "x-request-id": [
+        "42c3a35e-9ec1-46cb-833c-662ad8c883e9"
+      ],
+      "content-length": [
+        "420"
+      ],
+      "x-envoy-upstream-service-time": [
+        "8"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:38 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "price": {
+              "maxAge": 1,
+              "regularMarketTime": 1561759658,
+              "priceHint": 2,
+              "regularMarketSource": "DELAYED",
+              "exchange": "YHD",
+              "exchangeName": "YHD",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "MUTUALFUND",
+              "symbol": "ADH",
+              "underlyingSymbol": null,
+              "shortName": "54688",
+              "longName": null,
+              "quoteSourceName": "Delayed Quote",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-price-AFRAF.json
+++ b/tests/http/quoteSummary-price-AFRAF.json
@@ -1,0 +1,111 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=price"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "fr5et09g2nrre"
+      ],
+      "x-yahoo-request-id": [
+        "fr5et09g2nrre"
+      ],
+      "x-request-id": [
+        "f991df8e-49fc-45fb-bfd3-09b23ab0d499"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "397"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:38 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "price": {
+              "maxAge": 1,
+              "regularMarketChangePercent": -0.01666665,
+              "regularMarketChange": -0.099999905,
+              "regularMarketTime": 1613486803,
+              "priceHint": 2,
+              "regularMarketPrice": 5.9,
+              "regularMarketDayHigh": 5.9,
+              "regularMarketDayLow": 5.9,
+              "regularMarketVolume": 1050,
+              "regularMarketPreviousClose": 6,
+              "regularMarketSource": "DELAYED",
+              "regularMarketOpen": 5.9,
+              "exchange": "PNK",
+              "exchangeName": "Other OTC",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "EQUITY",
+              "symbol": "AFRAF",
+              "underlyingSymbol": null,
+              "shortName": "AIR FRANCE-KLM",
+              "longName": "Air France-KLM SA",
+              "currency": "USD",
+              "quoteSourceName": "Delayed Quote",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 2474265344
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-price-AMZN.json
+++ b/tests/http/quoteSummary-price-AMZN.json
@@ -1,0 +1,116 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=price"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "6cb5rodg2nrre"
+      ],
+      "x-yahoo-request-id": [
+        "6cb5rodg2nrre"
+      ],
+      "x-request-id": [
+        "645b0c4b-e8e0-4464-a5ee-12f213e0f857"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "468"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:38 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": -0.00722148,
+              "preMarketChange": -23.6699,
+              "preMarketTime": 1613485799,
+              "preMarketPrice": 3254.04,
+              "preMarketSource": "FREE_REALTIME",
+              "regularMarketChangePercent": 0.0005163309,
+              "regularMarketChange": 1.6923828,
+              "regularMarketTime": 1613492068,
+              "priceHint": 2,
+              "regularMarketPrice": 3279.4023,
+              "regularMarketDayHigh": 3308,
+              "regularMarketDayLow": 3257.75,
+              "regularMarketVolume": 1136617,
+              "regularMarketPreviousClose": 3277.71,
+              "regularMarketSource": "FREE_REALTIME",
+              "regularMarketOpen": 3254.05,
+              "exchange": "NMS",
+              "exchangeName": "NasdaqGS",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "EQUITY",
+              "symbol": "AMZN",
+              "underlyingSymbol": null,
+              "shortName": "Amazon.com, Inc.",
+              "longName": "Amazon.com, Inc.",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 1651392249856
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-price-AZT.OL.json
+++ b/tests/http/quoteSummary-price-AZT.OL.json
@@ -1,0 +1,110 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=price"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "0lj72tdg2nrre"
+      ],
+      "x-yahoo-request-id": [
+        "0lj72tdg2nrre"
+      ],
+      "x-request-id": [
+        "e9ea3a1a-8ed2-4ac4-8d38-6f4f90481f35"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "404"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:38 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "price": {
+              "maxAge": 1,
+              "regularMarketChangePercent": 0.011527311,
+              "regularMarketChange": 0.7999954,
+              "regularMarketTime": 1613489360,
+              "priceHint": 2,
+              "regularMarketPrice": 70.2,
+              "regularMarketDayHigh": 70.8,
+              "regularMarketDayLow": 68.4,
+              "regularMarketVolume": 286580,
+              "regularMarketPreviousClose": 69.4,
+              "regularMarketSource": "DELAYED",
+              "regularMarketOpen": 68.6,
+              "exchange": "OSL",
+              "exchangeName": "Oslo",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "POSTPOST",
+              "quoteType": "EQUITY",
+              "symbol": "AZT.OL",
+              "underlyingSymbol": null,
+              "shortName": "ARCTICZYMES TECH",
+              "longName": "ArcticZymes Technologies ASA",
+              "currency": "NOK",
+              "currencySymbol": "kr",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 3393095680
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-price-SIX.json
+++ b/tests/http/quoteSummary-price-SIX.json
@@ -1,0 +1,116 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=price"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "5joafp1g2nuhd"
+      ],
+      "x-yahoo-request-id": [
+        "5joafp1g2nuhd"
+      ],
+      "x-request-id": [
+        "948f8767-7034-420b-95fe-1fdb32c2ce07"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "473"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:29 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": 0.00050205,
+              "preMarketChange": 0.0199966,
+              "preMarketTime": 1613485603,
+              "preMarketPrice": 39.85,
+              "preMarketSource": "FREE_REALTIME",
+              "regularMarketChangePercent": 0.0052723843,
+              "regularMarketChange": 0.20999908,
+              "regularMarketTime": 1613494813,
+              "priceHint": 2,
+              "regularMarketPrice": 40.04,
+              "regularMarketDayHigh": 40.775,
+              "regularMarketDayLow": 39.92,
+              "regularMarketVolume": 405501,
+              "regularMarketPreviousClose": 39.83,
+              "regularMarketSource": "FREE_REALTIME",
+              "regularMarketOpen": 39.89,
+              "exchange": "NYQ",
+              "exchangeName": "NYSE",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "EQUITY",
+              "symbol": "SIX",
+              "underlyingSymbol": null,
+              "shortName": "Six Flags Entertainment Corpora",
+              "longName": "Six Flags Entertainment Corporation",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 3402483200
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-price-WSKT.JK.json
+++ b/tests/http/quoteSummary-price-WSKT.JK.json
@@ -1,0 +1,111 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=price"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "bn48o9pg2nuhd"
+      ],
+      "x-yahoo-request-id": [
+        "bn48o9pg2nuhd"
+      ],
+      "x-request-id": [
+        "6e0193f9-fdc1-40f3-9e8d-bf48e7b6aa42"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "423"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:29 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "price": {
+              "maxAge": 1,
+              "regularMarketChangePercent": -0.0031055901,
+              "regularMarketChange": -5,
+              "regularMarketTime": 1613463295,
+              "priceHint": 2,
+              "regularMarketPrice": 1605,
+              "regularMarketDayHigh": 1660,
+              "regularMarketDayLow": 1590,
+              "regularMarketVolume": 228998200,
+              "regularMarketPreviousClose": 1610,
+              "regularMarketSource": "DELAYED",
+              "regularMarketOpen": 1625,
+              "exchange": "JKT",
+              "exchangeName": "Jakarta",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "PREPRE",
+              "quoteType": "EQUITY",
+              "symbol": "WSKT.JK",
+              "underlyingSymbol": null,
+              "shortName": "Waskita Karya (Persero) Tbk.",
+              "longName": "PT Waskita Karya (Persero) Tbk",
+              "currency": "IDR",
+              "quoteSourceName": "Delayed Quote",
+              "currencySymbol": "Rp",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 21786110459904
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-quoteType-ADH.json
+++ b/tests/http/quoteSummary-quoteType-ADH.json
@@ -1,0 +1,93 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=quoteType"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "0jp1qchg2nrrf"
+      ],
+      "x-yahoo-request-id": [
+        "0jp1qchg2nrrf"
+      ],
+      "x-request-id": [
+        "4d0f867a-93e1-48f1-9266-ea310d8c8783"
+      ],
+      "content-length": [
+        "389"
+      ],
+      "x-envoy-upstream-service-time": [
+        "102"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:39 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "quoteType": {
+              "exchange": "YHD",
+              "quoteType": "MUTUALFUND",
+              "symbol": "ADH",
+              "underlyingSymbol": "ADH",
+              "shortName": "54688",
+              "longName": null,
+              "firstTradeDateEpochUtc": 1152538200,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "b5097600-41ff-3349-b2d2-500df46ffd88",
+              "messageBoardId": null,
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-quoteType-AFRAF.json
+++ b/tests/http/quoteSummary-quoteType-AFRAF.json
@@ -1,0 +1,93 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=quoteType"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "613k4u1g2nrrf"
+      ],
+      "x-yahoo-request-id": [
+        "613k4u1g2nrrf"
+      ],
+      "x-request-id": [
+        "625c4e4d-bf8c-45c7-a9aa-a553dcd381ef"
+      ],
+      "content-length": [
+        "424"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:39 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "quoteType": {
+              "exchange": "PNK",
+              "quoteType": "EQUITY",
+              "symbol": "AFRAF",
+              "underlyingSymbol": "AFRAF",
+              "shortName": "AIR FRANCE-KLM",
+              "longName": "Air France-KLM SA",
+              "firstTradeDateEpochUtc": 1331731800,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "41a9132e-8a86-3cb7-a251-da914aed6eac",
+              "messageBoardId": "finmb_4463198",
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-quoteType-AMZN.json
+++ b/tests/http/quoteSummary-quoteType-AMZN.json
@@ -1,0 +1,93 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=quoteType"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "ad83kr5g2nrrf"
+      ],
+      "x-yahoo-request-id": [
+        "ad83kr5g2nrrf"
+      ],
+      "x-request-id": [
+        "d822ed75-f6d2-4c10-98ab-bf0ec974bb47"
+      ],
+      "content-length": [
+        "420"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:39 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "quoteType": {
+              "exchange": "NMS",
+              "quoteType": "EQUITY",
+              "symbol": "AMZN",
+              "underlyingSymbol": "AMZN",
+              "shortName": "Amazon.com, Inc.",
+              "longName": "Amazon.com, Inc.",
+              "firstTradeDateEpochUtc": 863703000,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "261fd26b-0151-3813-b0d0-97e4ed4c6505",
+              "messageBoardId": "finmb_18749",
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-quoteType-AZT.OL.json
+++ b/tests/http/quoteSummary-quoteType-AZT.OL.json
@@ -1,0 +1,93 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=quoteType"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "1cinl05g2nrrf"
+      ],
+      "x-yahoo-request-id": [
+        "1cinl05g2nrrf"
+      ],
+      "x-request-id": [
+        "1cf4c10e-3e5f-46b3-972d-073e9408ed90"
+      ],
+      "content-length": [
+        "427"
+      ],
+      "x-envoy-upstream-service-time": [
+        "1"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:39 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "quoteType": {
+              "exchange": "OSL",
+              "quoteType": "EQUITY",
+              "symbol": "AZT.OL",
+              "underlyingSymbol": "AZT.OL",
+              "shortName": "ARCTICZYMES TECH",
+              "longName": "ArcticZymes Technologies ASA",
+              "firstTradeDateEpochUtc": null,
+              "timeZoneFullName": "Europe/Oslo",
+              "timeZoneShortName": "CET",
+              "uuid": "f653d689-5ab6-3b70-8909-46de02bfd311",
+              "messageBoardId": "finmb_13529463",
+              "gmtOffSetMilliseconds": 3600000,
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-quoteType-SIX.json
+++ b/tests/http/quoteSummary-quoteType-SIX.json
@@ -1,0 +1,93 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=quoteType"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "4jfabclg2nuhd"
+      ],
+      "x-yahoo-request-id": [
+        "4jfabclg2nuhd"
+      ],
+      "x-request-id": [
+        "f0f0200c-8ed1-4b0d-a9a5-1a6d0cd94489"
+      ],
+      "content-length": [
+        "454"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:29 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "quoteType": {
+              "exchange": "NYQ",
+              "quoteType": "EQUITY",
+              "symbol": "SIX",
+              "underlyingSymbol": "SIX",
+              "shortName": "Six Flags Entertainment Corpora",
+              "longName": "Six Flags Entertainment Corporation",
+              "firstTradeDateEpochUtc": 1273584600,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "48041ef8-474c-3edc-bcf2-fe8996056b7f",
+              "messageBoardId": "finmb_435998",
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-quoteType-WSKT.JK.json
+++ b/tests/http/quoteSummary-quoteType-WSKT.JK.json
@@ -1,0 +1,93 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=quoteType"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "c726g6lg2nuhd"
+      ],
+      "x-yahoo-request-id": [
+        "c726g6lg2nuhd"
+      ],
+      "x-request-id": [
+        "ec713ca5-98a1-4dc8-a7ff-cb86c14f7453"
+      ],
+      "content-length": [
+        "451"
+      ],
+      "x-envoy-upstream-service-time": [
+        "6"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:29 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "quoteType": {
+              "exchange": "JKT",
+              "quoteType": "EQUITY",
+              "symbol": "WSKT.JK",
+              "underlyingSymbol": "WSKT.JK",
+              "shortName": "Waskita Karya (Persero) Tbk.",
+              "longName": "PT Waskita Karya (Persero) Tbk",
+              "firstTradeDateEpochUtc": 1355882400,
+              "timeZoneFullName": "Asia/Jakarta",
+              "timeZoneShortName": "WIB",
+              "uuid": "e93eb405-3e83-3735-8abd-6a04213faba8",
+              "messageBoardId": "finmb_32989878",
+              "gmtOffSetMilliseconds": 25200000,
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-recommendationTrend-ADH.json
+++ b/tests/http/quoteSummary-recommendationTrend-ADH.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=recommendationTrend"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "9nfjnt5g2nrrf"
+      ],
+      "x-yahoo-request-id": [
+        "9nfjnt5g2nrrf"
+      ],
+      "x-request-id": [
+        "8ef79bb1-2e1b-4a60-9343-8ff7491fd25b"
+      ],
+      "content-length": [
+        "152"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:39 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=recommendationTrend"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-recommendationTrend-AFRAF.json
+++ b/tests/http/quoteSummary-recommendationTrend-AFRAF.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=recommendationTrend"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "43e82bpg2nrrf"
+      ],
+      "x-yahoo-request-id": [
+        "43e82bpg2nrrf"
+      ],
+      "x-request-id": [
+        "59d956d1-755a-4185-8df8-f02b6a3d57c5"
+      ],
+      "content-length": [
+        "152"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:39 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=recommendationTrend"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-recommendationTrend-AMZN.json
+++ b/tests/http/quoteSummary-recommendationTrend-AMZN.json
@@ -1,0 +1,115 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=recommendationTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "2l1rv01g2nrrf"
+      ],
+      "x-yahoo-request-id": [
+        "2l1rv01g2nrrf"
+      ],
+      "x-request-id": [
+        "d3557084-7d92-4e10-ba59-3b6ec5af09e1"
+      ],
+      "content-length": [
+        "388"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:39 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 15,
+                  "buy": 28,
+                  "hold": 3,
+                  "sell": 1,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 18,
+                  "buy": 29,
+                  "hold": 3,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 18,
+                  "buy": 29,
+                  "hold": 3,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 18,
+                  "buy": 27,
+                  "hold": 3,
+                  "sell": 1,
+                  "strongSell": 0
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-recommendationTrend-AZT.OL.json
+++ b/tests/http/quoteSummary-recommendationTrend-AZT.OL.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=recommendationTrend"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "01gntrhg2nrrg"
+      ],
+      "x-yahoo-request-id": [
+        "01gntrhg2nrrg"
+      ],
+      "x-request-id": [
+        "f7a216ac-96c5-41f1-8660-47f49f867ef9"
+      ],
+      "content-length": [
+        "152"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:39 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=recommendationTrend"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-recommendationTrend-SIX.json
+++ b/tests/http/quoteSummary-recommendationTrend-SIX.json
@@ -1,0 +1,115 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=recommendationTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "2vc54c5g2nuhd"
+      ],
+      "x-yahoo-request-id": [
+        "2vc54c5g2nuhd"
+      ],
+      "x-request-id": [
+        "e154d91e-9459-44ab-ac93-5f088501d0ae"
+      ],
+      "content-length": [
+        "380"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:29 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "3"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 6,
+                  "buy": 4,
+                  "hold": 1,
+                  "sell": 1,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 4,
+                  "buy": 3,
+                  "hold": 6,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 4,
+                  "buy": 3,
+                  "hold": 6,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 6,
+                  "buy": 3,
+                  "hold": 2,
+                  "sell": 1,
+                  "strongSell": 0
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-recommendationTrend-WSKT.JK.json
+++ b/tests/http/quoteSummary-recommendationTrend-WSKT.JK.json
@@ -1,0 +1,115 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=recommendationTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "3cfmhr9g2nuhd"
+      ],
+      "x-yahoo-request-id": [
+        "3cfmhr9g2nuhd"
+      ],
+      "x-request-id": [
+        "1502e701-43df-402b-a6d2-a44b1200731e"
+      ],
+      "content-length": [
+        "380"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:29 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 6,
+                  "buy": 6,
+                  "hold": 3,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 6,
+                  "buy": 6,
+                  "hold": 4,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 6,
+                  "buy": 7,
+                  "hold": 3,
+                  "sell": 0,
+                  "strongSell": 0
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-secFilings-ADH.json
+++ b/tests/http/quoteSummary-secFilings-ADH.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=secFilings"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "0rpavo5g2nrrg"
+      ],
+      "x-yahoo-request-id": [
+        "0rpavo5g2nrrg"
+      ],
+      "x-request-id": [
+        "0c5a8bbd-abe0-4748-af6f-95c94d123242"
+      ],
+      "content-length": [
+        "143"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:40 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=secFilings"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-secFilings-AFRAF.json
+++ b/tests/http/quoteSummary-secFilings-AFRAF.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=secFilings"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "a4rvfv9g2nrrg"
+      ],
+      "x-yahoo-request-id": [
+        "a4rvfv9g2nrrg"
+      ],
+      "x-request-id": [
+        "3d8caf26-b41b-9c34-bf24-fc8a111670dd"
+      ],
+      "content-length": [
+        "143"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:40 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=secFilings"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-secFilings-AMZN.json
+++ b/tests/http/quoteSummary-secFilings-AMZN.json
@@ -1,0 +1,254 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=secFilings"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "ec4qo95g2nrrg"
+      ],
+      "x-yahoo-request-id": [
+        "ec4qo95g2nrrg"
+      ],
+      "x-request-id": [
+        "99f96149-422e-45f8-9af3-e577a11d1afe"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "908"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:40 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "secFilings": {
+              "filings": [
+                {
+                  "date": "2021-02-03",
+                  "epochDate": 1612350353,
+                  "type": "10-K",
+                  "title": "Annual Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-21-000004&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-02-02",
+                  "epochDate": 1612301458,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Change in Directors or Principal Officers, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-21-000002&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-01-27",
+                  "epochDate": 1611746057,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001193125-21-018066&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-30",
+                  "epochDate": 1604056140,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-20-000030&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-29",
+                  "epochDate": 1604007787,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-20-000028&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-09-09",
+                  "epochDate": 1599685697,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-20-000026&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-08-21",
+                  "epochDate": 1598019657,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001193125-20-226520&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-07-31",
+                  "epochDate": 1596193864,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-20-000021&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-07-30",
+                  "epochDate": 1596154406,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-20-000019&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-06-23",
+                  "epochDate": 1592946902,
+                  "type": "8-K",
+                  "title": "Entry into a Material Definitive Agreement, Creation of a Direct Financial Obligation or an Obligation under an Off-Balance Sheet Arrangement of a Registrant, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001193125-20-176528&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-06-03",
+                  "epochDate": 1591215715,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001193125-20-159531&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-29",
+                  "epochDate": 1590787862,
+                  "type": "8-K",
+                  "title": "Disclosing Amendments to Articles of Inc. or Bylaws; Change in Fiscal Year, Submission of Mat",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-20-000015&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-01",
+                  "epochDate": 1588329988,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-20-000010&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-30",
+                  "epochDate": 1588279428,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-20-000008&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-16",
+                  "epochDate": 1587031458,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001193125-20-108427&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-01-31",
+                  "epochDate": 1580468772,
+                  "type": "10-K",
+                  "title": "Annual Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-20-000004&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-01-30",
+                  "epochDate": 1580420869,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-20-000002&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-10-25",
+                  "epochDate": 1571997935,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-19-000087&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-10-25",
+                  "epochDate": 1571997898,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-19-000089&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-07-26",
+                  "epochDate": 1564135329,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-19-000071&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-07-25",
+                  "epochDate": 1564086875,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001018724-19-000069&nav=1&src=Yahoo",
+                  "maxAge": 1
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-secFilings-AZT.OL.json
+++ b/tests/http/quoteSummary-secFilings-AZT.OL.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=secFilings"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "3e7kdf9g2nrrg"
+      ],
+      "x-yahoo-request-id": [
+        "3e7kdf9g2nrrg"
+      ],
+      "x-request-id": [
+        "4f51bcf1-9f1f-42c2-bd5c-eab73b54a642"
+      ],
+      "content-length": [
+        "143"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:40 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=secFilings"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-secFilings-SIX.json
+++ b/tests/http/quoteSummary-secFilings-SIX.json
@@ -1,0 +1,350 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=secFilings"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "7je68rlg2nuhe"
+      ],
+      "x-yahoo-request-id": [
+        "7je68rlg2nuhe"
+      ],
+      "x-request-id": [
+        "cfca0344-9c31-43aa-bf72-fd7110af8122"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:30 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "secFilings": {
+              "filings": [
+                {
+                  "date": "2021-02-12",
+                  "epochDate": 1613169771,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-21-000002&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-12-28",
+                  "epochDate": 1609190269,
+                  "type": "8-K",
+                  "title": "Entry into a Material Definitive Agreement, Change in Directors or Principal Officers, Amendments to Articles of Inc. or Bylaws; Change in Fiscal Year, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000079&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-28",
+                  "epochDate": 1603921901,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001558370-20-011903&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-28",
+                  "epochDate": 1603883299,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000075&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-13",
+                  "epochDate": 1602627267,
+                  "type": "8-K",
+                  "title": "Other Events",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000072&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-09-11",
+                  "epochDate": 1599863450,
+                  "type": "8-K/A",
+                  "title": "Change in Directors or Principal Officers",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000070&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-08-27",
+                  "epochDate": 1598563818,
+                  "type": "8-K/A",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000067&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-08-27",
+                  "epochDate": 1598563284,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000065&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-08-26",
+                  "epochDate": 1598476912,
+                  "type": "8-K",
+                  "title": "Entry into a Material Definitive Agreement, Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000061&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-08-05",
+                  "epochDate": 1596663713,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers, Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000056&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-07-30",
+                  "epochDate": 1596106982,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001558370-20-008662&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-06-24",
+                  "epochDate": 1593033086,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers, Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000048&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-30",
+                  "epochDate": 1588280792,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001558370-20-004827&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-30",
+                  "epochDate": 1588242354,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements ",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000039&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-23",
+                  "epochDate": 1587641499,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Creation of a Direct Fin",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-049974&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-15",
+                  "epochDate": 1586952494,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure, Other Events, Financial Statements and Exh",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000034&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-08",
+                  "epochDate": 1586377158,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Regulation FD Disclosure",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000028&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-03-31",
+                  "epochDate": 1585687003,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Material Modification to",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000023&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-03-30",
+                  "epochDate": 1585581500,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure, Other Events, Financial Statements and Exh",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000019&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-03-13",
+                  "epochDate": 1584116990,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000017&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-02-25",
+                  "epochDate": 1582629772,
+                  "type": "8-K",
+                  "title": "Disclosing Change in Directors or Principal Officers, Other Events, Financial S",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000014&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-02-20",
+                  "epochDate": 1582235054,
+                  "type": "10-K",
+                  "title": "Annual Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001558370-20-001092&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-02-20",
+                  "epochDate": 1582196898,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Other Events, Financi",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000009&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-01-31",
+                  "epochDate": 1580471880,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Change in Directors or P",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-20-000006&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-18",
+                  "epochDate": 1574082365,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-19-000160&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-15",
+                  "epochDate": 1573855057,
+                  "type": "8-K",
+                  "title": "Disclosing Change in Directors or Principal Officers, Financial Statements and ",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-19-000157&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-10-25",
+                  "epochDate": 1571997973,
+                  "type": "8-K",
+                  "title": "Disclosing Change in Directors or Principal Officers, Regulation FD Disclosure,",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001558370-19-009095&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-10-23",
+                  "epochDate": 1571862025,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-19-000147&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-10-22",
+                  "epochDate": 1571775037,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements ",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-19-000143&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-10-18",
+                  "epochDate": 1571431332,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Financial Statements and",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-19-000138&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-08-23",
+                  "epochDate": 1566561949,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-19-000133&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-07-24",
+                  "epochDate": 1564001782,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001558370-19-006272&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-07-24",
+                  "epochDate": 1563962772,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000701374-19-000120&nav=1&src=Yahoo",
+                  "maxAge": 1
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-secFilings-WSKT.JK.json
+++ b/tests/http/quoteSummary-secFilings-WSKT.JK.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=secFilings"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "avv3p3tg2nuhe"
+      ],
+      "x-yahoo-request-id": [
+        "avv3p3tg2nuhe"
+      ],
+      "x-request-id": [
+        "6fb04f9c-1e08-4dd8-af4e-d268fc2b7b87"
+      ],
+      "content-length": [
+        "143"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:29 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=secFilings"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryDetail-ADH.json
+++ b/tests/http/quoteSummary-summaryDetail-ADH.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=summaryDetail"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "ajh06jdg2nrrg"
+      ],
+      "x-yahoo-request-id": [
+        "ajh06jdg2nrrg"
+      ],
+      "x-request-id": [
+        "d43f3214-7890-403b-a164-898a3b536564"
+      ],
+      "content-length": [
+        "146"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:40 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=summaryDetail"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryDetail-AFRAF.json
+++ b/tests/http/quoteSummary-summaryDetail-AFRAF.json
@@ -1,0 +1,116 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=summaryDetail"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "8vaqpk9g2nrrg"
+      ],
+      "x-yahoo-request-id": [
+        "8vaqpk9g2nrrg"
+      ],
+      "x-request-id": [
+        "a058c481-02a3-444b-8d47-dab6967565d4"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "385"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:40 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 6,
+              "open": 5.9,
+              "dayLow": 5.9,
+              "dayHigh": 5.9,
+              "regularMarketPreviousClose": 6,
+              "regularMarketOpen": 5.9,
+              "regularMarketDayLow": 5.9,
+              "regularMarketDayHigh": 5.9,
+              "exDividendDate": 1215993600,
+              "payoutRatio": 0,
+              "beta": 2.112234,
+              "volume": 1050,
+              "regularMarketVolume": 1050,
+              "averageVolume": 2859,
+              "averageVolume10days": 1600,
+              "averageDailyVolume10Day": 1600,
+              "bid": 0,
+              "ask": 0,
+              "bidSize": 0,
+              "askSize": 0,
+              "marketCap": 2474265344,
+              "fiftyTwoWeekLow": 3.27,
+              "fiftyTwoWeekHigh": 10.95,
+              "fiftyDayAverage": 5.9954543,
+              "twoHundredDayAverage": 4.939559,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryDetail-AMZN.json
+++ b/tests/http/quoteSummary-summaryDetail-AMZN.json
@@ -1,0 +1,118 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=summaryDetail"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "8ibbtbpg2nrrh"
+      ],
+      "x-yahoo-request-id": [
+        "8ibbtbpg2nrrh"
+      ],
+      "x-request-id": [
+        "82af67a6-99ae-4bf6-bdcd-1c72c835c0c2"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "454"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:40 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 3277.71,
+              "open": 3254.05,
+              "dayLow": 3257.75,
+              "dayHigh": 3308,
+              "regularMarketPreviousClose": 3277.71,
+              "regularMarketOpen": 3254.05,
+              "regularMarketDayLow": 3257.75,
+              "regularMarketDayHigh": 3308,
+              "payoutRatio": 0,
+              "beta": 1.143009,
+              "trailingPE": 78.39833,
+              "forwardPE": 49.344,
+              "volume": 1136627,
+              "regularMarketVolume": 1136627,
+              "averageVolume": 3657442,
+              "averageVolume10days": 2649840,
+              "averageDailyVolume10Day": 2649840,
+              "bid": 3277.55,
+              "ask": 3281.27,
+              "bidSize": 900,
+              "askSize": 1100,
+              "marketCap": 1651392249856,
+              "fiftyTwoWeekLow": 1626.03,
+              "fiftyTwoWeekHigh": 3552.25,
+              "priceToSalesTrailing12Months": 4.277509,
+              "fiftyDayAverage": 3246.1387,
+              "twoHundredDayAverage": 3205.9446,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryDetail-AZT.OL.json
+++ b/tests/http/quoteSummary-summaryDetail-AZT.OL.json
@@ -1,0 +1,110 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=summaryDetail"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "0eo1ia1g2nrrh"
+      ],
+      "x-yahoo-request-id": [
+        "0eo1ia1g2nrrh"
+      ],
+      "x-request-id": [
+        "aa3c072c-22a0-40e0-b7e7-f6524739a1f1"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "345"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:40 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 69.4,
+              "open": 68.6,
+              "dayLow": 68.4,
+              "dayHigh": 70.8,
+              "regularMarketPreviousClose": 69.4,
+              "regularMarketOpen": 68.6,
+              "regularMarketDayLow": 68.4,
+              "regularMarketDayHigh": 70.8,
+              "payoutRatio": 0,
+              "beta": 1.681382,
+              "trailingPE": 40.81395,
+              "volume": 286580,
+              "regularMarketVolume": 286580,
+              "bid": 68.6,
+              "ask": 70.8,
+              "marketCap": 3393095680,
+              "fiftyTwoWeekLow": 68.4,
+              "fiftyTwoWeekHigh": 70.8,
+              "priceToSalesTrailing12Months": 34.686073,
+              "currency": "NOK",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryDetail-SIX.json
+++ b/tests/http/quoteSummary-summaryDetail-SIX.json
@@ -1,0 +1,120 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=summaryDetail"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "c7urg41g2nuhe"
+      ],
+      "x-yahoo-request-id": [
+        "c7urg41g2nuhe"
+      ],
+      "x-request-id": [
+        "4f5f646f-b1fb-445c-88e2-dcf6d7f6816f"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "489"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:30 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 39.83,
+              "open": 39.89,
+              "dayLow": 39.92,
+              "dayHigh": 40.775,
+              "regularMarketPreviousClose": 39.83,
+              "regularMarketOpen": 39.89,
+              "regularMarketDayLow": 39.92,
+              "regularMarketDayHigh": 40.775,
+              "exDividendDate": 1583193600,
+              "fiveYearAvgDividendYield": 5.86,
+              "beta": 2.497331,
+              "forwardPE": -36.733944,
+              "volume": 405501,
+              "regularMarketVolume": 405501,
+              "averageVolume": 1642390,
+              "averageVolume10days": 1090080,
+              "averageDailyVolume10Day": 1090080,
+              "bid": 40.54,
+              "ask": 40.57,
+              "bidSize": 1200,
+              "askSize": 800,
+              "marketCap": 3402483200,
+              "fiftyTwoWeekLow": 8.75,
+              "fiftyTwoWeekHigh": 40.775,
+              "priceToSalesTrailing12Months": 6.6849976,
+              "fiftyDayAverage": 36.065453,
+              "twoHundredDayAverage": 27.273088,
+              "trailingAnnualDividendRate": 1.08,
+              "trailingAnnualDividendYield": 0.027115239,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryDetail-WSKT.JK.json
+++ b/tests/http/quoteSummary-summaryDetail-WSKT.JK.json
@@ -1,0 +1,120 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=summaryDetail"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "bbbkhppg2nuhe"
+      ],
+      "x-yahoo-request-id": [
+        "bbbkhppg2nuhe"
+      ],
+      "x-request-id": [
+        "175f8dab-6d77-42c2-b513-ae493630b8c0"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "477"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:30 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 1610,
+              "open": 1625,
+              "dayLow": 1590,
+              "dayHigh": 1660,
+              "regularMarketPreviousClose": 1610,
+              "regularMarketOpen": 1625,
+              "regularMarketDayLow": 1590,
+              "regularMarketDayHigh": 1660,
+              "dividendRate": 3.46,
+              "dividendYield": 0.0021,
+              "exDividendDate": 1592265600,
+              "fiveYearAvgDividendYield": 2.67,
+              "beta": 2.181707,
+              "forwardPE": 6.8513618,
+              "volume": 228998200,
+              "regularMarketVolume": 228998200,
+              "averageVolume": 269827553,
+              "averageVolume10days": 198514460,
+              "averageDailyVolume10Day": 198514460,
+              "bid": 1605,
+              "ask": 1610,
+              "bidSize": 0,
+              "askSize": 0,
+              "marketCap": 21786110459904,
+              "fiftyTwoWeekLow": 394,
+              "fiftyTwoWeekHigh": 2080,
+              "priceToSalesTrailing12Months": 1.0318944,
+              "fiftyDayAverage": 1595.1562,
+              "twoHundredDayAverage": 980.8309,
+              "currency": "IDR",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryProfile-ADH.json
+++ b/tests/http/quoteSummary-summaryProfile-ADH.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=summaryProfile"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "fc3j2kdg2nrrh"
+      ],
+      "x-yahoo-request-id": [
+        "fc3j2kdg2nrrh"
+      ],
+      "x-request-id": [
+        "014e07a5-da9e-48d6-8a3d-f3be4cf8b356"
+      ],
+      "content-length": [
+        "147"
+      ],
+      "x-envoy-upstream-service-time": [
+        "1"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:40 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=summaryProfile"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryProfile-AFRAF.json
+++ b/tests/http/quoteSummary-summaryProfile-AFRAF.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=summaryProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "a5hifnlg2nrrh"
+      ],
+      "x-yahoo-request-id": [
+        "a5hifnlg2nrrh"
+      ],
+      "x-request-id": [
+        "efcb0c51-9928-4da0-a37c-a20b772a2095"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "611"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:41 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryProfile": {
+              "address1": "2 rue Robert Esnault-Pelterie",
+              "city": "Paris",
+              "zip": "75007",
+              "country": "France",
+              "phone": "33 1 43 17 21 96",
+              "website": "http://www.airfranceklm.com",
+              "industry": "Airlines",
+              "sector": "Industrials",
+              "longBusinessSummary": "Air France-KLM SA, together with its subsidiaries, provides passenger transportation services on scheduled flights. The company operates through Network, Maintenance, Transavia, and Other segments. It also offers cargo transportation and aeronautics maintenance, and other air-transport-related services. The company operates in France, Benelux, Europe, Africa, the Middle East, Gulf, India, the Asia-Pacific, North America, Caribbean, West Indies, French Guyana, Indian Ocean, and South America. As of December 31, 2019, it operated fleet of 554 aircraft. The company was founded in 1919 and is headquartered in Paris, France.",
+              "fullTimeEmployees": 82122,
+              "companyOfficers": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryProfile-AMZN.json
+++ b/tests/http/quoteSummary-summaryProfile-AMZN.json
@@ -1,0 +1,96 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=summaryProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "8ts6bi9g2nrrh"
+      ],
+      "x-yahoo-request-id": [
+        "8ts6bi9g2nrrh"
+      ],
+      "x-request-id": [
+        "bceea66f-79d0-43c2-8e03-dd200652409a"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "958"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:41 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryProfile": {
+              "address1": "410 Terry Avenue North",
+              "city": "Seattle",
+              "state": "WA",
+              "zip": "98109-5210",
+              "country": "United States",
+              "phone": "206-266-1000",
+              "website": "http://www.amazon.com",
+              "industry": "Internet Retail",
+              "sector": "Consumer Cyclical",
+              "longBusinessSummary": "Amazon.com, Inc. engages in the retail sale of consumer products and subscriptions in North America and internationally. The company operates through three segments: North America, International, and Amazon Web Services (AWS). It sells merchandise and content purchased for resale from third-party sellers through physical and online stores. The company also manufactures and sells electronic devices, including Kindle, Fire tablets, Fire TVs, Rings, and Echo and other devices; provides Kindle Direct Publishing, an online service that allows independent authors and publishers to make their books available in the Kindle Store; and develops and produces media content. In addition, it offers programs that enable sellers to sell their products on its websites, as well as its stores; and programs that allow authors, musicians, filmmakers, skill and app developers, and others to publish and sell content. Further, the company provides compute, storage, database, analytics, machine learning, and other services, as well as fulfillment, advertising, publishing, and digital content subscriptions. Additionally, it offers Amazon Prime, a membership program, which provides free shipping of various items; access to streaming of movies and TV episodes; and other services. The company serves consumers, sellers, developers, enterprises, and content creators. Amazon.com, Inc. was founded in 1994 and is headquartered in Seattle, Washington.",
+              "fullTimeEmployees": 1298000,
+              "companyOfficers": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryProfile-AZT.OL.json
+++ b/tests/http/quoteSummary-summaryProfile-AZT.OL.json
@@ -1,0 +1,96 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=summaryProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "eudstv1g2nrrh"
+      ],
+      "x-yahoo-request-id": [
+        "eudstv1g2nrrh"
+      ],
+      "x-request-id": [
+        "df0cd426-ed97-4aad-bd01-5c5b724264fb"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1024"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:41 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryProfile": {
+              "address1": "Sykehusveien 23",
+              "address2": "PO Box 6463",
+              "city": "TromsÃ¸",
+              "zip": "9294",
+              "country": "Norway",
+              "phone": "47 77 64 89 00",
+              "fax": "47 77 64 89 01",
+              "website": "http://arcticzymes.com",
+              "industry": "Biotechnology",
+              "sector": "Healthcare",
+              "longBusinessSummary": "ArcticZymes Technologies ASA develops, manufactures, and markets immunomodulating beta-glucans and recombinant enzymes in Norway, Europe, Asia, Australia, Africa, and the Americas. It operates through two segments, Enzymes and Beta-Glucans. The company provides recombinant enzymes that are primarily derived from cold-water marine species and organisms from other relevant environments for use in molecular research, in vitro diagnostics, and therapeutics. It offers shrimp alkaline phosphatase and derived kits for cleanup prior to Sanger sequencing and next generation sequencing (NGS) processes; cod UNG for use in viral and other molecular diagnostic assays; double-strand specific DNases and derived kits for the removal of DNA from RNA samples; polymerases for technology development for life science, molecular diagnostics, NGS, and synthetic biology; proteinase for microbiological diagnostics and liquid biopsies; salt active nuclease for the removal of nucleic acids during manufacturing of vaccines, viruses, recombinant proteins, and other reagents; and ligases for joining DNA fragments. The company also provides immunomodulating beta-glucans products for the wound care, animal and consumer health, and adjuvants markets. It offers Woulgan wound gel; M-Glucan, a natural immune-stimulating product for fish and animal feed; and M-Gard, a natural immune-stimulating ingredients to enhance physical health. The company was formerly known as Biotec Pharmacon ASA and changed its name to ArcticZymes Technologies ASA in June 2020. ArcticZymes Technologies ASA was founded in 1990 and is headquartered in TromsÃ¸, Norway.",
+              "companyOfficers": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryProfile-SIX.json
+++ b/tests/http/quoteSummary-summaryProfile-SIX.json
@@ -1,0 +1,96 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=summaryProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "3v5kdb5g2nuhe"
+      ],
+      "x-yahoo-request-id": [
+        "3v5kdb5g2nuhe"
+      ],
+      "x-request-id": [
+        "1d41d369-8409-47c8-baed-10f85b8c5e80"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "537"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:30 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryProfile": {
+              "address1": "924 Avenue J East",
+              "city": "Grand Prairie",
+              "state": "TX",
+              "zip": "75050",
+              "country": "United States",
+              "phone": "972-595-5000",
+              "website": "http://www.sixflags.com",
+              "industry": "Leisure",
+              "sector": "Consumer Cyclical",
+              "longBusinessSummary": "Six Flags Entertainment Corporation owns and operates regional theme and waterparks under the Six Flags name. The company's parks offer various thrill rides, water attractions, themed areas, concerts and shows, restaurants, game venues, and retail outlets. It owns and operates 26 parks in the United States, Mexico, and Canada. The company was formerly known as Six Flags, Inc. and changed its name to Six Flags Entertainment Corporation in April 2010. Six Flags Entertainment Corporation was founded in 1961 and is based in Grand Prairie, Texas.",
+              "fullTimeEmployees": 2450,
+              "companyOfficers": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryProfile-WSKT.JK.json
+++ b/tests/http/quoteSummary-summaryProfile-WSKT.JK.json
@@ -1,0 +1,97 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=summaryProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "78pf2ihg2nuhe"
+      ],
+      "x-yahoo-request-id": [
+        "78pf2ihg2nuhe"
+      ],
+      "x-request-id": [
+        "a39724ef-16d5-4057-8c0c-9fb3c650066d"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "620"
+      ],
+      "x-envoy-upstream-service-time": [
+        "6"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:30 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryProfile": {
+              "address1": "Gedung Waskita",
+              "address2": "Jl. MT Haryono Kav. No.10 Cawang",
+              "city": "Jakarta",
+              "zip": "13340",
+              "country": "Indonesia",
+              "phone": "62 21 850 8510",
+              "fax": "62 21 850 8506",
+              "website": "http://www.waskita.co.id",
+              "industry": "Engineering & Construction",
+              "sector": "Industrials",
+              "longBusinessSummary": "PT Waskita Karya (Persero) Tbk, together with its subsidiaries, engages in the engineering, procurement, and construction works in Indonesia. It constructs building projects, transportation facilities, and water resources and energy projects; invests in various toll roads; and operates realty projects. The company is also involved in the hotel management business; building and equipment rental business; and production of precast concrete. In addition, it operates as an independent power producer; and develops real estate properties. PT Waskita Karya (Persero) Tbk was founded in 1961 and is headquartered in Jakarta, Indonesia.",
+              "fullTimeEmployees": 2333,
+              "companyOfficers": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-upgradeDowngradeHistory-ADH.json
+++ b/tests/http/quoteSummary-upgradeDowngradeHistory-ADH.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ADH?formatted=false&modules=upgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "6etnuu1g2nrrh"
+      ],
+      "x-yahoo-request-id": [
+        "6etnuu1g2nrrh"
+      ],
+      "x-request-id": [
+        "4f755984-17bd-40eb-a82e-467bec359a54"
+      ],
+      "content-length": [
+        "156"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:41 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=upgradeDowngradeHistory"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-upgradeDowngradeHistory-AFRAF.json
+++ b/tests/http/quoteSummary-upgradeDowngradeHistory-AFRAF.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AFRAF?formatted=false&modules=upgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "b8eceb5g2nrrh"
+      ],
+      "x-yahoo-request-id": [
+        "b8eceb5g2nrrh"
+      ],
+      "x-request-id": [
+        "7ace6837-1134-4a1b-bbbb-436946e753ff"
+      ],
+      "content-length": [
+        "156"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:41 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=upgradeDowngradeHistory"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-upgradeDowngradeHistory-AMZN.json
+++ b/tests/http/quoteSummary-upgradeDowngradeHistory-AMZN.json
@@ -1,0 +1,3026 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AMZN?formatted=false&modules=upgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "bs8dev5g2nrri"
+      ],
+      "x-yahoo-request-id": [
+        "bs8dev5g2nrri"
+      ],
+      "x-request-id": [
+        "1ed2931b-aed7-4fa1-a6d4-832596ae6918"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "5"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:42 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "upgradeDowngradeHistory": {
+              "history": [
+                {
+                  "epochGradeDate": 1612376908,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612376096,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612374298,
+                  "firm": "Cowen & Co.",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612373479,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612371882,
+                  "firm": "Truist Securities",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612371343,
+                  "firm": "Monness, Crespi, Hardt",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612370453,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612369033,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612364844,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612358898,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612355314,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612355019,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612354706,
+                  "firm": "JMP Securities",
+                  "toGrade": "Market Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612354596,
+                  "firm": "Raymond James",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612354525,
+                  "firm": "Pivotal Research",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612348047,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1611769664,
+                  "firm": "Stifel",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1611322523,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1610718858,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1604491113,
+                  "firm": "China Renaissance",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1604420115,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1604077960,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1604076792,
+                  "firm": "Piper Sandler",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1604061065,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1603817616,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1603802435,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1602850533,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1602761580,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1602259918,
+                  "firm": "Mizuho",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1602068039,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1601557302,
+                  "firm": "Pivotal Research",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1600771861,
+                  "firm": "Bernstein",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1596202990,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1596199722,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1596195986,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1596195716,
+                  "firm": "Raymond James",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1596193180,
+                  "firm": "Needham",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1596184984,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1596127912,
+                  "firm": "BMO Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1595859868,
+                  "firm": "B of A Securities",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1595594151,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1595580207,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1595248547,
+                  "firm": "MKM Partners",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1594637221,
+                  "firm": "Mizuho",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1594124960,
+                  "firm": "Baird",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1593523799,
+                  "firm": "Mizuho",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1593178057,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1593177953,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1592385493,
+                  "firm": "Needham",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1591622085,
+                  "firm": "Baird",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1591621294,
+                  "firm": "RBC Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1591013273,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588352186,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588348269,
+                  "firm": "JMP Securities",
+                  "toGrade": "Market Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588344669,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588344475,
+                  "firm": "Guggenheim",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588344239,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588344081,
+                  "firm": "BMO Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588338598,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588338165,
+                  "firm": "MKM Partners",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588334977,
+                  "firm": "B of A Securities",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "reit"
+                },
+                {
+                  "epochGradeDate": 1588334844,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588333861,
+                  "firm": "Susquehanna",
+                  "toGrade": "Positive",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588333153,
+                  "firm": "Raymond James",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588332475,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588330464,
+                  "firm": "Pivotal Research",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588330355,
+                  "firm": "Mizuho",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588330243,
+                  "firm": "RBC Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588327554,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588253465,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1587999963,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1587992689,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1587990385,
+                  "firm": "Oppenheimer",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1587746820,
+                  "firm": "Stifel",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1587646973,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1587568433,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1586965916,
+                  "firm": "Baird",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1585225808,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1584458683,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1581608820,
+                  "firm": "Aegis Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580905628,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580491830,
+                  "firm": "CFRA",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580487947,
+                  "firm": "B of A Securities",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580485543,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580484494,
+                  "firm": "RBC Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580483930,
+                  "firm": "DA Davidson",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "reit"
+                },
+                {
+                  "epochGradeDate": 1580479677,
+                  "firm": "Baird",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580476098,
+                  "firm": "Piper Sandler",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580476024,
+                  "firm": "JMP Securities",
+                  "toGrade": "Market Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580475870,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580475709,
+                  "firm": "Stifel",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580475630,
+                  "firm": "Cowen & Co.",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580475135,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580474740,
+                  "firm": "Raymond James",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580472258,
+                  "firm": "Mizuho",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580472207,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580472088,
+                  "firm": "Wells Fargo",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580467903,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580305170,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580305088,
+                  "firm": "BMO Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580128735,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1579707810,
+                  "firm": "Pivotal Research",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1579265841,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1579183053,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1578660041,
+                  "firm": "Bernstein",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1574781108,
+                  "firm": "China Renaissance",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1572012335,
+                  "firm": "JMP Securities",
+                  "toGrade": "Market Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1572010119,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1572009847,
+                  "firm": "Oppenheimer",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1572009518,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1572007464,
+                  "firm": "MKM Partners",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1572007105,
+                  "firm": "BMO Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1572005722,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1572003330,
+                  "firm": "Piper Jaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1572003267,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1572003183,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1572003125,
+                  "firm": "Raymond James",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1571660240,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1569241247,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1567509298,
+                  "firm": "RBC Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1564148885,
+                  "firm": "Baird",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1564146031,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1564145147,
+                  "firm": "Raymond James",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1564142904,
+                  "firm": "Mizuho",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1564139707,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1563968948,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1563789703,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1563194075,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1556286403,
+                  "firm": "Oppenheimer",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1556286191,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1556285826,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1556285551,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1556284381,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1556284089,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1556283804,
+                  "firm": "Raymond James",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1556283429,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1556283090,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1554744121,
+                  "firm": "Societe Generale",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1553084844,
+                  "firm": "Evercore ISI Group",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1552645126,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Sector Weight",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1549036295,
+                  "firm": "Pivotal Research",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1549026083,
+                  "firm": "Raymond James",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1549025018,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1548247951,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1540568165,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1540563922,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1540562392,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1540300461,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1538046902,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1537880370,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1536581666,
+                  "firm": "Wells Fargo",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1536577864,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1536151685,
+                  "firm": "DA Davidson",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1535541478,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1532705774,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1532705036,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1532704752,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1532703191,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1532702595,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1532699185,
+                  "firm": "BMO Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1532698825,
+                  "firm": "PiperJaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1532692331,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1532691504,
+                  "firm": "JMP Securities",
+                  "toGrade": "Market Outperform",
+                  "fromGrade": "Market Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1531745433,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1531499749,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1531489660,
+                  "firm": "Cowen & Co.",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1528978353,
+                  "firm": "DA Davidson",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1528121868,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "reit"
+                },
+                {
+                  "epochGradeDate": 1525716333,
+                  "firm": "Telsey Advisory Group",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1524840711,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1524835866,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1524834218,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1524831340,
+                  "firm": "JMP Securities",
+                  "toGrade": "Market Outperform",
+                  "fromGrade": "Market Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1524829204,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1524227202,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1524138688,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1519228980,
+                  "firm": "MKM Partners",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1517835243,
+                  "firm": "Nomura",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1517587947,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1517586641,
+                  "firm": "JMP Securities",
+                  "toGrade": "Market Outperform",
+                  "fromGrade": "Market Outperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1517584163,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1517582814,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1517580664,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1517579506,
+                  "firm": "PiperJaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1516995809,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1516711103,
+                  "firm": "Loop Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1515160436,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1512569124,
+                  "firm": "Evercore ISI Group",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1512418004,
+                  "firm": "Moffett Nathanson",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1511183102,
+                  "firm": "Nomura",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1509385040,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1509132041,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1509127449,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1509126585,
+                  "firm": "Loop Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1509122381,
+                  "firm": "Oppenheimer",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1509119232,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1509107954,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1509106277,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1509103387,
+                  "firm": "Raymond James",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1508846359,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1507732645,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1505297947,
+                  "firm": "Loop Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1504732333,
+                  "firm": "DA Davidson",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1502885453,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1500577730,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1500384110,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1493383553,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "reit"
+                },
+                {
+                  "epochGradeDate": 1493382113,
+                  "firm": "Pacific Crest",
+                  "toGrade": "Sector Weight",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1493128067,
+                  "firm": "Raymond James",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1493034709,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1492703695,
+                  "firm": "Wolfe Research",
+                  "toGrade": "Peer Perform",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1491834059,
+                  "firm": "Needham",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1491315938,
+                  "firm": "BMO Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1490959033,
+                  "firm": "Loop Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1490735835,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1484921793,
+                  "firm": "Aegis Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1480335180,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1480354388,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1477994732,
+                  "firm": "Axiom Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1477294704,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1476692067,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1475679061,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1475679074,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1475231868,
+                  "firm": "JMP Securities",
+                  "toGrade": "Market Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1475219367,
+                  "firm": "Guggenheim",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1475143214,
+                  "firm": "Maxim Group",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1474960027,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1525527134,
+                  "firm": "Argus",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1470143957,
+                  "firm": "MKM Partners",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1469799730,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1469797781,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1469797118,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1469788989,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1469778745,
+                  "firm": "CLSA",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1469776676,
+                  "firm": "Pacific Crest",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1469776606,
+                  "firm": "JMP Securities",
+                  "toGrade": "Market Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1469775942,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1469774582,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1469427403,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1469081816,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1466656112,
+                  "firm": "Maxim Group",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1466063607,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1465539261,
+                  "firm": "William Blair",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1462272184,
+                  "firm": "Nomura",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1461904487,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1461904263,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1461903707,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1461903236,
+                  "firm": "Axiom Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1460030851,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1459492695,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1459239653,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1458624080,
+                  "firm": "Raymond James",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Strong Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1456900614,
+                  "firm": "BMO Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1456731325,
+                  "firm": "Bernstein",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1455769312,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1454054828,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1453203226,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1452841437,
+                  "firm": "Susquehanna",
+                  "toGrade": "Perform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1452572776,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1451893713,
+                  "firm": "Monness Crespi Hardt",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1450774272,
+                  "firm": "Macquarie",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1450162559,
+                  "firm": "MKM Partners",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1449648213,
+                  "firm": "Nomura",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1449559447,
+                  "firm": "Pacific Crest",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1448942499,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1445930684,
+                  "firm": "Axiom Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1445604845,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1445596322,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1445585575,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1445582670,
+                  "firm": "PiperJaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1445580512,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1445579475,
+                  "firm": "JMP Securities",
+                  "toGrade": "Market Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1445579277,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1445579164,
+                  "firm": "RBC Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1445578828,
+                  "firm": "Baird",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1445578813,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1441952731,
+                  "firm": "RBC Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1440658736,
+                  "firm": "Raymond James",
+                  "toGrade": "Strong Buy",
+                  "fromGrade": "Outperform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1440570551,
+                  "firm": "Evercore ISI Group",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1438152957,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1437735600,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1437725582,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1437720750,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1437712416,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1525528836,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1437710308,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1437710143,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Equal-Weight",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1437549413,
+                  "firm": "JMP Securities",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1437375485,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1437375308,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1437375135,
+                  "firm": "Cowen & Co.",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1436946437,
+                  "firm": "Nomura",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1436851298,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1435298143,
+                  "firm": "Mizuho",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1435210363,
+                  "firm": "Evercore ISI Group",
+                  "toGrade": "",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1434354039,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1433305233,
+                  "firm": "PiperJaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1430730000,
+                  "firm": "Oppenheimer",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1525527134,
+                  "firm": "Argus",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1429866000,
+                  "firm": "Nomura",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1429860251,
+                  "firm": "Janney Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1429856558,
+                  "firm": "Raymond James",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1429856435,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1429689230,
+                  "firm": "Monness Crespi Hardt",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1429610895,
+                  "firm": "BGC Financial",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1429002000,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1425979742,
+                  "firm": "Wolfe Research",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Peer Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1425888988,
+                  "firm": "Axiom Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1425882793,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1425449151,
+                  "firm": "Baird",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1424327255,
+                  "firm": "PiperJaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1422608400,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1422349200,
+                  "firm": "JP Morgan",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1422003020,
+                  "firm": "Oppenheimer",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1421855313,
+                  "firm": "BGC Financial",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1421107200,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1417155008,
+                  "firm": "PiperJaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1416528000,
+                  "firm": "Nomura",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1414569337,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1414398600,
+                  "firm": "Monness, Crespi, Hardt",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1414141200,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1414139400,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1413216000,
+                  "firm": "Wolfe Research",
+                  "toGrade": "",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1413189000,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1412931600,
+                  "firm": "Susquehanna",
+                  "toGrade": "Positive",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1406323278,
+                  "firm": "CRT Capital",
+                  "toGrade": "Fair Value",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1406321095,
+                  "firm": "Citigroup",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1406321093,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1406273324,
+                  "firm": "Raymond James",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1525528836,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1406254590,
+                  "firm": "UBS",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1406252455,
+                  "firm": "JP Morgan",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1406248769,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1406247747,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1406010002,
+                  "firm": "Citigroup",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1403764014,
+                  "firm": "Barclays",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1398873600,
+                  "firm": "Edward Jones",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1398467992,
+                  "firm": "Cantor Fitzgerald",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1398412800,
+                  "firm": "Raymond James",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Strong Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1398409757,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1398395478,
+                  "firm": "UBS",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1398393545,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1398391606,
+                  "firm": "JP Morgan",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1398386062,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1397635497,
+                  "firm": "Argus Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1392220800,
+                  "firm": "UBS",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1391169372,
+                  "firm": "FBN Securities",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1391155200,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1391153689,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1391150848,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1390838400,
+                  "firm": "Pacific Crest",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1389686709,
+                  "firm": "FBN Securities",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1389342600,
+                  "firm": "Susquehanna",
+                  "toGrade": "Positive",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1388990834,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1388764800,
+                  "firm": "Topeka",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1388505600,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1387262989,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1384417940,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1382968950,
+                  "firm": "Standpoint",
+                  "toGrade": "Sell",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1382945547,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1382687911,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1382685973,
+                  "firm": "Raymond James",
+                  "toGrade": "Strong Buy",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1382438725,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1382080642,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1379574000,
+                  "firm": "CRT Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1378882402,
+                  "firm": "Wedbush",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1374829535,
+                  "firm": "BMO Capital",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1374824865,
+                  "firm": "Nomura",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1373961231,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1373472676,
+                  "firm": "Susquehanna",
+                  "toGrade": "Positive",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1373390911,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1368691091,
+                  "firm": "Lazard",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1367487786,
+                  "firm": "Tigress Financial",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1366963317,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1366618113,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1366185916,
+                  "firm": "Nomura",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1363680464,
+                  "firm": "JMP Securities",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1363242452,
+                  "firm": "PiperJaffray",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1361347547,
+                  "firm": "Nomura",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1359552425,
+                  "firm": "Barclays",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1359540668,
+                  "firm": "Oppenheimer",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1359540255,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1359533243,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1359531886,
+                  "firm": "Credit Agricole",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1359531597,
+                  "firm": "Nomura",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1359531237,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1359530684,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1359389631,
+                  "firm": "BGC Financial",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1359366009,
+                  "firm": "PiperJaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1359364847,
+                  "firm": "PiperJaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1359109097,
+                  "firm": "ISI Group",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1359101356,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1359043430,
+                  "firm": "ISI Group",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1358496653,
+                  "firm": "Pacific Crest",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Sector Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1357713892,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1357540365,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Equal-Weight",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1351170540,
+                  "firm": "Barclays",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1348208580,
+                  "firm": "Cantor Fitzgerald",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1347365820,
+                  "firm": "Barclays",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1347000720,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1346395500,
+                  "firm": "PiperJaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1343378100,
+                  "firm": "Oppenheimer",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1343372400,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1342506540,
+                  "firm": "Lazard",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1341991740,
+                  "firm": "BMO Capital",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1338965820,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1337061720,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1335526620,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1335522540,
+                  "firm": "BGC Financial",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1335517380,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1335516060,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1335515880,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1335514680,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1335514140,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1335511200,
+                  "firm": "Benchmark",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1335507660,
+                  "firm": "Bank oferica",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1333346760,
+                  "firm": "Bank oferica",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1329373020,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1329291180,
+                  "firm": "PiperJaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1325162820,
+                  "firm": "PiperJaffray",
+                  "toGrade": "",
+                  "fromGrade": "",
+                  "action": "main"
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-upgradeDowngradeHistory-AZT.OL.json
+++ b/tests/http/quoteSummary-upgradeDowngradeHistory-AZT.OL.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/AZT.OL?formatted=false&modules=upgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "fvg7jvpg2nrri"
+      ],
+      "x-yahoo-request-id": [
+        "fvg7jvpg2nrri"
+      ],
+      "x-request-id": [
+        "7970080c-2e0f-4e7e-9501-30f26a4aa167"
+      ],
+      "content-length": [
+        "156"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:42 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=upgradeDowngradeHistory"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-upgradeDowngradeHistory-SIX.json
+++ b/tests/http/quoteSummary-upgradeDowngradeHistory-SIX.json
@@ -1,0 +1,639 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SIX?formatted=false&modules=upgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "ba5qdfpg2nuhf"
+      ],
+      "x-yahoo-request-id": [
+        "ba5qdfpg2nuhf"
+      ],
+      "x-request-id": [
+        "f60e9cc4-230c-4882-82ba-722eb948809b"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:31 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "upgradeDowngradeHistory": {
+              "history": [
+                {
+                  "epochGradeDate": 1604307883,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1604054666,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1601631741,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Sell",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1596122329,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1596099323,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1595938492,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1594295238,
+                  "firm": "Janney Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1592217228,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1590684068,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Sell",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1588683873,
+                  "firm": "Wells Fargo",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588352480,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588346698,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588328370,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1587397727,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1586431567,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1584961440,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1584954791,
+                  "firm": "B. Riley",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1584523978,
+                  "firm": "Oppenheimer",
+                  "toGrade": "Perform",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1583838519,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1582289408,
+                  "firm": "Wedbush",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1582289366,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1582279486,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1578939768,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1578678953,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1578668517,
+                  "firm": "Janney Capital",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1578664468,
+                  "firm": "Wells Fargo",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1578318281,
+                  "firm": "Wedbush",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1577969059,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "reit"
+                },
+                {
+                  "epochGradeDate": 1572610015,
+                  "firm": "Berenberg",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1571996638,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1571921789,
+                  "firm": "B. Riley",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1571918123,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1562673853,
+                  "firm": "Wells Fargo",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1561978552,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Sector Weight",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1560942985,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1555933988,
+                  "firm": "Jefferies",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1550230402,
+                  "firm": "KeyBanc",
+                  "toGrade": "Sector Weight",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1544624375,
+                  "firm": "Berenberg",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1541076814,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1540550519,
+                  "firm": "Macquarie",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Underperform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1540475034,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1532604530,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Overweight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1532086418,
+                  "firm": "Wedbush",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1531147804,
+                  "firm": "Wells Fargo",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1524757362,
+                  "firm": "Macquarie",
+                  "toGrade": "Underperform",
+                  "fromGrade": "Underperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1525528839,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1524741944,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1507210154,
+                  "firm": "Hilliard Lyons",
+                  "toGrade": "Long-Term Buy",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1504113822,
+                  "firm": "Hilliard Lyons",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1501161984,
+                  "firm": "Macquarie",
+                  "toGrade": "Underperform",
+                  "fromGrade": "Neutral",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1500642892,
+                  "firm": "William Blair",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1492793311,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1492086133,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1491485581,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1525528838,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1480534304,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1471944610,
+                  "firm": "Hilliard Lyons",
+                  "toGrade": "Long-Term Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1469797779,
+                  "firm": "FBR Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1461060494,
+                  "firm": "Stephens & Co.",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1459944784,
+                  "firm": "Oppenheimer",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1459492987,
+                  "firm": "FBR Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1459234553,
+                  "firm": "Sterne Agee CRT",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1456153042,
+                  "firm": "Macquarie",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1449650364,
+                  "firm": "Macquarie",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1442384686,
+                  "firm": "Janney Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1442340055,
+                  "firm": "Janney Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1525528838,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1431706999,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1430109789,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1403297662,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1394693271,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1385537388,
+                  "firm": "FBR Capital",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1366356493,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1364970865,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1355477782,
+                  "firm": "Wells Fargo",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1355306183,
+                  "firm": "Miller Tabak",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1353404640,
+                  "firm": "Longbow Research",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1346835360,
+                  "firm": "Oppenheimer",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1342605600,
+                  "firm": "Miller Tabak",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-upgradeDowngradeHistory-WSKT.JK.json
+++ b/tests/http/quoteSummary-upgradeDowngradeHistory-WSKT.JK.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/WSKT.JK?formatted=false&modules=upgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "0v1grqlg2nuhe"
+      ],
+      "x-yahoo-request-id": [
+        "0v1grqlg2nuhe"
+      ],
+      "x-request-id": [
+        "5c4ac8b5-b9b6-4bd7-aea4-a7f0ea0dcb33"
+      ],
+      "content-length": [
+        "156"
+      ],
+      "x-envoy-upstream-service-time": [
+        "5"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:30 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=upgradeDowngradeHistory"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-ADH.json
+++ b/tests/http/recommendationsBySymbol-ADH.json
@@ -1,0 +1,72 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/ADH?"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "x-yahoo-request-id": [
+        "1kr3sqdg2nrr2"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "58"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:26 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-AFRAF.json
+++ b/tests/http/recommendationsBySymbol-AFRAF.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/AFRAF?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "9buj2utg2nrr2"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "167"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:26 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "AFRAF",
+            "recommendedSymbols": [
+              {
+                "symbol": "AFLYY",
+                "score": 0.013432
+              },
+              {
+                "symbol": "2106.TW",
+                "score": 0.011183
+              },
+              {
+                "symbol": "INV.L",
+                "score": 0.01097
+              },
+              {
+                "symbol": "0675.HK",
+                "score": 0.009802
+              },
+              {
+                "symbol": "EMBR",
+                "score": 0.009148
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-AMZN.json
+++ b/tests/http/recommendationsBySymbol-AMZN.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/AMZN?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "5ojj07pg2nrr2"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "157"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:26 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "AMZN",
+            "recommendedSymbols": [
+              {
+                "symbol": "FB",
+                "score": 0.293812
+              },
+              {
+                "symbol": "AAPL",
+                "score": 0.292653
+              },
+              {
+                "symbol": "GOOG",
+                "score": 0.28682
+              },
+              {
+                "symbol": "TSLA",
+                "score": 0.2783
+              },
+              {
+                "symbol": "NFLX",
+                "score": 0.275253
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-AZT.OL.json
+++ b/tests/http/recommendationsBySymbol-AZT.OL.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/AZT.OL?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "153qd1tg2nrr2"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "166"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:26 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "AZT.OL",
+            "recommendedSymbols": [
+              {
+                "symbol": "BGBIO.OL",
+                "score": 0.008303
+              },
+              {
+                "symbol": "CARA.OL",
+                "score": 0.005888
+              },
+              {
+                "symbol": "PHO.OL",
+                "score": 0.005661
+              },
+              {
+                "symbol": "AKSO.OL",
+                "score": 0.005633
+              },
+              {
+                "symbol": "EMBRAC-B.ST",
+                "score": 0.005612
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-SIX.json
+++ b/tests/http/recommendationsBySymbol-SIX.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/SIX?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "8p0m4lpg2nuh6"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "157"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:22 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "SIX",
+            "recommendedSymbols": [
+              {
+                "symbol": "FUN",
+                "score": 0.086002
+              },
+              {
+                "symbol": "SEAS",
+                "score": 0.071116
+              },
+              {
+                "symbol": "PLAY",
+                "score": 0.05385
+              },
+              {
+                "symbol": "CNK",
+                "score": 0.049415
+              },
+              {
+                "symbol": "NCLH",
+                "score": 0.04001
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-WSKT.JK.json
+++ b/tests/http/recommendationsBySymbol-WSKT.JK.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/WSKT.JK?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "7vvbumdg2nuh6"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "167"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:22 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "WSKT.JK",
+            "recommendedSymbols": [
+              {
+                "symbol": "WIKA.JK",
+                "score": 0.252374
+              },
+              {
+                "symbol": "PTPP.JK",
+                "score": 0.239421
+              },
+              {
+                "symbol": "ADHI.JK",
+                "score": 0.207813
+              },
+              {
+                "symbol": "JSMR.JK",
+                "score": 0.150198
+              },
+              {
+                "symbol": "BSDE.JK",
+                "score": 0.144273
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/search-ADH.json
+++ b/tests/http/search-ADH.json
@@ -1,0 +1,190 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v1/finance/search?lang=en-US&region=US&quotesCount=6&newsCount=4&enableFuzzyQuery=false&quotesQueryId=tss_match_phrase_query&multiQuoteQueryId=multi_quote_single_token_query&newsQueryId=news_cie_vespa&enableCb=true&enableNavLinks=true&enableEnhancedTrivialQuery=true&q=ADH"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=120, stale-while-revalidate=180"
+      ],
+      "y-rid": [
+        "2bimonhg2nrr2"
+      ],
+      "x-yahoo-request-id": [
+        "2bimonhg2nrr2"
+      ],
+      "x-request-id": [
+        "c948a9e3-2f39-425c-bb85-cd65d99cca9c"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1192"
+      ],
+      "x-envoy-upstream-service-time": [
+        "38"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:26 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-search--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "explains": [],
+      "count": 11,
+      "quotes": [
+        {
+          "exchange": "PNK",
+          "shortname": "AMERICAN DIVERSIFIED HOLDINGS C",
+          "quoteType": "EQUITY",
+          "symbol": "ADHC",
+          "index": "quotes",
+          "score": 20566,
+          "typeDisp": "Equity",
+          "longname": "American Diversified Holdings Corporation",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "JKT",
+          "shortname": "Adhi Karya (Persero) Tbk.",
+          "quoteType": "EQUITY",
+          "symbol": "ADHI.JK",
+          "index": "quotes",
+          "score": 20505,
+          "typeDisp": "Equity",
+          "longname": "PT Adhi Karya (Persero) Tbk",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "PNK",
+          "shortname": "ADHERA THERAPEUTICS INC",
+          "quoteType": "EQUITY",
+          "symbol": "ATRX",
+          "index": "quotes",
+          "score": 20180,
+          "typeDisp": "Equity",
+          "longname": "Adhera Therapeutics, Inc.",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "ASX",
+          "shortname": "ADAIRS FPO",
+          "quoteType": "EQUITY",
+          "symbol": "ADH.AX",
+          "index": "quotes",
+          "score": 20092,
+          "typeDisp": "Equity",
+          "longname": "Adairs Limited",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "FRA",
+          "shortname": "AIR CANADA (VAR.VTG)",
+          "quoteType": "EQUITY",
+          "symbol": "ADH2.F",
+          "index": "quotes",
+          "score": 20038,
+          "typeDisp": "Equity",
+          "longname": "Air Canada",
+          "isYahooFinance": true
+        },
+        {
+          "index": "7f712744acad23405e56369ab035bccc",
+          "name": "Broadlume (formerly AdHawk)",
+          "permalink": "broadlume",
+          "isYahooFinance": false
+        },
+        {
+          "index": "aa9c59c6115b21dd20a0ec8ace24e139",
+          "name": "AdhereTech",
+          "permalink": "adheretech",
+          "isYahooFinance": false
+        }
+      ],
+      "news": [
+        {
+          "uuid": "a15582f6-eafa-3baa-8c2e-0ecfa05257ac",
+          "title": "Adairs Limited's (ASX:ADH) Stock Is Going Strong: Is the Market Following Fundamentals?",
+          "publisher": "Simply Wall St.",
+          "link": "https://finance.yahoo.com/news/adairs-limiteds-asx-adh-stock-142757989.html",
+          "providerPublishTime": 1610461677,
+          "type": "STORY"
+        },
+        {
+          "uuid": "942bcf8f-c337-33c4-b46b-eda79b878652",
+          "title": "Assured Healthcare Partners (AHP) Announces Partnership with Allied Digestive Health (ADH)",
+          "publisher": "PR Newswire",
+          "link": "https://finance.yahoo.com/news/assured-healthcare-partners-ahp-announces-130100892.html",
+          "providerPublishTime": 1610542860,
+          "type": "STORY"
+        },
+        {
+          "uuid": "d15ca764-93bd-34ba-a318-789c7a9b4a6a",
+          "title": "Edited Transcript of ADH.AX earnings conference call or presentation 16-Feb-21 12:01am GMT",
+          "publisher": "Thomson Reuters StreetEvents",
+          "link": "https://finance.yahoo.com/news/edited-transcript-adh-ax-earnings-000100814.html",
+          "providerPublishTime": 1613433660,
+          "type": "STORY"
+        },
+        {
+          "uuid": "932d0f1e-53b5-33bf-a8b1-edb9ac2818c4",
+          "title": "Shareholders Of Adairs (ASX:ADH) Must Be Happy With Their 146% Total Return",
+          "publisher": "Simply Wall St.",
+          "link": "https://finance.yahoo.com/news/shareholders-adairs-asx-adh-must-140448452.html",
+          "providerPublishTime": 1613052288,
+          "type": "STORY"
+        }
+      ],
+      "nav": [],
+      "lists": [],
+      "researchReports": [],
+      "totalTime": 36,
+      "timeTakenForQuotes": 421,
+      "timeTakenForNews": 600,
+      "timeTakenForAlgowatchlist": 400,
+      "timeTakenForPredefinedScreener": 400,
+      "timeTakenForCrunchbase": 400,
+      "timeTakenForNav": 400,
+      "timeTakenForResearchReports": 0
+    }
+  }
+}

--- a/tests/http/search-AFRAF.json
+++ b/tests/http/search-AFRAF.json
@@ -1,0 +1,134 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v1/finance/search?lang=en-US&region=US&quotesCount=6&newsCount=4&enableFuzzyQuery=false&quotesQueryId=tss_match_phrase_query&multiQuoteQueryId=multi_quote_single_token_query&newsQueryId=news_cie_vespa&enableCb=true&enableNavLinks=true&enableEnhancedTrivialQuery=true&q=AFRAF"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=120, stale-while-revalidate=180"
+      ],
+      "y-rid": [
+        "1312f39g2nrr2"
+      ],
+      "x-yahoo-request-id": [
+        "1312f39g2nrr2"
+      ],
+      "x-request-id": [
+        "67ac692a-1434-4298-99fa-f7746ecf2690"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "829"
+      ],
+      "x-envoy-upstream-service-time": [
+        "31"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:26 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-search--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "explains": [],
+      "count": 5,
+      "quotes": [
+        {
+          "exchange": "PNK",
+          "shortname": "AIR FRANCE-KLM",
+          "quoteType": "EQUITY",
+          "symbol": "AFRAF",
+          "index": "quotes",
+          "score": 20018,
+          "typeDisp": "Equity",
+          "longname": "Air France-KLM SA",
+          "isYahooFinance": true
+        }
+      ],
+      "news": [
+        {
+          "uuid": "f5194e16-acdc-3f34-a5e6-1dc95c64bbde",
+          "title": "FOCUS-Relaunching in a crisis, Alitalia scales back at home",
+          "publisher": "Reuters",
+          "link": "https://finance.yahoo.com/news/focus-relaunching-crisis-alitalia-scales-123744099.html",
+          "providerPublishTime": 1613479064,
+          "type": "STORY"
+        },
+        {
+          "uuid": "4f143668-52fd-3a5c-bb16-7940043c90d3",
+          "title": "Need Proportionate Rules on Airline Competition: Djebbari",
+          "publisher": "Bloomberg",
+          "link": "https://finance.yahoo.com/video/proportionate-rules-airline-competition-djebbari-102729740.html",
+          "providerPublishTime": 1613039249,
+          "type": "VIDEO"
+        },
+        {
+          "uuid": "af7f9079-e153-3650-be05-cc8541b1bda4",
+          "title": "Declaration of number of voting rights",
+          "publisher": "GlobeNewswire",
+          "link": "https://finance.yahoo.com/news/declaration-number-voting-rights-170000225.html",
+          "providerPublishTime": 1612371600,
+          "type": "STORY"
+        },
+        {
+          "uuid": "f9b647c7-c54d-32bd-86b2-2effcd91d87b",
+          "title": "Royal Schiphol Group N.V. -- Moody's announces completion of a periodic review of ratings of Royal Schiphol Group N.V.",
+          "publisher": "Moody's",
+          "link": "https://finance.yahoo.com/news/royal-schiphol-group-n-v-184907394.html",
+          "providerPublishTime": 1611600547,
+          "type": "STORY"
+        }
+      ],
+      "nav": [],
+      "lists": [],
+      "researchReports": [],
+      "totalTime": 30,
+      "timeTakenForQuotes": 417,
+      "timeTakenForNews": 600,
+      "timeTakenForAlgowatchlist": 400,
+      "timeTakenForPredefinedScreener": 400,
+      "timeTakenForCrunchbase": 400,
+      "timeTakenForNav": 400,
+      "timeTakenForResearchReports": 0
+    }
+  }
+}

--- a/tests/http/search-AMZN.json
+++ b/tests/http/search-AMZN.json
@@ -1,0 +1,188 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v1/finance/search?lang=en-US&region=US&quotesCount=6&newsCount=4&enableFuzzyQuery=false&quotesQueryId=tss_match_phrase_query&multiQuoteQueryId=multi_quote_single_token_query&newsQueryId=news_cie_vespa&enableCb=true&enableNavLinks=true&enableEnhancedTrivialQuery=true&q=AMZN"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=120, stale-while-revalidate=180"
+      ],
+      "y-rid": [
+        "9r2n8tlg2nrr2"
+      ],
+      "x-yahoo-request-id": [
+        "9r2n8tlg2nrr2"
+      ],
+      "x-request-id": [
+        "a25ee52c-0537-422f-b78b-3d06f35aae2f"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "970"
+      ],
+      "x-envoy-upstream-service-time": [
+        "32"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:26 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-search--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "explains": [],
+      "count": 10,
+      "quotes": [
+        {
+          "exchange": "NMS",
+          "shortname": "Amazon.com, Inc.",
+          "quoteType": "EQUITY",
+          "symbol": "AMZN",
+          "index": "quotes",
+          "score": 20322700,
+          "typeDisp": "Equity",
+          "longname": "Amazon.com, Inc.",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "MEX",
+          "shortname": "AMAZON COM INC",
+          "quoteType": "EQUITY",
+          "symbol": "AMZN.MX",
+          "index": "quotes",
+          "score": 20436,
+          "typeDisp": "Equity",
+          "longname": "Amazon.com, Inc.",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "BUE",
+          "shortname": "AMAZON COM INC",
+          "quoteType": "EQUITY",
+          "symbol": "AMZN.BA",
+          "index": "quotes",
+          "score": 20049,
+          "typeDisp": "Equity",
+          "longname": "Amazon.com, Inc.",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "MIL",
+          "shortname": "AMAZON",
+          "quoteType": "EQUITY",
+          "symbol": "AMZN.MI",
+          "index": "quotes",
+          "score": 20042,
+          "typeDisp": "Equity",
+          "longname": "Amazon.com, Inc.",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "OPR",
+          "shortname": "AMZN Feb 2021 3275.000 call",
+          "quoteType": "OPTION",
+          "symbol": "AMZN210219C03275000",
+          "index": "quotes",
+          "score": 20020,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "SGO",
+          "shortname": "AMAZON COM INC",
+          "quoteType": "EQUITY",
+          "symbol": "AMZN.SN",
+          "index": "quotes",
+          "score": 20012,
+          "typeDisp": "Equity",
+          "longname": "Amazon.com, Inc.",
+          "isYahooFinance": true
+        }
+      ],
+      "news": [
+        {
+          "uuid": "04b7cfbd-12fa-30e2-90fc-de9b79d5b310",
+          "title": "ROKU Stock: Earnings Option Trade Idea",
+          "publisher": "Investor's Business Daily",
+          "link": "https://finance.yahoo.com/m/04b7cfbd-12fa-30e2-90fc-de9b79d5b310/roku-stock%3A-earnings-option.html",
+          "providerPublishTime": 1613487676,
+          "type": "STORY"
+        },
+        {
+          "uuid": "91d95e98-fcbc-35f0-886b-1a2999cc0b14",
+          "title": "Chart Reading For Beginners: Nvidia, Amazon, DocuSign Reveal This Key Investing Skill",
+          "publisher": "Investor's Business Daily",
+          "link": "https://finance.yahoo.com/m/91d95e98-fcbc-35f0-886b-1a2999cc0b14/chart-reading-for-beginners%3A.html",
+          "providerPublishTime": 1613488272,
+          "type": "STORY"
+        },
+        {
+          "uuid": "c3960464-575e-31fa-99d4-b7950bd426db",
+          "title": "O’Shares Global Internet Giants ETF (OGIG) +107% in 2020, +10% YTD 2021. Why Kevin O’Leary is Buying More",
+          "publisher": "Business Wire",
+          "link": "https://finance.yahoo.com/news/o-shares-global-internet-giants-151500978.html",
+          "providerPublishTime": 1613488500,
+          "type": "STORY"
+        },
+        {
+          "uuid": "1c49bd26-bc2d-3c72-bc47-76159b91316a",
+          "title": "How Amazon Is Becoming a Digital Ad Titan",
+          "publisher": "Motley Fool",
+          "link": "https://finance.yahoo.com/m/1c49bd26-bc2d-3c72-bc47-76159b91316a/how-amazon-is-becoming-a.html",
+          "providerPublishTime": 1613478120,
+          "type": "STORY"
+        }
+      ],
+      "nav": [],
+      "lists": [],
+      "researchReports": [],
+      "totalTime": 30,
+      "timeTakenForQuotes": 420,
+      "timeTakenForNews": 600,
+      "timeTakenForAlgowatchlist": 400,
+      "timeTakenForPredefinedScreener": 400,
+      "timeTakenForCrunchbase": 400,
+      "timeTakenForNav": 400,
+      "timeTakenForResearchReports": 0
+    }
+  }
+}

--- a/tests/http/search-AZT.OL.json
+++ b/tests/http/search-AZT.OL.json
@@ -1,0 +1,98 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v1/finance/search?lang=en-US&region=US&quotesCount=6&newsCount=4&enableFuzzyQuery=false&quotesQueryId=tss_match_phrase_query&multiQuoteQueryId=multi_quote_single_token_query&newsQueryId=news_cie_vespa&enableCb=true&enableNavLinks=true&enableEnhancedTrivialQuery=true&q=AZT.OL"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=120, stale-while-revalidate=180"
+      ],
+      "y-rid": [
+        "2obq035g2nrr2"
+      ],
+      "x-yahoo-request-id": [
+        "2obq035g2nrr2"
+      ],
+      "x-request-id": [
+        "9b9c1e89-f4cd-4387-ad5e-27bf25debe7b"
+      ],
+      "content-length": [
+        "510"
+      ],
+      "x-envoy-upstream-service-time": [
+        "29"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 16:14:26 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-search--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "explains": [],
+      "count": 1,
+      "quotes": [
+        {
+          "exchange": "OSL",
+          "shortname": "ARCTICZYMES TECH",
+          "quoteType": "EQUITY",
+          "symbol": "AZT.OL",
+          "index": "quotes",
+          "score": 2005700,
+          "typeDisp": "Equity",
+          "longname": "ArcticZymes Technologies ASA",
+          "isYahooFinance": true
+        }
+      ],
+      "news": [],
+      "nav": [],
+      "lists": [],
+      "researchReports": [],
+      "totalTime": 28,
+      "timeTakenForQuotes": 417,
+      "timeTakenForNews": 600,
+      "timeTakenForAlgowatchlist": 400,
+      "timeTakenForPredefinedScreener": 400,
+      "timeTakenForCrunchbase": 400,
+      "timeTakenForNav": 400,
+      "timeTakenForResearchReports": 0
+    }
+  }
+}

--- a/tests/http/search-SIX.json
+++ b/tests/http/search-SIX.json
@@ -1,0 +1,190 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v1/finance/search?lang=en-US&region=US&quotesCount=6&newsCount=4&enableFuzzyQuery=false&quotesQueryId=tss_match_phrase_query&multiQuoteQueryId=multi_quote_single_token_query&newsQueryId=news_cie_vespa&enableCb=true&enableNavLinks=true&enableEnhancedTrivialQuery=true&q=SIX"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=120, stale-while-revalidate=180"
+      ],
+      "y-rid": [
+        "9137qopg2nuh6"
+      ],
+      "x-yahoo-request-id": [
+        "9137qopg2nuh6"
+      ],
+      "x-request-id": [
+        "66dc987e-68cd-425e-85a9-b8ba0b8340a3"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1134"
+      ],
+      "x-envoy-upstream-service-time": [
+        "98"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:22 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-search--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "4"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "explains": [],
+      "count": 11,
+      "quotes": [
+        {
+          "exchange": "NYQ",
+          "shortname": "Six Flags Entertainment Corpora",
+          "quoteType": "EQUITY",
+          "symbol": "SIX",
+          "index": "quotes",
+          "score": 2225000,
+          "typeDisp": "Equity",
+          "longname": "Six Flags Entertainment Corporation",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "NYQ",
+          "shortname": "Sixth Street Specialty Lending,",
+          "quoteType": "EQUITY",
+          "symbol": "TSLX",
+          "index": "quotes",
+          "score": 21158,
+          "typeDisp": "Equity",
+          "longname": "Sixth Street Specialty Lending, Inc.",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "CNQ",
+          "shortname": "SixthWaveInno",
+          "quoteType": "EQUITY",
+          "symbol": "SIXW.CN",
+          "index": "quotes",
+          "score": 20158,
+          "typeDisp": "Equity",
+          "longname": "Sixth Wave Innovations Inc.",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "PNK",
+          "shortname": "SIXTH WAVE INNOVATIONS INC",
+          "quoteType": "EQUITY",
+          "symbol": "ATURF",
+          "index": "quotes",
+          "score": 20130,
+          "typeDisp": "Equity",
+          "longname": "Sixth Wave Innovations Inc.",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "PNK",
+          "shortname": "SIXTY SIX OILFIELD SERVICES INC",
+          "quoteType": "EQUITY",
+          "symbol": "SSOF",
+          "index": "quotes",
+          "score": 20099,
+          "typeDisp": "Equity",
+          "longname": "665 Energy, Inc.",
+          "isYahooFinance": true
+        },
+        {
+          "index": "bf0b2ace1dfaf54c3554440f50efc756",
+          "name": "SixThirty",
+          "permalink": "sixthirty",
+          "isYahooFinance": false
+        },
+        {
+          "index": "2567dd7b024bc1a703969e3a0747521d",
+          "name": "Episode Six",
+          "permalink": "episode-six",
+          "isYahooFinance": false
+        }
+      ],
+      "news": [
+        {
+          "uuid": "a742717d-1183-36da-a377-b5e4d511d30e",
+          "title": "Fonar Announces 2nd Quarter and Six Months Financial Results for Fiscal 2021",
+          "publisher": "GlobeNewswire",
+          "link": "https://finance.yahoo.com/news/fonar-announces-2nd-quarter-six-130000442.html",
+          "providerPublishTime": 1613480400,
+          "type": "STORY"
+        },
+        {
+          "uuid": "8e9f84d4-f7d0-3a6e-9864-d11f1d48e177",
+          "title": "Noble Awarded One of Six Special Operations Logistics Contracts with $33B Combined Ceiling",
+          "publisher": "PR Newswire",
+          "link": "https://finance.yahoo.com/news/noble-awarded-one-six-special-154500442.html",
+          "providerPublishTime": 1613490300,
+          "type": "STORY"
+        },
+        {
+          "uuid": "15004169-8039-3e63-be6f-62e4f2b99915",
+          "title": "HealthyWomen and Myovant Sciences Launch “Voices of Periods” to Fight Menstrual Stigma",
+          "publisher": "GlobeNewswire",
+          "link": "https://finance.yahoo.com/news/healthywomen-myovant-sciences-launch-voices-133200289.html",
+          "providerPublishTime": 1613482320,
+          "type": "STORY"
+        },
+        {
+          "uuid": "8dd170fe-7ad6-3bdc-a2b7-314c90232f7b",
+          "title": "Curriculum Associates Launches New Webinar Series to Support Educators with Reading Instruction",
+          "publisher": "PR Newswire",
+          "link": "https://finance.yahoo.com/news/curriculum-associates-launches-webinar-series-150300653.html",
+          "providerPublishTime": 1613487780,
+          "type": "STORY"
+        }
+      ],
+      "nav": [],
+      "lists": [],
+      "researchReports": [],
+      "totalTime": 97,
+      "timeTakenForQuotes": 415,
+      "timeTakenForNews": 600,
+      "timeTakenForAlgowatchlist": 400,
+      "timeTakenForPredefinedScreener": 400,
+      "timeTakenForCrunchbase": 400,
+      "timeTakenForNav": 400,
+      "timeTakenForResearchReports": 0
+    }
+  }
+}

--- a/tests/http/search-WSKT.JK.json
+++ b/tests/http/search-WSKT.JK.json
@@ -1,0 +1,101 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v1/finance/search?lang=en-US&region=US&quotesCount=6&newsCount=4&enableFuzzyQuery=false&quotesQueryId=tss_match_phrase_query&multiQuoteQueryId=multi_quote_single_token_query&newsQueryId=news_cie_vespa&enableCb=true&enableNavLinks=true&enableEnhancedTrivialQuery=true&q=WSKT.JK"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=120, stale-while-revalidate=180"
+      ],
+      "y-rid": [
+        "fk2fpb1g2nuh6"
+      ],
+      "x-yahoo-request-id": [
+        "fk2fpb1g2nuh6"
+      ],
+      "x-request-id": [
+        "1244ba9f-7920-4a31-86d8-1ba10e39020e"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "307"
+      ],
+      "x-envoy-upstream-service-time": [
+        "30"
+      ],
+      "date": [
+        "Tue, 16 Feb 2021 17:00:22 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-search--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "explains": [],
+      "count": 1,
+      "quotes": [
+        {
+          "exchange": "JKT",
+          "shortname": "Waskita Karya (Persero) Tbk.",
+          "quoteType": "EQUITY",
+          "symbol": "WSKT.JK",
+          "index": "quotes",
+          "score": 2110000,
+          "typeDisp": "Equity",
+          "longname": "PT Waskita Karya (Persero) Tbk",
+          "isYahooFinance": true
+        }
+      ],
+      "news": [],
+      "nav": [],
+      "lists": [],
+      "researchReports": [],
+      "totalTime": 28,
+      "timeTakenForQuotes": 419,
+      "timeTakenForNews": 600,
+      "timeTakenForAlgowatchlist": 400,
+      "timeTakenForPredefinedScreener": 400,
+      "timeTakenForCrunchbase": 400,
+      "timeTakenForNav": 400,
+      "timeTakenForResearchReports": 0
+    }
+  }
+}

--- a/tests/symbols.ts
+++ b/tests/symbols.ts
@@ -1,5 +1,11 @@
 export const testSymbols = [
   "AAPL", // NMS (Nasdaq)
+  "ADH", // Mutual fund, YHD
+  "AFRAF", // PNK
+  "AMZN", // NMS (Nasdaq)
+  "AZT.OL", // Far less properties than other symbols (#42), OSL
+  "WSKT.JK", // JKT
+  "SIX", // NYSE
   "SPOT", // NMS (Nasdaq)
   "GOOG", // NMS (Nasdaq)
   "UNIR.MI", // FTSE MIB


### PR DESCRIPTION
Ref #51, #57 
This PR adds more symbols to `symbols.ts`. Some symbols added do not have all of the data, will need to fix by changing interfaces in a later PR.

## Changes
- Add 6 new symbols to `symbols.ts`, this allows for testing against more symbols and prevents #42, #46, #57, etc.

## Comments
- The CI **will** fail. This will be fixed in a later PR.
- The 10AM files are generated at 11AM, will need to fix that.