### PR TITLE
fix(quote): add additional properties (#61)

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -2599,6 +2599,9 @@
         "gmtOffSetMilliseconds": {
           "yahooFinanceType": "number"
         },
+        "ipoExpectedDate": {
+          "yahooFinanceType": "date"
+        },
         "language": {
           "type": "string"
         },
@@ -2624,6 +2627,9 @@
         },
         "messageBoardId": {
           "type": "string"
+        },
+        "newListingDate": {
+          "yahooFinanceType": "date"
         },
         "postMarketChange": {
           "yahooFinanceType": "number"
@@ -2876,6 +2882,9 @@
         "gmtOffSetMilliseconds": {
           "yahooFinanceType": "number"
         },
+        "ipoExpectedDate": {
+          "yahooFinanceType": "date"
+        },
         "language": {
           "type": "string"
         },
@@ -2901,6 +2910,9 @@
         },
         "messageBoardId": {
           "type": "string"
+        },
+        "newListingDate": {
+          "yahooFinanceType": "date"
         },
         "postMarketChange": {
           "yahooFinanceType": "number"
@@ -3154,6 +3166,9 @@
         "gmtOffSetMilliseconds": {
           "yahooFinanceType": "number"
         },
+        "ipoExpectedDate": {
+          "yahooFinanceType": "date"
+        },
         "language": {
           "type": "string"
         },
@@ -3179,6 +3194,9 @@
         },
         "messageBoardId": {
           "type": "string"
+        },
+        "newListingDate": {
+          "yahooFinanceType": "date"
         },
         "postMarketChange": {
           "yahooFinanceType": "number"
@@ -3432,6 +3450,9 @@
         "gmtOffSetMilliseconds": {
           "yahooFinanceType": "number"
         },
+        "ipoExpectedDate": {
+          "yahooFinanceType": "date"
+        },
         "language": {
           "type": "string"
         },
@@ -3457,6 +3478,9 @@
         },
         "messageBoardId": {
           "type": "string"
+        },
+        "newListingDate": {
+          "yahooFinanceType": "date"
         },
         "postMarketChange": {
           "yahooFinanceType": "number"

--- a/src/modules/quote.ts
+++ b/src/modules/quote.ts
@@ -94,6 +94,8 @@ export interface QuoteBase {
   ytdReturn?: number; // 0.31
   trailingThreeMonthReturns?: number; // 16.98
   trailingThreeMonthNavReturns?: number; // 17.08
+  ipoExpectedDate?: Date; // "2020-08-13",
+  newListingDate?: Date; // "2021-02-16",
 }
 
 export interface QuoteEquity extends QuoteBase {

--- a/tests/http/quote-BEKE-10am.json
+++ b/tests/http/quote-BEKE-10am.json
@@ -1,0 +1,143 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=BEKE"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "7ic0d7lg2q0sn"
+      ],
+      "x-yahoo-request-id": [
+        "7ic0d7lg2q0sn"
+      ],
+      "x-request-id": [
+        "f716fcf9-8937-45d1-83f9-ef67ebe5e8a6"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "845"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 11:52:55 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-sg3.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "regularMarketChange": 0.6800003,
+            "regularMarketChangePercent": 1.0101014,
+            "regularMarketTime": 1613509202,
+            "regularMarketPrice": 68,
+            "regularMarketDayHigh": 68.99,
+            "regularMarketDayRange": "65.88 - 68.99",
+            "regularMarketDayLow": 65.88,
+            "regularMarketVolume": 8990127,
+            "regularMarketPreviousClose": 67.32,
+            "bid": 67.51,
+            "ask": 68,
+            "bidSize": 8,
+            "askSize": 10,
+            "fullExchangeName": "NYSE",
+            "financialCurrency": "CNY",
+            "regularMarketOpen": 67.41,
+            "averageDailyVolume3Month": 3760300,
+            "averageDailyVolume10Day": 5531066,
+            "fiftyTwoWeekLowChange": 36.21,
+            "fiftyTwoWeekLowChangePercent": 1.1390374,
+            "fiftyTwoWeekRange": "31.79 - 79.4",
+            "fiftyTwoWeekHighChange": -11.400002,
+            "fiftyTwoWeekHighChangePercent": -0.14357685,
+            "fiftyTwoWeekLow": 31.79,
+            "fiftyTwoWeekHigh": 79.4,
+            "epsCurrentYear": 0.75,
+            "priceEpsCurrentYear": 90.666664,
+            "sharesOutstanding": 1143379968,
+            "fiftyDayAverage": 64.594246,
+            "fiftyDayAverageChange": 3.405754,
+            "fiftyDayAverageChangePercent": 0.05272535,
+            "twoHundredDayAverage": 61.68664,
+            "twoHundredDayAverageChange": 6.3133583,
+            "twoHundredDayAverageChangePercent": 0.10234563,
+            "marketCap": 80157040640,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "ipoExpectedDate": "2020-08-13",
+            "firstTradeDateMilliseconds": 1597325400000,
+            "priceHint": 2,
+            "preMarketChange": 0,
+            "preMarketChangePercent": 0,
+            "preMarketTime": 1613562741,
+            "preMarketPrice": 68,
+            "marketState": "PRE",
+            "exchange": "NYQ",
+            "shortName": "KE Holdings Inc",
+            "longName": "KE Holdings Inc.",
+            "messageBoardId": "finmb_665898843",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "tradeable": false,
+            "symbol": "BEKE"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-BEKE.json
+++ b/tests/http/quote-BEKE.json
@@ -1,0 +1,143 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=BEKE"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "8s5cd0dg2prhr"
+      ],
+      "x-yahoo-request-id": [
+        "8s5cd0dg2prhr"
+      ],
+      "x-request-id": [
+        "cc4ceb0b-bb01-4e74-bd29-801a32dbde0b"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "838"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 10:21:47 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-sg3.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "exchange": "NYQ",
+            "shortName": "KE Holdings Inc",
+            "longName": "KE Holdings Inc.",
+            "messageBoardId": "finmb_665898843",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "firstTradeDateMilliseconds": 1597325400000,
+            "priceHint": 2,
+            "preMarketChange": 0.0,
+            "preMarketChangePercent": 0.0,
+            "preMarketTime": 1613557294,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "ipoExpectedDate": "2020-08-13",
+            "tradeable": false,
+            "preMarketPrice": 68.0,
+            "regularMarketChange": 0.6800003,
+            "regularMarketChangePercent": 1.0101014,
+            "regularMarketTime": 1613509202,
+            "regularMarketPrice": 68.0,
+            "regularMarketDayHigh": 68.99,
+            "regularMarketDayRange": "65.88 - 68.99",
+            "regularMarketDayLow": 65.88,
+            "regularMarketVolume": 8990127,
+            "regularMarketPreviousClose": 67.32,
+            "bid": 0.0,
+            "ask": 68.55,
+            "bidSize": 8,
+            "askSize": 10,
+            "fullExchangeName": "NYSE",
+            "financialCurrency": "CNY",
+            "regularMarketOpen": 67.41,
+            "averageDailyVolume3Month": 3760300,
+            "averageDailyVolume10Day": 5531066,
+            "fiftyTwoWeekLowChange": 36.21,
+            "fiftyTwoWeekLowChangePercent": 1.1390374,
+            "fiftyTwoWeekRange": "31.79 - 79.4",
+            "fiftyTwoWeekHighChange": -11.400002,
+            "fiftyTwoWeekHighChangePercent": -0.14357685,
+            "fiftyTwoWeekLow": 31.79,
+            "fiftyTwoWeekHigh": 79.4,
+            "epsCurrentYear": 0.75,
+            "priceEpsCurrentYear": 90.666664,
+            "sharesOutstanding": 1143379968,
+            "fiftyDayAverage": 64.594246,
+            "fiftyDayAverageChange": 3.405754,
+            "fiftyDayAverageChangePercent": 0.05272535,
+            "twoHundredDayAverage": 61.68664,
+            "twoHundredDayAverageChange": 6.3133583,
+            "twoHundredDayAverageChangePercent": 0.10234563,
+            "marketCap": 80157040640,
+            "marketState": "PRE",
+            "symbol": "BEKE"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-BFLY-10am.json
+++ b/tests/http/quote-BFLY-10am.json
@@ -1,0 +1,136 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=BFLY"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "b571gkdg2q0so"
+      ],
+      "x-yahoo-request-id": [
+        "b571gkdg2q0so"
+      ],
+      "x-request-id": [
+        "5724b133-6e87-4b53-98ae-70acf038767f"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "690"
+      ],
+      "x-envoy-upstream-service-time": [
+        "1"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 11:52:55 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-sg3.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "exchange": "NYQ",
+            "shortName": "59637",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "firstTradeDateMilliseconds": 1594647000000,
+            "priceHint": 2,
+            "preMarketChange": 0.8999996,
+            "preMarketChangePercent": 3.9999983,
+            "preMarketTime": 1613562528,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "newListingDate": "2021-02-16",
+            "tradeable": false,
+            "preMarketPrice": 23.4,
+            "regularMarketChange": -0.549999,
+            "regularMarketChangePercent": -2.38611,
+            "regularMarketTime": 1613509202,
+            "regularMarketPrice": 22.5,
+            "regularMarketDayHigh": 24.8,
+            "regularMarketDayRange": "21.9501 - 24.8",
+            "regularMarketDayLow": 21.9501,
+            "regularMarketVolume": 2393331,
+            "regularMarketPreviousClose": 23.05,
+            "bid": 23.3,
+            "ask": 0,
+            "bidSize": 8,
+            "askSize": 8,
+            "fullExchangeName": "NYSE",
+            "regularMarketOpen": 24.8,
+            "averageDailyVolume3Month": 2347300,
+            "averageDailyVolume10Day": 2347300,
+            "fiftyTwoWeekLowChange": 0.54999924,
+            "fiftyTwoWeekLowChangePercent": 0.025056912,
+            "fiftyTwoWeekRange": "21.95 - 24.8",
+            "fiftyTwoWeekHighChange": -2.2999992,
+            "fiftyTwoWeekHighChangePercent": -0.09274191,
+            "fiftyTwoWeekLow": 21.95,
+            "fiftyTwoWeekHigh": 24.8,
+            "fiftyDayAverage": 22.5,
+            "fiftyDayAverageChange": 0,
+            "fiftyDayAverageChangePercent": 0,
+            "twoHundredDayAverage": 22.5,
+            "twoHundredDayAverageChange": 0,
+            "twoHundredDayAverageChangePercent": 0,
+            "marketState": "PRE",
+            "symbol": "BFLY"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-BFLY.json
+++ b/tests/http/quote-BFLY.json
@@ -1,0 +1,135 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=BFLY"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "a8h552lg2pvia"
+      ],
+      "x-yahoo-request-id": [
+        "a8h552lg2pvia"
+      ],
+      "x-request-id": [
+        "8a4b7cd1-eaec-4683-b4db-3fdbd861e257"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "692"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 11:30:18 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-sg3.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {"language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "regularMarketChange": -0.549999,
+            "regularMarketChangePercent": -2.38611,
+            "regularMarketTime": 1613509202,
+            "regularMarketPrice": 22.5,
+            "regularMarketDayHigh": 24.8,
+            "regularMarketDayRange": "21.9501 - 24.8",
+            "regularMarketDayLow": 21.9501,
+            "regularMarketVolume": 2393331,
+            "regularMarketPreviousClose": 23.05,
+            "bid": 23.3,
+            "ask": 0.0,
+            "bidSize": 8,
+            "askSize": 8,
+            "fullExchangeName": "NYSE",
+            "regularMarketOpen": 24.8,
+            "averageDailyVolume3Month": 2347300,
+            "averageDailyVolume10Day": 2347300,
+            "fiftyTwoWeekLowChange": 0.54999924,
+            "fiftyTwoWeekLowChangePercent": 0.025056912,
+            "fiftyTwoWeekRange": "21.95 - 24.8",
+            "fiftyTwoWeekHighChange": -2.2999992,
+            "fiftyTwoWeekHighChangePercent": -0.09274191,
+            "fiftyTwoWeekLow": 21.95,
+            "fiftyTwoWeekHigh": 24.8,
+            "fiftyDayAverage": 22.5,
+            "fiftyDayAverageChange": 0.0,
+            "fiftyDayAverageChangePercent": 0.0,
+            "twoHundredDayAverage": 22.5,
+            "twoHundredDayAverageChange": 0.0,
+            "twoHundredDayAverageChangePercent": 0.0,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "newListingDate": "2021-02-16",
+            "firstTradeDateMilliseconds": 1594647000000,
+            "priceHint": 2,
+            "preMarketChange": 0.6499996,
+            "preMarketChangePercent": 2.8888872,
+            "preMarketTime": 1613561311,
+            "preMarketPrice": 23.15,
+            "marketState": "PRE",
+            "exchange": "NYQ",
+            "shortName": "59637",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "tradeable": false,
+            "symbol": "BFLY"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/symbols.ts
+++ b/tests/symbols.ts
@@ -4,6 +4,8 @@ export const testSymbols = [
   "AFRAF", // PNK
   "AMZN", // NMS (Nasdaq)
   "AZT.OL", // Far less properties than other symbols (#42), OSL
+  "BEKE", // NYSE 
+  "BFLY", // NYSE
   "WSKT.JK", // JKT
   "SIX", // NYSE
   "SPOT", // NMS (Nasdaq)


### PR DESCRIPTION
## Change
Fixes #61 
* Add those property with optional to [quote.ts](https://github.com/gadicc/node-yahoo-finance2/blob/devel/src/modules/quote.ts#L96).
```javascript
  trailingThreeMonthReturns?: number; // 16.98
  trailingThreeMonthNavReturns?: number; // 17.08
  ipoExpectedDate?: Date; // "2020-08-13",     <---- added
  newListingDate?: Date; // "2021-02-16",      <---- added
```
* Add queto-BEKE.json 
* Add queto-BFLY.json 