### PR TITLE
chore(tests): use it.each with testSymbols for several test suites

### DIFF
--- a/src/modules/autoc.spec.ts
+++ b/src/modules/autoc.spec.ts
@@ -1,5 +1,5 @@
 import autoc from "./autoc";
-const { InvalidOptionsError } = require("../lib/errors");
+import { testSymbols } from "../../tests/symbols";
 
 import testYf from "../../tests/testYf";
 
@@ -8,8 +8,8 @@ const yf = testYf({ autoc });
 describe("autoc", () => {
   // See also common module tests in moduleExec.spec.js
 
-  it("passes validation", async () => {
-    await yf.autoc("AAPL", {}, { devel: "autoc-AAPL.json" });
+  it.each(testSymbols)("passes validation for symbol '%s'", async (symbol) => {
+    await yf.autoc(symbol, {}, { devel: `autoc-${symbol}.json` });
   });
 
   if (process.env.FETCH_DEVEL !== "nocache")

--- a/src/modules/historical.spec.ts
+++ b/src/modules/historical.spec.ts
@@ -1,5 +1,5 @@
 import historical from "./historical";
-const { InvalidOptionsError } = require("../lib/errors");
+import { testSymbols } from "../../tests/symbols";
 
 import testYf from "../../tests/testYf";
 
@@ -8,14 +8,16 @@ const yf = testYf({ historical });
 describe("historical", () => {
   // See also common module tests in moduleExec.spec.js
 
-  it("passes validation", async () => {
-    const result = await yf.historical(
-      "AAPL",
+  const symbolsToSkip = ["BEKE", "BFLY"];
+  const symbols = testSymbols.filter((s) => symbolsToSkip.indexOf(s) === -1);
+  it.each(symbols)("passes validation for symbol '%s'", async (symbol) => {
+    await yf.historical(
+      symbol,
       {
         period1: "2020-01-01",
         period2: "2020-01-03",
       },
-      { devel: "historical-AAPL-2020-01-01-to-2020-01-03.json" }
+      { devel: `historical-${symbol}-2020-01-01-to-2020-01-03.json` }
     );
   });
 

--- a/src/modules/search.spec.ts
+++ b/src/modules/search.spec.ts
@@ -17,10 +17,11 @@ describe("search", () => {
   // See also common module tests in moduleExec.spec.js
 
   // validate different searches
-  testSearches.forEach((search) => {
-    it(`passed validation for search: ${search}`, async () => {
-      const devel = `search-${search}.json`;
-      await yf.search(search, {}, { devel });
-    });
-  });
+  it.each(testSearches)(
+    "passed validation for search '%s'",
+    async (testSearch) => {
+      const devel = `search-${testSearch}.json`;
+      await yf.search(testSearch, {}, { devel });
+    }
+  );
 });

--- a/tests/http/autoc-0P000071W8.TO.json
+++ b/tests/http/autoc-0P000071W8.TO.json
@@ -1,0 +1,75 @@
+{
+  "request": {
+    "url": "https://autoc.finance.yahoo.com/autoc?region=1&lang=en&query=0P000071W8.TO"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-content-type-options": [
+        "nosniff"
+      ],
+      "x-yahoo-request-id": [
+        "eg6f4jhg2qdlb"
+      ],
+      "cache-control": [
+        "public, max-age=300, stale-while-revalidate=30, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "content-length": [
+        "141"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:30:51 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=31536000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ]
+    },
+    "bodyJson": {
+      "ResultSet": {
+        "Query": "0P000071W8.TO",
+        "Result": [
+          {
+            "symbol": "0P000071W8.TO",
+            "name": "TD U.S. Index Fund - e",
+            "exch": "TOR",
+            "type": "M",
+            "exchDisp": "Toronto",
+            "typeDisp": "Fund"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/http/autoc-ADH.json
+++ b/tests/http/autoc-ADH.json
@@ -1,0 +1,147 @@
+{
+  "request": {
+    "url": "https://autoc.finance.yahoo.com/autoc?region=1&lang=en&query=ADH"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-content-type-options": [
+        "nosniff"
+      ],
+      "x-yahoo-request-id": [
+        "25qq93lg2qdl7"
+      ],
+      "cache-control": [
+        "public, max-age=300, stale-while-revalidate=30, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "content-length": [
+        "418"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:30:47 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=31536000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ]
+    },
+    "bodyJson": {
+      "ResultSet": {
+        "Query": "ADH",
+        "Result": [
+          {
+            "symbol": "ATRX",
+            "name": "Adhera Therapeutics, Inc.",
+            "exch": "PNK",
+            "type": "S",
+            "exchDisp": "OTC Markets",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "ADHC",
+            "name": "American Diversified Holdings Corporation",
+            "exch": "PNK",
+            "type": "S",
+            "exchDisp": "OTC Markets",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "ADHI.JK",
+            "name": "PT Adhi Karya (Persero) Tbk",
+            "exch": "JKT",
+            "type": "S",
+            "exchDisp": "Jakarta",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "ADH.AX",
+            "name": "Adairs Limited",
+            "exch": "ASX",
+            "type": "S",
+            "exchDisp": "Australian",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "ADH2.SG",
+            "name": "Air Canada Inc. Reg.Shares (Var",
+            "exch": "STU",
+            "type": "S",
+            "exchDisp": "Stuttgart",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "ADH2.F",
+            "name": "Air Canada",
+            "exch": "FRA",
+            "type": "S",
+            "exchDisp": "Frankfurt",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "ADH2.BE",
+            "name": "AIR CANADA (VAR.VTG)",
+            "exch": "BER",
+            "type": "S",
+            "exchDisp": "Berlin",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "ADR.AX",
+            "name": "Adherium Limited",
+            "exch": "ASX",
+            "type": "S",
+            "exchDisp": "Australian",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "KM6.F",
+            "name": "PT Adhi Karya (Persero) Tbk",
+            "exch": "YHD",
+            "type": "S",
+            "exchDisp": "Industry",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "ADH.JO",
+            "name": "ADvTECH Limited",
+            "exch": "JNB",
+            "type": "S",
+            "exchDisp": "Johannesburg Stock Exchange",
+            "typeDisp": "Equity"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/http/autoc-AFRAF.json
+++ b/tests/http/autoc-AFRAF.json
@@ -1,0 +1,75 @@
+{
+  "request": {
+    "url": "https://autoc.finance.yahoo.com/autoc?region=1&lang=en&query=AFRAF"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-content-type-options": [
+        "nosniff"
+      ],
+      "x-yahoo-request-id": [
+        "bq2flulg2qdl8"
+      ],
+      "cache-control": [
+        "public, max-age=300, stale-while-revalidate=30, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "content-length": [
+        "138"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:30:48 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=31536000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ]
+    },
+    "bodyJson": {
+      "ResultSet": {
+        "Query": "AFRAF",
+        "Result": [
+          {
+            "symbol": "AFRAF",
+            "name": "Air France-KLM SA",
+            "exch": "PNK",
+            "type": "S",
+            "exchDisp": "OTC Markets",
+            "typeDisp": "Equity"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/http/autoc-AMZN.json
+++ b/tests/http/autoc-AMZN.json
@@ -1,0 +1,139 @@
+{
+  "request": {
+    "url": "https://autoc.finance.yahoo.com/autoc?region=1&lang=en&query=AMZN"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-content-type-options": [
+        "nosniff"
+      ],
+      "x-yahoo-request-id": [
+        "atim9atg2qdl8"
+      ],
+      "cache-control": [
+        "public, max-age=300, stale-while-revalidate=30, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "content-length": [
+        "293"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:30:48 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=31536000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ]
+    },
+    "bodyJson": {
+      "ResultSet": {
+        "Query": "AMZN",
+        "Result": [
+          {
+            "symbol": "AMZN",
+            "name": "Amazon.com, Inc.",
+            "exch": "NMS",
+            "type": "S",
+            "exchDisp": "NASDAQ",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "^NY2LAMZN",
+            "name": "ICE Leveraged 2x AMZN Index",
+            "exch": "NYS",
+            "type": "I",
+            "exchDisp": "NYSE",
+            "typeDisp": "Index"
+          },
+          {
+            "symbol": "AMZN.BA",
+            "name": "Amazon.com, Inc.",
+            "exch": "BUE",
+            "type": "S",
+            "exchDisp": "Buenos Aires",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "AMZN.MX",
+            "name": "Amazon.com, Inc.",
+            "exch": "MEX",
+            "type": "S",
+            "exchDisp": "Mexico",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "AMZN.MI",
+            "name": "Amazon.com, Inc.",
+            "exch": "MIL",
+            "type": "S",
+            "exchDisp": "Milan",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "AMZN.SN",
+            "name": "Amazon.com, Inc.",
+            "exch": "SGO",
+            "type": "S",
+            "exchDisp": "Santiago Stock Exchange",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "AMZN.VI",
+            "name": "Amazon.com, Inc.",
+            "exch": "VIE",
+            "type": "S",
+            "exchDisp": "Vienna",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "AMZNC.BA",
+            "name": "AMAZON COM INC",
+            "exch": "BUE",
+            "type": "S",
+            "exchDisp": "Buenos Aires",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "AMZND.BA",
+            "name": "AMAZON COM INC",
+            "exch": "BUE",
+            "type": "S",
+            "exchDisp": "Buenos Aires",
+            "typeDisp": "Equity"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/http/autoc-AZT.OL.json
+++ b/tests/http/autoc-AZT.OL.json
@@ -1,0 +1,75 @@
+{
+  "request": {
+    "url": "https://autoc.finance.yahoo.com/autoc?region=1&lang=en&query=AZT.OL"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-content-type-options": [
+        "nosniff"
+      ],
+      "x-yahoo-request-id": [
+        "4r9uoh5g2qdl8"
+      ],
+      "cache-control": [
+        "public, max-age=300, stale-while-revalidate=30, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "content-length": [
+        "139"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:30:48 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=31536000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ]
+    },
+    "bodyJson": {
+      "ResultSet": {
+        "Query": "AZT.OL",
+        "Result": [
+          {
+            "symbol": "AZT.OL",
+            "name": "ArcticZymes Technologies ASA",
+            "exch": "OSL",
+            "type": "S",
+            "exchDisp": "Oslo",
+            "typeDisp": "Equity"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/http/autoc-BABA.json
+++ b/tests/http/autoc-BABA.json
@@ -1,0 +1,139 @@
+{
+  "request": {
+    "url": "https://autoc.finance.yahoo.com/autoc?region=1&lang=en&query=BABA"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-content-type-options": [
+        "nosniff"
+      ],
+      "x-yahoo-request-id": [
+        "8jl4uk9g2qdla"
+      ],
+      "cache-control": [
+        "public, max-age=300, stale-while-revalidate=30, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "content-length": [
+        "309"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:30:50 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=31536000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ]
+    },
+    "bodyJson": {
+      "ResultSet": {
+        "Query": "BABA",
+        "Result": [
+          {
+            "symbol": "BABA",
+            "name": "Alibaba Group Holding Limited",
+            "exch": "NYS",
+            "type": "S",
+            "exchDisp": "NYSE",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "BABAF",
+            "name": "Alibaba Group Holding Limited",
+            "exch": "PNK",
+            "type": "S",
+            "exchDisp": "OTC Markets",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "BABAN.MX",
+            "name": "Alibaba Group Holding Limited",
+            "exch": "MEX",
+            "type": "S",
+            "exchDisp": "Mexico",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "BABA34.SA",
+            "name": "ALIBABAGR   DRN",
+            "exch": "SAO",
+            "type": "S",
+            "exchDisp": "Sao Paolo",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "BABA.BA",
+            "name": "Alibaba Group Holding Limited",
+            "exch": "BUE",
+            "type": "S",
+            "exchDisp": "Buenos Aires",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "BABAFOOD-SM.NS",
+            "name": "BABA AGRO FOOD LTD",
+            "exch": "NSI",
+            "type": "S",
+            "exchDisp": "NSE",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "BABA.BO",
+            "name": "Baba Arts Limited",
+            "exch": "BSE",
+            "type": "S",
+            "exchDisp": "Bombay",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "BABAD.BA",
+            "name": "ALIBABA GROUP HLDG",
+            "exch": "BUE",
+            "type": "S",
+            "exchDisp": "Buenos Aires",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "BABAC.BA",
+            "name": "ALIBABA GROUP HLDG",
+            "exch": "BUE",
+            "type": "S",
+            "exchDisp": "Buenos Aires",
+            "typeDisp": "Equity"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/http/autoc-BEKE.json
+++ b/tests/http/autoc-BEKE.json
@@ -1,0 +1,139 @@
+{
+  "request": {
+    "url": "https://autoc.finance.yahoo.com/autoc?region=1&lang=en&query=BEKE"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-content-type-options": [
+        "nosniff"
+      ],
+      "x-yahoo-request-id": [
+        "bq1ml61g2qdl8"
+      ],
+      "cache-control": [
+        "public, max-age=300, stale-while-revalidate=30, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "content-length": [
+        "339"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:30:48 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=31536000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ]
+    },
+    "bodyJson": {
+      "ResultSet": {
+        "Query": "BEKE",
+        "Result": [
+          {
+            "symbol": "BEKE",
+            "name": "KE Holdings Inc.",
+            "exch": "NYQ",
+            "type": "S",
+            "exchDisp": "NYSE",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "BKMM",
+            "name": "Bekem Metals, Inc.",
+            "exch": "PNK",
+            "type": "S",
+            "exchDisp": "OTC Markets",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "TERB.BR",
+            "name": "Ter Beke NV",
+            "exch": "YHD",
+            "type": "S",
+            "exchDisp": "Industry",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "603068.SS",
+            "name": "Beken Corporation",
+            "exch": "SHH",
+            "type": "S",
+            "exchDisp": "Shanghai",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "BEKEN.MX",
+            "name": "KE Holdings Inc.",
+            "exch": "MEX",
+            "type": "S",
+            "exchDisp": "Mexico",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "BEKE210219C00110000",
+            "name": "BEKE Feb 2021 call 110.000",
+            "exch": "OPR",
+            "type": "O",
+            "exchDisp": "OPR",
+            "typeDisp": "Option"
+          },
+          {
+            "symbol": "BEKE210219C00105000",
+            "name": "BEKE Feb 2021 call 105.000",
+            "exch": "OPR",
+            "type": "O",
+            "exchDisp": "OPR",
+            "typeDisp": "Option"
+          },
+          {
+            "symbol": "BEKE210219C00100000",
+            "name": "BEKE Feb 2021 call 100.000",
+            "exch": "OPR",
+            "type": "O",
+            "exchDisp": "OPR",
+            "typeDisp": "Option"
+          },
+          {
+            "symbol": "BEKE210416C00090000",
+            "name": "BEKE Apr 2021 call 90.000",
+            "exch": "OPR",
+            "type": "O",
+            "exchDisp": "OPR",
+            "typeDisp": "Option"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/http/autoc-BFLY.json
+++ b/tests/http/autoc-BFLY.json
@@ -1,0 +1,107 @@
+{
+  "request": {
+    "url": "https://autoc.finance.yahoo.com/autoc?region=1&lang=en&query=BFLY"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-content-type-options": [
+        "nosniff"
+      ],
+      "x-yahoo-request-id": [
+        "b8gmptdg2qdl9"
+      ],
+      "cache-control": [
+        "public, max-age=300, stale-while-revalidate=30, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "content-length": [
+        "258"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:30:49 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=31536000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ]
+    },
+    "bodyJson": {
+      "ResultSet": {
+        "Query": "BFLY",
+        "Result": [
+          {
+            "symbol": "^BFLY",
+            "name": "CBOE S&P 500 Iron Butterfly Ind",
+            "exch": "WCB",
+            "type": "I",
+            "exchDisp": "Chicago Board Options Exchange",
+            "typeDisp": "Index"
+          },
+          {
+            "symbol": "BFLY",
+            "name": "59637",
+            "exch": "NCM",
+            "type": "S",
+            "exchDisp": "NASDAQ",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "^BFLYEA",
+            "name": "^BFLYEA",
+            "exch": "WCB",
+            "type": "I",
+            "exchDisp": "Chicago Board Options Exchange",
+            "typeDisp": "Index"
+          },
+          {
+            "symbol": "^BFLYEF",
+            "name": "^BFLYEF",
+            "exch": "WCB",
+            "type": "I",
+            "exchDisp": "Chicago Board Options Exchange",
+            "typeDisp": "Index"
+          },
+          {
+            "symbol": "BFLY210219C00010000",
+            "name": "BFLY210219C00010000",
+            "exch": "OPR",
+            "type": "O",
+            "exchDisp": "OPR",
+            "typeDisp": "Option"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/http/autoc-GOOG.json
+++ b/tests/http/autoc-GOOG.json
@@ -1,0 +1,139 @@
+{
+  "request": {
+    "url": "https://autoc.finance.yahoo.com/autoc?region=1&lang=en&query=GOOG"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-content-type-options": [
+        "nosniff"
+      ],
+      "x-yahoo-request-id": [
+        "5h47sgpg2qdl9"
+      ],
+      "cache-control": [
+        "public, max-age=300, stale-while-revalidate=30, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "content-length": [
+        "318"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:30:49 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=31536000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ]
+    },
+    "bodyJson": {
+      "ResultSet": {
+        "Query": "GOOG",
+        "Result": [
+          {
+            "symbol": "GOOG",
+            "name": "Alphabet Inc.",
+            "exch": "NMS",
+            "type": "S",
+            "exchDisp": "NASDAQ",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "GOOGL",
+            "name": "Alphabet Inc.",
+            "exch": "NMS",
+            "type": "S",
+            "exchDisp": "NASDAQ",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "^VXGOG",
+            "name": "CBOE EQUITY VIXON GOOGLE",
+            "exch": "WCB",
+            "type": "I",
+            "exchDisp": "Chicago Board Options Exchange",
+            "typeDisp": "Index"
+          },
+          {
+            "symbol": "^NY2LGOOG",
+            "name": "ICE Leveraged 2x GOOG Index",
+            "exch": "NYS",
+            "type": "I",
+            "exchDisp": "NYSE",
+            "typeDisp": "Index"
+          },
+          {
+            "symbol": "GOOGL.MI",
+            "name": "ALPHABET CLASSE A",
+            "exch": "MIL",
+            "type": "S",
+            "exchDisp": "Milan",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "GOOGL.BA",
+            "name": "Alphabet Inc.",
+            "exch": "BUE",
+            "type": "S",
+            "exchDisp": "Buenos Aires",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "GOOGL.MX",
+            "name": "Alphabet Inc.",
+            "exch": "MEX",
+            "type": "S",
+            "exchDisp": "Mexico",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "GOOG.MI",
+            "name": "Alphabet Inc.",
+            "exch": "MIL",
+            "type": "S",
+            "exchDisp": "Milan",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "GOOG.MX",
+            "name": "Alphabet Inc.",
+            "exch": "MEX",
+            "type": "S",
+            "exchDisp": "Mexico",
+            "typeDisp": "Equity"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/http/autoc-OCDO.L.json
+++ b/tests/http/autoc-OCDO.L.json
@@ -1,0 +1,75 @@
+{
+  "request": {
+    "url": "https://autoc.finance.yahoo.com/autoc?region=1&lang=en&query=OCDO.L"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-content-type-options": [
+        "nosniff"
+      ],
+      "x-yahoo-request-id": [
+        "3hl43khg2qdla"
+      ],
+      "cache-control": [
+        "public, max-age=300, stale-while-revalidate=30, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "content-length": [
+        "134"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:30:50 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=31536000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ]
+    },
+    "bodyJson": {
+      "ResultSet": {
+        "Query": "OCDO.L",
+        "Result": [
+          {
+            "symbol": "OCDO.L",
+            "name": "Ocado Group plc",
+            "exch": "YHD",
+            "type": "S",
+            "exchDisp": "Industry",
+            "typeDisp": "Equity"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/http/autoc-QQQ.json
+++ b/tests/http/autoc-QQQ.json
@@ -1,0 +1,139 @@
+{
+  "request": {
+    "url": "https://autoc.finance.yahoo.com/autoc?region=1&lang=en&query=QQQ"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-content-type-options": [
+        "nosniff"
+      ],
+      "x-yahoo-request-id": [
+        "4o7kos9g2qdla"
+      ],
+      "cache-control": [
+        "public, max-age=300, stale-while-revalidate=30, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "content-length": [
+        "310"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:30:51 GMT"
+      ],
+      "age": [
+        "2"
+      ],
+      "strict-transport-security": [
+        "max-age=31536000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ]
+    },
+    "bodyJson": {
+      "ResultSet": {
+        "Query": "QQQ",
+        "Result": [
+          {
+            "symbol": "QQQ",
+            "name": "Invesco QQQ Trust",
+            "exch": "NMS",
+            "type": "E",
+            "exchDisp": "NASDAQ",
+            "typeDisp": "ETF"
+          },
+          {
+            "symbol": "TQQQ",
+            "name": "ProShares UltraPro QQQ",
+            "exch": "NMS",
+            "type": "E",
+            "exchDisp": "NASDAQ",
+            "typeDisp": "ETF"
+          },
+          {
+            "symbol": "SQQQ",
+            "name": "ProShares UltraPro Short QQQ",
+            "exch": "NGM",
+            "type": "E",
+            "exchDisp": "NASDAQ",
+            "typeDisp": "ETF"
+          },
+          {
+            "symbol": "QLD",
+            "name": "ProShares Ultra QQQ",
+            "exch": "NYQ",
+            "type": "E",
+            "exchDisp": "NYSE",
+            "typeDisp": "ETF"
+          },
+          {
+            "symbol": "QID",
+            "name": "ProShares UltraShort QQQ",
+            "exch": "NYQ",
+            "type": "E",
+            "exchDisp": "NYSE",
+            "typeDisp": "ETF"
+          },
+          {
+            "symbol": "PSQ",
+            "name": "ProShares Short QQQ",
+            "exch": "NYQ",
+            "type": "E",
+            "exchDisp": "NYSE",
+            "typeDisp": "ETF"
+          },
+          {
+            "symbol": "QQQX",
+            "name": "Nuveen Nasdaq 100 Dynamic Overwrite Fund",
+            "exch": "NMS",
+            "type": "S",
+            "exchDisp": "NASDAQ",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "QQQE",
+            "name": "Direxion NASDAQ-100 Equal Weighted Index Shares",
+            "exch": "NYQ",
+            "type": "E",
+            "exchDisp": "NYSE",
+            "typeDisp": "ETF"
+          },
+          {
+            "symbol": "^SQQQ-IV",
+            "name": "ProShares UltraPro Short QQQ",
+            "exch": "ASE",
+            "type": "I",
+            "exchDisp": "NYSE MKT",
+            "typeDisp": "Index"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/http/autoc-SIX.json
+++ b/tests/http/autoc-SIX.json
@@ -1,0 +1,139 @@
+{
+  "request": {
+    "url": "https://autoc.finance.yahoo.com/autoc?region=1&lang=en&query=SIX"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-content-type-options": [
+        "nosniff"
+      ],
+      "x-yahoo-request-id": [
+        "dqd18htg2qdl9"
+      ],
+      "cache-control": [
+        "public, max-age=300, stale-while-revalidate=30, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "content-length": [
+        "357"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:30:49 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=31536000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ]
+    },
+    "bodyJson": {
+      "ResultSet": {
+        "Query": "SIX",
+        "Result": [
+          {
+            "symbol": "SIX",
+            "name": "Six Flags Entertainment Corporation",
+            "exch": "NYQ",
+            "type": "S",
+            "exchDisp": "NYSE",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "TSLX",
+            "name": "Sixth Street Specialty Lending, Inc.",
+            "exch": "NYQ",
+            "type": "S",
+            "exchDisp": "NYSE",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "CUSUX",
+            "name": "Six Circles U.S. Unconstrained Equity Fund",
+            "exch": "NAS",
+            "type": "M",
+            "exchDisp": "NASDAQ",
+            "typeDisp": "Fund"
+          },
+          {
+            "symbol": "CUTAX",
+            "name": "Six Circles Tax Aware Ultra Short Duration Fund",
+            "exch": "NAS",
+            "type": "M",
+            "exchDisp": "NASDAQ",
+            "typeDisp": "Fund"
+          },
+          {
+            "symbol": "CIUEX",
+            "name": "Six Circles International Unconstrained Equity Fund",
+            "exch": "NAS",
+            "type": "M",
+            "exchDisp": "NASDAQ",
+            "typeDisp": "Fund"
+          },
+          {
+            "symbol": "SAYFF",
+            "name": "3 Sixty Risk Solutions Ltd.",
+            "exch": "PNK",
+            "type": "S",
+            "exchDisp": "OTC Markets",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "SIXGF",
+            "name": "Sixt SE",
+            "exch": "PNK",
+            "type": "S",
+            "exchDisp": "OTC Markets",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "CMEUX",
+            "name": "Six Circles Managed Equity Portfolio U.S. Unconstrained Fund",
+            "exch": "NAS",
+            "type": "M",
+            "exchDisp": "NASDAQ",
+            "typeDisp": "Fund"
+          },
+          {
+            "symbol": "CUSDX",
+            "name": "Six Circles Ultra Short Duration Fund",
+            "exch": "NAS",
+            "type": "M",
+            "exchDisp": "NASDAQ",
+            "typeDisp": "Fund"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/http/autoc-SPOT.json
+++ b/tests/http/autoc-SPOT.json
@@ -1,0 +1,139 @@
+{
+  "request": {
+    "url": "https://autoc.finance.yahoo.com/autoc?region=1&lang=en&query=SPOT"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-content-type-options": [
+        "nosniff"
+      ],
+      "x-yahoo-request-id": [
+        "3p3f5rtg2qdl9"
+      ],
+      "cache-control": [
+        "public, max-age=300, stale-while-revalidate=30, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "content-length": [
+        "376"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:30:49 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=31536000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ]
+    },
+    "bodyJson": {
+      "ResultSet": {
+        "Query": "SPOT",
+        "Result": [
+          {
+            "symbol": "SPOT",
+            "name": "Spotify Technology S.A.",
+            "exch": "NYS",
+            "type": "S",
+            "exchDisp": "NYSE",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "STLT",
+            "name": "Spotlight Innovation Inc.",
+            "exch": "PNK",
+            "type": "S",
+            "exchDisp": "OTC Markets",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "^GBP",
+            "name": "ISE Spot GBPUSD (INDEX)",
+            "exch": "NIM",
+            "type": "I",
+            "exchDisp": "NASDAQ GIDS",
+            "typeDisp": "Index"
+          },
+          {
+            "symbol": "^EUU",
+            "name": "ISE Spot EURUSD (INDEX)",
+            "exch": "NIM",
+            "type": "I",
+            "exchDisp": "NASDAQ GIDS",
+            "typeDisp": "Index"
+          },
+          {
+            "symbol": "^NDO",
+            "name": "INDISE Spot NZD USD",
+            "exch": "NIM",
+            "type": "I",
+            "exchDisp": "NASDAQ GIDS",
+            "typeDisp": "Index"
+          },
+          {
+            "symbol": "SCFFF",
+            "name": "Spot Coffee (Canada) Ltd.",
+            "exch": "PNK",
+            "type": "S",
+            "exchDisp": "OTC Markets",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "SIVSX",
+            "name": "State Street International Value Spotlight Fund Class K",
+            "exch": "NAS",
+            "type": "M",
+            "exchDisp": "NASDAQ",
+            "typeDisp": "Fund"
+          },
+          {
+            "symbol": "SLCH",
+            "name": "Spotlight Capital Holdings, Inc.",
+            "exch": "PNK",
+            "type": "S",
+            "exchDisp": "OTC Markets",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "^HFO",
+            "name": "Settle ISE Japanese Yen FX Spot",
+            "exch": "NIM",
+            "type": "I",
+            "exchDisp": "NASDAQ GIDS",
+            "typeDisp": "Index"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/http/autoc-UNIR.MI.json
+++ b/tests/http/autoc-UNIR.MI.json
@@ -1,0 +1,75 @@
+{
+  "request": {
+    "url": "https://autoc.finance.yahoo.com/autoc?region=1&lang=en&query=UNIR.MI"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-content-type-options": [
+        "nosniff"
+      ],
+      "x-yahoo-request-id": [
+        "2lfaha1g2qdla"
+      ],
+      "cache-control": [
+        "public, max-age=300, stale-while-revalidate=30, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "content-length": [
+        "130"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:30:50 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=31536000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ]
+    },
+    "bodyJson": {
+      "ResultSet": {
+        "Query": "UNIR.MI",
+        "Result": [
+          {
+            "symbol": "UNIR.MI",
+            "name": "Unieuro S.p.A.",
+            "exch": "MIL",
+            "type": "S",
+            "exchDisp": "Milan",
+            "typeDisp": "Equity"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/http/autoc-WSKT.JK.json
+++ b/tests/http/autoc-WSKT.JK.json
@@ -1,0 +1,75 @@
+{
+  "request": {
+    "url": "https://autoc.finance.yahoo.com/autoc?region=1&lang=en&query=WSKT.JK"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-content-type-options": [
+        "nosniff"
+      ],
+      "x-yahoo-request-id": [
+        "agrpustg2qdl9"
+      ],
+      "cache-control": [
+        "public, max-age=300, stale-while-revalidate=30, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "content-length": [
+        "146"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:30:49 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=31536000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ]
+    },
+    "bodyJson": {
+      "ResultSet": {
+        "Query": "WSKT.JK",
+        "Result": [
+          {
+            "symbol": "WSKT.JK",
+            "name": "PT Waskita Karya (Persero) Tbk",
+            "exch": "JKT",
+            "type": "S",
+            "exchDisp": "Jakarta",
+            "typeDisp": "Equity"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/http/historical-0P000071W8.TO-2020-01-01-to-2020-01-03.json
+++ b/tests/http/historical-0P000071W8.TO-2020-01-01-to-2020-01-03.json
@@ -1,0 +1,73 @@
+{
+  "request": {
+    "url": "https://query1.finance.yahoo.com/v7/finance/download/0P000071W8.TO?interval=1d&events=history&includeAdjustedClose=true&period1=1577836800&period2=1578009600"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-disposition": [
+        "attachment; filename=0P000071W8.TO.csv"
+      ],
+      "content-type": [
+        "text/csv"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "cache-control": [
+        "private, max-age=10, stale-while-revalidate=20"
+      ],
+      "y-rid": [
+        "fv3u3uhg2qe7g"
+      ],
+      "x-yahoo-request-id": [
+        "fv3u3uhg2qe7g"
+      ],
+      "x-request-id": [
+        "6b617dbf-8eb9-45c3-9e6e-6de12d7fb990"
+      ],
+      "content-length": [
+        "104"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:40:32 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-chart-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "body": "Date,Open,High,Low,Close,Adj Close,Volume\n2020-01-02,73.720001,73.720001,73.720001,73.720001,73.720001,0"
+  }
+}

--- a/tests/http/historical-ADH-2020-01-01-to-2020-01-03.json
+++ b/tests/http/historical-ADH-2020-01-01-to-2020-01-03.json
@@ -1,0 +1,73 @@
+{
+  "request": {
+    "url": "https://query1.finance.yahoo.com/v7/finance/download/ADH?interval=1d&events=history&includeAdjustedClose=true&period1=1577836800&period2=1578009600"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-disposition": [
+        "attachment; filename=ADH.csv"
+      ],
+      "content-type": [
+        "text/csv"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "cache-control": [
+        "private, max-age=10, stale-while-revalidate=20"
+      ],
+      "y-rid": [
+        "fd60135g2qe7e"
+      ],
+      "x-yahoo-request-id": [
+        "fd60135g2qe7e"
+      ],
+      "x-request-id": [
+        "dc360b51-b9a0-4d23-ba42-334a5a79bece"
+      ],
+      "content-length": [
+        "109"
+      ],
+      "x-envoy-upstream-service-time": [
+        "5"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:40:30 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-chart-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "body": "Date,Open,High,Low,Close,Adj Close,Volume\n2020-01-02,11.000000,11.000000,10.220000,10.380000,10.380000,637529"
+  }
+}

--- a/tests/http/historical-AFRAF-2020-01-01-to-2020-01-03.json
+++ b/tests/http/historical-AFRAF-2020-01-01-to-2020-01-03.json
@@ -1,0 +1,73 @@
+{
+  "request": {
+    "url": "https://query1.finance.yahoo.com/v7/finance/download/AFRAF?interval=1d&events=history&includeAdjustedClose=true&period1=1577836800&period2=1578009600"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-disposition": [
+        "attachment; filename=AFRAF.csv"
+      ],
+      "content-type": [
+        "text/csv"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "cache-control": [
+        "private, max-age=10, stale-while-revalidate=20"
+      ],
+      "y-rid": [
+        "beeb1flg2qe7e"
+      ],
+      "x-yahoo-request-id": [
+        "beeb1flg2qe7e"
+      ],
+      "x-request-id": [
+        "7c979620-7bdc-4877-ab2b-b63fc3289e02"
+      ],
+      "content-length": [
+        "104"
+      ],
+      "x-envoy-upstream-service-time": [
+        "7"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:40:30 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-chart-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "body": "Date,Open,High,Low,Close,Adj Close,Volume\n2020-01-02,11.270000,11.270000,11.270000,11.270000,11.270000,0"
+  }
+}

--- a/tests/http/historical-AMZN-2020-01-01-to-2020-01-03.json
+++ b/tests/http/historical-AMZN-2020-01-01-to-2020-01-03.json
@@ -1,0 +1,73 @@
+{
+  "request": {
+    "url": "https://query1.finance.yahoo.com/v7/finance/download/AMZN?interval=1d&events=history&includeAdjustedClose=true&period1=1577836800&period2=1578009600"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-disposition": [
+        "attachment; filename=AMZN.csv"
+      ],
+      "content-type": [
+        "text/csv"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "cache-control": [
+        "private, max-age=10, stale-while-revalidate=20"
+      ],
+      "y-rid": [
+        "bi2vk29g2qe7e"
+      ],
+      "x-yahoo-request-id": [
+        "bi2vk29g2qe7e"
+      ],
+      "x-request-id": [
+        "72cb8942-fb9e-4d9e-8efa-ecfa06fd2259"
+      ],
+      "content-length": [
+        "120"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:40:30 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-chart-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "body": "Date,Open,High,Low,Close,Adj Close,Volume\n2020-01-02,1875.000000,1898.010010,1864.150024,1898.010010,1898.010010,4029000"
+  }
+}

--- a/tests/http/historical-AZT.OL-2020-01-01-to-2020-01-03.json
+++ b/tests/http/historical-AZT.OL-2020-01-01-to-2020-01-03.json
@@ -1,0 +1,73 @@
+{
+  "request": {
+    "url": "https://query1.finance.yahoo.com/v7/finance/download/AZT.OL?interval=1d&events=history&includeAdjustedClose=true&period1=1577836800&period2=1578009600"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-disposition": [
+        "attachment; filename=AZT.OL.csv"
+      ],
+      "content-type": [
+        "text/csv"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "cache-control": [
+        "private, max-age=10, stale-while-revalidate=20"
+      ],
+      "y-rid": [
+        "ecm7i39g2qe7e"
+      ],
+      "x-yahoo-request-id": [
+        "ecm7i39g2qe7e"
+      ],
+      "x-request-id": [
+        "948f1dc2-1e07-4d25-85d4-0397d17f8c64"
+      ],
+      "content-length": [
+        "104"
+      ],
+      "x-envoy-upstream-service-time": [
+        "6"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:40:30 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-chart-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "body": "Date,Open,High,Low,Close,Adj Close,Volume\n2020-01-02,4.940000,5.360000,4.880000,4.990000,4.990000,151382"
+  }
+}

--- a/tests/http/historical-BABA-2020-01-01-to-2020-01-03.json
+++ b/tests/http/historical-BABA-2020-01-01-to-2020-01-03.json
@@ -1,0 +1,73 @@
+{
+  "request": {
+    "url": "https://query1.finance.yahoo.com/v7/finance/download/BABA?interval=1d&events=history&includeAdjustedClose=true&period1=1577836800&period2=1578009600"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-disposition": [
+        "attachment; filename=BABA.csv"
+      ],
+      "content-type": [
+        "text/csv"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "cache-control": [
+        "private, max-age=10, stale-while-revalidate=20"
+      ],
+      "y-rid": [
+        "f5jt5mtg2qe7g"
+      ],
+      "x-yahoo-request-id": [
+        "f5jt5mtg2qe7g"
+      ],
+      "x-request-id": [
+        "1a99223c-7405-4d1c-b986-40048af74e93"
+      ],
+      "content-length": [
+        "116"
+      ],
+      "x-envoy-upstream-service-time": [
+        "6"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:40:31 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-chart-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "body": "Date,Open,High,Low,Close,Adj Close,Volume\n2020-01-02,216.600006,219.979996,216.539993,219.770004,219.770004,15873500"
+  }
+}

--- a/tests/http/historical-BEKE-2020-01-01-to-2020-01-03.json
+++ b/tests/http/historical-BEKE-2020-01-01-to-2020-01-03.json
@@ -1,0 +1,73 @@
+{
+  "request": {
+    "url": "https://query1.finance.yahoo.com/v7/finance/download/BEKE?interval=1d&events=history&includeAdjustedClose=true&period1=1577836800&period2=1578009600"
+  },
+  "response": {
+    "ok": false,
+    "status": 400,
+    "statusText": "Bad Request",
+    "headers": {
+      "content-type": [
+        "text/csv"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "1c18nb1g2qe7e"
+      ],
+      "x-yahoo-request-id": [
+        "1c18nb1g2qe7e"
+      ],
+      "x-request-id": [
+        "ff6aa07a-286a-4a70-aabc-4f858fa16751"
+      ],
+      "content-length": [
+        "84"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:40:30 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-chart-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "2"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "body": "400 Bad Request: Data doesn't exist for startDate = 1577836800, endDate = 1578009600"
+  }
+}

--- a/tests/http/historical-BFLY-2020-01-01-to-2020-01-03.json
+++ b/tests/http/historical-BFLY-2020-01-01-to-2020-01-03.json
@@ -1,0 +1,73 @@
+{
+  "request": {
+    "url": "https://query1.finance.yahoo.com/v7/finance/download/BFLY?interval=1d&events=history&includeAdjustedClose=true&period1=1577836800&period2=1578009600"
+  },
+  "response": {
+    "ok": false,
+    "status": 400,
+    "statusText": "Bad Request",
+    "headers": {
+      "content-type": [
+        "text/csv"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "52c84k5g2qe7f"
+      ],
+      "x-yahoo-request-id": [
+        "52c84k5g2qe7f"
+      ],
+      "x-request-id": [
+        "cbe5b75b-6eab-498b-9f2a-a1ac50cba612"
+      ],
+      "content-length": [
+        "84"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:40:31 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-chart-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "body": "400 Bad Request: Data doesn't exist for startDate = 1577836800, endDate = 1578009600"
+  }
+}

--- a/tests/http/historical-GOOG-2020-01-01-to-2020-01-03.json
+++ b/tests/http/historical-GOOG-2020-01-01-to-2020-01-03.json
@@ -1,0 +1,73 @@
+{
+  "request": {
+    "url": "https://query1.finance.yahoo.com/v7/finance/download/GOOG?interval=1d&events=history&includeAdjustedClose=true&period1=1577836800&period2=1578009600"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-disposition": [
+        "attachment; filename=GOOG.csv"
+      ],
+      "content-type": [
+        "text/csv"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "cache-control": [
+        "private, max-age=10, stale-while-revalidate=20"
+      ],
+      "y-rid": [
+        "bcgmj2tg2qe7f"
+      ],
+      "x-yahoo-request-id": [
+        "bcgmj2tg2qe7f"
+      ],
+      "x-request-id": [
+        "60460930-766a-4bdf-b724-10020b392613"
+      ],
+      "content-length": [
+        "120"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:40:31 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-chart-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "body": "Date,Open,High,Low,Close,Adj Close,Volume\n2020-01-02,1341.550049,1368.140015,1341.550049,1367.369995,1367.369995,1406600"
+  }
+}

--- a/tests/http/historical-OCDO.L-2020-01-01-to-2020-01-03.json
+++ b/tests/http/historical-OCDO.L-2020-01-01-to-2020-01-03.json
@@ -1,0 +1,73 @@
+{
+  "request": {
+    "url": "https://query1.finance.yahoo.com/v7/finance/download/OCDO.L?interval=1d&events=history&includeAdjustedClose=true&period1=1577836800&period2=1578009600"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-disposition": [
+        "attachment; filename=OCDO.L.csv"
+      ],
+      "content-type": [
+        "text/csv"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "cache-control": [
+        "private, max-age=10, stale-while-revalidate=20"
+      ],
+      "y-rid": [
+        "3hfa0d5g2qe7f"
+      ],
+      "x-yahoo-request-id": [
+        "3hfa0d5g2qe7f"
+      ],
+      "x-request-id": [
+        "20ccc629-d80a-4c54-b771-1e2e5ce71c4c"
+      ],
+      "content-length": [
+        "119"
+      ],
+      "x-envoy-upstream-service-time": [
+        "5"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:40:31 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-chart-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "2"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "body": "Date,Open,High,Low,Close,Adj Close,Volume\n2020-01-02,1279.500000,1286.569946,1258.000000,1259.500000,1259.500000,728520"
+  }
+}

--- a/tests/http/historical-QQQ-2020-01-01-to-2020-01-03.json
+++ b/tests/http/historical-QQQ-2020-01-01-to-2020-01-03.json
@@ -1,0 +1,73 @@
+{
+  "request": {
+    "url": "https://query1.finance.yahoo.com/v7/finance/download/QQQ?interval=1d&events=history&includeAdjustedClose=true&period1=1577836800&period2=1578009600"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-disposition": [
+        "attachment; filename=QQQ.csv"
+      ],
+      "content-type": [
+        "text/csv"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "cache-control": [
+        "private, max-age=10, stale-while-revalidate=20"
+      ],
+      "y-rid": [
+        "410vl91g2qe7g"
+      ],
+      "x-yahoo-request-id": [
+        "410vl91g2qe7g"
+      ],
+      "x-request-id": [
+        "5a4d5f08-1162-9396-b929-0526cf1d08ba"
+      ],
+      "content-length": [
+        "116"
+      ],
+      "x-envoy-upstream-service-time": [
+        "22"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:40:32 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-chart-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "body": "Date,Open,High,Low,Close,Adj Close,Volume\n2020-01-02,214.399994,216.160004,213.979996,216.160004,214.936295,30969400"
+  }
+}

--- a/tests/http/historical-SIX-2020-01-01-to-2020-01-03.json
+++ b/tests/http/historical-SIX-2020-01-01-to-2020-01-03.json
@@ -1,0 +1,73 @@
+{
+  "request": {
+    "url": "https://query1.finance.yahoo.com/v7/finance/download/SIX?interval=1d&events=history&includeAdjustedClose=true&period1=1577836800&period2=1578009600"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-disposition": [
+        "attachment; filename=SIX.csv"
+      ],
+      "content-type": [
+        "text/csv"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "cache-control": [
+        "private, max-age=10, stale-while-revalidate=20"
+      ],
+      "y-rid": [
+        "1eb7tjpg2qe7f"
+      ],
+      "x-yahoo-request-id": [
+        "1eb7tjpg2qe7f"
+      ],
+      "x-request-id": [
+        "620f25e1-5db1-4890-8e9e-4f239b72eaf6"
+      ],
+      "content-length": [
+        "110"
+      ],
+      "x-envoy-upstream-service-time": [
+        "22"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:40:31 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-chart-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "body": "Date,Open,High,Low,Close,Adj Close,Volume\n2020-01-02,44.369999,45.060001,43.799999,45.060001,44.611912,1773900"
+  }
+}

--- a/tests/http/historical-SPOT-2020-01-01-to-2020-01-03.json
+++ b/tests/http/historical-SPOT-2020-01-01-to-2020-01-03.json
@@ -1,0 +1,73 @@
+{
+  "request": {
+    "url": "https://query1.finance.yahoo.com/v7/finance/download/SPOT?interval=1d&events=history&includeAdjustedClose=true&period1=1577836800&period2=1578009600"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-disposition": [
+        "attachment; filename=SPOT.csv"
+      ],
+      "content-type": [
+        "text/csv"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "cache-control": [
+        "private, max-age=10, stale-while-revalidate=20"
+      ],
+      "y-rid": [
+        "2kq0ic1g2qe7f"
+      ],
+      "x-yahoo-request-id": [
+        "2kq0ic1g2qe7f"
+      ],
+      "x-request-id": [
+        "155bb661-b84f-40be-9d36-a1968555c540"
+      ],
+      "content-length": [
+        "114"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:40:31 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-chart-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "body": "Date,Open,High,Low,Close,Adj Close,Volume\n2020-01-02,151.000000,152.800003,149.610001,151.619995,151.619995,662600"
+  }
+}

--- a/tests/http/historical-UNIR.MI-2020-01-01-to-2020-01-03.json
+++ b/tests/http/historical-UNIR.MI-2020-01-01-to-2020-01-03.json
@@ -1,0 +1,73 @@
+{
+  "request": {
+    "url": "https://query1.finance.yahoo.com/v7/finance/download/UNIR.MI?interval=1d&events=history&includeAdjustedClose=true&period1=1577836800&period2=1578009600"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-disposition": [
+        "attachment; filename=UNIR.MI.csv"
+      ],
+      "content-type": [
+        "text/csv"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "cache-control": [
+        "private, max-age=10, stale-while-revalidate=20"
+      ],
+      "y-rid": [
+        "en94eg9g2qe7f"
+      ],
+      "x-yahoo-request-id": [
+        "en94eg9g2qe7f"
+      ],
+      "x-request-id": [
+        "5168e97d-e775-9527-8d52-273a72bd7c54"
+      ],
+      "content-length": [
+        "108"
+      ],
+      "x-envoy-upstream-service-time": [
+        "6"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:40:31 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-chart-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "body": "Date,Open,High,Low,Close,Adj Close,Volume\n2020-01-02,13.480000,13.540000,13.360000,13.460000,13.460000,36095"
+  }
+}

--- a/tests/http/historical-WSKT.JK-2020-01-01-to-2020-01-03.json
+++ b/tests/http/historical-WSKT.JK-2020-01-01-to-2020-01-03.json
@@ -1,0 +1,73 @@
+{
+  "request": {
+    "url": "https://query1.finance.yahoo.com/v7/finance/download/WSKT.JK?interval=1d&events=history&includeAdjustedClose=true&period1=1577836800&period2=1578009600"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-disposition": [
+        "attachment; filename=WSKT.JK.csv"
+      ],
+      "content-type": [
+        "text/csv"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "cache-control": [
+        "private, max-age=10, stale-while-revalidate=20"
+      ],
+      "y-rid": [
+        "1b03o3pg2qe7f"
+      ],
+      "x-yahoo-request-id": [
+        "1b03o3pg2qe7f"
+      ],
+      "x-request-id": [
+        "66e21ee6-0c1f-49d8-b729-7b065382d51c"
+      ],
+      "content-length": [
+        "121"
+      ],
+      "x-envoy-upstream-service-time": [
+        "12"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:40:30 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-chart-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "body": "Date,Open,High,Low,Close,Adj Close,Volume\n2020-01-02,1485.000000,1515.000000,1480.000000,1505.000000,1497.776611,23547100"
+  }
+}

--- a/tests/http/quoteSummary-all-BEKE.json
+++ b/tests/http/quoteSummary-all-BEKE.json
@@ -1,0 +1,3685 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=assetProfile%2CbalanceSheetHistory%2CbalanceSheetHistoryQuarterly%2CcalendarEvents%2CcashflowStatementHistory%2CcashflowStatementHistoryQuarterly%2CdefaultKeyStatistics%2Cearnings%2CearningsHistory%2CearningsTrend%2CfinancialData%2CfundOwnership%2CfundPerformance%2CfundProfile%2CincomeStatementHistory%2CincomeStatementHistoryQuarterly%2CindexTrend%2CindustryTrend%2CinsiderHolders%2CinsiderTransactions%2CinstitutionOwnership%2CmajorDirectHolders%2CmajorHoldersBreakdown%2CnetSharePurchaseActivity%2Cprice%2CquoteType%2CrecommendationTrend%2CsecFilings%2CsectorTrend%2CsummaryDetail%2CsummaryProfile%2CtopHoldings%2CupgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "8qojl0dg2qdta"
+      ],
+      "x-yahoo-request-id": [
+        "8qojl0dg2qdta"
+      ],
+      "x-request-id": [
+        "afccde75-0504-4c1b-b4cd-a7363bdfbaf6"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "11"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:06 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "Building Fudao",
+              "address2": "No.11 Kaituo Road Haidian District",
+              "city": "Beijing",
+              "zip": "100085",
+              "country": "China",
+              "phone": "86 10 5810 4689",
+              "website": "http://ke.com",
+              "industry": "Real Estate Services",
+              "sector": "Real Estate",
+              "longBusinessSummary": "KE Holdings Inc. operates an integrated online and offline platform for housing transactions and services in the People's Republic of China. The company facilitates various housing transactions ranging from existing and new home sales and home rentals to home renovation, real estate financial solutions, and other services. It also owns and operates Lianjia, a real estate brokerage branded store. The company was founded in 2001 and is headquartered in Beijing, China.",
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Hui  Zuo",
+                  "age": 49,
+                  "title": "Founder & Chairman",
+                  "yearBorn": 1971,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Yongdong  Peng",
+                  "age": 41,
+                  "title": "CEO & Exec. Director",
+                  "yearBorn": 1979,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Tao  Xu",
+                  "age": 47,
+                  "title": "Chief Financial Officer",
+                  "yearBorn": 1973,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Wangang  Xu",
+                  "age": 55,
+                  "title": "Co-Chief Operating Officer",
+                  "yearBorn": 1965,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Yongqun  Wang",
+                  "age": 49,
+                  "title": "Co-Chief Operating Officer",
+                  "yearBorn": 1971,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Yigang  Shan",
+                  "age": 47,
+                  "title": "Exec. Director",
+                  "yearBorn": 1973,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 2,
+                  "buy": 3,
+                  "hold": 5,
+                  "sell": 1,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 1,
+                  "buy": 3,
+                  "hold": 5,
+                  "sell": 1,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 0,
+                  "buy": 3,
+                  "hold": 5,
+                  "sell": 1,
+                  "strongSell": 0
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -2183546000,
+                    "fmt": "-2.18B",
+                    "longFmt": "-2,183,546,000"
+                  },
+                  "depreciation": {
+                    "raw": 1039318000,
+                    "fmt": "1.04B",
+                    "longFmt": "1,039,318,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 3018688000,
+                    "fmt": "3.02B",
+                    "longFmt": "3,018,688,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -5040865000,
+                    "fmt": "-5.04B",
+                    "longFmt": "-5,040,865,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 3009276000,
+                    "fmt": "3.01B",
+                    "longFmt": "3,009,276,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -412586000,
+                    "fmt": "-412.59M",
+                    "longFmt": "-412,586,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 112626000,
+                    "fmt": "112.63M",
+                    "longFmt": "112,626,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -703008000,
+                    "fmt": "-703.01M",
+                    "longFmt": "-703,008,000"
+                  },
+                  "investments": {
+                    "raw": -1133063000,
+                    "fmt": "-1.13B",
+                    "longFmt": "-1,133,063,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 91216000,
+                    "fmt": "91.22M",
+                    "longFmt": "91,216,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -3873722000,
+                    "fmt": "-3.87B",
+                    "longFmt": "-3,873,722,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 6758437000,
+                    "fmt": "6.76B",
+                    "longFmt": "6,758,437,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -8628000,
+                    "fmt": "-8.63M",
+                    "longFmt": "-8,628,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 23026396000,
+                    "fmt": "23.03B",
+                    "longFmt": "23,026,396,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -94922000,
+                    "fmt": "-94.92M",
+                    "longFmt": "-94,922,000"
+                  },
+                  "changeInCash": {
+                    "raw": 19170378000,
+                    "fmt": "19.17B",
+                    "longFmt": "19,170,378,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -347219000,
+                    "fmt": "-347.22M",
+                    "longFmt": "-347,219,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 232885000,
+                    "fmt": "232.88M",
+                    "longFmt": "232,885,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -467824000,
+                    "fmt": "-467.82M",
+                    "longFmt": "-467,824,000"
+                  },
+                  "depreciation": {
+                    "raw": 792294000,
+                    "fmt": "792.29M",
+                    "longFmt": "792,294,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -186336000,
+                    "fmt": "-186.34M",
+                    "longFmt": "-186,336,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -769062000,
+                    "fmt": "-769.06M",
+                    "longFmt": "-769,062,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 1157138000,
+                    "fmt": "1.16B",
+                    "longFmt": "1,157,138,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 2913832000,
+                    "fmt": "2.91B",
+                    "longFmt": "2,913,832,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 3216797000,
+                    "fmt": "3.22B",
+                    "longFmt": "3,216,797,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -542853000,
+                    "fmt": "-542.85M",
+                    "longFmt": "-542,853,000"
+                  },
+                  "investments": {
+                    "raw": 5239066000,
+                    "fmt": "5.24B",
+                    "longFmt": "5,239,066,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -2010792000,
+                    "fmt": "-2.01B",
+                    "longFmt": "-2,010,792,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 2609149000,
+                    "fmt": "2.61B",
+                    "longFmt": "2,609,149,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -124121000,
+                    "fmt": "-124.12M",
+                    "longFmt": "-124,121,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -437019000,
+                    "fmt": "-437.02M",
+                    "longFmt": "-437,019,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -1282408000,
+                    "fmt": "-1.28B",
+                    "longFmt": "-1,282,408,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 416000,
+                    "fmt": "416k",
+                    "longFmt": "416,000"
+                  },
+                  "changeInCash": {
+                    "raw": 4543954000,
+                    "fmt": "4.54B",
+                    "longFmt": "4,543,954,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -347219000,
+                    "fmt": "-347.22M",
+                    "longFmt": "-347,219,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 232885000,
+                    "fmt": "232.88M",
+                    "longFmt": "232,885,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -574430000,
+                    "fmt": "-574.43M",
+                    "longFmt": "-574,430,000"
+                  },
+                  "depreciation": {
+                    "raw": 811203000,
+                    "fmt": "811.2M",
+                    "longFmt": "811,203,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 164271000,
+                    "fmt": "164.27M",
+                    "longFmt": "164,271,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -498216000,
+                    "fmt": "-498.22M",
+                    "longFmt": "-498,216,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -764294000,
+                    "fmt": "-764.29M",
+                    "longFmt": "-764,294,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -5733411000,
+                    "fmt": "-5.73B",
+                    "longFmt": "-5,733,411,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -6456226000,
+                    "fmt": "-6.46B",
+                    "longFmt": "-6,456,226,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -575185000,
+                    "fmt": "-575.18M",
+                    "longFmt": "-575,185,000"
+                  },
+                  "investments": {
+                    "raw": -959123000,
+                    "fmt": "-959.12M",
+                    "longFmt": "-959,123,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -5000000,
+                    "fmt": "-5M",
+                    "longFmt": "-5,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -2783562000,
+                    "fmt": "-2.78B",
+                    "longFmt": "-2,783,562,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -127188000,
+                    "fmt": "-127.19M",
+                    "longFmt": "-127,188,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 973472000,
+                    "fmt": "973.47M",
+                    "longFmt": "973,472,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -437019000,
+                    "fmt": "-437.02M",
+                    "longFmt": "-437,019,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 9576284000,
+                    "fmt": "9.58B",
+                    "longFmt": "9,576,284,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -330000,
+                    "fmt": "-330k",
+                    "longFmt": "-330,000"
+                  },
+                  "changeInCash": {
+                    "raw": 336166000,
+                    "fmt": "336.17M",
+                    "longFmt": "336,166,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -347219000,
+                    "fmt": "-347.22M",
+                    "longFmt": "-347,219,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 232885000,
+                    "fmt": "232.88M",
+                    "longFmt": "232,885,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 5.56217,
+              "pegRatio": 0.991258,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.269
+                },
+                {
+                  "period": "+1q",
+                  "growth": 0.96099997
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.148
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.155
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0821053
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            },
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": 79355428864,
+              "forwardPE": 73.188896,
+              "profitMargins": -0.02313,
+              "floatShares": 389103285,
+              "sharesOutstanding": 1143379968,
+              "sharesShort": 11331624,
+              "sharesShortPriorMonth": 10275253,
+              "sharesShortPreviousMonthDate": 1609372800,
+              "dateShortInterest": 1611878400,
+              "sharesPercentSharesOut": 0.0095999995,
+              "heldPercentInsiders": 0.0090499995,
+              "heldPercentInstitutions": 0.14386,
+              "shortRatio": 3.25,
+              "category": null,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1577750400,
+              "nextFiscalYearEnd": 1640908800,
+              "mostRecentQuarter": 1601424000,
+              "earningsQuarterlyGrowth": -0.804,
+              "pegRatio": 117.17,
+              "lastSplitFactor": null,
+              "52WeekChange": 0.81623936,
+              "SandP52WeekChange": 0.16137505
+            },
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "quoteType": {
+              "exchange": "NYQ",
+              "quoteType": "EQUITY",
+              "symbol": "BEKE",
+              "underlyingSymbol": "BEKE",
+              "shortName": "KE Holdings Inc",
+              "longName": "KE Holdings Inc.",
+              "firstTradeDateEpochUtc": 1597325400,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "36c211a8-04c4-368b-8141-b3e0d4048354",
+              "messageBoardId": "finmb_665898843",
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            },
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 46014906000,
+                    "fmt": "46.01B",
+                    "longFmt": "46,014,906,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 34746862000,
+                    "fmt": "34.75B",
+                    "longFmt": "34,746,862,000"
+                  },
+                  "grossProfit": {
+                    "raw": 11268044000,
+                    "fmt": "11.27B",
+                    "longFmt": "11,268,044,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 1571154000,
+                    "fmt": "1.57B",
+                    "longFmt": "1,571,154,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 11482430000,
+                    "fmt": "11.48B",
+                    "longFmt": "11,482,430,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 47800446000,
+                    "fmt": "47.8B",
+                    "longFmt": "47,800,446,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -1785540000,
+                    "fmt": "-1.79B",
+                    "longFmt": "-1,785,540,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 509776000,
+                    "fmt": "509.78M",
+                    "longFmt": "509,776,000"
+                  },
+                  "ebit": {
+                    "raw": -1785540000,
+                    "fmt": "-1.79B",
+                    "longFmt": "-1,785,540,000"
+                  },
+                  "interestExpense": {
+                    "raw": -181099000,
+                    "fmt": "-181.1M",
+                    "longFmt": "-181,099,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -1275764000,
+                    "fmt": "-1.28B",
+                    "longFmt": "-1,275,764,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 904363000,
+                    "fmt": "904.36M",
+                    "longFmt": "904,363,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 87203000,
+                    "fmt": "87.2M",
+                    "longFmt": "87,203,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -2180127000,
+                    "fmt": "-2.18B",
+                    "longFmt": "-2,180,127,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -2183546000,
+                    "fmt": "-2.18B",
+                    "longFmt": "-2,183,546,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -4050074000,
+                    "fmt": "-4.05B",
+                    "longFmt": "-4,050,074,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 28646499000,
+                    "fmt": "28.65B",
+                    "longFmt": "28,646,499,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 21776523000,
+                    "fmt": "21.78B",
+                    "longFmt": "21,776,523,000"
+                  },
+                  "grossProfit": {
+                    "raw": 6869976000,
+                    "fmt": "6.87B",
+                    "longFmt": "6,869,976,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 670922000,
+                    "fmt": "670.92M",
+                    "longFmt": "670,922,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 7417059000,
+                    "fmt": "7.42B",
+                    "longFmt": "7,417,059,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 29864504000,
+                    "fmt": "29.86B",
+                    "longFmt": "29,864,504,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -1218005000,
+                    "fmt": "-1.22B",
+                    "longFmt": "-1,218,005,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 718940000,
+                    "fmt": "718.94M",
+                    "longFmt": "718,940,000"
+                  },
+                  "ebit": {
+                    "raw": -1218005000,
+                    "fmt": "-1.22B",
+                    "longFmt": "-1,218,005,000"
+                  },
+                  "interestExpense": {
+                    "raw": -43517000,
+                    "fmt": "-43.52M",
+                    "longFmt": "-43,517,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -499065000,
+                    "fmt": "-499.06M",
+                    "longFmt": "-499,065,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -71384000,
+                    "fmt": "-71.38M",
+                    "longFmt": "-71,384,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 10467000,
+                    "fmt": "10.47M",
+                    "longFmt": "10,467,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -427681000,
+                    "fmt": "-427.68M",
+                    "longFmt": "-427,681,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -467824000,
+                    "fmt": "-467.82M",
+                    "longFmt": "-467,824,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -2386005000,
+                    "fmt": "-2.39B",
+                    "longFmt": "-2,386,005,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 25505698000,
+                    "fmt": "25.51B",
+                    "longFmt": "25,505,698,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 20737641000,
+                    "fmt": "20.74B",
+                    "longFmt": "20,737,641,000"
+                  },
+                  "grossProfit": {
+                    "raw": 4768057000,
+                    "fmt": "4.77B",
+                    "longFmt": "4,768,057,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 251802000,
+                    "fmt": "251.8M",
+                    "longFmt": "251,802,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 5280146000,
+                    "fmt": "5.28B",
+                    "longFmt": "5,280,146,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 26269589000,
+                    "fmt": "26.27B",
+                    "longFmt": "26,269,589,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -763891000,
+                    "fmt": "-763.89M",
+                    "longFmt": "-763,891,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 625553000,
+                    "fmt": "625.55M",
+                    "longFmt": "625,553,000"
+                  },
+                  "ebit": {
+                    "raw": -763891000,
+                    "fmt": "-763.89M",
+                    "longFmt": "-763,891,000"
+                  },
+                  "interestExpense": {
+                    "raw": -43791000,
+                    "fmt": "-43.79M",
+                    "longFmt": "-43,791,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -138338000,
+                    "fmt": "-138.34M",
+                    "longFmt": "-138,338,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 399283000,
+                    "fmt": "399.28M",
+                    "longFmt": "399,283,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 65836000,
+                    "fmt": "65.84M",
+                    "longFmt": "65,836,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -537621000,
+                    "fmt": "-537.62M",
+                    "longFmt": "-537,621,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -574430000,
+                    "fmt": "-574.43M",
+                    "longFmt": "-574,430,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -1441879000,
+                    "fmt": "-1.44B",
+                    "longFmt": "-1,441,879,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Europacific Growth Fund",
+                  "pctHeld": {
+                    "raw": 0.005,
+                    "fmt": "0.50%"
+                  },
+                  "position": {
+                    "raw": 4457516,
+                    "fmt": "4.46M",
+                    "longFmt": "4,457,516"
+                  },
+                  "value": {
+                    "raw": 274315534,
+                    "fmt": "274.32M",
+                    "longFmt": "274,315,534"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "ARK ETF Tr-ARK Innovation ETF",
+                  "pctHeld": {
+                    "raw": 0.0049,
+                    "fmt": "0.49%"
+                  },
+                  "position": {
+                    "raw": 4358188,
+                    "fmt": "4.36M",
+                    "longFmt": "4,358,188"
+                  },
+                  "value": {
+                    "raw": 268202889,
+                    "fmt": "268.2M",
+                    "longFmt": "268,202,889"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "KraneShares CSI China Internet ETF",
+                  "pctHeld": {
+                    "raw": 0.0023999999,
+                    "fmt": "0.24%"
+                  },
+                  "position": {
+                    "raw": 2150250,
+                    "fmt": "2.15M",
+                    "longFmt": "2,150,250"
+                  },
+                  "value": {
+                    "raw": 131810325,
+                    "fmt": "131.81M",
+                    "longFmt": "131,810,325"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1604102400,
+                    "fmt": "2020-10-31"
+                  },
+                  "organization": "Vanguard International Stock Index-Total Intl Stock Indx",
+                  "pctHeld": {
+                    "raw": 0.0018000001,
+                    "fmt": "0.18%"
+                  },
+                  "position": {
+                    "raw": 1625494,
+                    "fmt": "1.63M",
+                    "longFmt": "1,625,494"
+                  },
+                  "value": {
+                    "raw": 113378206,
+                    "fmt": "113.38M",
+                    "longFmt": "113,378,206"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Fidelity OTC Portfolio",
+                  "pctHeld": {
+                    "raw": 0.0018000001,
+                    "fmt": "0.18%"
+                  },
+                  "position": {
+                    "raw": 1598717,
+                    "fmt": "1.6M",
+                    "longFmt": "1,598,717"
+                  },
+                  "value": {
+                    "raw": 98385044,
+                    "fmt": "98.39M",
+                    "longFmt": "98,385,044"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1604102400,
+                    "fmt": "2020-10-31"
+                  },
+                  "organization": "Vanguard International Stock Index-Emerging Markets Stk",
+                  "pctHeld": {
+                    "raw": 0.0016,
+                    "fmt": "0.16%"
+                  },
+                  "position": {
+                    "raw": 1440142,
+                    "fmt": "1.44M",
+                    "longFmt": "1,440,142"
+                  },
+                  "value": {
+                    "raw": 100449904,
+                    "fmt": "100.45M",
+                    "longFmt": "100,449,904"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "ARK ETF Tr-ARK Next Generation Internet ETF",
+                  "pctHeld": {
+                    "raw": 0.0014,
+                    "fmt": "0.14%"
+                  },
+                  "position": {
+                    "raw": 1285541,
+                    "fmt": "1.29M",
+                    "longFmt": "1,285,541"
+                  },
+                  "value": {
+                    "raw": 79112193,
+                    "fmt": "79.11M",
+                    "longFmt": "79,112,193"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "New World Fund, Inc.",
+                  "pctHeld": {
+                    "raw": 0.0013,
+                    "fmt": "0.13%"
+                  },
+                  "position": {
+                    "raw": 1116780,
+                    "fmt": "1.12M",
+                    "longFmt": "1,116,780"
+                  },
+                  "value": {
+                    "raw": 68726641,
+                    "fmt": "68.73M",
+                    "longFmt": "68,726,641"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Fundamental Investors Inc",
+                  "pctHeld": {
+                    "raw": 0.0011,
+                    "fmt": "0.11%"
+                  },
+                  "position": {
+                    "raw": 986393,
+                    "fmt": "986.39k",
+                    "longFmt": "986,393"
+                  },
+                  "value": {
+                    "raw": 60702625,
+                    "fmt": "60.7M",
+                    "longFmt": "60,702,625"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Fidelity Growth Company Fund",
+                  "pctHeld": {
+                    "raw": 0.0011,
+                    "fmt": "0.11%"
+                  },
+                  "position": {
+                    "raw": 974704,
+                    "fmt": "974.7k",
+                    "longFmt": "974,704"
+                  },
+                  "value": {
+                    "raw": 59983284,
+                    "fmt": "59.98M",
+                    "longFmt": "59,983,284"
+                  }
+                }
+              ]
+            },
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 68,
+              "open": 66.39,
+              "dayLow": 65.25,
+              "dayHigh": 67.82,
+              "regularMarketPreviousClose": 68,
+              "regularMarketOpen": 66.39,
+              "regularMarketDayLow": 65.25,
+              "regularMarketDayHigh": 67.82,
+              "payoutRatio": 0,
+              "volume": 2244651,
+              "regularMarketVolume": 2244651,
+              "averageVolume": 3760300,
+              "averageVolume10days": 5531066,
+              "averageDailyVolume10Day": 5531066,
+              "bid": 66.81,
+              "ask": 66.82,
+              "bidSize": 1000,
+              "askSize": 1000,
+              "marketCap": 77646241792,
+              "fiftyTwoWeekLow": 31.79,
+              "fiftyTwoWeekHigh": 79.4,
+              "fiftyDayAverage": 64.594246,
+              "twoHundredDayAverage": 61.68664,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            },
+            "insiderHolders": {
+              "holders": [],
+              "maxAge": 1
+            },
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": [],
+                "earningsAverage": 0.13,
+                "earningsLow": 0.01,
+                "earningsHigh": 0.17,
+                "revenueAverage": 3082150000,
+                "revenueLow": 2998670000,
+                "revenueHigh": 3182420000
+              }
+            },
+            "upgradeDowngradeHistory": {
+              "history": [
+                {
+                  "epochGradeDate": 1609859636,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                }
+              ],
+              "maxAge": 86400
+            },
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": -0.0220588,
+              "preMarketChange": -1.5,
+              "preMarketTime": 1613572197,
+              "preMarketPrice": 66.5,
+              "preMarketSource": "FREE_REALTIME",
+              "regularMarketChangePercent": -0.03132349,
+              "regularMarketChange": -2.1299973,
+              "regularMarketTime": 1613576103,
+              "priceHint": 2,
+              "regularMarketPrice": 65.87,
+              "regularMarketDayHigh": 67.82,
+              "regularMarketDayLow": 65.25,
+              "regularMarketVolume": 2244651,
+              "averageDailyVolume10Day": 5531066,
+              "averageDailyVolume3Month": 3760300,
+              "regularMarketPreviousClose": 68,
+              "regularMarketSource": "FREE_REALTIME",
+              "regularMarketOpen": 66.39,
+              "exchange": "NYQ",
+              "exchangeName": "NYSE",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "EQUITY",
+              "symbol": "BEKE",
+              "underlyingSymbol": null,
+              "shortName": "KE Holdings Inc",
+              "longName": "KE Holdings Inc.",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 77646241792
+            },
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 24319332000,
+                    "fmt": "24.32B",
+                    "longFmt": "24,319,332,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 1844595000,
+                    "fmt": "1.84B",
+                    "longFmt": "1,844,595,000"
+                  },
+                  "netReceivables": {
+                    "raw": 13169172000,
+                    "fmt": "13.17B",
+                    "longFmt": "13,169,172,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 12139612000,
+                    "fmt": "12.14B",
+                    "longFmt": "12,139,612,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 51912486000,
+                    "fmt": "51.91B",
+                    "longFmt": "51,912,486,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2333745000,
+                    "fmt": "2.33B",
+                    "longFmt": "2,333,745,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6759243000,
+                    "fmt": "6.76B",
+                    "longFmt": "6,759,243,000"
+                  },
+                  "goodWill": {
+                    "raw": 2477075000,
+                    "fmt": "2.48B",
+                    "longFmt": "2,477,075,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 2560442000,
+                    "fmt": "2.56B",
+                    "longFmt": "2,560,442,000"
+                  },
+                  "otherAssets": {
+                    "raw": 1222321000,
+                    "fmt": "1.22B",
+                    "longFmt": "1,222,321,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 520292000,
+                    "fmt": "520.29M",
+                    "longFmt": "520,292,000"
+                  },
+                  "totalAssets": {
+                    "raw": 67265312000,
+                    "fmt": "67.27B",
+                    "longFmt": "67,265,312,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 4475170000,
+                    "fmt": "4.48B",
+                    "longFmt": "4,475,170,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2291723000,
+                    "fmt": "2.29B",
+                    "longFmt": "2,291,723,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 8584074000,
+                    "fmt": "8.58B",
+                    "longFmt": "8,584,074,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 4897530000,
+                    "fmt": "4.9B",
+                    "longFmt": "4,897,530,000"
+                  },
+                  "otherLiab": {
+                    "raw": 120275000,
+                    "fmt": "120.28M",
+                    "longFmt": "120,275,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 87203000,
+                    "fmt": "87.2M",
+                    "longFmt": "87,203,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 27797675000,
+                    "fmt": "27.8B",
+                    "longFmt": "27,797,675,000"
+                  },
+                  "totalLiab": {
+                    "raw": 35729720000,
+                    "fmt": "35.73B",
+                    "longFmt": "35,729,720,000"
+                  },
+                  "commonStock": {
+                    "raw": 202000,
+                    "fmt": "202k",
+                    "longFmt": "202,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -11521905000,
+                    "fmt": "-11.52B",
+                    "longFmt": "-11,521,905,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 63308000,
+                    "fmt": "63.31M",
+                    "longFmt": "63,308,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 2533889000,
+                    "fmt": "2.53B",
+                    "longFmt": "2,533,889,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 63308000,
+                    "fmt": "63.31M",
+                    "longFmt": "63,308,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -8924506000,
+                    "fmt": "-8.92B",
+                    "longFmt": "-8,924,506,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -13962023000,
+                    "fmt": "-13.96B",
+                    "longFmt": "-13,962,023,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "cash": {
+                    "raw": 9115649000,
+                    "fmt": "9.12B",
+                    "longFmt": "9,115,649,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 2523199000,
+                    "fmt": "2.52B",
+                    "longFmt": "2,523,199,000"
+                  },
+                  "netReceivables": {
+                    "raw": 10369552000,
+                    "fmt": "10.37B",
+                    "longFmt": "10,369,552,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 4972534000,
+                    "fmt": "4.97B",
+                    "longFmt": "4,972,534,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 27374784000,
+                    "fmt": "27.37B",
+                    "longFmt": "27,374,784,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 418469000,
+                    "fmt": "418.47M",
+                    "longFmt": "418,469,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6089232000,
+                    "fmt": "6.09B",
+                    "longFmt": "6,089,232,000"
+                  },
+                  "goodWill": {
+                    "raw": 1135034000,
+                    "fmt": "1.14B",
+                    "longFmt": "1,135,034,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 196998000,
+                    "fmt": "197M",
+                    "longFmt": "196,998,000"
+                  },
+                  "otherAssets": {
+                    "raw": 3651747000,
+                    "fmt": "3.65B",
+                    "longFmt": "3,651,747,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 672622000,
+                    "fmt": "672.62M",
+                    "longFmt": "672,622,000"
+                  },
+                  "totalAssets": {
+                    "raw": 38866264000,
+                    "fmt": "38.87B",
+                    "longFmt": "38,866,264,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1573343000,
+                    "fmt": "1.57B",
+                    "longFmt": "1,573,343,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2414607000,
+                    "fmt": "2.41B",
+                    "longFmt": "2,414,607,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 4762200000,
+                    "fmt": "4.76B",
+                    "longFmt": "4,762,200,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 112900000,
+                    "fmt": "112.9M",
+                    "longFmt": "112,900,000"
+                  },
+                  "otherLiab": {
+                    "raw": 532931000,
+                    "fmt": "532.93M",
+                    "longFmt": "532,931,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 10467000,
+                    "fmt": "10.47M",
+                    "longFmt": "10,467,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 20572881000,
+                    "fmt": "20.57B",
+                    "longFmt": "20,572,881,000"
+                  },
+                  "totalLiab": {
+                    "raw": 24007724000,
+                    "fmt": "24.01B",
+                    "longFmt": "24,007,724,000"
+                  },
+                  "commonStock": {
+                    "raw": 189000,
+                    "fmt": "189k",
+                    "longFmt": "189,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -7814291000,
+                    "fmt": "-7.81B",
+                    "longFmt": "-7,814,291,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -134000,
+                    "fmt": "-134k",
+                    "longFmt": "-134,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -134000,
+                    "fmt": "-134k",
+                    "longFmt": "-134,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -7814236000,
+                    "fmt": "-7.81B",
+                    "longFmt": "-7,814,236,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -9146268000,
+                    "fmt": "-9.15B",
+                    "longFmt": "-9,146,268,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "cash": {
+                    "raw": 5236100000,
+                    "fmt": "5.24B",
+                    "longFmt": "5,236,100,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 7587433000,
+                    "fmt": "7.59B",
+                    "longFmt": "7,587,433,000"
+                  },
+                  "netReceivables": {
+                    "raw": 4676434000,
+                    "fmt": "4.68B",
+                    "longFmt": "4,676,434,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 6227975000,
+                    "fmt": "6.23B",
+                    "longFmt": "6,227,975,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 24067931000,
+                    "fmt": "24.07B",
+                    "longFmt": "24,067,931,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 379972000,
+                    "fmt": "379.97M",
+                    "longFmt": "379,972,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6002914000,
+                    "fmt": "6B",
+                    "longFmt": "6,002,914,000"
+                  },
+                  "goodWill": {
+                    "raw": 710983000,
+                    "fmt": "710.98M",
+                    "longFmt": "710,983,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 264726000,
+                    "fmt": "264.73M",
+                    "longFmt": "264,726,000"
+                  },
+                  "otherAssets": {
+                    "raw": 153409000,
+                    "fmt": "153.41M",
+                    "longFmt": "153,409,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 147535000,
+                    "fmt": "147.53M",
+                    "longFmt": "147,535,000"
+                  },
+                  "totalAssets": {
+                    "raw": 31579935000,
+                    "fmt": "31.58B",
+                    "longFmt": "31,579,935,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 370496000,
+                    "fmt": "370.5M",
+                    "longFmt": "370,496,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 4665524000,
+                    "fmt": "4.67B",
+                    "longFmt": "4,665,524,000"
+                  },
+                  "otherLiab": {
+                    "raw": 518091000,
+                    "fmt": "518.09M",
+                    "longFmt": "518,091,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 65836000,
+                    "fmt": "65.84M",
+                    "longFmt": "65,836,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 16047286000,
+                    "fmt": "16.05B",
+                    "longFmt": "16,047,286,000"
+                  },
+                  "totalLiab": {
+                    "raw": 19143150000,
+                    "fmt": "19.14B",
+                    "longFmt": "19,143,150,000"
+                  },
+                  "commonStock": {
+                    "raw": 178000,
+                    "fmt": "178k",
+                    "longFmt": "178,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -5226325000,
+                    "fmt": "-5.23B",
+                    "longFmt": "-5,226,325,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -327000,
+                    "fmt": "-327k",
+                    "longFmt": "-327,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -327000,
+                    "fmt": "-327k",
+                    "longFmt": "-327,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -5226474000,
+                    "fmt": "-5.23B",
+                    "longFmt": "-5,226,474,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -6202183000,
+                    "fmt": "-6.2B",
+                    "longFmt": "-6,202,183,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": "2020-12-31",
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "low": {
+                      "raw": 0.01,
+                      "fmt": "0.01"
+                    },
+                    "high": {
+                      "raw": 0.17,
+                      "fmt": "0.17"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 6,
+                      "fmt": "6",
+                      "longFmt": "6"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 3082150000,
+                      "fmt": "3.08B",
+                      "longFmt": "3,082,150,000"
+                    },
+                    "low": {
+                      "raw": 2998670000,
+                      "fmt": "3B",
+                      "longFmt": "2,998,670,000"
+                    },
+                    "high": {
+                      "raw": 3182420000,
+                      "fmt": "3.18B",
+                      "longFmt": "3,182,420,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 7,
+                      "fmt": "7",
+                      "longFmt": "7"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.11,
+                      "fmt": "0.11"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": "2021-03-31",
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "low": {
+                      "raw": 0.09,
+                      "fmt": "0.09"
+                    },
+                    "high": {
+                      "raw": 0.14,
+                      "fmt": "0.14"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 3,
+                      "fmt": "3",
+                      "longFmt": "3"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 2126150000,
+                      "fmt": "2.13B",
+                      "longFmt": "2,126,150,000"
+                    },
+                    "low": {
+                      "raw": 1891260000,
+                      "fmt": "1.89B",
+                      "longFmt": "1,891,260,000"
+                    },
+                    "high": {
+                      "raw": 2252600000,
+                      "fmt": "2.25B",
+                      "longFmt": "2,252,600,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 3,
+                      "fmt": "3",
+                      "longFmt": "3"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.08,
+                      "fmt": "0.08"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": "2020-12-31",
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "low": {
+                      "raw": 0.63,
+                      "fmt": "0.63"
+                    },
+                    "high": {
+                      "raw": 1.02,
+                      "fmt": "1.02"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 9,
+                      "fmt": "9",
+                      "longFmt": "9"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 10527000000,
+                      "fmt": "10.53B",
+                      "longFmt": "10,527,000,000"
+                    },
+                    "low": {
+                      "raw": 10400500000,
+                      "fmt": "10.4B",
+                      "longFmt": "10,400,500,000"
+                    },
+                    "high": {
+                      "raw": 10688500000,
+                      "fmt": "10.69B",
+                      "longFmt": "10,688,500,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 11,
+                      "fmt": "11",
+                      "longFmt": "11"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.74,
+                      "fmt": "0.74"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.67,
+                      "fmt": "0.67"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": "2021-12-31",
+                  "growth": {
+                    "raw": 0.2,
+                    "fmt": "20.00%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.9,
+                      "fmt": "0.9"
+                    },
+                    "low": {
+                      "raw": 0.64,
+                      "fmt": "0.64"
+                    },
+                    "high": {
+                      "raw": 0.99,
+                      "fmt": "0.99"
+                    },
+                    "yearAgoEps": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 9,
+                      "fmt": "9",
+                      "longFmt": "9"
+                    },
+                    "growth": {
+                      "raw": 0.2,
+                      "fmt": "20.00%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 13237800000,
+                      "fmt": "13.24B",
+                      "longFmt": "13,237,800,000"
+                    },
+                    "low": {
+                      "raw": 11327900000,
+                      "fmt": "11.33B",
+                      "longFmt": "11,327,900,000"
+                    },
+                    "high": {
+                      "raw": 14382900000,
+                      "fmt": "14.38B",
+                      "longFmt": "14,382,900,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 11,
+                      "fmt": "11",
+                      "longFmt": "11"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 10527000000,
+                      "fmt": "10.53B",
+                      "longFmt": "10,527,000,000"
+                    },
+                    "growth": {
+                      "raw": 0.258,
+                      "fmt": "25.80%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.9,
+                      "fmt": "0.9"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.9,
+                      "fmt": "0.9"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.9,
+                      "fmt": "0.9"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.89,
+                      "fmt": "0.89"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.88,
+                      "fmt": "0.88"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": 0.046,
+                    "fmt": "4.60%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            },
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Baillie Gifford and Company",
+                  "pctHeld": {
+                    "raw": 0.0198,
+                    "fmt": "1.98%"
+                  },
+                  "position": {
+                    "raw": 17631431,
+                    "fmt": "17.63M",
+                    "longFmt": "17,631,431"
+                  },
+                  "value": {
+                    "raw": 1085038263,
+                    "fmt": "1.09B",
+                    "longFmt": "1,085,038,263"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "SC US (TTGP) Ltd",
+                  "pctHeld": {
+                    "raw": 0.0123000005,
+                    "fmt": "1.23%"
+                  },
+                  "position": {
+                    "raw": 10964911,
+                    "fmt": "10.96M",
+                    "longFmt": "10,964,911"
+                  },
+                  "value": {
+                    "raw": 672149044,
+                    "fmt": "672.15M",
+                    "longFmt": "672,149,044"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "FMR, LLC",
+                  "pctHeld": {
+                    "raw": 0.0089,
+                    "fmt": "0.89%"
+                  },
+                  "position": {
+                    "raw": 7903919,
+                    "fmt": "7.9M",
+                    "longFmt": "7,903,919"
+                  },
+                  "value": {
+                    "raw": 486407175,
+                    "fmt": "486.41M",
+                    "longFmt": "486,407,175"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Capital World Investors",
+                  "pctHeld": {
+                    "raw": 0.0088,
+                    "fmt": "0.88%"
+                  },
+                  "position": {
+                    "raw": 7821189,
+                    "fmt": "7.82M",
+                    "longFmt": "7,821,189"
+                  },
+                  "value": {
+                    "raw": 479438885,
+                    "fmt": "479.44M",
+                    "longFmt": "479,438,885"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Blackrock Inc.",
+                  "pctHeld": {
+                    "raw": 0.0074,
+                    "fmt": "0.74%"
+                  },
+                  "position": {
+                    "raw": 6536139,
+                    "fmt": "6.54M",
+                    "longFmt": "6,536,139"
+                  },
+                  "value": {
+                    "raw": 402233994,
+                    "fmt": "402.23M",
+                    "longFmt": "402,233,994"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Hillhouse Capital Advisors Ltd.",
+                  "pctHeld": {
+                    "raw": 0.0056,
+                    "fmt": "0.56%"
+                  },
+                  "position": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "value": {
+                    "raw": 306500000,
+                    "fmt": "306.5M",
+                    "longFmt": "306,500,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "D1 Capital Partners, LP",
+                  "pctHeld": {
+                    "raw": 0.0056,
+                    "fmt": "0.56%"
+                  },
+                  "position": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "value": {
+                    "raw": 306500000,
+                    "fmt": "306.5M",
+                    "longFmt": "306,500,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Credit Suisse Ag/",
+                  "pctHeld": {
+                    "raw": 0.0043,
+                    "fmt": "0.43%"
+                  },
+                  "position": {
+                    "raw": 3778354,
+                    "fmt": "3.78M",
+                    "longFmt": "3,778,354"
+                  },
+                  "value": {
+                    "raw": 231613100,
+                    "fmt": "231.61M",
+                    "longFmt": "231,613,100"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Group, Inc. (The)",
+                  "pctHeld": {
+                    "raw": 0.0042,
+                    "fmt": "0.42%"
+                  },
+                  "position": {
+                    "raw": 3750841,
+                    "fmt": "3.75M",
+                    "longFmt": "3,750,841"
+                  },
+                  "value": {
+                    "raw": 229926553,
+                    "fmt": "229.93M",
+                    "longFmt": "229,926,553"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Sumitomo Mitsui Trust Holdings, Inc.",
+                  "pctHeld": {
+                    "raw": 0.004,
+                    "fmt": "0.40%"
+                  },
+                  "position": {
+                    "raw": 3512686,
+                    "fmt": "3.51M",
+                    "longFmt": "3,512,686"
+                  },
+                  "value": {
+                    "raw": 216170696,
+                    "fmt": "216.17M",
+                    "longFmt": "216,170,696"
+                  }
+                }
+              ]
+            },
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.0090499995,
+              "institutionsPercentHeld": 0.14386,
+              "institutionsFloatPercentHeld": 0.14517,
+              "institutionsCount": 234
+            },
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 38046404000,
+                    "fmt": "38.05B",
+                    "longFmt": "38,046,404,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 13156851000,
+                    "fmt": "13.16B",
+                    "longFmt": "13,156,851,000"
+                  },
+                  "netReceivables": {
+                    "raw": 12955146000,
+                    "fmt": "12.96B",
+                    "longFmt": "12,955,146,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 10926407000,
+                    "fmt": "10.93B",
+                    "longFmt": "10,926,407,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 75696700000,
+                    "fmt": "75.7B",
+                    "longFmt": "75,696,700,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2461657000,
+                    "fmt": "2.46B",
+                    "longFmt": "2,461,657,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 7389774000,
+                    "fmt": "7.39B",
+                    "longFmt": "7,389,774,000"
+                  },
+                  "goodWill": {
+                    "raw": 2490155000,
+                    "fmt": "2.49B",
+                    "longFmt": "2,490,155,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 2062294000,
+                    "fmt": "2.06B",
+                    "longFmt": "2,062,294,000"
+                  },
+                  "otherAssets": {
+                    "raw": 873615000,
+                    "fmt": "873.62M",
+                    "longFmt": "873,615,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 530164000,
+                    "fmt": "530.16M",
+                    "longFmt": "530,164,000"
+                  },
+                  "totalAssets": {
+                    "raw": 90974195000,
+                    "fmt": "90.97B",
+                    "longFmt": "90,974,195,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 6499745000,
+                    "fmt": "6.5B",
+                    "longFmt": "6,499,745,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2411361000,
+                    "fmt": "2.41B",
+                    "longFmt": "2,411,361,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 9611704000,
+                    "fmt": "9.61B",
+                    "longFmt": "9,611,704,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 4793875000,
+                    "fmt": "4.79B",
+                    "longFmt": "4,793,875,000"
+                  },
+                  "otherLiab": {
+                    "raw": 22446000,
+                    "fmt": "22.45M",
+                    "longFmt": "22,446,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 26490000,
+                    "fmt": "26.49M",
+                    "longFmt": "26,490,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 31727200000,
+                    "fmt": "31.73B",
+                    "longFmt": "31,727,200,000"
+                  },
+                  "totalLiab": {
+                    "raw": 39843179000,
+                    "fmt": "39.84B",
+                    "longFmt": "39,843,179,000"
+                  },
+                  "commonStock": {
+                    "raw": 466000,
+                    "fmt": "466k",
+                    "longFmt": "466,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -9929807000,
+                    "fmt": "-9.93B",
+                    "longFmt": "-9,929,807,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -531354000,
+                    "fmt": "-531.35M",
+                    "longFmt": "-531,354,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 61565221000,
+                    "fmt": "61.57B",
+                    "longFmt": "61,565,221,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -531354000,
+                    "fmt": "-531.35M",
+                    "longFmt": "-531,354,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 51104526000,
+                    "fmt": "51.1B",
+                    "longFmt": "51,104,526,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 46552077000,
+                    "fmt": "46.55B",
+                    "longFmt": "46,552,077,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "cash": {
+                    "raw": 25079605000,
+                    "fmt": "25.08B",
+                    "longFmt": "25,079,605,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 5869529000,
+                    "fmt": "5.87B",
+                    "longFmt": "5,869,529,000"
+                  },
+                  "netReceivables": {
+                    "raw": 13068816000,
+                    "fmt": "13.07B",
+                    "longFmt": "13,068,816,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 12353005000,
+                    "fmt": "12.35B",
+                    "longFmt": "12,353,005,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 56925376000,
+                    "fmt": "56.93B",
+                    "longFmt": "56,925,376,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2466889000,
+                    "fmt": "2.47B",
+                    "longFmt": "2,466,889,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6911464000,
+                    "fmt": "6.91B",
+                    "longFmt": "6,911,464,000"
+                  },
+                  "goodWill": {
+                    "raw": 2490155000,
+                    "fmt": "2.49B",
+                    "longFmt": "2,490,155,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 2288794000,
+                    "fmt": "2.29B",
+                    "longFmt": "2,288,794,000"
+                  },
+                  "otherAssets": {
+                    "raw": 923040000,
+                    "fmt": "923.04M",
+                    "longFmt": "923,040,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 530164000,
+                    "fmt": "530.16M",
+                    "longFmt": "530,164,000"
+                  },
+                  "totalAssets": {
+                    "raw": 72005718000,
+                    "fmt": "72.01B",
+                    "longFmt": "72,005,718,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 5287577000,
+                    "fmt": "5.29B",
+                    "longFmt": "5,287,577,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2199275000,
+                    "fmt": "2.2B",
+                    "longFmt": "2,199,275,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 11037514000,
+                    "fmt": "11.04B",
+                    "longFmt": "11,037,514,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 4885370000,
+                    "fmt": "4.89B",
+                    "longFmt": "4,885,370,000"
+                  },
+                  "otherLiab": {
+                    "raw": 116203000,
+                    "fmt": "116.2M",
+                    "longFmt": "116,203,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 25846000,
+                    "fmt": "25.85M",
+                    "longFmt": "25,846,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 30175739000,
+                    "fmt": "30.18B",
+                    "longFmt": "30,175,739,000"
+                  },
+                  "totalLiab": {
+                    "raw": 38219015000,
+                    "fmt": "38.22B",
+                    "longFmt": "38,219,015,000"
+                  },
+                  "commonStock": {
+                    "raw": 205000,
+                    "fmt": "205k",
+                    "longFmt": "205,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -10004504000,
+                    "fmt": "-10B",
+                    "longFmt": "-10,004,504,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 213691000,
+                    "fmt": "213.69M",
+                    "longFmt": "213,691,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1769485000,
+                    "fmt": "1.77B",
+                    "longFmt": "1,769,485,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 213691000,
+                    "fmt": "213.69M",
+                    "longFmt": "213,691,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -8021123000,
+                    "fmt": "-8.02B",
+                    "longFmt": "-8,021,123,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -12800072000,
+                    "fmt": "-12.8B",
+                    "longFmt": "-12,800,072,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "cash": {
+                    "raw": 15538844000,
+                    "fmt": "15.54B",
+                    "longFmt": "15,538,844,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 7709598000,
+                    "fmt": "7.71B",
+                    "longFmt": "7,709,598,000"
+                  },
+                  "netReceivables": {
+                    "raw": 11799844000,
+                    "fmt": "11.8B",
+                    "longFmt": "11,799,844,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 10805983000,
+                    "fmt": "10.81B",
+                    "longFmt": "10,805,983,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 46380397000,
+                    "fmt": "46.38B",
+                    "longFmt": "46,380,397,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2347955000,
+                    "fmt": "2.35B",
+                    "longFmt": "2,347,955,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6700269000,
+                    "fmt": "6.7B",
+                    "longFmt": "6,700,269,000"
+                  },
+                  "goodWill": {
+                    "raw": 2477075000,
+                    "fmt": "2.48B",
+                    "longFmt": "2,477,075,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 2433454000,
+                    "fmt": "2.43B",
+                    "longFmt": "2,433,454,000"
+                  },
+                  "otherAssets": {
+                    "raw": 901375000,
+                    "fmt": "901.38M",
+                    "longFmt": "901,375,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 530164000,
+                    "fmt": "530.16M",
+                    "longFmt": "530,164,000"
+                  },
+                  "totalAssets": {
+                    "raw": 61240525000,
+                    "fmt": "61.24B",
+                    "longFmt": "61,240,525,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 3645940000,
+                    "fmt": "3.65B",
+                    "longFmt": "3,645,940,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 1767844000,
+                    "fmt": "1.77B",
+                    "longFmt": "1,767,844,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 8597488000,
+                    "fmt": "8.6B",
+                    "longFmt": "8,597,488,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 4980956000,
+                    "fmt": "4.98B",
+                    "longFmt": "4,980,956,000"
+                  },
+                  "otherLiab": {
+                    "raw": 120365000,
+                    "fmt": "120.36M",
+                    "longFmt": "120,365,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 84466000,
+                    "fmt": "84.47M",
+                    "longFmt": "84,466,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 22876987000,
+                    "fmt": "22.88B",
+                    "longFmt": "22,876,987,000"
+                  },
+                  "totalLiab": {
+                    "raw": 30855825000,
+                    "fmt": "30.86B",
+                    "longFmt": "30,855,825,000"
+                  },
+                  "commonStock": {
+                    "raw": 202000,
+                    "fmt": "202k",
+                    "longFmt": "202,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -12841072000,
+                    "fmt": "-12.84B",
+                    "longFmt": "-12,841,072,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 234320000,
+                    "fmt": "234.32M",
+                    "longFmt": "234,320,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1840586000,
+                    "fmt": "1.84B",
+                    "longFmt": "1,840,586,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 234320000,
+                    "fmt": "234.32M",
+                    "longFmt": "234,320,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -10765964000,
+                    "fmt": "-10.77B",
+                    "longFmt": "-10,765,964,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -15676493000,
+                    "fmt": "-15.68B",
+                    "longFmt": "-15,676,493,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1569801600,
+                    "fmt": "2019-09-30"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.21,
+                    "fmt": "0.21"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.17,
+                    "fmt": "0.17"
+                  },
+                  "epsDifference": {
+                    "raw": 0.04,
+                    "fmt": "0.04"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.235,
+                    "fmt": "23.50%"
+                  },
+                  "quarter": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            },
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            },
+            "summaryProfile": {
+              "address1": "Building Fudao",
+              "address2": "No.11 Kaituo Road Haidian District",
+              "city": "Beijing",
+              "zip": "100085",
+              "country": "China",
+              "phone": "86 10 5810 4689",
+              "website": "http://ke.com",
+              "industry": "Real Estate Services",
+              "sector": "Real Estate",
+              "longBusinessSummary": "KE Holdings Inc. operates an integrated online and offline platform for housing transactions and services in the People's Republic of China. The company facilitates various housing transactions ranging from existing and new home sales and home rentals to home renovation, real estate financial solutions, and other services. It also owns and operates Lianjia, a real estate brokerage branded store. The company was founded in 2001 and is headquartered in Beijing, China.",
+              "companyOfficers": [],
+              "maxAge": 86400
+            },
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 0,
+              "buyInfoShares": 0,
+              "sellInfoCount": 0,
+              "netInfoCount": 0,
+              "netInfoShares": 0,
+              "netPercentInsiderShares": 0,
+              "totalInsiderShares": 10667953
+            },
+            "sectorTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 20548915000,
+                    "fmt": "20.55B",
+                    "longFmt": "20,548,915,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 16165685000,
+                    "fmt": "16.17B",
+                    "longFmt": "16,165,685,000"
+                  },
+                  "grossProfit": {
+                    "raw": 4383230000,
+                    "fmt": "4.38B",
+                    "longFmt": "4,383,230,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 789089000,
+                    "fmt": "789.09M",
+                    "longFmt": "789,089,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 3675157000,
+                    "fmt": "3.68B",
+                    "longFmt": "3,675,157,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 20629931000,
+                    "fmt": "20.63B",
+                    "longFmt": "20,629,931,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -81016000,
+                    "fmt": "-81.02M",
+                    "longFmt": "-81,016,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 415348000,
+                    "fmt": "415.35M",
+                    "longFmt": "415,348,000"
+                  },
+                  "ebit": {
+                    "raw": -81016000,
+                    "fmt": "-81.02M",
+                    "longFmt": "-81,016,000"
+                  },
+                  "interestExpense": {
+                    "raw": -128157000,
+                    "fmt": "-128.16M",
+                    "longFmt": "-128,157,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 334332000,
+                    "fmt": "334.33M",
+                    "longFmt": "334,332,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 258991000,
+                    "fmt": "258.99M",
+                    "longFmt": "258,991,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 26490000,
+                    "fmt": "26.49M",
+                    "longFmt": "26,490,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 75341000,
+                    "fmt": "75.34M",
+                    "longFmt": "75,341,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 74697000,
+                    "fmt": "74.7M",
+                    "longFmt": "74,697,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -271446000,
+                    "fmt": "-271.45M",
+                    "longFmt": "-271,446,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 20141659000,
+                    "fmt": "20.14B",
+                    "longFmt": "20,141,659,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 13590784000,
+                    "fmt": "13.59B",
+                    "longFmt": "13,590,784,000"
+                  },
+                  "grossProfit": {
+                    "raw": 6550875000,
+                    "fmt": "6.55B",
+                    "longFmt": "6,550,875,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 523670000,
+                    "fmt": "523.67M",
+                    "longFmt": "523,670,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 2739831000,
+                    "fmt": "2.74B",
+                    "longFmt": "2,739,831,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 16854285000,
+                    "fmt": "16.85B",
+                    "longFmt": "16,854,285,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 3287374000,
+                    "fmt": "3.29B",
+                    "longFmt": "3,287,374,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 333154000,
+                    "fmt": "333.15M",
+                    "longFmt": "333,154,000"
+                  },
+                  "ebit": {
+                    "raw": 3287374000,
+                    "fmt": "3.29B",
+                    "longFmt": "3,287,374,000"
+                  },
+                  "interestExpense": {
+                    "raw": -128157000,
+                    "fmt": "-128.16M",
+                    "longFmt": "-128,157,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 3620528000,
+                    "fmt": "3.62B",
+                    "longFmt": "3,620,528,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 781715000,
+                    "fmt": "781.72M",
+                    "longFmt": "781,715,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 25846000,
+                    "fmt": "25.85M",
+                    "longFmt": "25,846,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 2838813000,
+                    "fmt": "2.84B",
+                    "longFmt": "2,838,813,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 2836568000,
+                    "fmt": "2.84B",
+                    "longFmt": "2,836,568,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 2120786000,
+                    "fmt": "2.12B",
+                    "longFmt": "2,120,786,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 7119759000,
+                    "fmt": "7.12B",
+                    "longFmt": "7,119,759,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 6618227000,
+                    "fmt": "6.62B",
+                    "longFmt": "6,618,227,000"
+                  },
+                  "grossProfit": {
+                    "raw": 501532000,
+                    "fmt": "501.53M",
+                    "longFmt": "501,532,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 450761000,
+                    "fmt": "450.76M",
+                    "longFmt": "450,761,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 1682124000,
+                    "fmt": "1.68B",
+                    "longFmt": "1,682,124,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 8751112000,
+                    "fmt": "8.75B",
+                    "longFmt": "8,751,112,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -1631353000,
+                    "fmt": "-1.63B",
+                    "longFmt": "-1,631,353,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 251105000,
+                    "fmt": "251.1M",
+                    "longFmt": "251,105,000"
+                  },
+                  "ebit": {
+                    "raw": -1631353000,
+                    "fmt": "-1.63B",
+                    "longFmt": "-1,631,353,000"
+                  },
+                  "interestExpense": {
+                    "raw": -50113000,
+                    "fmt": "-50.11M",
+                    "longFmt": "-50,113,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -1380248000,
+                    "fmt": "-1.38B",
+                    "longFmt": "-1,380,248,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -148861000,
+                    "fmt": "-148.86M",
+                    "longFmt": "-148,861,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 84466000,
+                    "fmt": "84.47M",
+                    "longFmt": "84,466,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -1231387000,
+                    "fmt": "-1.23B",
+                    "longFmt": "-1,231,387,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -1228650000,
+                    "fmt": "-1.23B",
+                    "longFmt": "-1,228,650,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -1921953000,
+                    "fmt": "-1.92B",
+                    "longFmt": "-1,921,953,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1569801600,
+                    "fmt": "2019-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 12022659000,
+                    "fmt": "12.02B",
+                    "longFmt": "12,022,659,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 9083190000,
+                    "fmt": "9.08B",
+                    "longFmt": "9,083,190,000"
+                  },
+                  "grossProfit": {
+                    "raw": 2939469000,
+                    "fmt": "2.94B",
+                    "longFmt": "2,939,469,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 436056000,
+                    "fmt": "436.06M",
+                    "longFmt": "436,056,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 2103745000,
+                    "fmt": "2.1B",
+                    "longFmt": "2,103,745,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 11622991000,
+                    "fmt": "11.62B",
+                    "longFmt": "11,622,991,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 399668000,
+                    "fmt": "399.67M",
+                    "longFmt": "399,668,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 301713000,
+                    "fmt": "301.71M",
+                    "longFmt": "301,713,000"
+                  },
+                  "ebit": {
+                    "raw": 399668000,
+                    "fmt": "399.67M",
+                    "longFmt": "399,668,000"
+                  },
+                  "interestExpense": {
+                    "raw": -34558000,
+                    "fmt": "-34.56M",
+                    "longFmt": "-34,558,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 701381000,
+                    "fmt": "701.38M",
+                    "longFmt": "701,381,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 317120000,
+                    "fmt": "317.12M",
+                    "longFmt": "317,120,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 84466000,
+                    "fmt": "84.47M",
+                    "longFmt": "84,466,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 384261000,
+                    "fmt": "384.26M",
+                    "longFmt": "384,261,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 381354000,
+                    "fmt": "381.35M",
+                    "longFmt": "381,354,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -76584000,
+                    "fmt": "-76.58M",
+                    "longFmt": "-76,584,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 74697000,
+                    "fmt": "74.7M",
+                    "longFmt": "74,697,000"
+                  },
+                  "depreciation": {
+                    "raw": 303789000,
+                    "fmt": "303.79M",
+                    "longFmt": "303,789,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -746842000,
+                    "fmt": "-746.84M",
+                    "longFmt": "-746,842,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -3341525000,
+                    "fmt": "-3.34B",
+                    "longFmt": "-3,341,525,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 2217374000,
+                    "fmt": "2.22B",
+                    "longFmt": "2,217,374,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 5410498000,
+                    "fmt": "5.41B",
+                    "longFmt": "5,410,498,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 3213000000,
+                    "fmt": "3.21B",
+                    "longFmt": "3,213,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -566050000,
+                    "fmt": "-566.05M",
+                    "longFmt": "-566,050,000"
+                  },
+                  "investments": {
+                    "raw": -11199382000,
+                    "fmt": "-11.2B",
+                    "longFmt": "-11,199,382,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 4307818000,
+                    "fmt": "4.31B",
+                    "longFmt": "4,307,818,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -6945255000,
+                    "fmt": "-6.95B",
+                    "longFmt": "-6,945,255,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -105172000,
+                    "fmt": "-105.17M",
+                    "longFmt": "-105,172,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 324758000,
+                    "fmt": "324.76M",
+                    "longFmt": "324,758,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 16565408000,
+                    "fmt": "16.57B",
+                    "longFmt": "16,565,408,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -815884000,
+                    "fmt": "-815.88M",
+                    "longFmt": "-815,884,000"
+                  },
+                  "changeInCash": {
+                    "raw": 12017269000,
+                    "fmt": "12.02B",
+                    "longFmt": "12,017,269,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 16345822000,
+                    "fmt": "16.35B",
+                    "longFmt": "16,345,822,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "netIncome": {
+                    "raw": 2836568000,
+                    "fmt": "2.84B",
+                    "longFmt": "2,836,568,000"
+                  },
+                  "depreciation": {
+                    "raw": 272184000,
+                    "fmt": "272.18M",
+                    "longFmt": "272,184,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 2743463000,
+                    "fmt": "2.74B",
+                    "longFmt": "2,743,463,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -719861000,
+                    "fmt": "-719.86M",
+                    "longFmt": "-719,861,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 785185000,
+                    "fmt": "785.18M",
+                    "longFmt": "785,185,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 2426120000,
+                    "fmt": "2.43B",
+                    "longFmt": "2,426,120,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 9133566000,
+                    "fmt": "9.13B",
+                    "longFmt": "9,133,566,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": 149136000,
+                    "fmt": "149.14M",
+                    "longFmt": "149,136,000"
+                  },
+                  "investments": {
+                    "raw": 5786363000,
+                    "fmt": "5.79B",
+                    "longFmt": "5,786,363,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -2409715000,
+                    "fmt": "-2.41B",
+                    "longFmt": "-2,409,715,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 2751829000,
+                    "fmt": "2.75B",
+                    "longFmt": "2,751,829,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 898389000,
+                    "fmt": "898.39M",
+                    "longFmt": "898,389,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -569320000,
+                    "fmt": "-569.32M",
+                    "longFmt": "-569,320,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 329069000,
+                    "fmt": "329.07M",
+                    "longFmt": "329,069,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -14448000,
+                    "fmt": "-14.45M",
+                    "longFmt": "-14,448,000"
+                  },
+                  "changeInCash": {
+                    "raw": 12200016000,
+                    "fmt": "12.2B",
+                    "longFmt": "12,200,016,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 16345822000,
+                    "fmt": "16.35B",
+                    "longFmt": "16,345,822,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "netIncome": {
+                    "raw": -1228650000,
+                    "fmt": "-1.23B",
+                    "longFmt": "-1,228,650,000"
+                  },
+                  "depreciation": {
+                    "raw": 271845000,
+                    "fmt": "271.85M",
+                    "longFmt": "271,845,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 149055000,
+                    "fmt": "149.06M",
+                    "longFmt": "149,055,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 719861000,
+                    "fmt": "719.86M",
+                    "longFmt": "719,861,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -785185000,
+                    "fmt": "-785.18M",
+                    "longFmt": "-785,185,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -2426120000,
+                    "fmt": "-2.43B",
+                    "longFmt": "-2,426,120,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -4089101000,
+                    "fmt": "-4.09B",
+                    "longFmt": "-4,089,101,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -149136000,
+                    "fmt": "-149.14M",
+                    "longFmt": "-149,136,000"
+                  },
+                  "investments": {
+                    "raw": -5786363000,
+                    "fmt": "-5.79B",
+                    "longFmt": "-5,786,363,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -14819000,
+                    "fmt": "-14.82M",
+                    "longFmt": "-14,819,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -5176363000,
+                    "fmt": "-5.18B",
+                    "longFmt": "-5,176,363,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -898389000,
+                    "fmt": "-898.39M",
+                    "longFmt": "-898,389,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -569320000,
+                    "fmt": "-569.32M",
+                    "longFmt": "-569,320,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -898389000,
+                    "fmt": "-898.39M",
+                    "longFmt": "-898,389,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 131392000,
+                    "fmt": "131.39M",
+                    "longFmt": "131,392,000"
+                  },
+                  "changeInCash": {
+                    "raw": -10032461000,
+                    "fmt": "-10.03B",
+                    "longFmt": "-10,032,461,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 16345822000,
+                    "fmt": "16.35B",
+                    "longFmt": "16,345,822,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1569801600,
+                    "fmt": "2019-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 381354000,
+                    "fmt": "381.35M",
+                    "longFmt": "381,354,000"
+                  },
+                  "depreciation": {
+                    "raw": 308036000,
+                    "fmt": "308.04M",
+                    "longFmt": "308,036,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 56176000,
+                    "fmt": "56.18M",
+                    "longFmt": "56,176,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -1204448000,
+                    "fmt": "-1.2B",
+                    "longFmt": "-1,204,448,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 940491000,
+                    "fmt": "940.49M",
+                    "longFmt": "940,491,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 394199000,
+                    "fmt": "394.2M",
+                    "longFmt": "394,199,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 1257660000,
+                    "fmt": "1.26B",
+                    "longFmt": "1,257,660,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -123413000,
+                    "fmt": "-123.41M",
+                    "longFmt": "-123,413,000"
+                  },
+                  "investments": {
+                    "raw": 1040954000,
+                    "fmt": "1.04B",
+                    "longFmt": "1,040,954,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -4488000,
+                    "fmt": "-4.49M",
+                    "longFmt": "-4,488,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 132616000,
+                    "fmt": "132.62M",
+                    "longFmt": "132,616,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 64710000,
+                    "fmt": "64.71M",
+                    "longFmt": "64,710,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -569320000,
+                    "fmt": "-569.32M",
+                    "longFmt": "-569,320,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -2222516000,
+                    "fmt": "-2.22B",
+                    "longFmt": "-2,222,516,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 109779000,
+                    "fmt": "109.78M",
+                    "longFmt": "109,779,000"
+                  },
+                  "changeInCash": {
+                    "raw": -722461000,
+                    "fmt": "-722.46M",
+                    "longFmt": "-722,461,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -140074000,
+                    "fmt": "-140.07M",
+                    "longFmt": "-140,074,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 16345822000,
+                    "fmt": "16.35B",
+                    "longFmt": "16,345,822,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [
+                  {
+                    "date": "3Q2020",
+                    "actual": 0.21,
+                    "estimate": 0.17
+                  }
+                ],
+                "currentQuarterEstimate": 0.13,
+                "currentQuarterEstimateDate": "4Q",
+                "currentQuarterEstimateYear": 2020,
+                "earningsDate": []
+              },
+              "financialsChart": {
+                "yearly": [
+                  {
+                    "date": 2017,
+                    "revenue": 25505698000,
+                    "earnings": -574430000
+                  },
+                  {
+                    "date": 2018,
+                    "revenue": 28646499000,
+                    "earnings": -467824000
+                  },
+                  {
+                    "date": 2019,
+                    "revenue": 46014906000,
+                    "earnings": -2183546000
+                  }
+                ],
+                "quarterly": [
+                  {
+                    "date": "3Q2019",
+                    "revenue": 12022659000,
+                    "earnings": 381354000
+                  },
+                  {
+                    "date": "1Q2020",
+                    "revenue": 7119759000,
+                    "earnings": -1228650000
+                  },
+                  {
+                    "date": "2Q2020",
+                    "revenue": 20141659000,
+                    "earnings": 2836568000
+                  },
+                  {
+                    "date": "3Q2020",
+                    "revenue": 20548915000,
+                    "earnings": 74697000
+                  }
+                ]
+              },
+              "financialCurrency": "CNY"
+            },
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 65.87,
+              "targetHighPrice": 90.48,
+              "targetLowPrice": 20.99,
+              "targetMeanPrice": 67.22,
+              "targetMedianPrice": 67.57,
+              "recommendationMean": 2.5,
+              "recommendationKey": "buy",
+              "numberOfAnalystOpinions": 10,
+              "quickRatio": 2.013,
+              "currentRatio": 2.386,
+              "debtToEquity": 26.427,
+              "grossProfits": 11268044000,
+              "revenueGrowth": 0.709,
+              "grossMargins": 0.22805999,
+              "ebitdaMargins": -0.00654,
+              "operatingMargins": 0,
+              "profitMargins": -0.02313,
+              "financialCurrency": "CNY"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-all-BFLY.json
+++ b/tests/http/quoteSummary-all-BFLY.json
@@ -1,0 +1,951 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=assetProfile%2CbalanceSheetHistory%2CbalanceSheetHistoryQuarterly%2CcalendarEvents%2CcashflowStatementHistory%2CcashflowStatementHistoryQuarterly%2CdefaultKeyStatistics%2Cearnings%2CearningsHistory%2CearningsTrend%2CfinancialData%2CfundOwnership%2CfundPerformance%2CfundProfile%2CincomeStatementHistory%2CincomeStatementHistoryQuarterly%2CindexTrend%2CindustryTrend%2CinsiderHolders%2CinsiderTransactions%2CinstitutionOwnership%2CmajorDirectHolders%2CmajorHoldersBreakdown%2CnetSharePurchaseActivity%2Cprice%2CquoteType%2CrecommendationTrend%2CsecFilings%2CsectorTrend%2CsummaryDetail%2CsummaryProfile%2CtopHoldings%2CupgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "euk9hphg2qdtb"
+      ],
+      "x-yahoo-request-id": [
+        "euk9hphg2qdtb"
+      ],
+      "x-request-id": [
+        "2157791f-f3dd-432c-b1ec-efb3f7563a28"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "10"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:07 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "530 Old Whitfield Street",
+              "city": "Guilford",
+              "state": "CT",
+              "zip": "06437",
+              "country": "United States",
+              "phone": "203-458-2514",
+              "website": "http://english.butterflynetwork.com",
+              "industry": "Medical Devices",
+              "sector": "Healthcare",
+              "longBusinessSummary": "Butterfly Network, Inc. develops medical imaging device for hospitals and organizations to scale their point of care ultrasound programs through a new suite of tools that enable ultrasound workflow mobile and system integrations simple and secure. The company's device provides diagnostic imaging and measurement of blood vessels and examines the cardiac, abdominal, urological, fetal, gynecological, and musculoskeletal systems. The company also offers Butterfly iQ, a handheld and single-probe whole body ultrasound system. The company was founded in 2011 and is based in Guilford, Connecticut.",
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Darius  Shahida",
+                  "age": 29,
+                  "title": "Chief Strategy Officer & Chief Bus. Devel. Officer",
+                  "yearBorn": 1991,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 413625,
+                    "fmt": "413.62k",
+                    "longFmt": "413,625"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Jonathan M. Rothberg",
+                  "age": 56,
+                  "title": "Founder & Chairman",
+                  "yearBorn": 1964,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Todd M. Fruchterman",
+                  "age": 50,
+                  "title": "Pres & CEO",
+                  "yearBorn": 1970,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Gregory C. Fergus",
+                  "age": 56,
+                  "title": "Board Member and Chief Commercial Officer",
+                  "yearBorn": 1964,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Michael J. Rothberg",
+                  "title": "Chief Financial Officer",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Elizabeth A. Whayland",
+                  "title": "Sec. & Director",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "compensationAsOfEpochDate": 1577750400,
+              "maxAge": 86400
+            },
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistory": {
+              "cashflowStatements": [],
+              "maxAge": 86400
+            },
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 5.56217,
+              "pegRatio": 0.991258,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.269
+                },
+                {
+                  "period": "+1q",
+                  "growth": 0.96099997
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.148
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.155
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0821053
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            },
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "profitMargins": 0,
+              "category": null,
+              "fundFamily": null,
+              "legalType": null,
+              "lastSplitFactor": null,
+              "52WeekChange": 0,
+              "SandP52WeekChange": 0.16137505
+            },
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "quoteType": {
+              "exchange": "NYQ",
+              "quoteType": "EQUITY",
+              "symbol": "BFLY",
+              "underlyingSymbol": "BFLY",
+              "shortName": "Butterfly Network, Inc. Class A",
+              "longName": "Butterfly Network, Inc.",
+              "firstTradeDateEpochUtc": 1594647000,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "5f9449d1-1162-3804-a742-88e2f8b5fb0e",
+              "messageBoardId": null,
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            },
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [],
+              "maxAge": 86400
+            },
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            },
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 22.5,
+              "open": 23.11,
+              "dayLow": 22.1807,
+              "dayHigh": 23.31,
+              "regularMarketPreviousClose": 22.5,
+              "regularMarketOpen": 23.11,
+              "regularMarketDayLow": 22.1807,
+              "regularMarketDayHigh": 23.31,
+              "volume": 1122067,
+              "regularMarketVolume": 1122067,
+              "averageVolume": 2347300,
+              "averageVolume10days": 2347300,
+              "averageDailyVolume10Day": 2347300,
+              "bid": 22.52,
+              "ask": 22.56,
+              "bidSize": 1000,
+              "askSize": 900,
+              "fiftyTwoWeekLow": 21.95,
+              "fiftyTwoWeekHigh": 24.8,
+              "fiftyDayAverage": 22.5,
+              "twoHundredDayAverage": 22.5,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            },
+            "insiderHolders": {
+              "holders": [],
+              "maxAge": 1
+            },
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": []
+              }
+            },
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": 0.0288889,
+              "preMarketChange": 0.65,
+              "preMarketTime": 1613572193,
+              "preMarketPrice": 23.15,
+              "preMarketSource": "FREE_REALTIME",
+              "regularMarketChangePercent": 0.004888916,
+              "regularMarketChange": 0.11000061,
+              "regularMarketTime": 1613576106,
+              "priceHint": 2,
+              "regularMarketPrice": 22.61,
+              "regularMarketDayHigh": 23.31,
+              "regularMarketDayLow": 22.1807,
+              "regularMarketVolume": 1122067,
+              "averageDailyVolume10Day": 2347300,
+              "averageDailyVolume3Month": 2347300,
+              "regularMarketPreviousClose": 22.5,
+              "regularMarketSource": "FREE_REALTIME",
+              "regularMarketOpen": 23.11,
+              "exchange": "NYQ",
+              "exchangeName": "NYSE",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "EQUITY",
+              "symbol": "BFLY",
+              "underlyingSymbol": null,
+              "shortName": "Butterfly Network, Inc. Class A",
+              "longName": "Butterfly Network, Inc.",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null
+            },
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [],
+              "maxAge": 86400
+            },
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            },
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            },
+            "majorHoldersBreakdown": {
+              "maxAge": 1
+            },
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [],
+              "maxAge": 86400
+            },
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            },
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            },
+            "summaryProfile": {
+              "address1": "530 Old Whitfield Street",
+              "city": "Guilford",
+              "state": "CT",
+              "zip": "06437",
+              "country": "United States",
+              "phone": "203-458-2514",
+              "website": "http://english.butterflynetwork.com",
+              "industry": "Medical Devices",
+              "sector": "Healthcare",
+              "longBusinessSummary": "Butterfly Network, Inc. develops medical imaging device for hospitals and organizations to scale their point of care ultrasound programs through a new suite of tools that enable ultrasound workflow mobile and system integrations simple and secure. The company's device provides diagnostic imaging and measurement of blood vessels and examines the cardiac, abdominal, urological, fetal, gynecological, and musculoskeletal systems. The company also offers Butterfly iQ, a handheld and single-probe whole body ultrasound system. The company was founded in 2011 and is based in Guilford, Connecticut.",
+              "companyOfficers": [],
+              "maxAge": 86400
+            },
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 0,
+              "buyInfoShares": 0,
+              "sellInfoCount": 0,
+              "netInfoCount": 0,
+              "netInfoShares": 0,
+              "totalInsiderShares": 0
+            },
+            "sectorTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [],
+              "maxAge": 86400
+            },
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [],
+                "earningsDate": []
+              },
+              "financialsChart": {
+                "yearly": [],
+                "quarterly": []
+              }
+            },
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 22.61,
+              "targetHighPrice": 15,
+              "targetLowPrice": 15,
+              "targetMeanPrice": 15,
+              "targetMedianPrice": 15,
+              "recommendationKey": "none",
+              "numberOfAnalystOpinions": 1,
+              "grossMargins": 0,
+              "ebitdaMargins": 0,
+              "operatingMargins": 0,
+              "profitMargins": 0,
+              "financialCurrency": null
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-assetProfile-BEKE.json
+++ b/tests/http/quoteSummary-assetProfile-BEKE.json
@@ -1,0 +1,198 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=assetProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "8ouheh9g2qdt2"
+      ],
+      "x-yahoo-request-id": [
+        "8ouheh9g2qdt2"
+      ],
+      "x-request-id": [
+        "52aa20f9-fa2c-4eba-a489-32ff2ff223f2"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "721"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:34:58 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "Building Fudao",
+              "address2": "No.11 Kaituo Road Haidian District",
+              "city": "Beijing",
+              "zip": "100085",
+              "country": "China",
+              "phone": "86 10 5810 4689",
+              "website": "http://ke.com",
+              "industry": "Real Estate Services",
+              "sector": "Real Estate",
+              "longBusinessSummary": "KE Holdings Inc. operates an integrated online and offline platform for housing transactions and services in the People's Republic of China. The company facilitates various housing transactions ranging from existing and new home sales and home rentals to home renovation, real estate financial solutions, and other services. It also owns and operates Lianjia, a real estate brokerage branded store. The company was founded in 2001 and is headquartered in Beijing, China.",
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Hui  Zuo",
+                  "age": 49,
+                  "title": "Founder & Chairman",
+                  "yearBorn": 1971,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Yongdong  Peng",
+                  "age": 41,
+                  "title": "CEO & Exec. Director",
+                  "yearBorn": 1979,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Tao  Xu",
+                  "age": 47,
+                  "title": "Chief Financial Officer",
+                  "yearBorn": 1973,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Wangang  Xu",
+                  "age": 55,
+                  "title": "Co-Chief Operating Officer",
+                  "yearBorn": 1965,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Yongqun  Wang",
+                  "age": 49,
+                  "title": "Co-Chief Operating Officer",
+                  "yearBorn": 1971,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Yigang  Shan",
+                  "age": 47,
+                  "title": "Exec. Director",
+                  "yearBorn": 1973,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-assetProfile-BFLY.json
+++ b/tests/http/quoteSummary-assetProfile-BFLY.json
@@ -1,0 +1,201 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=assetProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "ckrlfpdg2qdt2"
+      ],
+      "x-yahoo-request-id": [
+        "ckrlfpdg2qdt2"
+      ],
+      "x-request-id": [
+        "3a802a9d-2eb2-43ed-bf66-7887d82d3164"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "925"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:34:58 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "530 Old Whitfield Street",
+              "city": "Guilford",
+              "state": "CT",
+              "zip": "06437",
+              "country": "United States",
+              "phone": "203-458-2514",
+              "website": "http://english.butterflynetwork.com",
+              "industry": "Medical Devices",
+              "sector": "Healthcare",
+              "longBusinessSummary": "Butterfly Network, Inc. develops medical imaging device for hospitals and organizations to scale their point of care ultrasound programs through a new suite of tools that enable ultrasound workflow mobile and system integrations simple and secure. The company's device provides diagnostic imaging and measurement of blood vessels and examines the cardiac, abdominal, urological, fetal, gynecological, and musculoskeletal systems. The company also offers Butterfly iQ, a handheld and single-probe whole body ultrasound system. The company was founded in 2011 and is based in Guilford, Connecticut.",
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Darius  Shahida",
+                  "age": 29,
+                  "title": "Chief Strategy Officer & Chief Bus. Devel. Officer",
+                  "yearBorn": 1991,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 413625,
+                    "fmt": "413.62k",
+                    "longFmt": "413,625"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Jonathan M. Rothberg",
+                  "age": 56,
+                  "title": "Founder & Chairman",
+                  "yearBorn": 1964,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Todd M. Fruchterman",
+                  "age": 50,
+                  "title": "Pres & CEO",
+                  "yearBorn": 1970,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Gregory C. Fergus",
+                  "age": 56,
+                  "title": "Board Member and Chief Commercial Officer",
+                  "yearBorn": 1964,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Michael J. Rothberg",
+                  "title": "Chief Financial Officer",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Elizabeth A. Whayland",
+                  "title": "Sec. & Director",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "compensationAsOfEpochDate": 1577750400,
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistory-BEKE.json
+++ b/tests/http/quoteSummary-balanceSheetHistory-BEKE.json
@@ -1,0 +1,492 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=balanceSheetHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "19jjjp9g2qdt2"
+      ],
+      "x-yahoo-request-id": [
+        "19jjjp9g2qdt2"
+      ],
+      "x-request-id": [
+        "fd168e81-6f5c-4a7c-b24a-10906eb4b6e8"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1682"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:34:58 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 24319332000,
+                    "fmt": "24.32B",
+                    "longFmt": "24,319,332,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 1844595000,
+                    "fmt": "1.84B",
+                    "longFmt": "1,844,595,000"
+                  },
+                  "netReceivables": {
+                    "raw": 13169172000,
+                    "fmt": "13.17B",
+                    "longFmt": "13,169,172,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 12139612000,
+                    "fmt": "12.14B",
+                    "longFmt": "12,139,612,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 51912486000,
+                    "fmt": "51.91B",
+                    "longFmt": "51,912,486,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2333745000,
+                    "fmt": "2.33B",
+                    "longFmt": "2,333,745,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6759243000,
+                    "fmt": "6.76B",
+                    "longFmt": "6,759,243,000"
+                  },
+                  "goodWill": {
+                    "raw": 2477075000,
+                    "fmt": "2.48B",
+                    "longFmt": "2,477,075,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 2560442000,
+                    "fmt": "2.56B",
+                    "longFmt": "2,560,442,000"
+                  },
+                  "otherAssets": {
+                    "raw": 1222321000,
+                    "fmt": "1.22B",
+                    "longFmt": "1,222,321,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 520292000,
+                    "fmt": "520.29M",
+                    "longFmt": "520,292,000"
+                  },
+                  "totalAssets": {
+                    "raw": 67265312000,
+                    "fmt": "67.27B",
+                    "longFmt": "67,265,312,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 4475170000,
+                    "fmt": "4.48B",
+                    "longFmt": "4,475,170,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2291723000,
+                    "fmt": "2.29B",
+                    "longFmt": "2,291,723,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 8584074000,
+                    "fmt": "8.58B",
+                    "longFmt": "8,584,074,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 4897530000,
+                    "fmt": "4.9B",
+                    "longFmt": "4,897,530,000"
+                  },
+                  "otherLiab": {
+                    "raw": 120275000,
+                    "fmt": "120.28M",
+                    "longFmt": "120,275,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 87203000,
+                    "fmt": "87.2M",
+                    "longFmt": "87,203,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 27797675000,
+                    "fmt": "27.8B",
+                    "longFmt": "27,797,675,000"
+                  },
+                  "totalLiab": {
+                    "raw": 35729720000,
+                    "fmt": "35.73B",
+                    "longFmt": "35,729,720,000"
+                  },
+                  "commonStock": {
+                    "raw": 202000,
+                    "fmt": "202k",
+                    "longFmt": "202,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -11521905000,
+                    "fmt": "-11.52B",
+                    "longFmt": "-11,521,905,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 63308000,
+                    "fmt": "63.31M",
+                    "longFmt": "63,308,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 2533889000,
+                    "fmt": "2.53B",
+                    "longFmt": "2,533,889,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 63308000,
+                    "fmt": "63.31M",
+                    "longFmt": "63,308,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -8924506000,
+                    "fmt": "-8.92B",
+                    "longFmt": "-8,924,506,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -13962023000,
+                    "fmt": "-13.96B",
+                    "longFmt": "-13,962,023,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "cash": {
+                    "raw": 9115649000,
+                    "fmt": "9.12B",
+                    "longFmt": "9,115,649,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 2523199000,
+                    "fmt": "2.52B",
+                    "longFmt": "2,523,199,000"
+                  },
+                  "netReceivables": {
+                    "raw": 10369552000,
+                    "fmt": "10.37B",
+                    "longFmt": "10,369,552,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 4972534000,
+                    "fmt": "4.97B",
+                    "longFmt": "4,972,534,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 27374784000,
+                    "fmt": "27.37B",
+                    "longFmt": "27,374,784,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 418469000,
+                    "fmt": "418.47M",
+                    "longFmt": "418,469,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6089232000,
+                    "fmt": "6.09B",
+                    "longFmt": "6,089,232,000"
+                  },
+                  "goodWill": {
+                    "raw": 1135034000,
+                    "fmt": "1.14B",
+                    "longFmt": "1,135,034,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 196998000,
+                    "fmt": "197M",
+                    "longFmt": "196,998,000"
+                  },
+                  "otherAssets": {
+                    "raw": 3651747000,
+                    "fmt": "3.65B",
+                    "longFmt": "3,651,747,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 672622000,
+                    "fmt": "672.62M",
+                    "longFmt": "672,622,000"
+                  },
+                  "totalAssets": {
+                    "raw": 38866264000,
+                    "fmt": "38.87B",
+                    "longFmt": "38,866,264,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1573343000,
+                    "fmt": "1.57B",
+                    "longFmt": "1,573,343,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2414607000,
+                    "fmt": "2.41B",
+                    "longFmt": "2,414,607,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 4762200000,
+                    "fmt": "4.76B",
+                    "longFmt": "4,762,200,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 112900000,
+                    "fmt": "112.9M",
+                    "longFmt": "112,900,000"
+                  },
+                  "otherLiab": {
+                    "raw": 532931000,
+                    "fmt": "532.93M",
+                    "longFmt": "532,931,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 10467000,
+                    "fmt": "10.47M",
+                    "longFmt": "10,467,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 20572881000,
+                    "fmt": "20.57B",
+                    "longFmt": "20,572,881,000"
+                  },
+                  "totalLiab": {
+                    "raw": 24007724000,
+                    "fmt": "24.01B",
+                    "longFmt": "24,007,724,000"
+                  },
+                  "commonStock": {
+                    "raw": 189000,
+                    "fmt": "189k",
+                    "longFmt": "189,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -7814291000,
+                    "fmt": "-7.81B",
+                    "longFmt": "-7,814,291,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -134000,
+                    "fmt": "-134k",
+                    "longFmt": "-134,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -134000,
+                    "fmt": "-134k",
+                    "longFmt": "-134,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -7814236000,
+                    "fmt": "-7.81B",
+                    "longFmt": "-7,814,236,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -9146268000,
+                    "fmt": "-9.15B",
+                    "longFmt": "-9,146,268,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "cash": {
+                    "raw": 5236100000,
+                    "fmt": "5.24B",
+                    "longFmt": "5,236,100,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 7587433000,
+                    "fmt": "7.59B",
+                    "longFmt": "7,587,433,000"
+                  },
+                  "netReceivables": {
+                    "raw": 4676434000,
+                    "fmt": "4.68B",
+                    "longFmt": "4,676,434,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 6227975000,
+                    "fmt": "6.23B",
+                    "longFmt": "6,227,975,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 24067931000,
+                    "fmt": "24.07B",
+                    "longFmt": "24,067,931,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 379972000,
+                    "fmt": "379.97M",
+                    "longFmt": "379,972,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6002914000,
+                    "fmt": "6B",
+                    "longFmt": "6,002,914,000"
+                  },
+                  "goodWill": {
+                    "raw": 710983000,
+                    "fmt": "710.98M",
+                    "longFmt": "710,983,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 264726000,
+                    "fmt": "264.73M",
+                    "longFmt": "264,726,000"
+                  },
+                  "otherAssets": {
+                    "raw": 153409000,
+                    "fmt": "153.41M",
+                    "longFmt": "153,409,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 147535000,
+                    "fmt": "147.53M",
+                    "longFmt": "147,535,000"
+                  },
+                  "totalAssets": {
+                    "raw": 31579935000,
+                    "fmt": "31.58B",
+                    "longFmt": "31,579,935,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 370496000,
+                    "fmt": "370.5M",
+                    "longFmt": "370,496,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 4665524000,
+                    "fmt": "4.67B",
+                    "longFmt": "4,665,524,000"
+                  },
+                  "otherLiab": {
+                    "raw": 518091000,
+                    "fmt": "518.09M",
+                    "longFmt": "518,091,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 65836000,
+                    "fmt": "65.84M",
+                    "longFmt": "65,836,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 16047286000,
+                    "fmt": "16.05B",
+                    "longFmt": "16,047,286,000"
+                  },
+                  "totalLiab": {
+                    "raw": 19143150000,
+                    "fmt": "19.14B",
+                    "longFmt": "19,143,150,000"
+                  },
+                  "commonStock": {
+                    "raw": 178000,
+                    "fmt": "178k",
+                    "longFmt": "178,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -5226325000,
+                    "fmt": "-5.23B",
+                    "longFmt": "-5,226,325,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -327000,
+                    "fmt": "-327k",
+                    "longFmt": "-327,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -327000,
+                    "fmt": "-327k",
+                    "longFmt": "-327,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -5226474000,
+                    "fmt": "-5.23B",
+                    "longFmt": "-5,226,474,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -6202183000,
+                    "fmt": "-6.2B",
+                    "longFmt": "-6,202,183,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistory-BFLY.json
+++ b/tests/http/quoteSummary-balanceSheetHistory-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=balanceSheetHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "bcgg64pg2qdt2"
+      ],
+      "x-yahoo-request-id": [
+        "bcgg64pg2qdt2"
+      ],
+      "x-request-id": [
+        "5ff23ce2-5a26-44f3-aedc-237f0208c430"
+      ],
+      "content-length": [
+        "111"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:34:58 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistoryQuarterly-BEKE.json
+++ b/tests/http/quoteSummary-balanceSheetHistoryQuarterly-BEKE.json
@@ -1,0 +1,519 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=balanceSheetHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "7h878rlg2qdt2"
+      ],
+      "x-yahoo-request-id": [
+        "7h878rlg2qdt2"
+      ],
+      "x-request-id": [
+        "32b2867e-8ebe-4d29-a688-01ff9f9c82e2"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1750"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:34:58 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 38046404000,
+                    "fmt": "38.05B",
+                    "longFmt": "38,046,404,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 13156851000,
+                    "fmt": "13.16B",
+                    "longFmt": "13,156,851,000"
+                  },
+                  "netReceivables": {
+                    "raw": 12955146000,
+                    "fmt": "12.96B",
+                    "longFmt": "12,955,146,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 10926407000,
+                    "fmt": "10.93B",
+                    "longFmt": "10,926,407,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 75696700000,
+                    "fmt": "75.7B",
+                    "longFmt": "75,696,700,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2461657000,
+                    "fmt": "2.46B",
+                    "longFmt": "2,461,657,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 7389774000,
+                    "fmt": "7.39B",
+                    "longFmt": "7,389,774,000"
+                  },
+                  "goodWill": {
+                    "raw": 2490155000,
+                    "fmt": "2.49B",
+                    "longFmt": "2,490,155,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 2062294000,
+                    "fmt": "2.06B",
+                    "longFmt": "2,062,294,000"
+                  },
+                  "otherAssets": {
+                    "raw": 873615000,
+                    "fmt": "873.62M",
+                    "longFmt": "873,615,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 530164000,
+                    "fmt": "530.16M",
+                    "longFmt": "530,164,000"
+                  },
+                  "totalAssets": {
+                    "raw": 90974195000,
+                    "fmt": "90.97B",
+                    "longFmt": "90,974,195,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 6499745000,
+                    "fmt": "6.5B",
+                    "longFmt": "6,499,745,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2411361000,
+                    "fmt": "2.41B",
+                    "longFmt": "2,411,361,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 9611704000,
+                    "fmt": "9.61B",
+                    "longFmt": "9,611,704,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 4793875000,
+                    "fmt": "4.79B",
+                    "longFmt": "4,793,875,000"
+                  },
+                  "otherLiab": {
+                    "raw": 22446000,
+                    "fmt": "22.45M",
+                    "longFmt": "22,446,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 26490000,
+                    "fmt": "26.49M",
+                    "longFmt": "26,490,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 31727200000,
+                    "fmt": "31.73B",
+                    "longFmt": "31,727,200,000"
+                  },
+                  "totalLiab": {
+                    "raw": 39843179000,
+                    "fmt": "39.84B",
+                    "longFmt": "39,843,179,000"
+                  },
+                  "commonStock": {
+                    "raw": 466000,
+                    "fmt": "466k",
+                    "longFmt": "466,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -9929807000,
+                    "fmt": "-9.93B",
+                    "longFmt": "-9,929,807,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -531354000,
+                    "fmt": "-531.35M",
+                    "longFmt": "-531,354,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 61565221000,
+                    "fmt": "61.57B",
+                    "longFmt": "61,565,221,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -531354000,
+                    "fmt": "-531.35M",
+                    "longFmt": "-531,354,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 51104526000,
+                    "fmt": "51.1B",
+                    "longFmt": "51,104,526,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 46552077000,
+                    "fmt": "46.55B",
+                    "longFmt": "46,552,077,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "cash": {
+                    "raw": 25079605000,
+                    "fmt": "25.08B",
+                    "longFmt": "25,079,605,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 5869529000,
+                    "fmt": "5.87B",
+                    "longFmt": "5,869,529,000"
+                  },
+                  "netReceivables": {
+                    "raw": 13068816000,
+                    "fmt": "13.07B",
+                    "longFmt": "13,068,816,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 12353005000,
+                    "fmt": "12.35B",
+                    "longFmt": "12,353,005,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 56925376000,
+                    "fmt": "56.93B",
+                    "longFmt": "56,925,376,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2466889000,
+                    "fmt": "2.47B",
+                    "longFmt": "2,466,889,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6911464000,
+                    "fmt": "6.91B",
+                    "longFmt": "6,911,464,000"
+                  },
+                  "goodWill": {
+                    "raw": 2490155000,
+                    "fmt": "2.49B",
+                    "longFmt": "2,490,155,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 2288794000,
+                    "fmt": "2.29B",
+                    "longFmt": "2,288,794,000"
+                  },
+                  "otherAssets": {
+                    "raw": 923040000,
+                    "fmt": "923.04M",
+                    "longFmt": "923,040,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 530164000,
+                    "fmt": "530.16M",
+                    "longFmt": "530,164,000"
+                  },
+                  "totalAssets": {
+                    "raw": 72005718000,
+                    "fmt": "72.01B",
+                    "longFmt": "72,005,718,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 5287577000,
+                    "fmt": "5.29B",
+                    "longFmt": "5,287,577,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2199275000,
+                    "fmt": "2.2B",
+                    "longFmt": "2,199,275,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 11037514000,
+                    "fmt": "11.04B",
+                    "longFmt": "11,037,514,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 4885370000,
+                    "fmt": "4.89B",
+                    "longFmt": "4,885,370,000"
+                  },
+                  "otherLiab": {
+                    "raw": 116203000,
+                    "fmt": "116.2M",
+                    "longFmt": "116,203,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 25846000,
+                    "fmt": "25.85M",
+                    "longFmt": "25,846,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 30175739000,
+                    "fmt": "30.18B",
+                    "longFmt": "30,175,739,000"
+                  },
+                  "totalLiab": {
+                    "raw": 38219015000,
+                    "fmt": "38.22B",
+                    "longFmt": "38,219,015,000"
+                  },
+                  "commonStock": {
+                    "raw": 205000,
+                    "fmt": "205k",
+                    "longFmt": "205,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -10004504000,
+                    "fmt": "-10B",
+                    "longFmt": "-10,004,504,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 213691000,
+                    "fmt": "213.69M",
+                    "longFmt": "213,691,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1769485000,
+                    "fmt": "1.77B",
+                    "longFmt": "1,769,485,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 213691000,
+                    "fmt": "213.69M",
+                    "longFmt": "213,691,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -8021123000,
+                    "fmt": "-8.02B",
+                    "longFmt": "-8,021,123,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -12800072000,
+                    "fmt": "-12.8B",
+                    "longFmt": "-12,800,072,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "cash": {
+                    "raw": 15538844000,
+                    "fmt": "15.54B",
+                    "longFmt": "15,538,844,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 7709598000,
+                    "fmt": "7.71B",
+                    "longFmt": "7,709,598,000"
+                  },
+                  "netReceivables": {
+                    "raw": 11799844000,
+                    "fmt": "11.8B",
+                    "longFmt": "11,799,844,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 10805983000,
+                    "fmt": "10.81B",
+                    "longFmt": "10,805,983,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 46380397000,
+                    "fmt": "46.38B",
+                    "longFmt": "46,380,397,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2347955000,
+                    "fmt": "2.35B",
+                    "longFmt": "2,347,955,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6700269000,
+                    "fmt": "6.7B",
+                    "longFmt": "6,700,269,000"
+                  },
+                  "goodWill": {
+                    "raw": 2477075000,
+                    "fmt": "2.48B",
+                    "longFmt": "2,477,075,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 2433454000,
+                    "fmt": "2.43B",
+                    "longFmt": "2,433,454,000"
+                  },
+                  "otherAssets": {
+                    "raw": 901375000,
+                    "fmt": "901.38M",
+                    "longFmt": "901,375,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 530164000,
+                    "fmt": "530.16M",
+                    "longFmt": "530,164,000"
+                  },
+                  "totalAssets": {
+                    "raw": 61240525000,
+                    "fmt": "61.24B",
+                    "longFmt": "61,240,525,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 3645940000,
+                    "fmt": "3.65B",
+                    "longFmt": "3,645,940,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 1767844000,
+                    "fmt": "1.77B",
+                    "longFmt": "1,767,844,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 8597488000,
+                    "fmt": "8.6B",
+                    "longFmt": "8,597,488,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 4980956000,
+                    "fmt": "4.98B",
+                    "longFmt": "4,980,956,000"
+                  },
+                  "otherLiab": {
+                    "raw": 120365000,
+                    "fmt": "120.36M",
+                    "longFmt": "120,365,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 84466000,
+                    "fmt": "84.47M",
+                    "longFmt": "84,466,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 22876987000,
+                    "fmt": "22.88B",
+                    "longFmt": "22,876,987,000"
+                  },
+                  "totalLiab": {
+                    "raw": 30855825000,
+                    "fmt": "30.86B",
+                    "longFmt": "30,855,825,000"
+                  },
+                  "commonStock": {
+                    "raw": 202000,
+                    "fmt": "202k",
+                    "longFmt": "202,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -12841072000,
+                    "fmt": "-12.84B",
+                    "longFmt": "-12,841,072,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 234320000,
+                    "fmt": "234.32M",
+                    "longFmt": "234,320,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1840586000,
+                    "fmt": "1.84B",
+                    "longFmt": "1,840,586,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 234320000,
+                    "fmt": "234.32M",
+                    "longFmt": "234,320,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -10765964000,
+                    "fmt": "-10.77B",
+                    "longFmt": "-10,765,964,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -15676493000,
+                    "fmt": "-15.68B",
+                    "longFmt": "-15,676,493,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1569801600,
+                    "fmt": "2019-09-30"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistoryQuarterly-BFLY.json
+++ b/tests/http/quoteSummary-balanceSheetHistoryQuarterly-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=balanceSheetHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "be4gk8pg2qdt3"
+      ],
+      "x-yahoo-request-id": [
+        "be4gk8pg2qdt3"
+      ],
+      "x-request-id": [
+        "818e03c1-7217-4e05-b64b-715eb3ca9646"
+      ],
+      "content-length": [
+        "120"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:34:58 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-calendarEvents-BEKE.json
+++ b/tests/http/quoteSummary-calendarEvents-BEKE.json
@@ -1,0 +1,90 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=calendarEvents"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "9afsirtg2qdt3"
+      ],
+      "x-yahoo-request-id": [
+        "9afsirtg2qdt3"
+      ],
+      "x-request-id": [
+        "afd0c173-d0ab-4441-ba9d-7eeebab41c93"
+      ],
+      "content-length": [
+        "244"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:34:59 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": [],
+                "earningsAverage": 0.13,
+                "earningsLow": 0.01,
+                "earningsHigh": 0.17,
+                "revenueAverage": 3082150000,
+                "revenueLow": 2998670000,
+                "revenueHigh": 3182420000
+              }
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-calendarEvents-BFLY.json
+++ b/tests/http/quoteSummary-calendarEvents-BFLY.json
@@ -1,0 +1,84 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=calendarEvents"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "dv2k1s9g2qdt3"
+      ],
+      "x-yahoo-request-id": [
+        "dv2k1s9g2qdt3"
+      ],
+      "x-request-id": [
+        "edb571f1-d5f4-4953-bf69-60f6a0a2f76e"
+      ],
+      "content-length": [
+        "105"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:34:59 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": []
+              }
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistory-BEKE.json
+++ b/tests/http/quoteSummary-cashflowStatementHistory-BEKE.json
@@ -1,0 +1,382 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=cashflowStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "2ne7dr1g2qdt3"
+      ],
+      "x-yahoo-request-id": [
+        "2ne7dr1g2qdt3"
+      ],
+      "x-request-id": [
+        "52a5ba62-18f5-41ea-82d4-b2dcfd365b93"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1246"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:34:59 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -2183546000,
+                    "fmt": "-2.18B",
+                    "longFmt": "-2,183,546,000"
+                  },
+                  "depreciation": {
+                    "raw": 1039318000,
+                    "fmt": "1.04B",
+                    "longFmt": "1,039,318,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 3018688000,
+                    "fmt": "3.02B",
+                    "longFmt": "3,018,688,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -5040865000,
+                    "fmt": "-5.04B",
+                    "longFmt": "-5,040,865,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 3009276000,
+                    "fmt": "3.01B",
+                    "longFmt": "3,009,276,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -412586000,
+                    "fmt": "-412.59M",
+                    "longFmt": "-412,586,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 112626000,
+                    "fmt": "112.63M",
+                    "longFmt": "112,626,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -703008000,
+                    "fmt": "-703.01M",
+                    "longFmt": "-703,008,000"
+                  },
+                  "investments": {
+                    "raw": -1133063000,
+                    "fmt": "-1.13B",
+                    "longFmt": "-1,133,063,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 91216000,
+                    "fmt": "91.22M",
+                    "longFmt": "91,216,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -3873722000,
+                    "fmt": "-3.87B",
+                    "longFmt": "-3,873,722,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 6758437000,
+                    "fmt": "6.76B",
+                    "longFmt": "6,758,437,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -8628000,
+                    "fmt": "-8.63M",
+                    "longFmt": "-8,628,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 23026396000,
+                    "fmt": "23.03B",
+                    "longFmt": "23,026,396,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -94922000,
+                    "fmt": "-94.92M",
+                    "longFmt": "-94,922,000"
+                  },
+                  "changeInCash": {
+                    "raw": 19170378000,
+                    "fmt": "19.17B",
+                    "longFmt": "19,170,378,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -347219000,
+                    "fmt": "-347.22M",
+                    "longFmt": "-347,219,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 232885000,
+                    "fmt": "232.88M",
+                    "longFmt": "232,885,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -467824000,
+                    "fmt": "-467.82M",
+                    "longFmt": "-467,824,000"
+                  },
+                  "depreciation": {
+                    "raw": 792294000,
+                    "fmt": "792.29M",
+                    "longFmt": "792,294,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -186336000,
+                    "fmt": "-186.34M",
+                    "longFmt": "-186,336,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -769062000,
+                    "fmt": "-769.06M",
+                    "longFmt": "-769,062,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 1157138000,
+                    "fmt": "1.16B",
+                    "longFmt": "1,157,138,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 2913832000,
+                    "fmt": "2.91B",
+                    "longFmt": "2,913,832,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 3216797000,
+                    "fmt": "3.22B",
+                    "longFmt": "3,216,797,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -542853000,
+                    "fmt": "-542.85M",
+                    "longFmt": "-542,853,000"
+                  },
+                  "investments": {
+                    "raw": 5239066000,
+                    "fmt": "5.24B",
+                    "longFmt": "5,239,066,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -2010792000,
+                    "fmt": "-2.01B",
+                    "longFmt": "-2,010,792,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 2609149000,
+                    "fmt": "2.61B",
+                    "longFmt": "2,609,149,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -124121000,
+                    "fmt": "-124.12M",
+                    "longFmt": "-124,121,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -437019000,
+                    "fmt": "-437.02M",
+                    "longFmt": "-437,019,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -1282408000,
+                    "fmt": "-1.28B",
+                    "longFmt": "-1,282,408,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 416000,
+                    "fmt": "416k",
+                    "longFmt": "416,000"
+                  },
+                  "changeInCash": {
+                    "raw": 4543954000,
+                    "fmt": "4.54B",
+                    "longFmt": "4,543,954,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -347219000,
+                    "fmt": "-347.22M",
+                    "longFmt": "-347,219,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 232885000,
+                    "fmt": "232.88M",
+                    "longFmt": "232,885,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -574430000,
+                    "fmt": "-574.43M",
+                    "longFmt": "-574,430,000"
+                  },
+                  "depreciation": {
+                    "raw": 811203000,
+                    "fmt": "811.2M",
+                    "longFmt": "811,203,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 164271000,
+                    "fmt": "164.27M",
+                    "longFmt": "164,271,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -498216000,
+                    "fmt": "-498.22M",
+                    "longFmt": "-498,216,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -764294000,
+                    "fmt": "-764.29M",
+                    "longFmt": "-764,294,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -5733411000,
+                    "fmt": "-5.73B",
+                    "longFmt": "-5,733,411,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -6456226000,
+                    "fmt": "-6.46B",
+                    "longFmt": "-6,456,226,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -575185000,
+                    "fmt": "-575.18M",
+                    "longFmt": "-575,185,000"
+                  },
+                  "investments": {
+                    "raw": -959123000,
+                    "fmt": "-959.12M",
+                    "longFmt": "-959,123,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -5000000,
+                    "fmt": "-5M",
+                    "longFmt": "-5,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -2783562000,
+                    "fmt": "-2.78B",
+                    "longFmt": "-2,783,562,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -127188000,
+                    "fmt": "-127.19M",
+                    "longFmt": "-127,188,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 973472000,
+                    "fmt": "973.47M",
+                    "longFmt": "973,472,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -437019000,
+                    "fmt": "-437.02M",
+                    "longFmt": "-437,019,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 9576284000,
+                    "fmt": "9.58B",
+                    "longFmt": "9,576,284,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -330000,
+                    "fmt": "-330k",
+                    "longFmt": "-330,000"
+                  },
+                  "changeInCash": {
+                    "raw": 336166000,
+                    "fmt": "336.17M",
+                    "longFmt": "336,166,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -347219000,
+                    "fmt": "-347.22M",
+                    "longFmt": "-347,219,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 232885000,
+                    "fmt": "232.88M",
+                    "longFmt": "232,885,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistory-BFLY.json
+++ b/tests/http/quoteSummary-cashflowStatementHistory-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=cashflowStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "4ckj6c1g2qdt3"
+      ],
+      "x-yahoo-request-id": [
+        "4ckj6c1g2qdt3"
+      ],
+      "x-request-id": [
+        "3bbc751b-5379-42ae-8547-67cad3c7a405"
+      ],
+      "content-length": [
+        "112"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:34:59 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistory": {
+              "cashflowStatements": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-BEKE.json
+++ b/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-BEKE.json
@@ -1,0 +1,459 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=cashflowStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "c3pu845g2qdt3"
+      ],
+      "x-yahoo-request-id": [
+        "c3pu845g2qdt3"
+      ],
+      "x-request-id": [
+        "76d27b0f-ee08-40cd-a65a-7bb57d47022a"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1436"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:34:59 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 74697000,
+                    "fmt": "74.7M",
+                    "longFmt": "74,697,000"
+                  },
+                  "depreciation": {
+                    "raw": 303789000,
+                    "fmt": "303.79M",
+                    "longFmt": "303,789,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -746842000,
+                    "fmt": "-746.84M",
+                    "longFmt": "-746,842,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -3341525000,
+                    "fmt": "-3.34B",
+                    "longFmt": "-3,341,525,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 2217374000,
+                    "fmt": "2.22B",
+                    "longFmt": "2,217,374,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 5410498000,
+                    "fmt": "5.41B",
+                    "longFmt": "5,410,498,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 3213000000,
+                    "fmt": "3.21B",
+                    "longFmt": "3,213,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -566050000,
+                    "fmt": "-566.05M",
+                    "longFmt": "-566,050,000"
+                  },
+                  "investments": {
+                    "raw": -11199382000,
+                    "fmt": "-11.2B",
+                    "longFmt": "-11,199,382,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 4307818000,
+                    "fmt": "4.31B",
+                    "longFmt": "4,307,818,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -6945255000,
+                    "fmt": "-6.95B",
+                    "longFmt": "-6,945,255,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -105172000,
+                    "fmt": "-105.17M",
+                    "longFmt": "-105,172,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 324758000,
+                    "fmt": "324.76M",
+                    "longFmt": "324,758,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 16565408000,
+                    "fmt": "16.57B",
+                    "longFmt": "16,565,408,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -815884000,
+                    "fmt": "-815.88M",
+                    "longFmt": "-815,884,000"
+                  },
+                  "changeInCash": {
+                    "raw": 12017269000,
+                    "fmt": "12.02B",
+                    "longFmt": "12,017,269,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 16345822000,
+                    "fmt": "16.35B",
+                    "longFmt": "16,345,822,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "netIncome": {
+                    "raw": 2836568000,
+                    "fmt": "2.84B",
+                    "longFmt": "2,836,568,000"
+                  },
+                  "depreciation": {
+                    "raw": 272184000,
+                    "fmt": "272.18M",
+                    "longFmt": "272,184,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 2743463000,
+                    "fmt": "2.74B",
+                    "longFmt": "2,743,463,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -719861000,
+                    "fmt": "-719.86M",
+                    "longFmt": "-719,861,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 785185000,
+                    "fmt": "785.18M",
+                    "longFmt": "785,185,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 2426120000,
+                    "fmt": "2.43B",
+                    "longFmt": "2,426,120,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 9133566000,
+                    "fmt": "9.13B",
+                    "longFmt": "9,133,566,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": 149136000,
+                    "fmt": "149.14M",
+                    "longFmt": "149,136,000"
+                  },
+                  "investments": {
+                    "raw": 5786363000,
+                    "fmt": "5.79B",
+                    "longFmt": "5,786,363,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -2409715000,
+                    "fmt": "-2.41B",
+                    "longFmt": "-2,409,715,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 2751829000,
+                    "fmt": "2.75B",
+                    "longFmt": "2,751,829,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 898389000,
+                    "fmt": "898.39M",
+                    "longFmt": "898,389,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -569320000,
+                    "fmt": "-569.32M",
+                    "longFmt": "-569,320,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 329069000,
+                    "fmt": "329.07M",
+                    "longFmt": "329,069,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -14448000,
+                    "fmt": "-14.45M",
+                    "longFmt": "-14,448,000"
+                  },
+                  "changeInCash": {
+                    "raw": 12200016000,
+                    "fmt": "12.2B",
+                    "longFmt": "12,200,016,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 16345822000,
+                    "fmt": "16.35B",
+                    "longFmt": "16,345,822,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "netIncome": {
+                    "raw": -1228650000,
+                    "fmt": "-1.23B",
+                    "longFmt": "-1,228,650,000"
+                  },
+                  "depreciation": {
+                    "raw": 271845000,
+                    "fmt": "271.85M",
+                    "longFmt": "271,845,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 149055000,
+                    "fmt": "149.06M",
+                    "longFmt": "149,055,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 719861000,
+                    "fmt": "719.86M",
+                    "longFmt": "719,861,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -785185000,
+                    "fmt": "-785.18M",
+                    "longFmt": "-785,185,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -2426120000,
+                    "fmt": "-2.43B",
+                    "longFmt": "-2,426,120,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -4089101000,
+                    "fmt": "-4.09B",
+                    "longFmt": "-4,089,101,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -149136000,
+                    "fmt": "-149.14M",
+                    "longFmt": "-149,136,000"
+                  },
+                  "investments": {
+                    "raw": -5786363000,
+                    "fmt": "-5.79B",
+                    "longFmt": "-5,786,363,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -14819000,
+                    "fmt": "-14.82M",
+                    "longFmt": "-14,819,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -5176363000,
+                    "fmt": "-5.18B",
+                    "longFmt": "-5,176,363,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -898389000,
+                    "fmt": "-898.39M",
+                    "longFmt": "-898,389,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -569320000,
+                    "fmt": "-569.32M",
+                    "longFmt": "-569,320,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -898389000,
+                    "fmt": "-898.39M",
+                    "longFmt": "-898,389,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 131392000,
+                    "fmt": "131.39M",
+                    "longFmt": "131,392,000"
+                  },
+                  "changeInCash": {
+                    "raw": -10032461000,
+                    "fmt": "-10.03B",
+                    "longFmt": "-10,032,461,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 16345822000,
+                    "fmt": "16.35B",
+                    "longFmt": "16,345,822,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1569801600,
+                    "fmt": "2019-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 381354000,
+                    "fmt": "381.35M",
+                    "longFmt": "381,354,000"
+                  },
+                  "depreciation": {
+                    "raw": 308036000,
+                    "fmt": "308.04M",
+                    "longFmt": "308,036,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 56176000,
+                    "fmt": "56.18M",
+                    "longFmt": "56,176,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -1204448000,
+                    "fmt": "-1.2B",
+                    "longFmt": "-1,204,448,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 940491000,
+                    "fmt": "940.49M",
+                    "longFmt": "940,491,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 394199000,
+                    "fmt": "394.2M",
+                    "longFmt": "394,199,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 1257660000,
+                    "fmt": "1.26B",
+                    "longFmt": "1,257,660,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -123413000,
+                    "fmt": "-123.41M",
+                    "longFmt": "-123,413,000"
+                  },
+                  "investments": {
+                    "raw": 1040954000,
+                    "fmt": "1.04B",
+                    "longFmt": "1,040,954,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -4488000,
+                    "fmt": "-4.49M",
+                    "longFmt": "-4,488,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 132616000,
+                    "fmt": "132.62M",
+                    "longFmt": "132,616,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 64710000,
+                    "fmt": "64.71M",
+                    "longFmt": "64,710,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -569320000,
+                    "fmt": "-569.32M",
+                    "longFmt": "-569,320,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -2222516000,
+                    "fmt": "-2.22B",
+                    "longFmt": "-2,222,516,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 109779000,
+                    "fmt": "109.78M",
+                    "longFmt": "109,779,000"
+                  },
+                  "changeInCash": {
+                    "raw": -722461000,
+                    "fmt": "-722.46M",
+                    "longFmt": "-722,461,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -140074000,
+                    "fmt": "-140.07M",
+                    "longFmt": "-140,074,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 16345822000,
+                    "fmt": "16.35B",
+                    "longFmt": "16,345,822,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-BFLY.json
+++ b/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=cashflowStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "e0jgk6lg2qdt3"
+      ],
+      "x-yahoo-request-id": [
+        "e0jgk6lg2qdt3"
+      ],
+      "x-request-id": [
+        "494f0b9c-5446-4afb-95a4-02833caed646"
+      ],
+      "content-length": [
+        "121"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:34:59 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-defaultKeyStatistics-BEKE.json
+++ b/tests/http/quoteSummary-defaultKeyStatistics-BEKE.json
@@ -1,0 +1,109 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=defaultKeyStatistics"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "fijkuthg2qdt3"
+      ],
+      "x-yahoo-request-id": [
+        "fijkuthg2qdt3"
+      ],
+      "x-request-id": [
+        "f02f942d-dcb7-4ed3-98b1-08cd2637af36"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "469"
+      ],
+      "x-envoy-upstream-service-time": [
+        "7"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:34:59 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "3"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": 79355428864,
+              "forwardPE": 73.100006,
+              "profitMargins": -0.02313,
+              "floatShares": 389103285,
+              "sharesOutstanding": 1143379968,
+              "sharesShort": 11331624,
+              "sharesShortPriorMonth": 10275253,
+              "sharesShortPreviousMonthDate": 1609372800,
+              "dateShortInterest": 1611878400,
+              "sharesPercentSharesOut": 0.0095999995,
+              "heldPercentInsiders": 0.0090499995,
+              "heldPercentInstitutions": 0.14386,
+              "shortRatio": 3.25,
+              "category": null,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1577750400,
+              "nextFiscalYearEnd": 1640908800,
+              "mostRecentQuarter": 1601424000,
+              "earningsQuarterlyGrowth": -0.804,
+              "pegRatio": 117.17,
+              "lastSplitFactor": null,
+              "52WeekChange": 0.81623936,
+              "SandP52WeekChange": 0.16137505
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-defaultKeyStatistics-BFLY.json
+++ b/tests/http/quoteSummary-defaultKeyStatistics-BFLY.json
@@ -1,0 +1,89 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=defaultKeyStatistics"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "er6gsldg2qdt4"
+      ],
+      "x-yahoo-request-id": [
+        "er6gsldg2qdt4"
+      ],
+      "x-request-id": [
+        "b90297a4-b4a7-4326-a4a3-b8585916298b"
+      ],
+      "content-length": [
+        "238"
+      ],
+      "x-envoy-upstream-service-time": [
+        "6"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:00 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "profitMargins": 0,
+              "category": null,
+              "fundFamily": null,
+              "legalType": null,
+              "lastSplitFactor": null,
+              "52WeekChange": 0,
+              "SandP52WeekChange": 0.16137505
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earnings-BEKE.json
+++ b/tests/http/quoteSummary-earnings-BEKE.json
@@ -1,0 +1,139 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=earnings"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "9frjr55g2qdt4"
+      ],
+      "x-yahoo-request-id": [
+        "9frjr55g2qdt4"
+      ],
+      "x-request-id": [
+        "179f84c3-86a9-4323-98af-159235244faf"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "337"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:34:59 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [
+                  {
+                    "date": "3Q2020",
+                    "actual": 0.21,
+                    "estimate": 0.17
+                  }
+                ],
+                "currentQuarterEstimate": 0.13,
+                "currentQuarterEstimateDate": "4Q",
+                "currentQuarterEstimateYear": 2020,
+                "earningsDate": []
+              },
+              "financialsChart": {
+                "yearly": [
+                  {
+                    "date": 2017,
+                    "revenue": 25505698000,
+                    "earnings": -574430000
+                  },
+                  {
+                    "date": 2018,
+                    "revenue": 28646499000,
+                    "earnings": -467824000
+                  },
+                  {
+                    "date": 2019,
+                    "revenue": 46014906000,
+                    "earnings": -2183546000
+                  }
+                ],
+                "quarterly": [
+                  {
+                    "date": "3Q2019",
+                    "revenue": 12022659000,
+                    "earnings": 381354000
+                  },
+                  {
+                    "date": "1Q2020",
+                    "revenue": 7119759000,
+                    "earnings": -1228650000
+                  },
+                  {
+                    "date": "2Q2020",
+                    "revenue": 20141659000,
+                    "earnings": 2836568000
+                  },
+                  {
+                    "date": "3Q2020",
+                    "revenue": 20548915000,
+                    "earnings": 74697000
+                  }
+                ]
+              },
+              "financialCurrency": "CNY"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earnings-BFLY.json
+++ b/tests/http/quoteSummary-earnings-BFLY.json
@@ -1,0 +1,89 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=earnings"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "3pfdn1tg2qdt4"
+      ],
+      "x-yahoo-request-id": [
+        "3pfdn1tg2qdt4"
+      ],
+      "x-request-id": [
+        "c748f51f-f3fd-48e8-bd14-30eaa9a79a1b"
+      ],
+      "content-length": [
+        "170"
+      ],
+      "x-envoy-upstream-service-time": [
+        "1"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:00 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [],
+                "earningsDate": []
+              },
+              "financialsChart": {
+                "yearly": [],
+                "quarterly": []
+              }
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsHistory-BEKE.json
+++ b/tests/http/quoteSummary-earningsHistory-BEKE.json
@@ -1,0 +1,137 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=earningsHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "ffamjqhg2qdt4"
+      ],
+      "x-yahoo-request-id": [
+        "ffamjqhg2qdt4"
+      ],
+      "x-request-id": [
+        "b797c345-f31e-4a5a-8f00-e8264a0fc01f"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "252"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:00 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.21,
+                    "fmt": "0.21"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.17,
+                    "fmt": "0.17"
+                  },
+                  "epsDifference": {
+                    "raw": 0.04,
+                    "fmt": "0.04"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.235,
+                    "fmt": "23.50%"
+                  },
+                  "quarter": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsHistory-BFLY.json
+++ b/tests/http/quoteSummary-earningsHistory-BFLY.json
@@ -1,0 +1,122 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=earningsHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "fbql141g2qdt4"
+      ],
+      "x-yahoo-request-id": [
+        "fbql141g2qdt4"
+      ],
+      "x-request-id": [
+        "a64ea968-246b-4b39-b31c-902299f1788e"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "176"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:00 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsTrend-BEKE.json
+++ b/tests/http/quoteSummary-earningsTrend-BEKE.json
@@ -1,0 +1,539 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=earningsTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "e9fdoc1g2qdt4"
+      ],
+      "x-yahoo-request-id": [
+        "e9fdoc1g2qdt4"
+      ],
+      "x-request-id": [
+        "2e0fc29d-ec62-4040-a3f6-36a51f217b4e"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "849"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:00 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": "2020-12-31",
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "low": {
+                      "raw": 0.01,
+                      "fmt": "0.01"
+                    },
+                    "high": {
+                      "raw": 0.17,
+                      "fmt": "0.17"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 6,
+                      "fmt": "6",
+                      "longFmt": "6"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 3082150000,
+                      "fmt": "3.08B",
+                      "longFmt": "3,082,150,000"
+                    },
+                    "low": {
+                      "raw": 2998670000,
+                      "fmt": "3B",
+                      "longFmt": "2,998,670,000"
+                    },
+                    "high": {
+                      "raw": 3182420000,
+                      "fmt": "3.18B",
+                      "longFmt": "3,182,420,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 7,
+                      "fmt": "7",
+                      "longFmt": "7"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.11,
+                      "fmt": "0.11"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": "2021-03-31",
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "low": {
+                      "raw": 0.09,
+                      "fmt": "0.09"
+                    },
+                    "high": {
+                      "raw": 0.14,
+                      "fmt": "0.14"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 3,
+                      "fmt": "3",
+                      "longFmt": "3"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 2126150000,
+                      "fmt": "2.13B",
+                      "longFmt": "2,126,150,000"
+                    },
+                    "low": {
+                      "raw": 1891260000,
+                      "fmt": "1.89B",
+                      "longFmt": "1,891,260,000"
+                    },
+                    "high": {
+                      "raw": 2252600000,
+                      "fmt": "2.25B",
+                      "longFmt": "2,252,600,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 3,
+                      "fmt": "3",
+                      "longFmt": "3"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.08,
+                      "fmt": "0.08"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": "2020-12-31",
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "low": {
+                      "raw": 0.63,
+                      "fmt": "0.63"
+                    },
+                    "high": {
+                      "raw": 1.02,
+                      "fmt": "1.02"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 9,
+                      "fmt": "9",
+                      "longFmt": "9"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 10527000000,
+                      "fmt": "10.53B",
+                      "longFmt": "10,527,000,000"
+                    },
+                    "low": {
+                      "raw": 10400500000,
+                      "fmt": "10.4B",
+                      "longFmt": "10,400,500,000"
+                    },
+                    "high": {
+                      "raw": 10688500000,
+                      "fmt": "10.69B",
+                      "longFmt": "10,688,500,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 11,
+                      "fmt": "11",
+                      "longFmt": "11"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.74,
+                      "fmt": "0.74"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.67,
+                      "fmt": "0.67"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": "2021-12-31",
+                  "growth": {
+                    "raw": 0.2,
+                    "fmt": "20.00%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.9,
+                      "fmt": "0.9"
+                    },
+                    "low": {
+                      "raw": 0.64,
+                      "fmt": "0.64"
+                    },
+                    "high": {
+                      "raw": 0.99,
+                      "fmt": "0.99"
+                    },
+                    "yearAgoEps": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 9,
+                      "fmt": "9",
+                      "longFmt": "9"
+                    },
+                    "growth": {
+                      "raw": 0.2,
+                      "fmt": "20.00%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 13237800000,
+                      "fmt": "13.24B",
+                      "longFmt": "13,237,800,000"
+                    },
+                    "low": {
+                      "raw": 11327900000,
+                      "fmt": "11.33B",
+                      "longFmt": "11,327,900,000"
+                    },
+                    "high": {
+                      "raw": 14382900000,
+                      "fmt": "14.38B",
+                      "longFmt": "14,382,900,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 11,
+                      "fmt": "11",
+                      "longFmt": "11"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 10527000000,
+                      "fmt": "10.53B",
+                      "longFmt": "10,527,000,000"
+                    },
+                    "growth": {
+                      "raw": 0.258,
+                      "fmt": "25.80%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.9,
+                      "fmt": "0.9"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.9,
+                      "fmt": "0.9"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.9,
+                      "fmt": "0.9"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.89,
+                      "fmt": "0.89"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.88,
+                      "fmt": "0.88"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": 0.046,
+                    "fmt": "4.60%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsTrend-BFLY.json
+++ b/tests/http/quoteSummary-earningsTrend-BFLY.json
@@ -1,0 +1,520 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=earningsTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "f0kgrk1g2qdt4"
+      ],
+      "x-yahoo-request-id": [
+        "f0kgrk1g2qdt4"
+      ],
+      "x-request-id": [
+        "8e71d092-06c5-48d4-839a-460223df499e"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "385"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:00 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "2"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-financialData-BEKE.json
+++ b/tests/http/quoteSummary-financialData-BEKE.json
@@ -1,0 +1,99 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=financialData"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "6u7373pg2qdt5"
+      ],
+      "x-yahoo-request-id": [
+        "6u7373pg2qdt5"
+      ],
+      "x-request-id": [
+        "39a17e0d-36b1-41f9-ad98-5df06b20c6fe"
+      ],
+      "content-length": [
+        "511"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:00 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 65.79,
+              "targetHighPrice": 90.48,
+              "targetLowPrice": 20.99,
+              "targetMeanPrice": 67.22,
+              "targetMedianPrice": 67.57,
+              "recommendationMean": 2.5,
+              "recommendationKey": "buy",
+              "numberOfAnalystOpinions": 10,
+              "quickRatio": 2.013,
+              "currentRatio": 2.386,
+              "debtToEquity": 26.427,
+              "grossProfits": 11268044000,
+              "revenueGrowth": 0.709,
+              "grossMargins": 0.22805999,
+              "ebitdaMargins": -0.00654,
+              "operatingMargins": 0,
+              "profitMargins": -0.02313,
+              "financialCurrency": "CNY"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-financialData-BFLY.json
+++ b/tests/http/quoteSummary-financialData-BFLY.json
@@ -1,0 +1,93 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=financialData"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "el4s7dhg2qdt5"
+      ],
+      "x-yahoo-request-id": [
+        "el4s7dhg2qdt5"
+      ],
+      "x-request-id": [
+        "8c22c2f0-8e2c-45c9-8ff3-d891002c0db3"
+      ],
+      "content-length": [
+        "353"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:01 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 22.61,
+              "targetHighPrice": 15,
+              "targetLowPrice": 15,
+              "targetMeanPrice": 15,
+              "targetMedianPrice": 15,
+              "recommendationKey": "none",
+              "numberOfAnalystOpinions": 1,
+              "grossMargins": 0,
+              "ebitdaMargins": 0,
+              "operatingMargins": 0,
+              "profitMargins": 0,
+              "financialCurrency": null
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-fundOwnership-BEKE.json
+++ b/tests/http/quoteSummary-fundOwnership-BEKE.json
@@ -1,0 +1,306 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=fundOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "7fri1e1g2qdt5"
+      ],
+      "x-yahoo-request-id": [
+        "7fri1e1g2qdt5"
+      ],
+      "x-request-id": [
+        "ae1d9bd2-a4a6-4433-80fb-dc695972238b"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "848"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:01 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Europacific Growth Fund",
+                  "pctHeld": {
+                    "raw": 0.005,
+                    "fmt": "0.50%"
+                  },
+                  "position": {
+                    "raw": 4457516,
+                    "fmt": "4.46M",
+                    "longFmt": "4,457,516"
+                  },
+                  "value": {
+                    "raw": 274315534,
+                    "fmt": "274.32M",
+                    "longFmt": "274,315,534"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "ARK ETF Tr-ARK Innovation ETF",
+                  "pctHeld": {
+                    "raw": 0.0049,
+                    "fmt": "0.49%"
+                  },
+                  "position": {
+                    "raw": 4358188,
+                    "fmt": "4.36M",
+                    "longFmt": "4,358,188"
+                  },
+                  "value": {
+                    "raw": 268202889,
+                    "fmt": "268.2M",
+                    "longFmt": "268,202,889"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "KraneShares CSI China Internet ETF",
+                  "pctHeld": {
+                    "raw": 0.0023999999,
+                    "fmt": "0.24%"
+                  },
+                  "position": {
+                    "raw": 2150250,
+                    "fmt": "2.15M",
+                    "longFmt": "2,150,250"
+                  },
+                  "value": {
+                    "raw": 131810325,
+                    "fmt": "131.81M",
+                    "longFmt": "131,810,325"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1604102400,
+                    "fmt": "2020-10-31"
+                  },
+                  "organization": "Vanguard International Stock Index-Total Intl Stock Indx",
+                  "pctHeld": {
+                    "raw": 0.0018000001,
+                    "fmt": "0.18%"
+                  },
+                  "position": {
+                    "raw": 1625494,
+                    "fmt": "1.63M",
+                    "longFmt": "1,625,494"
+                  },
+                  "value": {
+                    "raw": 113378206,
+                    "fmt": "113.38M",
+                    "longFmt": "113,378,206"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Fidelity OTC Portfolio",
+                  "pctHeld": {
+                    "raw": 0.0018000001,
+                    "fmt": "0.18%"
+                  },
+                  "position": {
+                    "raw": 1598717,
+                    "fmt": "1.6M",
+                    "longFmt": "1,598,717"
+                  },
+                  "value": {
+                    "raw": 98385044,
+                    "fmt": "98.39M",
+                    "longFmt": "98,385,044"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1604102400,
+                    "fmt": "2020-10-31"
+                  },
+                  "organization": "Vanguard International Stock Index-Emerging Markets Stk",
+                  "pctHeld": {
+                    "raw": 0.0016,
+                    "fmt": "0.16%"
+                  },
+                  "position": {
+                    "raw": 1440142,
+                    "fmt": "1.44M",
+                    "longFmt": "1,440,142"
+                  },
+                  "value": {
+                    "raw": 100449904,
+                    "fmt": "100.45M",
+                    "longFmt": "100,449,904"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "ARK ETF Tr-ARK Next Generation Internet ETF",
+                  "pctHeld": {
+                    "raw": 0.0014,
+                    "fmt": "0.14%"
+                  },
+                  "position": {
+                    "raw": 1285541,
+                    "fmt": "1.29M",
+                    "longFmt": "1,285,541"
+                  },
+                  "value": {
+                    "raw": 79112193,
+                    "fmt": "79.11M",
+                    "longFmt": "79,112,193"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "New World Fund, Inc.",
+                  "pctHeld": {
+                    "raw": 0.0013,
+                    "fmt": "0.13%"
+                  },
+                  "position": {
+                    "raw": 1116780,
+                    "fmt": "1.12M",
+                    "longFmt": "1,116,780"
+                  },
+                  "value": {
+                    "raw": 68726641,
+                    "fmt": "68.73M",
+                    "longFmt": "68,726,641"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Fundamental Investors Inc",
+                  "pctHeld": {
+                    "raw": 0.0011,
+                    "fmt": "0.11%"
+                  },
+                  "position": {
+                    "raw": 986393,
+                    "fmt": "986.39k",
+                    "longFmt": "986,393"
+                  },
+                  "value": {
+                    "raw": 60702625,
+                    "fmt": "60.7M",
+                    "longFmt": "60,702,625"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Fidelity Growth Company Fund",
+                  "pctHeld": {
+                    "raw": 0.0011,
+                    "fmt": "0.11%"
+                  },
+                  "position": {
+                    "raw": 974704,
+                    "fmt": "974.7k",
+                    "longFmt": "974,704"
+                  },
+                  "value": {
+                    "raw": 59983284,
+                    "fmt": "59.98M",
+                    "longFmt": "59,983,284"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-fundOwnership-BFLY.json
+++ b/tests/http/quoteSummary-fundOwnership-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=fundOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "9fepvt9g2qdt5"
+      ],
+      "x-yahoo-request-id": [
+        "9fepvt9g2qdt5"
+      ],
+      "x-request-id": [
+        "6678e81d-dfd6-4b01-b9d4-fc19358aee18"
+      ],
+      "content-length": [
+        "92"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:01 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistory-BEKE.json
+++ b/tests/http/quoteSummary-incomeStatementHistory-BEKE.json
@@ -1,0 +1,365 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=incomeStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "6v79c4hg2qdt5"
+      ],
+      "x-yahoo-request-id": [
+        "6v79c4hg2qdt5"
+      ],
+      "x-request-id": [
+        "2da46424-c28d-4288-8f99-7f25f9957074"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1242"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:01 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 46014906000,
+                    "fmt": "46.01B",
+                    "longFmt": "46,014,906,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 34746862000,
+                    "fmt": "34.75B",
+                    "longFmt": "34,746,862,000"
+                  },
+                  "grossProfit": {
+                    "raw": 11268044000,
+                    "fmt": "11.27B",
+                    "longFmt": "11,268,044,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 1571154000,
+                    "fmt": "1.57B",
+                    "longFmt": "1,571,154,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 11482430000,
+                    "fmt": "11.48B",
+                    "longFmt": "11,482,430,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 47800446000,
+                    "fmt": "47.8B",
+                    "longFmt": "47,800,446,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -1785540000,
+                    "fmt": "-1.79B",
+                    "longFmt": "-1,785,540,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 509776000,
+                    "fmt": "509.78M",
+                    "longFmt": "509,776,000"
+                  },
+                  "ebit": {
+                    "raw": -1785540000,
+                    "fmt": "-1.79B",
+                    "longFmt": "-1,785,540,000"
+                  },
+                  "interestExpense": {
+                    "raw": -181099000,
+                    "fmt": "-181.1M",
+                    "longFmt": "-181,099,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -1275764000,
+                    "fmt": "-1.28B",
+                    "longFmt": "-1,275,764,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 904363000,
+                    "fmt": "904.36M",
+                    "longFmt": "904,363,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 87203000,
+                    "fmt": "87.2M",
+                    "longFmt": "87,203,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -2180127000,
+                    "fmt": "-2.18B",
+                    "longFmt": "-2,180,127,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -2183546000,
+                    "fmt": "-2.18B",
+                    "longFmt": "-2,183,546,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -4050074000,
+                    "fmt": "-4.05B",
+                    "longFmt": "-4,050,074,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 28646499000,
+                    "fmt": "28.65B",
+                    "longFmt": "28,646,499,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 21776523000,
+                    "fmt": "21.78B",
+                    "longFmt": "21,776,523,000"
+                  },
+                  "grossProfit": {
+                    "raw": 6869976000,
+                    "fmt": "6.87B",
+                    "longFmt": "6,869,976,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 670922000,
+                    "fmt": "670.92M",
+                    "longFmt": "670,922,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 7417059000,
+                    "fmt": "7.42B",
+                    "longFmt": "7,417,059,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 29864504000,
+                    "fmt": "29.86B",
+                    "longFmt": "29,864,504,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -1218005000,
+                    "fmt": "-1.22B",
+                    "longFmt": "-1,218,005,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 718940000,
+                    "fmt": "718.94M",
+                    "longFmt": "718,940,000"
+                  },
+                  "ebit": {
+                    "raw": -1218005000,
+                    "fmt": "-1.22B",
+                    "longFmt": "-1,218,005,000"
+                  },
+                  "interestExpense": {
+                    "raw": -43517000,
+                    "fmt": "-43.52M",
+                    "longFmt": "-43,517,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -499065000,
+                    "fmt": "-499.06M",
+                    "longFmt": "-499,065,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -71384000,
+                    "fmt": "-71.38M",
+                    "longFmt": "-71,384,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 10467000,
+                    "fmt": "10.47M",
+                    "longFmt": "10,467,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -427681000,
+                    "fmt": "-427.68M",
+                    "longFmt": "-427,681,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -467824000,
+                    "fmt": "-467.82M",
+                    "longFmt": "-467,824,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -2386005000,
+                    "fmt": "-2.39B",
+                    "longFmt": "-2,386,005,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 25505698000,
+                    "fmt": "25.51B",
+                    "longFmt": "25,505,698,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 20737641000,
+                    "fmt": "20.74B",
+                    "longFmt": "20,737,641,000"
+                  },
+                  "grossProfit": {
+                    "raw": 4768057000,
+                    "fmt": "4.77B",
+                    "longFmt": "4,768,057,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 251802000,
+                    "fmt": "251.8M",
+                    "longFmt": "251,802,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 5280146000,
+                    "fmt": "5.28B",
+                    "longFmt": "5,280,146,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 26269589000,
+                    "fmt": "26.27B",
+                    "longFmt": "26,269,589,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -763891000,
+                    "fmt": "-763.89M",
+                    "longFmt": "-763,891,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 625553000,
+                    "fmt": "625.55M",
+                    "longFmt": "625,553,000"
+                  },
+                  "ebit": {
+                    "raw": -763891000,
+                    "fmt": "-763.89M",
+                    "longFmt": "-763,891,000"
+                  },
+                  "interestExpense": {
+                    "raw": -43791000,
+                    "fmt": "-43.79M",
+                    "longFmt": "-43,791,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -138338000,
+                    "fmt": "-138.34M",
+                    "longFmt": "-138,338,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 399283000,
+                    "fmt": "399.28M",
+                    "longFmt": "399,283,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 65836000,
+                    "fmt": "65.84M",
+                    "longFmt": "65,836,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -537621000,
+                    "fmt": "-537.62M",
+                    "longFmt": "-537,621,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -574430000,
+                    "fmt": "-574.43M",
+                    "longFmt": "-574,430,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -1441879000,
+                    "fmt": "-1.44B",
+                    "longFmt": "-1,441,879,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistory-BFLY.json
+++ b/tests/http/quoteSummary-incomeStatementHistory-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=incomeStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "c3vkod5g2qdt6"
+      ],
+      "x-yahoo-request-id": [
+        "c3vkod5g2qdt6"
+      ],
+      "x-request-id": [
+        "5b979fbe-f3fa-41cd-83ac-21bcc5002d68"
+      ],
+      "content-length": [
+        "114"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:01 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistoryQuarterly-BEKE.json
+++ b/tests/http/quoteSummary-incomeStatementHistoryQuarterly-BEKE.json
@@ -1,0 +1,458 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=incomeStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "0ug3et9g2qdt6"
+      ],
+      "x-yahoo-request-id": [
+        "0ug3et9g2qdt6"
+      ],
+      "x-request-id": [
+        "b20617a2-f04d-4f05-8532-e05f30d90662"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1462"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:02 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 20548915000,
+                    "fmt": "20.55B",
+                    "longFmt": "20,548,915,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 16165685000,
+                    "fmt": "16.17B",
+                    "longFmt": "16,165,685,000"
+                  },
+                  "grossProfit": {
+                    "raw": 4383230000,
+                    "fmt": "4.38B",
+                    "longFmt": "4,383,230,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 789089000,
+                    "fmt": "789.09M",
+                    "longFmt": "789,089,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 3675157000,
+                    "fmt": "3.68B",
+                    "longFmt": "3,675,157,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 20629931000,
+                    "fmt": "20.63B",
+                    "longFmt": "20,629,931,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -81016000,
+                    "fmt": "-81.02M",
+                    "longFmt": "-81,016,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 415348000,
+                    "fmt": "415.35M",
+                    "longFmt": "415,348,000"
+                  },
+                  "ebit": {
+                    "raw": -81016000,
+                    "fmt": "-81.02M",
+                    "longFmt": "-81,016,000"
+                  },
+                  "interestExpense": {
+                    "raw": -128157000,
+                    "fmt": "-128.16M",
+                    "longFmt": "-128,157,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 334332000,
+                    "fmt": "334.33M",
+                    "longFmt": "334,332,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 258991000,
+                    "fmt": "258.99M",
+                    "longFmt": "258,991,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 26490000,
+                    "fmt": "26.49M",
+                    "longFmt": "26,490,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 75341000,
+                    "fmt": "75.34M",
+                    "longFmt": "75,341,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 74697000,
+                    "fmt": "74.7M",
+                    "longFmt": "74,697,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -271446000,
+                    "fmt": "-271.45M",
+                    "longFmt": "-271,446,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 20141659000,
+                    "fmt": "20.14B",
+                    "longFmt": "20,141,659,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 13590784000,
+                    "fmt": "13.59B",
+                    "longFmt": "13,590,784,000"
+                  },
+                  "grossProfit": {
+                    "raw": 6550875000,
+                    "fmt": "6.55B",
+                    "longFmt": "6,550,875,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 523670000,
+                    "fmt": "523.67M",
+                    "longFmt": "523,670,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 2739831000,
+                    "fmt": "2.74B",
+                    "longFmt": "2,739,831,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 16854285000,
+                    "fmt": "16.85B",
+                    "longFmt": "16,854,285,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 3287374000,
+                    "fmt": "3.29B",
+                    "longFmt": "3,287,374,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 333154000,
+                    "fmt": "333.15M",
+                    "longFmt": "333,154,000"
+                  },
+                  "ebit": {
+                    "raw": 3287374000,
+                    "fmt": "3.29B",
+                    "longFmt": "3,287,374,000"
+                  },
+                  "interestExpense": {
+                    "raw": -128157000,
+                    "fmt": "-128.16M",
+                    "longFmt": "-128,157,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 3620528000,
+                    "fmt": "3.62B",
+                    "longFmt": "3,620,528,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 781715000,
+                    "fmt": "781.72M",
+                    "longFmt": "781,715,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 25846000,
+                    "fmt": "25.85M",
+                    "longFmt": "25,846,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 2838813000,
+                    "fmt": "2.84B",
+                    "longFmt": "2,838,813,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 2836568000,
+                    "fmt": "2.84B",
+                    "longFmt": "2,836,568,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 2120786000,
+                    "fmt": "2.12B",
+                    "longFmt": "2,120,786,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 7119759000,
+                    "fmt": "7.12B",
+                    "longFmt": "7,119,759,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 6618227000,
+                    "fmt": "6.62B",
+                    "longFmt": "6,618,227,000"
+                  },
+                  "grossProfit": {
+                    "raw": 501532000,
+                    "fmt": "501.53M",
+                    "longFmt": "501,532,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 450761000,
+                    "fmt": "450.76M",
+                    "longFmt": "450,761,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 1682124000,
+                    "fmt": "1.68B",
+                    "longFmt": "1,682,124,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 8751112000,
+                    "fmt": "8.75B",
+                    "longFmt": "8,751,112,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -1631353000,
+                    "fmt": "-1.63B",
+                    "longFmt": "-1,631,353,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 251105000,
+                    "fmt": "251.1M",
+                    "longFmt": "251,105,000"
+                  },
+                  "ebit": {
+                    "raw": -1631353000,
+                    "fmt": "-1.63B",
+                    "longFmt": "-1,631,353,000"
+                  },
+                  "interestExpense": {
+                    "raw": -50113000,
+                    "fmt": "-50.11M",
+                    "longFmt": "-50,113,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -1380248000,
+                    "fmt": "-1.38B",
+                    "longFmt": "-1,380,248,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -148861000,
+                    "fmt": "-148.86M",
+                    "longFmt": "-148,861,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 84466000,
+                    "fmt": "84.47M",
+                    "longFmt": "84,466,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -1231387000,
+                    "fmt": "-1.23B",
+                    "longFmt": "-1,231,387,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -1228650000,
+                    "fmt": "-1.23B",
+                    "longFmt": "-1,228,650,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -1921953000,
+                    "fmt": "-1.92B",
+                    "longFmt": "-1,921,953,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1569801600,
+                    "fmt": "2019-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 12022659000,
+                    "fmt": "12.02B",
+                    "longFmt": "12,022,659,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 9083190000,
+                    "fmt": "9.08B",
+                    "longFmt": "9,083,190,000"
+                  },
+                  "grossProfit": {
+                    "raw": 2939469000,
+                    "fmt": "2.94B",
+                    "longFmt": "2,939,469,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 436056000,
+                    "fmt": "436.06M",
+                    "longFmt": "436,056,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 2103745000,
+                    "fmt": "2.1B",
+                    "longFmt": "2,103,745,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 11622991000,
+                    "fmt": "11.62B",
+                    "longFmt": "11,622,991,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 399668000,
+                    "fmt": "399.67M",
+                    "longFmt": "399,668,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 301713000,
+                    "fmt": "301.71M",
+                    "longFmt": "301,713,000"
+                  },
+                  "ebit": {
+                    "raw": 399668000,
+                    "fmt": "399.67M",
+                    "longFmt": "399,668,000"
+                  },
+                  "interestExpense": {
+                    "raw": -34558000,
+                    "fmt": "-34.56M",
+                    "longFmt": "-34,558,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 701381000,
+                    "fmt": "701.38M",
+                    "longFmt": "701,381,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 317120000,
+                    "fmt": "317.12M",
+                    "longFmt": "317,120,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 84466000,
+                    "fmt": "84.47M",
+                    "longFmt": "84,466,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 384261000,
+                    "fmt": "384.26M",
+                    "longFmt": "384,261,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 381354000,
+                    "fmt": "381.35M",
+                    "longFmt": "381,354,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -76584000,
+                    "fmt": "-76.58M",
+                    "longFmt": "-76,584,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistoryQuarterly-BFLY.json
+++ b/tests/http/quoteSummary-incomeStatementHistoryQuarterly-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=incomeStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "8aht8stg2qdt6"
+      ],
+      "x-yahoo-request-id": [
+        "8aht8stg2qdt6"
+      ],
+      "x-request-id": [
+        "04ed0e3e-e75c-4f77-a18b-7783e0943ecd"
+      ],
+      "content-length": [
+        "123"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:02 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-indexTrend-BEKE.json
+++ b/tests/http/quoteSummary-indexTrend-BEKE.json
@@ -1,0 +1,109 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=indexTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "9so3989g2qdt6"
+      ],
+      "x-yahoo-request-id": [
+        "9so3989g2qdt6"
+      ],
+      "x-request-id": [
+        "cdbd5975-f154-411f-97c7-5af78c5784fa"
+      ],
+      "content-length": [
+        "321"
+      ],
+      "x-envoy-upstream-service-time": [
+        "5"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:02 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 5.56217,
+              "pegRatio": 0.991258,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.269
+                },
+                {
+                  "period": "+1q",
+                  "growth": 0.96099997
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.148
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.155
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0821053
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-indexTrend-BFLY.json
+++ b/tests/http/quoteSummary-indexTrend-BFLY.json
@@ -1,0 +1,109 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=indexTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "8h7ob2lg2qdt6"
+      ],
+      "x-yahoo-request-id": [
+        "8h7ob2lg2qdt6"
+      ],
+      "x-request-id": [
+        "0de05264-7b58-4367-b1f8-2e54d358fbe6"
+      ],
+      "content-length": [
+        "321"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:02 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 5.56217,
+              "pegRatio": 0.991258,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.269
+                },
+                {
+                  "period": "+1q",
+                  "growth": 0.96099997
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.148
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.155
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0821053
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-industryTrend-BEKE.json
+++ b/tests/http/quoteSummary-industryTrend-BEKE.json
@@ -1,0 +1,83 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=industryTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "et376jhg2qdt6"
+      ],
+      "x-yahoo-request-id": [
+        "et376jhg2qdt6"
+      ],
+      "x-request-id": [
+        "1f084512-230d-4033-a646-06407f3d2a80"
+      ],
+      "content-length": [
+        "102"
+      ],
+      "x-envoy-upstream-service-time": [
+        "5"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:02 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-industryTrend-BFLY.json
+++ b/tests/http/quoteSummary-industryTrend-BFLY.json
@@ -1,0 +1,83 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=industryTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "05djdc1g2qdt6"
+      ],
+      "x-yahoo-request-id": [
+        "05djdc1g2qdt6"
+      ],
+      "x-request-id": [
+        "01452992-d6d0-43ef-950c-62dd5ae9762c"
+      ],
+      "content-length": [
+        "102"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:02 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderHolders-BEKE.json
+++ b/tests/http/quoteSummary-insiderHolders-BEKE.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=insiderHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "87g9hppg2qdt7"
+      ],
+      "x-yahoo-request-id": [
+        "87g9hppg2qdt7"
+      ],
+      "x-request-id": [
+        "beb997f1-89d4-421c-a81d-df39d67bce83"
+      ],
+      "content-length": [
+        "87"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:02 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "insiderHolders": {
+              "holders": [],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderHolders-BFLY.json
+++ b/tests/http/quoteSummary-insiderHolders-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=insiderHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "0uv5r5dg2qdt7"
+      ],
+      "x-yahoo-request-id": [
+        "0uv5r5dg2qdt7"
+      ],
+      "x-request-id": [
+        "c1d8031e-e05d-4dd2-b1cb-562bb7a292a7"
+      ],
+      "content-length": [
+        "87"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:02 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "insiderHolders": {
+              "holders": [],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderTransactions-BEKE.json
+++ b/tests/http/quoteSummary-insiderTransactions-BEKE.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=insiderTransactions"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "eh70kbdg2qdt7"
+      ],
+      "x-yahoo-request-id": [
+        "eh70kbdg2qdt7"
+      ],
+      "x-request-id": [
+        "fc0a0af9-2ff9-469e-a135-5a9e04b2cefb"
+      ],
+      "content-length": [
+        "152"
+      ],
+      "x-envoy-upstream-service-time": [
+        "6"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:03 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=insiderTransactions"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderTransactions-BFLY.json
+++ b/tests/http/quoteSummary-insiderTransactions-BFLY.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=insiderTransactions"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "77cvua5g2qdt7"
+      ],
+      "x-yahoo-request-id": [
+        "77cvua5g2qdt7"
+      ],
+      "x-request-id": [
+        "53889d75-5e83-4d73-84bd-ab8c1d026ef2"
+      ],
+      "content-length": [
+        "152"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:03 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=insiderTransactions"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-institutionOwnership-BEKE.json
+++ b/tests/http/quoteSummary-institutionOwnership-BEKE.json
@@ -1,0 +1,306 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=institutionOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "c7lnoclg2qdt7"
+      ],
+      "x-yahoo-request-id": [
+        "c7lnoclg2qdt7"
+      ],
+      "x-request-id": [
+        "a5c779d8-d83d-496e-9788-87eb5dc507f5"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "801"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:03 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Baillie Gifford and Company",
+                  "pctHeld": {
+                    "raw": 0.0198,
+                    "fmt": "1.98%"
+                  },
+                  "position": {
+                    "raw": 17631431,
+                    "fmt": "17.63M",
+                    "longFmt": "17,631,431"
+                  },
+                  "value": {
+                    "raw": 1085038263,
+                    "fmt": "1.09B",
+                    "longFmt": "1,085,038,263"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "SC US (TTGP) Ltd",
+                  "pctHeld": {
+                    "raw": 0.0123000005,
+                    "fmt": "1.23%"
+                  },
+                  "position": {
+                    "raw": 10964911,
+                    "fmt": "10.96M",
+                    "longFmt": "10,964,911"
+                  },
+                  "value": {
+                    "raw": 672149044,
+                    "fmt": "672.15M",
+                    "longFmt": "672,149,044"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "FMR, LLC",
+                  "pctHeld": {
+                    "raw": 0.0089,
+                    "fmt": "0.89%"
+                  },
+                  "position": {
+                    "raw": 7903919,
+                    "fmt": "7.9M",
+                    "longFmt": "7,903,919"
+                  },
+                  "value": {
+                    "raw": 486407175,
+                    "fmt": "486.41M",
+                    "longFmt": "486,407,175"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Capital World Investors",
+                  "pctHeld": {
+                    "raw": 0.0088,
+                    "fmt": "0.88%"
+                  },
+                  "position": {
+                    "raw": 7821189,
+                    "fmt": "7.82M",
+                    "longFmt": "7,821,189"
+                  },
+                  "value": {
+                    "raw": 479438885,
+                    "fmt": "479.44M",
+                    "longFmt": "479,438,885"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Blackrock Inc.",
+                  "pctHeld": {
+                    "raw": 0.0074,
+                    "fmt": "0.74%"
+                  },
+                  "position": {
+                    "raw": 6536139,
+                    "fmt": "6.54M",
+                    "longFmt": "6,536,139"
+                  },
+                  "value": {
+                    "raw": 402233994,
+                    "fmt": "402.23M",
+                    "longFmt": "402,233,994"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Hillhouse Capital Advisors Ltd.",
+                  "pctHeld": {
+                    "raw": 0.0056,
+                    "fmt": "0.56%"
+                  },
+                  "position": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "value": {
+                    "raw": 306500000,
+                    "fmt": "306.5M",
+                    "longFmt": "306,500,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "D1 Capital Partners, LP",
+                  "pctHeld": {
+                    "raw": 0.0056,
+                    "fmt": "0.56%"
+                  },
+                  "position": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "value": {
+                    "raw": 306500000,
+                    "fmt": "306.5M",
+                    "longFmt": "306,500,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Credit Suisse Ag/",
+                  "pctHeld": {
+                    "raw": 0.0043,
+                    "fmt": "0.43%"
+                  },
+                  "position": {
+                    "raw": 3778354,
+                    "fmt": "3.78M",
+                    "longFmt": "3,778,354"
+                  },
+                  "value": {
+                    "raw": 231613100,
+                    "fmt": "231.61M",
+                    "longFmt": "231,613,100"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Group, Inc. (The)",
+                  "pctHeld": {
+                    "raw": 0.0042,
+                    "fmt": "0.42%"
+                  },
+                  "position": {
+                    "raw": 3750841,
+                    "fmt": "3.75M",
+                    "longFmt": "3,750,841"
+                  },
+                  "value": {
+                    "raw": 229926553,
+                    "fmt": "229.93M",
+                    "longFmt": "229,926,553"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Sumitomo Mitsui Trust Holdings, Inc.",
+                  "pctHeld": {
+                    "raw": 0.004,
+                    "fmt": "0.40%"
+                  },
+                  "position": {
+                    "raw": 3512686,
+                    "fmt": "3.51M",
+                    "longFmt": "3,512,686"
+                  },
+                  "value": {
+                    "raw": 216170696,
+                    "fmt": "216.17M",
+                    "longFmt": "216,170,696"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-institutionOwnership-BFLY.json
+++ b/tests/http/quoteSummary-institutionOwnership-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=institutionOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "6ruaf9pg2qdt7"
+      ],
+      "x-yahoo-request-id": [
+        "6ruaf9pg2qdt7"
+      ],
+      "x-request-id": [
+        "c539a90e-801b-41cd-9eab-69df50d2e88f"
+      ],
+      "content-length": [
+        "99"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:03 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorDirectHolders-BEKE.json
+++ b/tests/http/quoteSummary-majorDirectHolders-BEKE.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=majorDirectHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "90g75vlg2qdt7"
+      ],
+      "x-yahoo-request-id": [
+        "90g75vlg2qdt7"
+      ],
+      "x-request-id": [
+        "c7588a06-a278-4b70-8d5d-721213652e96"
+      ],
+      "content-length": [
+        "91"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:03 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorDirectHolders-BFLY.json
+++ b/tests/http/quoteSummary-majorDirectHolders-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=majorDirectHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "4tip9q1g2qdt8"
+      ],
+      "x-yahoo-request-id": [
+        "4tip9q1g2qdt8"
+      ],
+      "x-request-id": [
+        "31851f62-afc6-42df-b6ba-41efd0106d16"
+      ],
+      "content-length": [
+        "91"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:03 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorHoldersBreakdown-BEKE.json
+++ b/tests/http/quoteSummary-majorHoldersBreakdown-BEKE.json
@@ -1,0 +1,85 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=majorHoldersBreakdown"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "05jgmf5g2qdt8"
+      ],
+      "x-yahoo-request-id": [
+        "05jgmf5g2qdt8"
+      ],
+      "x-request-id": [
+        "f6d08f70-dfa7-471c-b418-f4d8dcd516f0"
+      ],
+      "content-length": [
+        "213"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:04 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.0090499995,
+              "institutionsPercentHeld": 0.14386,
+              "institutionsFloatPercentHeld": 0.14517,
+              "institutionsCount": 234
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorHoldersBreakdown-BFLY.json
+++ b/tests/http/quoteSummary-majorHoldersBreakdown-BFLY.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=majorHoldersBreakdown"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "652ja0pg2qdt8"
+      ],
+      "x-yahoo-request-id": [
+        "652ja0pg2qdt8"
+      ],
+      "x-request-id": [
+        "6024180c-aa3f-4e7c-9e01-64b3efd7c95b"
+      ],
+      "content-length": [
+        "81"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:04 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorHoldersBreakdown": {
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-netSharePurchaseActivity-BEKE.json
+++ b/tests/http/quoteSummary-netSharePurchaseActivity-BEKE.json
@@ -1,0 +1,89 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=netSharePurchaseActivity"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "5lmrkvtg2qdt8"
+      ],
+      "x-yahoo-request-id": [
+        "5lmrkvtg2qdt8"
+      ],
+      "x-request-id": [
+        "6a74a627-9104-49bb-9bc9-433b89d67fdb"
+      ],
+      "content-length": [
+        "246"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:04 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 0,
+              "buyInfoShares": 0,
+              "sellInfoCount": 0,
+              "netInfoCount": 0,
+              "netInfoShares": 0,
+              "netPercentInsiderShares": 0,
+              "totalInsiderShares": 10667953
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-netSharePurchaseActivity-BFLY.json
+++ b/tests/http/quoteSummary-netSharePurchaseActivity-BFLY.json
@@ -1,0 +1,88 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=netSharePurchaseActivity"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "88nd891g2qdt8"
+      ],
+      "x-yahoo-request-id": [
+        "88nd891g2qdt8"
+      ],
+      "x-request-id": [
+        "1182ab7f-3eff-4c32-961b-82ba1f510ff2"
+      ],
+      "content-length": [
+        "209"
+      ],
+      "x-envoy-upstream-service-time": [
+        "85"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:04 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 0,
+              "buyInfoShares": 0,
+              "sellInfoCount": 0,
+              "netInfoCount": 0,
+              "netInfoShares": 0,
+              "totalInsiderShares": 0
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-price-BEKE.json
+++ b/tests/http/quoteSummary-price-BEKE.json
@@ -1,0 +1,116 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=price"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "0qghb5dg2qdt8"
+      ],
+      "x-yahoo-request-id": [
+        "0qghb5dg2qdt8"
+      ],
+      "x-request-id": [
+        "2223cb0a-e968-4920-a30f-71411971db34"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "454"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:04 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": -0.0220588,
+              "preMarketChange": -1.5,
+              "preMarketTime": 1613572197,
+              "preMarketPrice": 66.5,
+              "preMarketSource": "FREE_REALTIME",
+              "regularMarketChangePercent": -0.03132349,
+              "regularMarketChange": -2.1299973,
+              "regularMarketTime": 1613576103,
+              "priceHint": 2,
+              "regularMarketPrice": 65.87,
+              "regularMarketDayHigh": 67.82,
+              "regularMarketDayLow": 65.25,
+              "regularMarketVolume": 2244401,
+              "regularMarketPreviousClose": 68,
+              "regularMarketSource": "FREE_REALTIME",
+              "regularMarketOpen": 66.39,
+              "exchange": "NYQ",
+              "exchangeName": "NYSE",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "EQUITY",
+              "symbol": "BEKE",
+              "underlyingSymbol": null,
+              "shortName": "KE Holdings Inc",
+              "longName": "KE Holdings Inc.",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 77646241792
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-price-BFLY.json
+++ b/tests/http/quoteSummary-price-BFLY.json
@@ -1,0 +1,115 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=price"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "2ujnpp9g2qdt9"
+      ],
+      "x-yahoo-request-id": [
+        "2ujnpp9g2qdt9"
+      ],
+      "x-request-id": [
+        "7fbcd69b-c7ae-4913-847c-0e8ef3d51405"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "443"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:04 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": 0.0288889,
+              "preMarketChange": 0.65,
+              "preMarketTime": 1613572193,
+              "preMarketPrice": 23.15,
+              "preMarketSource": "FREE_REALTIME",
+              "regularMarketChangePercent": 0.004888916,
+              "regularMarketChange": 0.11000061,
+              "regularMarketTime": 1613576096,
+              "priceHint": 2,
+              "regularMarketPrice": 22.61,
+              "regularMarketDayHigh": 23.31,
+              "regularMarketDayLow": 22.1807,
+              "regularMarketVolume": 1121012,
+              "regularMarketPreviousClose": 22.5,
+              "regularMarketSource": "FREE_REALTIME",
+              "regularMarketOpen": 23.11,
+              "exchange": "NYQ",
+              "exchangeName": "NYSE",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "EQUITY",
+              "symbol": "BFLY",
+              "underlyingSymbol": null,
+              "shortName": "Butterfly Network, Inc. Class A",
+              "longName": "Butterfly Network, Inc.",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-quoteType-BEKE.json
+++ b/tests/http/quoteSummary-quoteType-BEKE.json
@@ -1,0 +1,93 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=quoteType"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "ekgtif5g2qdt9"
+      ],
+      "x-yahoo-request-id": [
+        "ekgtif5g2qdt9"
+      ],
+      "x-request-id": [
+        "caf57817-c972-49cf-afca-422f2f45ecaa"
+      ],
+      "content-length": [
+        "424"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:04 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "quoteType": {
+              "exchange": "NYQ",
+              "quoteType": "EQUITY",
+              "symbol": "BEKE",
+              "underlyingSymbol": "BEKE",
+              "shortName": "KE Holdings Inc",
+              "longName": "KE Holdings Inc.",
+              "firstTradeDateEpochUtc": 1597325400,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "36c211a8-04c4-368b-8141-b3e0d4048354",
+              "messageBoardId": "finmb_665898843",
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-quoteType-BFLY.json
+++ b/tests/http/quoteSummary-quoteType-BFLY.json
@@ -1,0 +1,93 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=quoteType"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "9ug0i31g2qdt9"
+      ],
+      "x-yahoo-request-id": [
+        "9ug0i31g2qdt9"
+      ],
+      "x-request-id": [
+        "47e1beb3-1ef1-44ad-8fe9-e6eab72e8b2e"
+      ],
+      "content-length": [
+        "434"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:05 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "quoteType": {
+              "exchange": "NYQ",
+              "quoteType": "EQUITY",
+              "symbol": "BFLY",
+              "underlyingSymbol": "BFLY",
+              "shortName": "Butterfly Network, Inc. Class A",
+              "longName": "Butterfly Network, Inc.",
+              "firstTradeDateEpochUtc": 1594647000,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "5f9449d1-1162-3804-a742-88e2f8b5fb0e",
+              "messageBoardId": null,
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-recommendationTrend-BEKE.json
+++ b/tests/http/quoteSummary-recommendationTrend-BEKE.json
@@ -1,0 +1,115 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=recommendationTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "a3ke3u1g2qdt9"
+      ],
+      "x-yahoo-request-id": [
+        "a3ke3u1g2qdt9"
+      ],
+      "x-request-id": [
+        "e4ee7c98-af2d-4a57-a4c3-84155a92b4d3"
+      ],
+      "content-length": [
+        "380"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:05 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 2,
+                  "buy": 3,
+                  "hold": 5,
+                  "sell": 1,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 1,
+                  "buy": 3,
+                  "hold": 5,
+                  "sell": 1,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 0,
+                  "buy": 3,
+                  "hold": 5,
+                  "sell": 1,
+                  "strongSell": 0
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-recommendationTrend-BFLY.json
+++ b/tests/http/quoteSummary-recommendationTrend-BFLY.json
@@ -1,0 +1,115 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=recommendationTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "5hetiudg2qdt9"
+      ],
+      "x-yahoo-request-id": [
+        "5hetiudg2qdt9"
+      ],
+      "x-request-id": [
+        "3293abb5-8891-436d-a1f7-b9da5e820391"
+      ],
+      "content-length": [
+        "380"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:05 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-secFilings-BEKE.json
+++ b/tests/http/quoteSummary-secFilings-BEKE.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=secFilings"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "e1nbc95g2qdt9"
+      ],
+      "x-yahoo-request-id": [
+        "e1nbc95g2qdt9"
+      ],
+      "x-request-id": [
+        "24e26556-e3ef-4398-a5f6-75b30a001103"
+      ],
+      "content-length": [
+        "143"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:05 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=secFilings"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-secFilings-BFLY.json
+++ b/tests/http/quoteSummary-secFilings-BFLY.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=secFilings"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "6laj99pg2qdt9"
+      ],
+      "x-yahoo-request-id": [
+        "6laj99pg2qdt9"
+      ],
+      "x-request-id": [
+        "afedbaf9-3b6c-415a-83a8-e261fc4bd1d5"
+      ],
+      "content-length": [
+        "143"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:05 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=secFilings"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryDetail-BEKE.json
+++ b/tests/http/quoteSummary-summaryDetail-BEKE.json
@@ -1,0 +1,114 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=summaryDetail"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "a462j3lg2qdt9"
+      ],
+      "x-yahoo-request-id": [
+        "a462j3lg2qdt9"
+      ],
+      "x-request-id": [
+        "3a5af4d7-49af-4656-9c9e-15728bf1256d"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "382"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:05 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "2"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 68,
+              "open": 66.39,
+              "dayLow": 65.25,
+              "dayHigh": 67.82,
+              "regularMarketPreviousClose": 68,
+              "regularMarketOpen": 66.39,
+              "regularMarketDayLow": 65.25,
+              "regularMarketDayHigh": 67.82,
+              "payoutRatio": 0,
+              "volume": 2244651,
+              "regularMarketVolume": 2244651,
+              "averageVolume": 3760300,
+              "averageVolume10days": 5531066,
+              "averageDailyVolume10Day": 5531066,
+              "bid": 66.81,
+              "ask": 66.82,
+              "bidSize": 1000,
+              "askSize": 1000,
+              "marketCap": 77646241792,
+              "fiftyTwoWeekLow": 31.79,
+              "fiftyTwoWeekHigh": 79.4,
+              "fiftyDayAverage": 64.594246,
+              "twoHundredDayAverage": 61.68664,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryDetail-BFLY.json
+++ b/tests/http/quoteSummary-summaryDetail-BFLY.json
@@ -1,0 +1,112 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=summaryDetail"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "064553hg2qdta"
+      ],
+      "x-yahoo-request-id": [
+        "064553hg2qdta"
+      ],
+      "x-request-id": [
+        "39f8c1f4-c3dd-492a-b6b0-9543e921db5c"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "331"
+      ],
+      "x-envoy-upstream-service-time": [
+        "5"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:06 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 22.5,
+              "open": 23.11,
+              "dayLow": 22.1807,
+              "dayHigh": 23.31,
+              "regularMarketPreviousClose": 22.5,
+              "regularMarketOpen": 23.11,
+              "regularMarketDayLow": 22.1807,
+              "regularMarketDayHigh": 23.31,
+              "volume": 1121012,
+              "regularMarketVolume": 1121012,
+              "averageVolume": 2347300,
+              "averageVolume10days": 2347300,
+              "averageDailyVolume10Day": 2347300,
+              "bid": 22.52,
+              "ask": 22.56,
+              "bidSize": 1000,
+              "askSize": 900,
+              "fiftyTwoWeekLow": 21.95,
+              "fiftyTwoWeekHigh": 24.8,
+              "fiftyDayAverage": 22.5,
+              "twoHundredDayAverage": 22.5,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryProfile-BEKE.json
+++ b/tests/http/quoteSummary-summaryProfile-BEKE.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=summaryProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "cn5dqsdg2qdta"
+      ],
+      "x-yahoo-request-id": [
+        "cn5dqsdg2qdta"
+      ],
+      "x-request-id": [
+        "ee52fa21-13f4-409a-8334-f139e1383e8d"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "502"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:06 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryProfile": {
+              "address1": "Building Fudao",
+              "address2": "No.11 Kaituo Road Haidian District",
+              "city": "Beijing",
+              "zip": "100085",
+              "country": "China",
+              "phone": "86 10 5810 4689",
+              "website": "http://ke.com",
+              "industry": "Real Estate Services",
+              "sector": "Real Estate",
+              "longBusinessSummary": "KE Holdings Inc. operates an integrated online and offline platform for housing transactions and services in the People's Republic of China. The company facilitates various housing transactions ranging from existing and new home sales and home rentals to home renovation, real estate financial solutions, and other services. It also owns and operates Lianjia, a real estate brokerage branded store. The company was founded in 2001 and is headquartered in Beijing, China.",
+              "companyOfficers": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryProfile-BFLY.json
+++ b/tests/http/quoteSummary-summaryProfile-BFLY.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=summaryProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "719mv19g2qdta"
+      ],
+      "x-yahoo-request-id": [
+        "719mv19g2qdta"
+      ],
+      "x-request-id": [
+        "8830b3da-6210-4593-b3bf-e765f2dc53f7"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "582"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:06 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryProfile": {
+              "address1": "530 Old Whitfield Street",
+              "city": "Guilford",
+              "state": "CT",
+              "zip": "06437",
+              "country": "United States",
+              "phone": "203-458-2514",
+              "website": "http://english.butterflynetwork.com",
+              "industry": "Medical Devices",
+              "sector": "Healthcare",
+              "longBusinessSummary": "Butterfly Network, Inc. develops medical imaging device for hospitals and organizations to scale their point of care ultrasound programs through a new suite of tools that enable ultrasound workflow mobile and system integrations simple and secure. The company's device provides diagnostic imaging and measurement of blood vessels and examines the cardiac, abdominal, urological, fetal, gynecological, and musculoskeletal systems. The company also offers Butterfly iQ, a handheld and single-probe whole body ultrasound system. The company was founded in 2011 and is based in Guilford, Connecticut.",
+              "companyOfficers": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-upgradeDowngradeHistory-BEKE.json
+++ b/tests/http/quoteSummary-upgradeDowngradeHistory-BEKE.json
@@ -1,0 +1,90 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=upgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "ep5egm5g2qdta"
+      ],
+      "x-yahoo-request-id": [
+        "ep5egm5g2qdta"
+      ],
+      "x-request-id": [
+        "c9bb9b10-86ea-4b1c-ad3d-197fdc73ca53"
+      ],
+      "content-length": [
+        "195"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:06 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "upgradeDowngradeHistory": {
+              "history": [
+                {
+                  "epochGradeDate": 1609859636,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-upgradeDowngradeHistory-BFLY.json
+++ b/tests/http/quoteSummary-upgradeDowngradeHistory-BFLY.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=upgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "7m9h5d9g2qdta"
+      ],
+      "x-yahoo-request-id": [
+        "7m9h5d9g2qdta"
+      ],
+      "x-request-id": [
+        "3491d947-194c-47c6-877f-8d9e7973f000"
+      ],
+      "content-length": [
+        "156"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:35:06 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=upgradeDowngradeHistory"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-BEKE.json
+++ b/tests/http/recommendationsBySymbol-BEKE.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/BEKE?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "97cn2cpg2qdt1"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "157"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:34:57 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "BEKE",
+            "recommendedSymbols": [
+              {
+                "symbol": "DOYU",
+                "score": 0.058686
+              },
+              {
+                "symbol": "API",
+                "score": 0.05831
+              },
+              {
+                "symbol": "FUTU",
+                "score": 0.057564
+              },
+              {
+                "symbol": "YSG",
+                "score": 0.056893
+              },
+              {
+                "symbol": "DADA",
+                "score": 0.055502
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-BFLY.json
+++ b/tests/http/recommendationsBySymbol-BFLY.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/BFLY?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "ahvt6jlg2qdt1"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "161"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:34:57 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "BFLY",
+            "recommendedSymbols": [
+              {
+                "symbol": "LGVW",
+                "score": 0.028571
+              },
+              {
+                "symbol": "TGLO",
+                "score": 0.020148
+              },
+              {
+                "symbol": "AWEB",
+                "score": 0.018328
+              },
+              {
+                "symbol": "CMLF",
+                "score": 0.015492
+              },
+              {
+                "symbol": "EXPC",
+                "score": 0.014967
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/search-BEKE.json
+++ b/tests/http/search-BEKE.json
@@ -1,0 +1,186 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v1/finance/search?lang=en-US&region=US&quotesCount=6&newsCount=4&enableFuzzyQuery=false&quotesQueryId=tss_match_phrase_query&multiQuoteQueryId=multi_quote_single_token_query&newsQueryId=news_cie_vespa&enableCb=true&enableNavLinks=true&enableEnhancedTrivialQuery=true&q=BEKE"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=120, stale-while-revalidate=180"
+      ],
+      "y-rid": [
+        "asqjs81g2qdt1"
+      ],
+      "x-yahoo-request-id": [
+        "asqjs81g2qdt1"
+      ],
+      "x-request-id": [
+        "2e483732-d968-4a79-a55c-f2cb8481930e"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "975"
+      ],
+      "x-envoy-upstream-service-time": [
+        "37"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:34:57 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-search--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "explains": [],
+      "count": 10,
+      "quotes": [
+        {
+          "exchange": "NYQ",
+          "shortname": "KE Holdings Inc",
+          "quoteType": "EQUITY",
+          "symbol": "BEKE",
+          "index": "quotes",
+          "score": 3171900,
+          "typeDisp": "Equity",
+          "longname": "KE Holdings Inc.",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "PNK",
+          "shortname": "BEKEM METALS INC",
+          "quoteType": "EQUITY",
+          "symbol": "BKMM",
+          "index": "quotes",
+          "score": 20033,
+          "typeDisp": "Equity",
+          "longname": "Bekem Metals, Inc.",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "BRU",
+          "shortname": "TER BEKE",
+          "quoteType": "EQUITY",
+          "symbol": "TERB.BR",
+          "index": "quotes",
+          "score": 20030,
+          "typeDisp": "Equity",
+          "longname": "Ter Beke NV",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "OPR",
+          "shortname": "BEKE Mar 2021 80.000 call",
+          "quoteType": "OPTION",
+          "symbol": "BEKE210319C00080000",
+          "index": "quotes",
+          "score": 20006,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "OPR",
+          "shortname": "BEKE Jan 2023 80.000 call",
+          "quoteType": "OPTION",
+          "symbol": "BEKE230120C00080000",
+          "index": "quotes",
+          "score": 20004,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "OPR",
+          "shortname": "BEKE Apr 2021 115.000 call",
+          "quoteType": "OPTION",
+          "symbol": "BEKE210416C00115000",
+          "index": "quotes",
+          "score": 20003,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        }
+      ],
+      "news": [
+        {
+          "uuid": "3f33877f-d553-3330-be49-03f87c8cabc4",
+          "title": "Is the Options Market Predicting a Spike in KE Holdings (BEKE) Stock?",
+          "publisher": "Zacks",
+          "link": "https://finance.yahoo.com/news/options-market-predicting-spike-ke-134701283.html",
+          "providerPublishTime": 1610027221,
+          "type": "STORY"
+        },
+        {
+          "uuid": "533b5a72-a0b2-3fdf-a82f-a946f0905d74",
+          "title": "Why This 'Redfin of China' Should Be on Your Stock Watch List",
+          "publisher": "Motley Fool",
+          "link": "https://finance.yahoo.com/m/533b5a72-a0b2-3fdf-a82f-a946f0905d74/why-this-%27redfin-of-china%27.html",
+          "providerPublishTime": 1608126147,
+          "type": "STORY"
+        },
+        {
+          "uuid": "235e86f1-ba04-3066-8d49-be911ecab0d1",
+          "title": "JLL vs. BEKE: Which Stock Should Value Investors Buy Now?",
+          "publisher": "Zacks",
+          "link": "https://finance.yahoo.com/news/jll-vs-beke-stock-value-164004152.html",
+          "providerPublishTime": 1610037604,
+          "type": "STORY"
+        },
+        {
+          "uuid": "e45f1067-7704-3d7d-ad65-8a669633c34a",
+          "title": "Breakeven Is Near for KE Holdings Inc. (NYSE:BEKE)",
+          "publisher": "Simply Wall St.",
+          "link": "https://finance.yahoo.com/news/breakeven-near-ke-holdings-inc-052423184.html",
+          "providerPublishTime": 1613021063,
+          "type": "STORY"
+        }
+      ],
+      "nav": [],
+      "lists": [],
+      "researchReports": [],
+      "totalTime": 35,
+      "timeTakenForQuotes": 424,
+      "timeTakenForNews": 600,
+      "timeTakenForAlgowatchlist": 400,
+      "timeTakenForPredefinedScreener": 400,
+      "timeTakenForCrunchbase": 400,
+      "timeTakenForNav": 400,
+      "timeTakenForResearchReports": 0
+    }
+  }
+}

--- a/tests/http/search-BFLY.json
+++ b/tests/http/search-BFLY.json
@@ -1,0 +1,179 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v1/finance/search?lang=en-US&region=US&quotesCount=6&newsCount=4&enableFuzzyQuery=false&quotesQueryId=tss_match_phrase_query&multiQuoteQueryId=multi_quote_single_token_query&newsQueryId=news_cie_vespa&enableCb=true&enableNavLinks=true&enableEnhancedTrivialQuery=true&q=BFLY"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=120, stale-while-revalidate=180"
+      ],
+      "y-rid": [
+        "f885pe9g2qdt1"
+      ],
+      "x-yahoo-request-id": [
+        "f885pe9g2qdt1"
+      ],
+      "x-request-id": [
+        "fef6eb6a-3353-4574-99f9-e36caba80bba"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "956"
+      ],
+      "x-envoy-upstream-service-time": [
+        "24"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 15:34:57 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-search--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "4"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "explains": [],
+      "count": 10,
+      "quotes": [
+        {
+          "exchange": "NYQ",
+          "quoteType": "EQUITY",
+          "symbol": "BFLY",
+          "index": "quotes",
+          "score": 6615100,
+          "typeDisp": "Equity",
+          "longname": "Butterfly Network, Inc.",
+          "isYahooFinance": true,
+          "newListingDate": "2021-02-16"
+        },
+        {
+          "exchange": "OPR",
+          "quoteType": "OPTION",
+          "symbol": "BFLY210319P00025000",
+          "index": "quotes",
+          "score": 20890,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "NYQ",
+          "quoteType": "EQUITY",
+          "symbol": "BFLY-WT",
+          "index": "quotes",
+          "score": 20866,
+          "typeDisp": "Equity",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "OPR",
+          "quoteType": "OPTION",
+          "symbol": "BFLY210319P00015000",
+          "index": "quotes",
+          "score": 20243,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "OPR",
+          "quoteType": "OPTION",
+          "symbol": "BFLY210716P00035000",
+          "index": "quotes",
+          "score": 20039,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "OPR",
+          "quoteType": "OPTION",
+          "symbol": "BFLY210219P00012500",
+          "index": "quotes",
+          "score": 20023,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        }
+      ],
+      "news": [
+        {
+          "uuid": "72c5cf01-8a4d-3a4c-b14b-2de4c12217c6",
+          "title": "Butterfly Network Goes Public, Taking Portable Ultrasound Device Global",
+          "publisher": "IPO-Edge.com",
+          "link": "https://finance.yahoo.com/news/butterfly-network-goes-public-taking-110022864.html",
+          "providerPublishTime": 1613473222,
+          "type": "STORY"
+        },
+        {
+          "uuid": "6d1a2e8d-dc02-3e4c-abe4-b4816c8a7ea9",
+          "title": "Butterfly Network, a Global Leader in Democratizing Medical Imaging, Closes Business Combination and Will Begin Trading on the New York Stock Exchange",
+          "publisher": "PR Newswire",
+          "link": "https://finance.yahoo.com/news/butterfly-network-global-leader-democratizing-110000819.html",
+          "providerPublishTime": 1613473200,
+          "type": "STORY"
+        },
+        {
+          "uuid": "aee165c1-9b33-3afe-bf7c-ec0226f7ec4b",
+          "title": "Butterfly Network, a global leader in democratizing medical imaging, to be listed on NYSE through a merger with Longview Acquisition Corp.",
+          "publisher": "PR Newswire",
+          "link": "https://finance.yahoo.com/news/butterfly-network-global-leader-democratizing-120000797.html",
+          "providerPublishTime": 1605873600,
+          "type": "STORY"
+        },
+        {
+          "uuid": "d1980323-e654-3b3b-b9ff-280876c0f2d5",
+          "title": "SHAREHOLDER ALERT: WeissLaw LLP Investigates Longview Acquisition Corp.",
+          "publisher": "PR Newswire",
+          "link": "https://finance.yahoo.com/news/shareholder-alert-weisslaw-llp-investigates-011300059.html",
+          "providerPublishTime": 1605921180,
+          "type": "STORY"
+        }
+      ],
+      "nav": [],
+      "lists": [],
+      "researchReports": [],
+      "totalTime": 23,
+      "timeTakenForQuotes": 418,
+      "timeTakenForNews": 600,
+      "timeTakenForAlgowatchlist": 400,
+      "timeTakenForPredefinedScreener": 400,
+      "timeTakenForCrunchbase": 400,
+      "timeTakenForNav": 400,
+      "timeTakenForResearchReports": 0
+    }
+  }
+}


### PR DESCRIPTION
Ref #51 
This PR switches from using `it()` alone to `it.each()` for the `search`, `historical`, and `autoc` modules.

## Changes
- Use `it.each(testSymbols)` instead of `it()` alone.

## Benefits
- Makes sure that the validation is working properly and isn't being too strict
- Makes sure that #57, #42, #46, etc. won't pop up

## Comments
- CI will fail, there are a few problems with the `quoteSummary` module (fixed in #64)