### PR TITLE
fix(validation): make a few quoteSummary properties optional

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -2059,11 +2059,7 @@
         }
       },
       "required": [
-        "maxAge",
-        "insidersPercentHeld",
-        "institutionsPercentHeld",
-        "institutionsFloatPercentHeld",
-        "institutionsCount"
+        "maxAge"
       ],
       "type": "object"
     },
@@ -2202,7 +2198,6 @@
         "sellInfoCount",
         "netInfoCount",
         "netInfoShares",
-        "netPercentInsiderShares",
         "totalInsiderShares"
       ],
       "type": "object"

--- a/src/modules/quoteSummary-iface.ts
+++ b/src/modules/quoteSummary-iface.ts
@@ -607,12 +607,11 @@ export enum OwnershipEnum {
 
 export interface MajorHoldersBreakdown {
   maxAge: number;
-  insidersPercentHeld: number;
-  institutionsPercentHeld: number;
-  institutionsFloatPercentHeld: number;
-  institutionsCount: number;
+  insidersPercentHeld?: number;
+  institutionsPercentHeld?: number;
+  institutionsFloatPercentHeld?: number;
+  institutionsCount?: number;
 }
-
 export interface NetSharePurchaseActivity {
   maxAge: number;
   period: string;
@@ -624,7 +623,7 @@ export interface NetSharePurchaseActivity {
   sellPercentInsiderShares?: number;
   netInfoCount: number;
   netInfoShares: number;
-  netPercentInsiderShares: number;
+  netPercentInsiderShares?: number;
   totalInsiderShares: number;
 }
 

--- a/tests/http/quoteSummary-all-BEKE.json
+++ b/tests/http/quoteSummary-all-BEKE.json
@@ -1,0 +1,3685 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=assetProfile%2CbalanceSheetHistory%2CbalanceSheetHistoryQuarterly%2CcalendarEvents%2CcashflowStatementHistory%2CcashflowStatementHistoryQuarterly%2CdefaultKeyStatistics%2Cearnings%2CearningsHistory%2CearningsTrend%2CfinancialData%2CfundOwnership%2CfundPerformance%2CfundProfile%2CincomeStatementHistory%2CincomeStatementHistoryQuarterly%2CindexTrend%2CindustryTrend%2CinsiderHolders%2CinsiderTransactions%2CinstitutionOwnership%2CmajorDirectHolders%2CmajorHoldersBreakdown%2CnetSharePurchaseActivity%2Cprice%2CquoteType%2CrecommendationTrend%2CsecFilings%2CsectorTrend%2CsummaryDetail%2CsummaryProfile%2CtopHoldings%2CupgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "7eeokahg2qh40"
+      ],
+      "x-yahoo-request-id": [
+        "7eeokahg2qh40"
+      ],
+      "x-request-id": [
+        "f1cceb31-4c9b-4279-9b17-1d8c4e240939"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "20"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:52 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "Building Fudao",
+              "address2": "No.11 Kaituo Road Haidian District",
+              "city": "Beijing",
+              "zip": "100085",
+              "country": "China",
+              "phone": "86 10 5810 4689",
+              "website": "http://ke.com",
+              "industry": "Real Estate Services",
+              "sector": "Real Estate",
+              "longBusinessSummary": "KE Holdings Inc. operates an integrated online and offline platform for housing transactions and services in the People's Republic of China. The company facilitates various housing transactions ranging from existing and new home sales and home rentals to home renovation, real estate financial solutions, and other services. It also owns and operates Lianjia, a real estate brokerage branded store. The company was founded in 2001 and is headquartered in Beijing, China.",
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Hui  Zuo",
+                  "age": 49,
+                  "title": "Founder & Chairman",
+                  "yearBorn": 1971,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Yongdong  Peng",
+                  "age": 41,
+                  "title": "CEO & Exec. Director",
+                  "yearBorn": 1979,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Tao  Xu",
+                  "age": 47,
+                  "title": "Chief Financial Officer",
+                  "yearBorn": 1973,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Wangang  Xu",
+                  "age": 55,
+                  "title": "Co-Chief Operating Officer",
+                  "yearBorn": 1965,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Yongqun  Wang",
+                  "age": 49,
+                  "title": "Co-Chief Operating Officer",
+                  "yearBorn": 1971,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Yigang  Shan",
+                  "age": 47,
+                  "title": "Exec. Director",
+                  "yearBorn": 1973,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 2,
+                  "buy": 3,
+                  "hold": 5,
+                  "sell": 1,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 1,
+                  "buy": 3,
+                  "hold": 5,
+                  "sell": 1,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 0,
+                  "buy": 3,
+                  "hold": 5,
+                  "sell": 1,
+                  "strongSell": 0
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -2183546000,
+                    "fmt": "-2.18B",
+                    "longFmt": "-2,183,546,000"
+                  },
+                  "depreciation": {
+                    "raw": 1039318000,
+                    "fmt": "1.04B",
+                    "longFmt": "1,039,318,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 3018688000,
+                    "fmt": "3.02B",
+                    "longFmt": "3,018,688,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -5040865000,
+                    "fmt": "-5.04B",
+                    "longFmt": "-5,040,865,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 3009276000,
+                    "fmt": "3.01B",
+                    "longFmt": "3,009,276,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -412586000,
+                    "fmt": "-412.59M",
+                    "longFmt": "-412,586,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 112626000,
+                    "fmt": "112.63M",
+                    "longFmt": "112,626,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -703008000,
+                    "fmt": "-703.01M",
+                    "longFmt": "-703,008,000"
+                  },
+                  "investments": {
+                    "raw": -1133063000,
+                    "fmt": "-1.13B",
+                    "longFmt": "-1,133,063,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 91216000,
+                    "fmt": "91.22M",
+                    "longFmt": "91,216,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -3873722000,
+                    "fmt": "-3.87B",
+                    "longFmt": "-3,873,722,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 6758437000,
+                    "fmt": "6.76B",
+                    "longFmt": "6,758,437,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -8628000,
+                    "fmt": "-8.63M",
+                    "longFmt": "-8,628,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 23026396000,
+                    "fmt": "23.03B",
+                    "longFmt": "23,026,396,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -94922000,
+                    "fmt": "-94.92M",
+                    "longFmt": "-94,922,000"
+                  },
+                  "changeInCash": {
+                    "raw": 19170378000,
+                    "fmt": "19.17B",
+                    "longFmt": "19,170,378,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -347219000,
+                    "fmt": "-347.22M",
+                    "longFmt": "-347,219,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 232885000,
+                    "fmt": "232.88M",
+                    "longFmt": "232,885,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -467824000,
+                    "fmt": "-467.82M",
+                    "longFmt": "-467,824,000"
+                  },
+                  "depreciation": {
+                    "raw": 792294000,
+                    "fmt": "792.29M",
+                    "longFmt": "792,294,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -186336000,
+                    "fmt": "-186.34M",
+                    "longFmt": "-186,336,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -769062000,
+                    "fmt": "-769.06M",
+                    "longFmt": "-769,062,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 1157138000,
+                    "fmt": "1.16B",
+                    "longFmt": "1,157,138,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 2913832000,
+                    "fmt": "2.91B",
+                    "longFmt": "2,913,832,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 3216797000,
+                    "fmt": "3.22B",
+                    "longFmt": "3,216,797,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -542853000,
+                    "fmt": "-542.85M",
+                    "longFmt": "-542,853,000"
+                  },
+                  "investments": {
+                    "raw": 5239066000,
+                    "fmt": "5.24B",
+                    "longFmt": "5,239,066,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -2010792000,
+                    "fmt": "-2.01B",
+                    "longFmt": "-2,010,792,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 2609149000,
+                    "fmt": "2.61B",
+                    "longFmt": "2,609,149,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -124121000,
+                    "fmt": "-124.12M",
+                    "longFmt": "-124,121,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -437019000,
+                    "fmt": "-437.02M",
+                    "longFmt": "-437,019,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -1282408000,
+                    "fmt": "-1.28B",
+                    "longFmt": "-1,282,408,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 416000,
+                    "fmt": "416k",
+                    "longFmt": "416,000"
+                  },
+                  "changeInCash": {
+                    "raw": 4543954000,
+                    "fmt": "4.54B",
+                    "longFmt": "4,543,954,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -347219000,
+                    "fmt": "-347.22M",
+                    "longFmt": "-347,219,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 232885000,
+                    "fmt": "232.88M",
+                    "longFmt": "232,885,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -574430000,
+                    "fmt": "-574.43M",
+                    "longFmt": "-574,430,000"
+                  },
+                  "depreciation": {
+                    "raw": 811203000,
+                    "fmt": "811.2M",
+                    "longFmt": "811,203,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 164271000,
+                    "fmt": "164.27M",
+                    "longFmt": "164,271,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -498216000,
+                    "fmt": "-498.22M",
+                    "longFmt": "-498,216,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -764294000,
+                    "fmt": "-764.29M",
+                    "longFmt": "-764,294,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -5733411000,
+                    "fmt": "-5.73B",
+                    "longFmt": "-5,733,411,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -6456226000,
+                    "fmt": "-6.46B",
+                    "longFmt": "-6,456,226,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -575185000,
+                    "fmt": "-575.18M",
+                    "longFmt": "-575,185,000"
+                  },
+                  "investments": {
+                    "raw": -959123000,
+                    "fmt": "-959.12M",
+                    "longFmt": "-959,123,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -5000000,
+                    "fmt": "-5M",
+                    "longFmt": "-5,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -2783562000,
+                    "fmt": "-2.78B",
+                    "longFmt": "-2,783,562,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -127188000,
+                    "fmt": "-127.19M",
+                    "longFmt": "-127,188,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 973472000,
+                    "fmt": "973.47M",
+                    "longFmt": "973,472,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -437019000,
+                    "fmt": "-437.02M",
+                    "longFmt": "-437,019,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 9576284000,
+                    "fmt": "9.58B",
+                    "longFmt": "9,576,284,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -330000,
+                    "fmt": "-330k",
+                    "longFmt": "-330,000"
+                  },
+                  "changeInCash": {
+                    "raw": 336166000,
+                    "fmt": "336.17M",
+                    "longFmt": "336,166,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -347219000,
+                    "fmt": "-347.22M",
+                    "longFmt": "-347,219,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 232885000,
+                    "fmt": "232.88M",
+                    "longFmt": "232,885,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 5.56217,
+              "pegRatio": 0.991258,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.269
+                },
+                {
+                  "period": "+1q",
+                  "growth": 0.96099997
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.148
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.155
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0821053
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            },
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": 79355428864,
+              "forwardPE": 73.23334,
+              "profitMargins": -0.02313,
+              "floatShares": 389103285,
+              "sharesOutstanding": 1143379968,
+              "sharesShort": 11331624,
+              "sharesShortPriorMonth": 10275253,
+              "sharesShortPreviousMonthDate": 1609372800,
+              "dateShortInterest": 1611878400,
+              "sharesPercentSharesOut": 0.0095999995,
+              "heldPercentInsiders": 0.0090499995,
+              "heldPercentInstitutions": 0.14386,
+              "shortRatio": 3.25,
+              "category": null,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1577750400,
+              "nextFiscalYearEnd": 1640908800,
+              "mostRecentQuarter": 1601424000,
+              "earningsQuarterlyGrowth": -0.804,
+              "pegRatio": 117.17,
+              "lastSplitFactor": null,
+              "52WeekChange": 0.81623936,
+              "SandP52WeekChange": 0.16137505
+            },
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "quoteType": {
+              "exchange": "NYQ",
+              "quoteType": "EQUITY",
+              "symbol": "BEKE",
+              "underlyingSymbol": "BEKE",
+              "shortName": "KE Holdings Inc",
+              "longName": "KE Holdings Inc.",
+              "firstTradeDateEpochUtc": 1597325400,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "36c211a8-04c4-368b-8141-b3e0d4048354",
+              "messageBoardId": "finmb_665898843",
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            },
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 46014906000,
+                    "fmt": "46.01B",
+                    "longFmt": "46,014,906,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 34746862000,
+                    "fmt": "34.75B",
+                    "longFmt": "34,746,862,000"
+                  },
+                  "grossProfit": {
+                    "raw": 11268044000,
+                    "fmt": "11.27B",
+                    "longFmt": "11,268,044,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 1571154000,
+                    "fmt": "1.57B",
+                    "longFmt": "1,571,154,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 11482430000,
+                    "fmt": "11.48B",
+                    "longFmt": "11,482,430,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 47800446000,
+                    "fmt": "47.8B",
+                    "longFmt": "47,800,446,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -1785540000,
+                    "fmt": "-1.79B",
+                    "longFmt": "-1,785,540,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 509776000,
+                    "fmt": "509.78M",
+                    "longFmt": "509,776,000"
+                  },
+                  "ebit": {
+                    "raw": -1785540000,
+                    "fmt": "-1.79B",
+                    "longFmt": "-1,785,540,000"
+                  },
+                  "interestExpense": {
+                    "raw": -181099000,
+                    "fmt": "-181.1M",
+                    "longFmt": "-181,099,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -1275764000,
+                    "fmt": "-1.28B",
+                    "longFmt": "-1,275,764,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 904363000,
+                    "fmt": "904.36M",
+                    "longFmt": "904,363,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 87203000,
+                    "fmt": "87.2M",
+                    "longFmt": "87,203,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -2180127000,
+                    "fmt": "-2.18B",
+                    "longFmt": "-2,180,127,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -2183546000,
+                    "fmt": "-2.18B",
+                    "longFmt": "-2,183,546,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -4050074000,
+                    "fmt": "-4.05B",
+                    "longFmt": "-4,050,074,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 28646499000,
+                    "fmt": "28.65B",
+                    "longFmt": "28,646,499,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 21776523000,
+                    "fmt": "21.78B",
+                    "longFmt": "21,776,523,000"
+                  },
+                  "grossProfit": {
+                    "raw": 6869976000,
+                    "fmt": "6.87B",
+                    "longFmt": "6,869,976,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 670922000,
+                    "fmt": "670.92M",
+                    "longFmt": "670,922,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 7417059000,
+                    "fmt": "7.42B",
+                    "longFmt": "7,417,059,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 29864504000,
+                    "fmt": "29.86B",
+                    "longFmt": "29,864,504,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -1218005000,
+                    "fmt": "-1.22B",
+                    "longFmt": "-1,218,005,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 718940000,
+                    "fmt": "718.94M",
+                    "longFmt": "718,940,000"
+                  },
+                  "ebit": {
+                    "raw": -1218005000,
+                    "fmt": "-1.22B",
+                    "longFmt": "-1,218,005,000"
+                  },
+                  "interestExpense": {
+                    "raw": -43517000,
+                    "fmt": "-43.52M",
+                    "longFmt": "-43,517,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -499065000,
+                    "fmt": "-499.06M",
+                    "longFmt": "-499,065,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -71384000,
+                    "fmt": "-71.38M",
+                    "longFmt": "-71,384,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 10467000,
+                    "fmt": "10.47M",
+                    "longFmt": "10,467,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -427681000,
+                    "fmt": "-427.68M",
+                    "longFmt": "-427,681,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -467824000,
+                    "fmt": "-467.82M",
+                    "longFmt": "-467,824,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -2386005000,
+                    "fmt": "-2.39B",
+                    "longFmt": "-2,386,005,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 25505698000,
+                    "fmt": "25.51B",
+                    "longFmt": "25,505,698,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 20737641000,
+                    "fmt": "20.74B",
+                    "longFmt": "20,737,641,000"
+                  },
+                  "grossProfit": {
+                    "raw": 4768057000,
+                    "fmt": "4.77B",
+                    "longFmt": "4,768,057,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 251802000,
+                    "fmt": "251.8M",
+                    "longFmt": "251,802,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 5280146000,
+                    "fmt": "5.28B",
+                    "longFmt": "5,280,146,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 26269589000,
+                    "fmt": "26.27B",
+                    "longFmt": "26,269,589,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -763891000,
+                    "fmt": "-763.89M",
+                    "longFmt": "-763,891,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 625553000,
+                    "fmt": "625.55M",
+                    "longFmt": "625,553,000"
+                  },
+                  "ebit": {
+                    "raw": -763891000,
+                    "fmt": "-763.89M",
+                    "longFmt": "-763,891,000"
+                  },
+                  "interestExpense": {
+                    "raw": -43791000,
+                    "fmt": "-43.79M",
+                    "longFmt": "-43,791,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -138338000,
+                    "fmt": "-138.34M",
+                    "longFmt": "-138,338,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 399283000,
+                    "fmt": "399.28M",
+                    "longFmt": "399,283,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 65836000,
+                    "fmt": "65.84M",
+                    "longFmt": "65,836,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -537621000,
+                    "fmt": "-537.62M",
+                    "longFmt": "-537,621,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -574430000,
+                    "fmt": "-574.43M",
+                    "longFmt": "-574,430,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -1441879000,
+                    "fmt": "-1.44B",
+                    "longFmt": "-1,441,879,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Europacific Growth Fund",
+                  "pctHeld": {
+                    "raw": 0.005,
+                    "fmt": "0.50%"
+                  },
+                  "position": {
+                    "raw": 4457516,
+                    "fmt": "4.46M",
+                    "longFmt": "4,457,516"
+                  },
+                  "value": {
+                    "raw": 274315534,
+                    "fmt": "274.32M",
+                    "longFmt": "274,315,534"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "ARK ETF Tr-ARK Innovation ETF",
+                  "pctHeld": {
+                    "raw": 0.0049,
+                    "fmt": "0.49%"
+                  },
+                  "position": {
+                    "raw": 4358188,
+                    "fmt": "4.36M",
+                    "longFmt": "4,358,188"
+                  },
+                  "value": {
+                    "raw": 268202889,
+                    "fmt": "268.2M",
+                    "longFmt": "268,202,889"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "KraneShares CSI China Internet ETF",
+                  "pctHeld": {
+                    "raw": 0.0023999999,
+                    "fmt": "0.24%"
+                  },
+                  "position": {
+                    "raw": 2150250,
+                    "fmt": "2.15M",
+                    "longFmt": "2,150,250"
+                  },
+                  "value": {
+                    "raw": 131810325,
+                    "fmt": "131.81M",
+                    "longFmt": "131,810,325"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1604102400,
+                    "fmt": "2020-10-31"
+                  },
+                  "organization": "Vanguard International Stock Index-Total Intl Stock Indx",
+                  "pctHeld": {
+                    "raw": 0.0018000001,
+                    "fmt": "0.18%"
+                  },
+                  "position": {
+                    "raw": 1625494,
+                    "fmt": "1.63M",
+                    "longFmt": "1,625,494"
+                  },
+                  "value": {
+                    "raw": 113378206,
+                    "fmt": "113.38M",
+                    "longFmt": "113,378,206"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Fidelity OTC Portfolio",
+                  "pctHeld": {
+                    "raw": 0.0018000001,
+                    "fmt": "0.18%"
+                  },
+                  "position": {
+                    "raw": 1598717,
+                    "fmt": "1.6M",
+                    "longFmt": "1,598,717"
+                  },
+                  "value": {
+                    "raw": 98385044,
+                    "fmt": "98.39M",
+                    "longFmt": "98,385,044"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1604102400,
+                    "fmt": "2020-10-31"
+                  },
+                  "organization": "Vanguard International Stock Index-Emerging Markets Stk",
+                  "pctHeld": {
+                    "raw": 0.0016,
+                    "fmt": "0.16%"
+                  },
+                  "position": {
+                    "raw": 1440142,
+                    "fmt": "1.44M",
+                    "longFmt": "1,440,142"
+                  },
+                  "value": {
+                    "raw": 100449904,
+                    "fmt": "100.45M",
+                    "longFmt": "100,449,904"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "ARK ETF Tr-ARK Next Generation Internet ETF",
+                  "pctHeld": {
+                    "raw": 0.0014,
+                    "fmt": "0.14%"
+                  },
+                  "position": {
+                    "raw": 1285541,
+                    "fmt": "1.29M",
+                    "longFmt": "1,285,541"
+                  },
+                  "value": {
+                    "raw": 79112193,
+                    "fmt": "79.11M",
+                    "longFmt": "79,112,193"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "New World Fund, Inc.",
+                  "pctHeld": {
+                    "raw": 0.0013,
+                    "fmt": "0.13%"
+                  },
+                  "position": {
+                    "raw": 1116780,
+                    "fmt": "1.12M",
+                    "longFmt": "1,116,780"
+                  },
+                  "value": {
+                    "raw": 68726641,
+                    "fmt": "68.73M",
+                    "longFmt": "68,726,641"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Fundamental Investors Inc",
+                  "pctHeld": {
+                    "raw": 0.0011,
+                    "fmt": "0.11%"
+                  },
+                  "position": {
+                    "raw": 986393,
+                    "fmt": "986.39k",
+                    "longFmt": "986,393"
+                  },
+                  "value": {
+                    "raw": 60702625,
+                    "fmt": "60.7M",
+                    "longFmt": "60,702,625"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Fidelity Growth Company Fund",
+                  "pctHeld": {
+                    "raw": 0.0011,
+                    "fmt": "0.11%"
+                  },
+                  "position": {
+                    "raw": 974704,
+                    "fmt": "974.7k",
+                    "longFmt": "974,704"
+                  },
+                  "value": {
+                    "raw": 59983284,
+                    "fmt": "59.98M",
+                    "longFmt": "59,983,284"
+                  }
+                }
+              ]
+            },
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 68,
+              "open": 66.39,
+              "dayLow": 65.25,
+              "dayHigh": 67.82,
+              "regularMarketPreviousClose": 68,
+              "regularMarketOpen": 66.39,
+              "regularMarketDayLow": 65.25,
+              "regularMarketDayHigh": 67.82,
+              "payoutRatio": 0,
+              "volume": 2665475,
+              "regularMarketVolume": 2665475,
+              "averageVolume": 3760300,
+              "averageVolume10days": 5531066,
+              "averageDailyVolume10Day": 5531066,
+              "bid": 66.05,
+              "ask": 66.24,
+              "bidSize": 900,
+              "askSize": 1000,
+              "marketCap": 77693394944,
+              "fiftyTwoWeekLow": 31.79,
+              "fiftyTwoWeekHigh": 79.4,
+              "fiftyDayAverage": 64.594246,
+              "twoHundredDayAverage": 61.68664,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            },
+            "insiderHolders": {
+              "holders": [],
+              "maxAge": 1
+            },
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": [],
+                "earningsAverage": 0.13,
+                "earningsLow": 0.01,
+                "earningsHigh": 0.17,
+                "revenueAverage": 3082150000,
+                "revenueLow": 2998670000,
+                "revenueHigh": 3182420000
+              }
+            },
+            "upgradeDowngradeHistory": {
+              "history": [
+                {
+                  "epochGradeDate": 1609859636,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                }
+              ],
+              "maxAge": 86400
+            },
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": -0.0220588,
+              "preMarketChange": -1.5,
+              "preMarketTime": 1613572197,
+              "preMarketPrice": 66.5,
+              "preMarketSource": "FREE_REALTIME",
+              "regularMarketChangePercent": -0.03073524,
+              "regularMarketChange": -2.0899963,
+              "regularMarketTime": 1613579385,
+              "priceHint": 2,
+              "regularMarketPrice": 65.91,
+              "regularMarketDayHigh": 67.82,
+              "regularMarketDayLow": 65.25,
+              "regularMarketVolume": 2665475,
+              "averageDailyVolume10Day": 5531066,
+              "averageDailyVolume3Month": 3760300,
+              "regularMarketPreviousClose": 68,
+              "regularMarketSource": "FREE_REALTIME",
+              "regularMarketOpen": 66.39,
+              "exchange": "NYQ",
+              "exchangeName": "NYSE",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "EQUITY",
+              "symbol": "BEKE",
+              "underlyingSymbol": null,
+              "shortName": "KE Holdings Inc",
+              "longName": "KE Holdings Inc.",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 77693394944
+            },
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 24319332000,
+                    "fmt": "24.32B",
+                    "longFmt": "24,319,332,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 1844595000,
+                    "fmt": "1.84B",
+                    "longFmt": "1,844,595,000"
+                  },
+                  "netReceivables": {
+                    "raw": 13169172000,
+                    "fmt": "13.17B",
+                    "longFmt": "13,169,172,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 12139612000,
+                    "fmt": "12.14B",
+                    "longFmt": "12,139,612,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 51912486000,
+                    "fmt": "51.91B",
+                    "longFmt": "51,912,486,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2333745000,
+                    "fmt": "2.33B",
+                    "longFmt": "2,333,745,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6759243000,
+                    "fmt": "6.76B",
+                    "longFmt": "6,759,243,000"
+                  },
+                  "goodWill": {
+                    "raw": 2477075000,
+                    "fmt": "2.48B",
+                    "longFmt": "2,477,075,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 2560442000,
+                    "fmt": "2.56B",
+                    "longFmt": "2,560,442,000"
+                  },
+                  "otherAssets": {
+                    "raw": 1222321000,
+                    "fmt": "1.22B",
+                    "longFmt": "1,222,321,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 520292000,
+                    "fmt": "520.29M",
+                    "longFmt": "520,292,000"
+                  },
+                  "totalAssets": {
+                    "raw": 67265312000,
+                    "fmt": "67.27B",
+                    "longFmt": "67,265,312,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 4475170000,
+                    "fmt": "4.48B",
+                    "longFmt": "4,475,170,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2291723000,
+                    "fmt": "2.29B",
+                    "longFmt": "2,291,723,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 8584074000,
+                    "fmt": "8.58B",
+                    "longFmt": "8,584,074,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 4897530000,
+                    "fmt": "4.9B",
+                    "longFmt": "4,897,530,000"
+                  },
+                  "otherLiab": {
+                    "raw": 120275000,
+                    "fmt": "120.28M",
+                    "longFmt": "120,275,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 87203000,
+                    "fmt": "87.2M",
+                    "longFmt": "87,203,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 27797675000,
+                    "fmt": "27.8B",
+                    "longFmt": "27,797,675,000"
+                  },
+                  "totalLiab": {
+                    "raw": 35729720000,
+                    "fmt": "35.73B",
+                    "longFmt": "35,729,720,000"
+                  },
+                  "commonStock": {
+                    "raw": 202000,
+                    "fmt": "202k",
+                    "longFmt": "202,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -11521905000,
+                    "fmt": "-11.52B",
+                    "longFmt": "-11,521,905,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 63308000,
+                    "fmt": "63.31M",
+                    "longFmt": "63,308,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 2533889000,
+                    "fmt": "2.53B",
+                    "longFmt": "2,533,889,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 63308000,
+                    "fmt": "63.31M",
+                    "longFmt": "63,308,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -8924506000,
+                    "fmt": "-8.92B",
+                    "longFmt": "-8,924,506,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -13962023000,
+                    "fmt": "-13.96B",
+                    "longFmt": "-13,962,023,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "cash": {
+                    "raw": 9115649000,
+                    "fmt": "9.12B",
+                    "longFmt": "9,115,649,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 2523199000,
+                    "fmt": "2.52B",
+                    "longFmt": "2,523,199,000"
+                  },
+                  "netReceivables": {
+                    "raw": 10369552000,
+                    "fmt": "10.37B",
+                    "longFmt": "10,369,552,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 4972534000,
+                    "fmt": "4.97B",
+                    "longFmt": "4,972,534,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 27374784000,
+                    "fmt": "27.37B",
+                    "longFmt": "27,374,784,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 418469000,
+                    "fmt": "418.47M",
+                    "longFmt": "418,469,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6089232000,
+                    "fmt": "6.09B",
+                    "longFmt": "6,089,232,000"
+                  },
+                  "goodWill": {
+                    "raw": 1135034000,
+                    "fmt": "1.14B",
+                    "longFmt": "1,135,034,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 196998000,
+                    "fmt": "197M",
+                    "longFmt": "196,998,000"
+                  },
+                  "otherAssets": {
+                    "raw": 3651747000,
+                    "fmt": "3.65B",
+                    "longFmt": "3,651,747,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 672622000,
+                    "fmt": "672.62M",
+                    "longFmt": "672,622,000"
+                  },
+                  "totalAssets": {
+                    "raw": 38866264000,
+                    "fmt": "38.87B",
+                    "longFmt": "38,866,264,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1573343000,
+                    "fmt": "1.57B",
+                    "longFmt": "1,573,343,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2414607000,
+                    "fmt": "2.41B",
+                    "longFmt": "2,414,607,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 4762200000,
+                    "fmt": "4.76B",
+                    "longFmt": "4,762,200,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 112900000,
+                    "fmt": "112.9M",
+                    "longFmt": "112,900,000"
+                  },
+                  "otherLiab": {
+                    "raw": 532931000,
+                    "fmt": "532.93M",
+                    "longFmt": "532,931,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 10467000,
+                    "fmt": "10.47M",
+                    "longFmt": "10,467,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 20572881000,
+                    "fmt": "20.57B",
+                    "longFmt": "20,572,881,000"
+                  },
+                  "totalLiab": {
+                    "raw": 24007724000,
+                    "fmt": "24.01B",
+                    "longFmt": "24,007,724,000"
+                  },
+                  "commonStock": {
+                    "raw": 189000,
+                    "fmt": "189k",
+                    "longFmt": "189,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -7814291000,
+                    "fmt": "-7.81B",
+                    "longFmt": "-7,814,291,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -134000,
+                    "fmt": "-134k",
+                    "longFmt": "-134,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -134000,
+                    "fmt": "-134k",
+                    "longFmt": "-134,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -7814236000,
+                    "fmt": "-7.81B",
+                    "longFmt": "-7,814,236,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -9146268000,
+                    "fmt": "-9.15B",
+                    "longFmt": "-9,146,268,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "cash": {
+                    "raw": 5236100000,
+                    "fmt": "5.24B",
+                    "longFmt": "5,236,100,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 7587433000,
+                    "fmt": "7.59B",
+                    "longFmt": "7,587,433,000"
+                  },
+                  "netReceivables": {
+                    "raw": 4676434000,
+                    "fmt": "4.68B",
+                    "longFmt": "4,676,434,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 6227975000,
+                    "fmt": "6.23B",
+                    "longFmt": "6,227,975,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 24067931000,
+                    "fmt": "24.07B",
+                    "longFmt": "24,067,931,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 379972000,
+                    "fmt": "379.97M",
+                    "longFmt": "379,972,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6002914000,
+                    "fmt": "6B",
+                    "longFmt": "6,002,914,000"
+                  },
+                  "goodWill": {
+                    "raw": 710983000,
+                    "fmt": "710.98M",
+                    "longFmt": "710,983,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 264726000,
+                    "fmt": "264.73M",
+                    "longFmt": "264,726,000"
+                  },
+                  "otherAssets": {
+                    "raw": 153409000,
+                    "fmt": "153.41M",
+                    "longFmt": "153,409,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 147535000,
+                    "fmt": "147.53M",
+                    "longFmt": "147,535,000"
+                  },
+                  "totalAssets": {
+                    "raw": 31579935000,
+                    "fmt": "31.58B",
+                    "longFmt": "31,579,935,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 370496000,
+                    "fmt": "370.5M",
+                    "longFmt": "370,496,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 4665524000,
+                    "fmt": "4.67B",
+                    "longFmt": "4,665,524,000"
+                  },
+                  "otherLiab": {
+                    "raw": 518091000,
+                    "fmt": "518.09M",
+                    "longFmt": "518,091,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 65836000,
+                    "fmt": "65.84M",
+                    "longFmt": "65,836,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 16047286000,
+                    "fmt": "16.05B",
+                    "longFmt": "16,047,286,000"
+                  },
+                  "totalLiab": {
+                    "raw": 19143150000,
+                    "fmt": "19.14B",
+                    "longFmt": "19,143,150,000"
+                  },
+                  "commonStock": {
+                    "raw": 178000,
+                    "fmt": "178k",
+                    "longFmt": "178,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -5226325000,
+                    "fmt": "-5.23B",
+                    "longFmt": "-5,226,325,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -327000,
+                    "fmt": "-327k",
+                    "longFmt": "-327,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -327000,
+                    "fmt": "-327k",
+                    "longFmt": "-327,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -5226474000,
+                    "fmt": "-5.23B",
+                    "longFmt": "-5,226,474,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -6202183000,
+                    "fmt": "-6.2B",
+                    "longFmt": "-6,202,183,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": "2020-12-31",
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "low": {
+                      "raw": 0.01,
+                      "fmt": "0.01"
+                    },
+                    "high": {
+                      "raw": 0.17,
+                      "fmt": "0.17"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 6,
+                      "fmt": "6",
+                      "longFmt": "6"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 3082150000,
+                      "fmt": "3.08B",
+                      "longFmt": "3,082,150,000"
+                    },
+                    "low": {
+                      "raw": 2998670000,
+                      "fmt": "3B",
+                      "longFmt": "2,998,670,000"
+                    },
+                    "high": {
+                      "raw": 3182420000,
+                      "fmt": "3.18B",
+                      "longFmt": "3,182,420,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 7,
+                      "fmt": "7",
+                      "longFmt": "7"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.11,
+                      "fmt": "0.11"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": "2021-03-31",
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "low": {
+                      "raw": 0.09,
+                      "fmt": "0.09"
+                    },
+                    "high": {
+                      "raw": 0.14,
+                      "fmt": "0.14"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 3,
+                      "fmt": "3",
+                      "longFmt": "3"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 2126150000,
+                      "fmt": "2.13B",
+                      "longFmt": "2,126,150,000"
+                    },
+                    "low": {
+                      "raw": 1891260000,
+                      "fmt": "1.89B",
+                      "longFmt": "1,891,260,000"
+                    },
+                    "high": {
+                      "raw": 2252600000,
+                      "fmt": "2.25B",
+                      "longFmt": "2,252,600,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 3,
+                      "fmt": "3",
+                      "longFmt": "3"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.08,
+                      "fmt": "0.08"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": "2020-12-31",
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "low": {
+                      "raw": 0.63,
+                      "fmt": "0.63"
+                    },
+                    "high": {
+                      "raw": 1.02,
+                      "fmt": "1.02"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 9,
+                      "fmt": "9",
+                      "longFmt": "9"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 10527000000,
+                      "fmt": "10.53B",
+                      "longFmt": "10,527,000,000"
+                    },
+                    "low": {
+                      "raw": 10400500000,
+                      "fmt": "10.4B",
+                      "longFmt": "10,400,500,000"
+                    },
+                    "high": {
+                      "raw": 10688500000,
+                      "fmt": "10.69B",
+                      "longFmt": "10,688,500,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 11,
+                      "fmt": "11",
+                      "longFmt": "11"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.74,
+                      "fmt": "0.74"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.67,
+                      "fmt": "0.67"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": "2021-12-31",
+                  "growth": {
+                    "raw": 0.2,
+                    "fmt": "20.00%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.9,
+                      "fmt": "0.9"
+                    },
+                    "low": {
+                      "raw": 0.64,
+                      "fmt": "0.64"
+                    },
+                    "high": {
+                      "raw": 0.99,
+                      "fmt": "0.99"
+                    },
+                    "yearAgoEps": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 9,
+                      "fmt": "9",
+                      "longFmt": "9"
+                    },
+                    "growth": {
+                      "raw": 0.2,
+                      "fmt": "20.00%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 13237800000,
+                      "fmt": "13.24B",
+                      "longFmt": "13,237,800,000"
+                    },
+                    "low": {
+                      "raw": 11327900000,
+                      "fmt": "11.33B",
+                      "longFmt": "11,327,900,000"
+                    },
+                    "high": {
+                      "raw": 14382900000,
+                      "fmt": "14.38B",
+                      "longFmt": "14,382,900,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 11,
+                      "fmt": "11",
+                      "longFmt": "11"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 10527000000,
+                      "fmt": "10.53B",
+                      "longFmt": "10,527,000,000"
+                    },
+                    "growth": {
+                      "raw": 0.258,
+                      "fmt": "25.80%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.9,
+                      "fmt": "0.9"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.9,
+                      "fmt": "0.9"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.9,
+                      "fmt": "0.9"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.89,
+                      "fmt": "0.89"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.88,
+                      "fmt": "0.88"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": 0.046,
+                    "fmt": "4.60%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            },
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Baillie Gifford and Company",
+                  "pctHeld": {
+                    "raw": 0.0198,
+                    "fmt": "1.98%"
+                  },
+                  "position": {
+                    "raw": 17631431,
+                    "fmt": "17.63M",
+                    "longFmt": "17,631,431"
+                  },
+                  "value": {
+                    "raw": 1085038263,
+                    "fmt": "1.09B",
+                    "longFmt": "1,085,038,263"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "SC US (TTGP) Ltd",
+                  "pctHeld": {
+                    "raw": 0.0123000005,
+                    "fmt": "1.23%"
+                  },
+                  "position": {
+                    "raw": 10964911,
+                    "fmt": "10.96M",
+                    "longFmt": "10,964,911"
+                  },
+                  "value": {
+                    "raw": 672149044,
+                    "fmt": "672.15M",
+                    "longFmt": "672,149,044"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "FMR, LLC",
+                  "pctHeld": {
+                    "raw": 0.0089,
+                    "fmt": "0.89%"
+                  },
+                  "position": {
+                    "raw": 7903919,
+                    "fmt": "7.9M",
+                    "longFmt": "7,903,919"
+                  },
+                  "value": {
+                    "raw": 486407175,
+                    "fmt": "486.41M",
+                    "longFmt": "486,407,175"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Capital World Investors",
+                  "pctHeld": {
+                    "raw": 0.0088,
+                    "fmt": "0.88%"
+                  },
+                  "position": {
+                    "raw": 7821189,
+                    "fmt": "7.82M",
+                    "longFmt": "7,821,189"
+                  },
+                  "value": {
+                    "raw": 479438885,
+                    "fmt": "479.44M",
+                    "longFmt": "479,438,885"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Blackrock Inc.",
+                  "pctHeld": {
+                    "raw": 0.0074,
+                    "fmt": "0.74%"
+                  },
+                  "position": {
+                    "raw": 6536139,
+                    "fmt": "6.54M",
+                    "longFmt": "6,536,139"
+                  },
+                  "value": {
+                    "raw": 402233994,
+                    "fmt": "402.23M",
+                    "longFmt": "402,233,994"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Hillhouse Capital Advisors Ltd.",
+                  "pctHeld": {
+                    "raw": 0.0056,
+                    "fmt": "0.56%"
+                  },
+                  "position": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "value": {
+                    "raw": 306500000,
+                    "fmt": "306.5M",
+                    "longFmt": "306,500,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "D1 Capital Partners, LP",
+                  "pctHeld": {
+                    "raw": 0.0056,
+                    "fmt": "0.56%"
+                  },
+                  "position": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "value": {
+                    "raw": 306500000,
+                    "fmt": "306.5M",
+                    "longFmt": "306,500,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Credit Suisse Ag/",
+                  "pctHeld": {
+                    "raw": 0.0043,
+                    "fmt": "0.43%"
+                  },
+                  "position": {
+                    "raw": 3778354,
+                    "fmt": "3.78M",
+                    "longFmt": "3,778,354"
+                  },
+                  "value": {
+                    "raw": 231613100,
+                    "fmt": "231.61M",
+                    "longFmt": "231,613,100"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Group, Inc. (The)",
+                  "pctHeld": {
+                    "raw": 0.0042,
+                    "fmt": "0.42%"
+                  },
+                  "position": {
+                    "raw": 3750841,
+                    "fmt": "3.75M",
+                    "longFmt": "3,750,841"
+                  },
+                  "value": {
+                    "raw": 229926553,
+                    "fmt": "229.93M",
+                    "longFmt": "229,926,553"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Sumitomo Mitsui Trust Holdings, Inc.",
+                  "pctHeld": {
+                    "raw": 0.004,
+                    "fmt": "0.40%"
+                  },
+                  "position": {
+                    "raw": 3512686,
+                    "fmt": "3.51M",
+                    "longFmt": "3,512,686"
+                  },
+                  "value": {
+                    "raw": 216170696,
+                    "fmt": "216.17M",
+                    "longFmt": "216,170,696"
+                  }
+                }
+              ]
+            },
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.0090499995,
+              "institutionsPercentHeld": 0.14386,
+              "institutionsFloatPercentHeld": 0.14517,
+              "institutionsCount": 234
+            },
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 38046404000,
+                    "fmt": "38.05B",
+                    "longFmt": "38,046,404,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 13156851000,
+                    "fmt": "13.16B",
+                    "longFmt": "13,156,851,000"
+                  },
+                  "netReceivables": {
+                    "raw": 12955146000,
+                    "fmt": "12.96B",
+                    "longFmt": "12,955,146,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 10926407000,
+                    "fmt": "10.93B",
+                    "longFmt": "10,926,407,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 75696700000,
+                    "fmt": "75.7B",
+                    "longFmt": "75,696,700,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2461657000,
+                    "fmt": "2.46B",
+                    "longFmt": "2,461,657,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 7389774000,
+                    "fmt": "7.39B",
+                    "longFmt": "7,389,774,000"
+                  },
+                  "goodWill": {
+                    "raw": 2490155000,
+                    "fmt": "2.49B",
+                    "longFmt": "2,490,155,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 2062294000,
+                    "fmt": "2.06B",
+                    "longFmt": "2,062,294,000"
+                  },
+                  "otherAssets": {
+                    "raw": 873615000,
+                    "fmt": "873.62M",
+                    "longFmt": "873,615,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 530164000,
+                    "fmt": "530.16M",
+                    "longFmt": "530,164,000"
+                  },
+                  "totalAssets": {
+                    "raw": 90974195000,
+                    "fmt": "90.97B",
+                    "longFmt": "90,974,195,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 6499745000,
+                    "fmt": "6.5B",
+                    "longFmt": "6,499,745,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2411361000,
+                    "fmt": "2.41B",
+                    "longFmt": "2,411,361,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 9611704000,
+                    "fmt": "9.61B",
+                    "longFmt": "9,611,704,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 4793875000,
+                    "fmt": "4.79B",
+                    "longFmt": "4,793,875,000"
+                  },
+                  "otherLiab": {
+                    "raw": 22446000,
+                    "fmt": "22.45M",
+                    "longFmt": "22,446,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 26490000,
+                    "fmt": "26.49M",
+                    "longFmt": "26,490,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 31727200000,
+                    "fmt": "31.73B",
+                    "longFmt": "31,727,200,000"
+                  },
+                  "totalLiab": {
+                    "raw": 39843179000,
+                    "fmt": "39.84B",
+                    "longFmt": "39,843,179,000"
+                  },
+                  "commonStock": {
+                    "raw": 466000,
+                    "fmt": "466k",
+                    "longFmt": "466,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -9929807000,
+                    "fmt": "-9.93B",
+                    "longFmt": "-9,929,807,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -531354000,
+                    "fmt": "-531.35M",
+                    "longFmt": "-531,354,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 61565221000,
+                    "fmt": "61.57B",
+                    "longFmt": "61,565,221,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -531354000,
+                    "fmt": "-531.35M",
+                    "longFmt": "-531,354,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 51104526000,
+                    "fmt": "51.1B",
+                    "longFmt": "51,104,526,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 46552077000,
+                    "fmt": "46.55B",
+                    "longFmt": "46,552,077,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "cash": {
+                    "raw": 25079605000,
+                    "fmt": "25.08B",
+                    "longFmt": "25,079,605,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 5869529000,
+                    "fmt": "5.87B",
+                    "longFmt": "5,869,529,000"
+                  },
+                  "netReceivables": {
+                    "raw": 13068816000,
+                    "fmt": "13.07B",
+                    "longFmt": "13,068,816,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 12353005000,
+                    "fmt": "12.35B",
+                    "longFmt": "12,353,005,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 56925376000,
+                    "fmt": "56.93B",
+                    "longFmt": "56,925,376,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2466889000,
+                    "fmt": "2.47B",
+                    "longFmt": "2,466,889,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6911464000,
+                    "fmt": "6.91B",
+                    "longFmt": "6,911,464,000"
+                  },
+                  "goodWill": {
+                    "raw": 2490155000,
+                    "fmt": "2.49B",
+                    "longFmt": "2,490,155,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 2288794000,
+                    "fmt": "2.29B",
+                    "longFmt": "2,288,794,000"
+                  },
+                  "otherAssets": {
+                    "raw": 923040000,
+                    "fmt": "923.04M",
+                    "longFmt": "923,040,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 530164000,
+                    "fmt": "530.16M",
+                    "longFmt": "530,164,000"
+                  },
+                  "totalAssets": {
+                    "raw": 72005718000,
+                    "fmt": "72.01B",
+                    "longFmt": "72,005,718,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 5287577000,
+                    "fmt": "5.29B",
+                    "longFmt": "5,287,577,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2199275000,
+                    "fmt": "2.2B",
+                    "longFmt": "2,199,275,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 11037514000,
+                    "fmt": "11.04B",
+                    "longFmt": "11,037,514,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 4885370000,
+                    "fmt": "4.89B",
+                    "longFmt": "4,885,370,000"
+                  },
+                  "otherLiab": {
+                    "raw": 116203000,
+                    "fmt": "116.2M",
+                    "longFmt": "116,203,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 25846000,
+                    "fmt": "25.85M",
+                    "longFmt": "25,846,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 30175739000,
+                    "fmt": "30.18B",
+                    "longFmt": "30,175,739,000"
+                  },
+                  "totalLiab": {
+                    "raw": 38219015000,
+                    "fmt": "38.22B",
+                    "longFmt": "38,219,015,000"
+                  },
+                  "commonStock": {
+                    "raw": 205000,
+                    "fmt": "205k",
+                    "longFmt": "205,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -10004504000,
+                    "fmt": "-10B",
+                    "longFmt": "-10,004,504,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 213691000,
+                    "fmt": "213.69M",
+                    "longFmt": "213,691,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1769485000,
+                    "fmt": "1.77B",
+                    "longFmt": "1,769,485,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 213691000,
+                    "fmt": "213.69M",
+                    "longFmt": "213,691,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -8021123000,
+                    "fmt": "-8.02B",
+                    "longFmt": "-8,021,123,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -12800072000,
+                    "fmt": "-12.8B",
+                    "longFmt": "-12,800,072,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "cash": {
+                    "raw": 15538844000,
+                    "fmt": "15.54B",
+                    "longFmt": "15,538,844,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 7709598000,
+                    "fmt": "7.71B",
+                    "longFmt": "7,709,598,000"
+                  },
+                  "netReceivables": {
+                    "raw": 11799844000,
+                    "fmt": "11.8B",
+                    "longFmt": "11,799,844,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 10805983000,
+                    "fmt": "10.81B",
+                    "longFmt": "10,805,983,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 46380397000,
+                    "fmt": "46.38B",
+                    "longFmt": "46,380,397,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2347955000,
+                    "fmt": "2.35B",
+                    "longFmt": "2,347,955,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6700269000,
+                    "fmt": "6.7B",
+                    "longFmt": "6,700,269,000"
+                  },
+                  "goodWill": {
+                    "raw": 2477075000,
+                    "fmt": "2.48B",
+                    "longFmt": "2,477,075,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 2433454000,
+                    "fmt": "2.43B",
+                    "longFmt": "2,433,454,000"
+                  },
+                  "otherAssets": {
+                    "raw": 901375000,
+                    "fmt": "901.38M",
+                    "longFmt": "901,375,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 530164000,
+                    "fmt": "530.16M",
+                    "longFmt": "530,164,000"
+                  },
+                  "totalAssets": {
+                    "raw": 61240525000,
+                    "fmt": "61.24B",
+                    "longFmt": "61,240,525,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 3645940000,
+                    "fmt": "3.65B",
+                    "longFmt": "3,645,940,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 1767844000,
+                    "fmt": "1.77B",
+                    "longFmt": "1,767,844,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 8597488000,
+                    "fmt": "8.6B",
+                    "longFmt": "8,597,488,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 4980956000,
+                    "fmt": "4.98B",
+                    "longFmt": "4,980,956,000"
+                  },
+                  "otherLiab": {
+                    "raw": 120365000,
+                    "fmt": "120.36M",
+                    "longFmt": "120,365,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 84466000,
+                    "fmt": "84.47M",
+                    "longFmt": "84,466,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 22876987000,
+                    "fmt": "22.88B",
+                    "longFmt": "22,876,987,000"
+                  },
+                  "totalLiab": {
+                    "raw": 30855825000,
+                    "fmt": "30.86B",
+                    "longFmt": "30,855,825,000"
+                  },
+                  "commonStock": {
+                    "raw": 202000,
+                    "fmt": "202k",
+                    "longFmt": "202,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -12841072000,
+                    "fmt": "-12.84B",
+                    "longFmt": "-12,841,072,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 234320000,
+                    "fmt": "234.32M",
+                    "longFmt": "234,320,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1840586000,
+                    "fmt": "1.84B",
+                    "longFmt": "1,840,586,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 234320000,
+                    "fmt": "234.32M",
+                    "longFmt": "234,320,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -10765964000,
+                    "fmt": "-10.77B",
+                    "longFmt": "-10,765,964,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -15676493000,
+                    "fmt": "-15.68B",
+                    "longFmt": "-15,676,493,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1569801600,
+                    "fmt": "2019-09-30"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.21,
+                    "fmt": "0.21"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.17,
+                    "fmt": "0.17"
+                  },
+                  "epsDifference": {
+                    "raw": 0.04,
+                    "fmt": "0.04"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.235,
+                    "fmt": "23.50%"
+                  },
+                  "quarter": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            },
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            },
+            "summaryProfile": {
+              "address1": "Building Fudao",
+              "address2": "No.11 Kaituo Road Haidian District",
+              "city": "Beijing",
+              "zip": "100085",
+              "country": "China",
+              "phone": "86 10 5810 4689",
+              "website": "http://ke.com",
+              "industry": "Real Estate Services",
+              "sector": "Real Estate",
+              "longBusinessSummary": "KE Holdings Inc. operates an integrated online and offline platform for housing transactions and services in the People's Republic of China. The company facilitates various housing transactions ranging from existing and new home sales and home rentals to home renovation, real estate financial solutions, and other services. It also owns and operates Lianjia, a real estate brokerage branded store. The company was founded in 2001 and is headquartered in Beijing, China.",
+              "companyOfficers": [],
+              "maxAge": 86400
+            },
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 0,
+              "buyInfoShares": 0,
+              "sellInfoCount": 0,
+              "netInfoCount": 0,
+              "netInfoShares": 0,
+              "netPercentInsiderShares": 0,
+              "totalInsiderShares": 10667953
+            },
+            "sectorTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 20548915000,
+                    "fmt": "20.55B",
+                    "longFmt": "20,548,915,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 16165685000,
+                    "fmt": "16.17B",
+                    "longFmt": "16,165,685,000"
+                  },
+                  "grossProfit": {
+                    "raw": 4383230000,
+                    "fmt": "4.38B",
+                    "longFmt": "4,383,230,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 789089000,
+                    "fmt": "789.09M",
+                    "longFmt": "789,089,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 3675157000,
+                    "fmt": "3.68B",
+                    "longFmt": "3,675,157,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 20629931000,
+                    "fmt": "20.63B",
+                    "longFmt": "20,629,931,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -81016000,
+                    "fmt": "-81.02M",
+                    "longFmt": "-81,016,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 415348000,
+                    "fmt": "415.35M",
+                    "longFmt": "415,348,000"
+                  },
+                  "ebit": {
+                    "raw": -81016000,
+                    "fmt": "-81.02M",
+                    "longFmt": "-81,016,000"
+                  },
+                  "interestExpense": {
+                    "raw": -128157000,
+                    "fmt": "-128.16M",
+                    "longFmt": "-128,157,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 334332000,
+                    "fmt": "334.33M",
+                    "longFmt": "334,332,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 258991000,
+                    "fmt": "258.99M",
+                    "longFmt": "258,991,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 26490000,
+                    "fmt": "26.49M",
+                    "longFmt": "26,490,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 75341000,
+                    "fmt": "75.34M",
+                    "longFmt": "75,341,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 74697000,
+                    "fmt": "74.7M",
+                    "longFmt": "74,697,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -271446000,
+                    "fmt": "-271.45M",
+                    "longFmt": "-271,446,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 20141659000,
+                    "fmt": "20.14B",
+                    "longFmt": "20,141,659,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 13590784000,
+                    "fmt": "13.59B",
+                    "longFmt": "13,590,784,000"
+                  },
+                  "grossProfit": {
+                    "raw": 6550875000,
+                    "fmt": "6.55B",
+                    "longFmt": "6,550,875,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 523670000,
+                    "fmt": "523.67M",
+                    "longFmt": "523,670,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 2739831000,
+                    "fmt": "2.74B",
+                    "longFmt": "2,739,831,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 16854285000,
+                    "fmt": "16.85B",
+                    "longFmt": "16,854,285,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 3287374000,
+                    "fmt": "3.29B",
+                    "longFmt": "3,287,374,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 333154000,
+                    "fmt": "333.15M",
+                    "longFmt": "333,154,000"
+                  },
+                  "ebit": {
+                    "raw": 3287374000,
+                    "fmt": "3.29B",
+                    "longFmt": "3,287,374,000"
+                  },
+                  "interestExpense": {
+                    "raw": -128157000,
+                    "fmt": "-128.16M",
+                    "longFmt": "-128,157,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 3620528000,
+                    "fmt": "3.62B",
+                    "longFmt": "3,620,528,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 781715000,
+                    "fmt": "781.72M",
+                    "longFmt": "781,715,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 25846000,
+                    "fmt": "25.85M",
+                    "longFmt": "25,846,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 2838813000,
+                    "fmt": "2.84B",
+                    "longFmt": "2,838,813,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 2836568000,
+                    "fmt": "2.84B",
+                    "longFmt": "2,836,568,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 2120786000,
+                    "fmt": "2.12B",
+                    "longFmt": "2,120,786,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 7119759000,
+                    "fmt": "7.12B",
+                    "longFmt": "7,119,759,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 6618227000,
+                    "fmt": "6.62B",
+                    "longFmt": "6,618,227,000"
+                  },
+                  "grossProfit": {
+                    "raw": 501532000,
+                    "fmt": "501.53M",
+                    "longFmt": "501,532,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 450761000,
+                    "fmt": "450.76M",
+                    "longFmt": "450,761,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 1682124000,
+                    "fmt": "1.68B",
+                    "longFmt": "1,682,124,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 8751112000,
+                    "fmt": "8.75B",
+                    "longFmt": "8,751,112,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -1631353000,
+                    "fmt": "-1.63B",
+                    "longFmt": "-1,631,353,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 251105000,
+                    "fmt": "251.1M",
+                    "longFmt": "251,105,000"
+                  },
+                  "ebit": {
+                    "raw": -1631353000,
+                    "fmt": "-1.63B",
+                    "longFmt": "-1,631,353,000"
+                  },
+                  "interestExpense": {
+                    "raw": -50113000,
+                    "fmt": "-50.11M",
+                    "longFmt": "-50,113,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -1380248000,
+                    "fmt": "-1.38B",
+                    "longFmt": "-1,380,248,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -148861000,
+                    "fmt": "-148.86M",
+                    "longFmt": "-148,861,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 84466000,
+                    "fmt": "84.47M",
+                    "longFmt": "84,466,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -1231387000,
+                    "fmt": "-1.23B",
+                    "longFmt": "-1,231,387,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -1228650000,
+                    "fmt": "-1.23B",
+                    "longFmt": "-1,228,650,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -1921953000,
+                    "fmt": "-1.92B",
+                    "longFmt": "-1,921,953,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1569801600,
+                    "fmt": "2019-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 12022659000,
+                    "fmt": "12.02B",
+                    "longFmt": "12,022,659,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 9083190000,
+                    "fmt": "9.08B",
+                    "longFmt": "9,083,190,000"
+                  },
+                  "grossProfit": {
+                    "raw": 2939469000,
+                    "fmt": "2.94B",
+                    "longFmt": "2,939,469,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 436056000,
+                    "fmt": "436.06M",
+                    "longFmt": "436,056,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 2103745000,
+                    "fmt": "2.1B",
+                    "longFmt": "2,103,745,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 11622991000,
+                    "fmt": "11.62B",
+                    "longFmt": "11,622,991,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 399668000,
+                    "fmt": "399.67M",
+                    "longFmt": "399,668,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 301713000,
+                    "fmt": "301.71M",
+                    "longFmt": "301,713,000"
+                  },
+                  "ebit": {
+                    "raw": 399668000,
+                    "fmt": "399.67M",
+                    "longFmt": "399,668,000"
+                  },
+                  "interestExpense": {
+                    "raw": -34558000,
+                    "fmt": "-34.56M",
+                    "longFmt": "-34,558,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 701381000,
+                    "fmt": "701.38M",
+                    "longFmt": "701,381,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 317120000,
+                    "fmt": "317.12M",
+                    "longFmt": "317,120,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 84466000,
+                    "fmt": "84.47M",
+                    "longFmt": "84,466,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 384261000,
+                    "fmt": "384.26M",
+                    "longFmt": "384,261,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 381354000,
+                    "fmt": "381.35M",
+                    "longFmt": "381,354,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -76584000,
+                    "fmt": "-76.58M",
+                    "longFmt": "-76,584,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 74697000,
+                    "fmt": "74.7M",
+                    "longFmt": "74,697,000"
+                  },
+                  "depreciation": {
+                    "raw": 303789000,
+                    "fmt": "303.79M",
+                    "longFmt": "303,789,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -746842000,
+                    "fmt": "-746.84M",
+                    "longFmt": "-746,842,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -3341525000,
+                    "fmt": "-3.34B",
+                    "longFmt": "-3,341,525,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 2217374000,
+                    "fmt": "2.22B",
+                    "longFmt": "2,217,374,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 5410498000,
+                    "fmt": "5.41B",
+                    "longFmt": "5,410,498,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 3213000000,
+                    "fmt": "3.21B",
+                    "longFmt": "3,213,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -566050000,
+                    "fmt": "-566.05M",
+                    "longFmt": "-566,050,000"
+                  },
+                  "investments": {
+                    "raw": -11199382000,
+                    "fmt": "-11.2B",
+                    "longFmt": "-11,199,382,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 4307818000,
+                    "fmt": "4.31B",
+                    "longFmt": "4,307,818,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -6945255000,
+                    "fmt": "-6.95B",
+                    "longFmt": "-6,945,255,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -105172000,
+                    "fmt": "-105.17M",
+                    "longFmt": "-105,172,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 324758000,
+                    "fmt": "324.76M",
+                    "longFmt": "324,758,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 16565408000,
+                    "fmt": "16.57B",
+                    "longFmt": "16,565,408,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -815884000,
+                    "fmt": "-815.88M",
+                    "longFmt": "-815,884,000"
+                  },
+                  "changeInCash": {
+                    "raw": 12017269000,
+                    "fmt": "12.02B",
+                    "longFmt": "12,017,269,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 16345822000,
+                    "fmt": "16.35B",
+                    "longFmt": "16,345,822,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "netIncome": {
+                    "raw": 2836568000,
+                    "fmt": "2.84B",
+                    "longFmt": "2,836,568,000"
+                  },
+                  "depreciation": {
+                    "raw": 272184000,
+                    "fmt": "272.18M",
+                    "longFmt": "272,184,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 2743463000,
+                    "fmt": "2.74B",
+                    "longFmt": "2,743,463,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -719861000,
+                    "fmt": "-719.86M",
+                    "longFmt": "-719,861,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 785185000,
+                    "fmt": "785.18M",
+                    "longFmt": "785,185,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 2426120000,
+                    "fmt": "2.43B",
+                    "longFmt": "2,426,120,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 9133566000,
+                    "fmt": "9.13B",
+                    "longFmt": "9,133,566,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": 149136000,
+                    "fmt": "149.14M",
+                    "longFmt": "149,136,000"
+                  },
+                  "investments": {
+                    "raw": 5786363000,
+                    "fmt": "5.79B",
+                    "longFmt": "5,786,363,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -2409715000,
+                    "fmt": "-2.41B",
+                    "longFmt": "-2,409,715,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 2751829000,
+                    "fmt": "2.75B",
+                    "longFmt": "2,751,829,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 898389000,
+                    "fmt": "898.39M",
+                    "longFmt": "898,389,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -569320000,
+                    "fmt": "-569.32M",
+                    "longFmt": "-569,320,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 329069000,
+                    "fmt": "329.07M",
+                    "longFmt": "329,069,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -14448000,
+                    "fmt": "-14.45M",
+                    "longFmt": "-14,448,000"
+                  },
+                  "changeInCash": {
+                    "raw": 12200016000,
+                    "fmt": "12.2B",
+                    "longFmt": "12,200,016,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 16345822000,
+                    "fmt": "16.35B",
+                    "longFmt": "16,345,822,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "netIncome": {
+                    "raw": -1228650000,
+                    "fmt": "-1.23B",
+                    "longFmt": "-1,228,650,000"
+                  },
+                  "depreciation": {
+                    "raw": 271845000,
+                    "fmt": "271.85M",
+                    "longFmt": "271,845,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 149055000,
+                    "fmt": "149.06M",
+                    "longFmt": "149,055,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 719861000,
+                    "fmt": "719.86M",
+                    "longFmt": "719,861,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -785185000,
+                    "fmt": "-785.18M",
+                    "longFmt": "-785,185,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -2426120000,
+                    "fmt": "-2.43B",
+                    "longFmt": "-2,426,120,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -4089101000,
+                    "fmt": "-4.09B",
+                    "longFmt": "-4,089,101,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -149136000,
+                    "fmt": "-149.14M",
+                    "longFmt": "-149,136,000"
+                  },
+                  "investments": {
+                    "raw": -5786363000,
+                    "fmt": "-5.79B",
+                    "longFmt": "-5,786,363,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -14819000,
+                    "fmt": "-14.82M",
+                    "longFmt": "-14,819,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -5176363000,
+                    "fmt": "-5.18B",
+                    "longFmt": "-5,176,363,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -898389000,
+                    "fmt": "-898.39M",
+                    "longFmt": "-898,389,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -569320000,
+                    "fmt": "-569.32M",
+                    "longFmt": "-569,320,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -898389000,
+                    "fmt": "-898.39M",
+                    "longFmt": "-898,389,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 131392000,
+                    "fmt": "131.39M",
+                    "longFmt": "131,392,000"
+                  },
+                  "changeInCash": {
+                    "raw": -10032461000,
+                    "fmt": "-10.03B",
+                    "longFmt": "-10,032,461,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 16345822000,
+                    "fmt": "16.35B",
+                    "longFmt": "16,345,822,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1569801600,
+                    "fmt": "2019-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 381354000,
+                    "fmt": "381.35M",
+                    "longFmt": "381,354,000"
+                  },
+                  "depreciation": {
+                    "raw": 308036000,
+                    "fmt": "308.04M",
+                    "longFmt": "308,036,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 56176000,
+                    "fmt": "56.18M",
+                    "longFmt": "56,176,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -1204448000,
+                    "fmt": "-1.2B",
+                    "longFmt": "-1,204,448,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 940491000,
+                    "fmt": "940.49M",
+                    "longFmt": "940,491,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 394199000,
+                    "fmt": "394.2M",
+                    "longFmt": "394,199,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 1257660000,
+                    "fmt": "1.26B",
+                    "longFmt": "1,257,660,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -123413000,
+                    "fmt": "-123.41M",
+                    "longFmt": "-123,413,000"
+                  },
+                  "investments": {
+                    "raw": 1040954000,
+                    "fmt": "1.04B",
+                    "longFmt": "1,040,954,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -4488000,
+                    "fmt": "-4.49M",
+                    "longFmt": "-4,488,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 132616000,
+                    "fmt": "132.62M",
+                    "longFmt": "132,616,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 64710000,
+                    "fmt": "64.71M",
+                    "longFmt": "64,710,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -569320000,
+                    "fmt": "-569.32M",
+                    "longFmt": "-569,320,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -2222516000,
+                    "fmt": "-2.22B",
+                    "longFmt": "-2,222,516,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 109779000,
+                    "fmt": "109.78M",
+                    "longFmt": "109,779,000"
+                  },
+                  "changeInCash": {
+                    "raw": -722461000,
+                    "fmt": "-722.46M",
+                    "longFmt": "-722,461,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -140074000,
+                    "fmt": "-140.07M",
+                    "longFmt": "-140,074,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 16345822000,
+                    "fmt": "16.35B",
+                    "longFmt": "16,345,822,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [
+                  {
+                    "date": "3Q2020",
+                    "actual": 0.21,
+                    "estimate": 0.17
+                  }
+                ],
+                "currentQuarterEstimate": 0.13,
+                "currentQuarterEstimateDate": "4Q",
+                "currentQuarterEstimateYear": 2020,
+                "earningsDate": []
+              },
+              "financialsChart": {
+                "yearly": [
+                  {
+                    "date": 2017,
+                    "revenue": 25505698000,
+                    "earnings": -574430000
+                  },
+                  {
+                    "date": 2018,
+                    "revenue": 28646499000,
+                    "earnings": -467824000
+                  },
+                  {
+                    "date": 2019,
+                    "revenue": 46014906000,
+                    "earnings": -2183546000
+                  }
+                ],
+                "quarterly": [
+                  {
+                    "date": "3Q2019",
+                    "revenue": 12022659000,
+                    "earnings": 381354000
+                  },
+                  {
+                    "date": "1Q2020",
+                    "revenue": 7119759000,
+                    "earnings": -1228650000
+                  },
+                  {
+                    "date": "2Q2020",
+                    "revenue": 20141659000,
+                    "earnings": 2836568000
+                  },
+                  {
+                    "date": "3Q2020",
+                    "revenue": 20548915000,
+                    "earnings": 74697000
+                  }
+                ]
+              },
+              "financialCurrency": "CNY"
+            },
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 65.91,
+              "targetHighPrice": 90.48,
+              "targetLowPrice": 20.99,
+              "targetMeanPrice": 67.22,
+              "targetMedianPrice": 67.57,
+              "recommendationMean": 2.5,
+              "recommendationKey": "buy",
+              "numberOfAnalystOpinions": 10,
+              "quickRatio": 2.013,
+              "currentRatio": 2.386,
+              "debtToEquity": 26.427,
+              "grossProfits": 11268044000,
+              "revenueGrowth": 0.709,
+              "grossMargins": 0.22805999,
+              "ebitdaMargins": -0.00654,
+              "operatingMargins": 0,
+              "profitMargins": -0.02313,
+              "financialCurrency": "CNY"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-all-BFLY.json
+++ b/tests/http/quoteSummary-all-BFLY.json
@@ -1,0 +1,951 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=assetProfile%2CbalanceSheetHistory%2CbalanceSheetHistoryQuarterly%2CcalendarEvents%2CcashflowStatementHistory%2CcashflowStatementHistoryQuarterly%2CdefaultKeyStatistics%2Cearnings%2CearningsHistory%2CearningsTrend%2CfinancialData%2CfundOwnership%2CfundPerformance%2CfundProfile%2CincomeStatementHistory%2CincomeStatementHistoryQuarterly%2CindexTrend%2CindustryTrend%2CinsiderHolders%2CinsiderTransactions%2CinstitutionOwnership%2CmajorDirectHolders%2CmajorHoldersBreakdown%2CnetSharePurchaseActivity%2Cprice%2CquoteType%2CrecommendationTrend%2CsecFilings%2CsectorTrend%2CsummaryDetail%2CsummaryProfile%2CtopHoldings%2CupgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "5i47vvhg2qh41"
+      ],
+      "x-yahoo-request-id": [
+        "5i47vvhg2qh41"
+      ],
+      "x-request-id": [
+        "45ae3085-a130-487c-9c9b-e1dae70815b4"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "11"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:52 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "530 Old Whitfield Street",
+              "city": "Guilford",
+              "state": "CT",
+              "zip": "06437",
+              "country": "United States",
+              "phone": "203-458-2514",
+              "website": "http://english.butterflynetwork.com",
+              "industry": "Medical Devices",
+              "sector": "Healthcare",
+              "longBusinessSummary": "Butterfly Network, Inc. develops medical imaging device for hospitals and organizations to scale their point of care ultrasound programs through a new suite of tools that enable ultrasound workflow mobile and system integrations simple and secure. The company's device provides diagnostic imaging and measurement of blood vessels and examines the cardiac, abdominal, urological, fetal, gynecological, and musculoskeletal systems. The company also offers Butterfly iQ, a handheld and single-probe whole body ultrasound system. The company was founded in 2011 and is based in Guilford, Connecticut.",
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Darius  Shahida",
+                  "age": 29,
+                  "title": "Chief Strategy Officer & Chief Bus. Devel. Officer",
+                  "yearBorn": 1991,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 413625,
+                    "fmt": "413.62k",
+                    "longFmt": "413,625"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Jonathan M. Rothberg",
+                  "age": 56,
+                  "title": "Founder & Chairman",
+                  "yearBorn": 1964,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Todd M. Fruchterman",
+                  "age": 50,
+                  "title": "Pres & CEO",
+                  "yearBorn": 1970,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Gregory C. Fergus",
+                  "age": 56,
+                  "title": "Board Member and Chief Commercial Officer",
+                  "yearBorn": 1964,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Michael J. Rothberg",
+                  "title": "Chief Financial Officer",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Elizabeth A. Whayland",
+                  "title": "Sec. & Director",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "compensationAsOfEpochDate": 1577750400,
+              "maxAge": 86400
+            },
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistory": {
+              "cashflowStatements": [],
+              "maxAge": 86400
+            },
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 5.56217,
+              "pegRatio": 0.991258,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.269
+                },
+                {
+                  "period": "+1q",
+                  "growth": 0.96099997
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.148
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.155
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0821053
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            },
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "profitMargins": 0,
+              "category": null,
+              "fundFamily": null,
+              "legalType": null,
+              "lastSplitFactor": null,
+              "52WeekChange": 0,
+              "SandP52WeekChange": 0.16137505
+            },
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "quoteType": {
+              "exchange": "NYQ",
+              "quoteType": "EQUITY",
+              "symbol": "BFLY",
+              "underlyingSymbol": "BFLY",
+              "shortName": "Butterfly Network, Inc. Class A",
+              "longName": "Butterfly Network, Inc.",
+              "firstTradeDateEpochUtc": 1594647000,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "5f9449d1-1162-3804-a742-88e2f8b5fb0e",
+              "messageBoardId": null,
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            },
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [],
+              "maxAge": 86400
+            },
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            },
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 22.5,
+              "open": 23.11,
+              "dayLow": 22.1807,
+              "dayHigh": 23.31,
+              "regularMarketPreviousClose": 22.5,
+              "regularMarketOpen": 23.11,
+              "regularMarketDayLow": 22.1807,
+              "regularMarketDayHigh": 23.31,
+              "volume": 1508514,
+              "regularMarketVolume": 1508514,
+              "averageVolume": 2347300,
+              "averageVolume10days": 2347300,
+              "averageDailyVolume10Day": 2347300,
+              "bid": 22.68,
+              "ask": 22.71,
+              "bidSize": 900,
+              "askSize": 1200,
+              "fiftyTwoWeekLow": 21.95,
+              "fiftyTwoWeekHigh": 24.8,
+              "fiftyDayAverage": 22.5,
+              "twoHundredDayAverage": 22.5,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            },
+            "insiderHolders": {
+              "holders": [],
+              "maxAge": 1
+            },
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": []
+              }
+            },
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": 0.0288889,
+              "preMarketChange": 0.65,
+              "preMarketTime": 1613572193,
+              "preMarketPrice": 23.15,
+              "preMarketSource": "FREE_REALTIME",
+              "regularMarketChangePercent": -0.008222198,
+              "regularMarketChange": -0.18499947,
+              "regularMarketTime": 1613579380,
+              "priceHint": 2,
+              "regularMarketPrice": 22.315,
+              "regularMarketDayHigh": 23.31,
+              "regularMarketDayLow": 22.1807,
+              "regularMarketVolume": 1508514,
+              "averageDailyVolume10Day": 2347300,
+              "averageDailyVolume3Month": 2347300,
+              "regularMarketPreviousClose": 22.5,
+              "regularMarketSource": "FREE_REALTIME",
+              "regularMarketOpen": 23.11,
+              "exchange": "NYQ",
+              "exchangeName": "NYSE",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "EQUITY",
+              "symbol": "BFLY",
+              "underlyingSymbol": null,
+              "shortName": "Butterfly Network, Inc. Class A",
+              "longName": "Butterfly Network, Inc.",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null
+            },
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [],
+              "maxAge": 86400
+            },
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            },
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            },
+            "majorHoldersBreakdown": {
+              "maxAge": 1
+            },
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [],
+              "maxAge": 86400
+            },
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            },
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            },
+            "summaryProfile": {
+              "address1": "530 Old Whitfield Street",
+              "city": "Guilford",
+              "state": "CT",
+              "zip": "06437",
+              "country": "United States",
+              "phone": "203-458-2514",
+              "website": "http://english.butterflynetwork.com",
+              "industry": "Medical Devices",
+              "sector": "Healthcare",
+              "longBusinessSummary": "Butterfly Network, Inc. develops medical imaging device for hospitals and organizations to scale their point of care ultrasound programs through a new suite of tools that enable ultrasound workflow mobile and system integrations simple and secure. The company's device provides diagnostic imaging and measurement of blood vessels and examines the cardiac, abdominal, urological, fetal, gynecological, and musculoskeletal systems. The company also offers Butterfly iQ, a handheld and single-probe whole body ultrasound system. The company was founded in 2011 and is based in Guilford, Connecticut.",
+              "companyOfficers": [],
+              "maxAge": 86400
+            },
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 0,
+              "buyInfoShares": 0,
+              "sellInfoCount": 0,
+              "netInfoCount": 0,
+              "netInfoShares": 0,
+              "totalInsiderShares": 0
+            },
+            "sectorTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [],
+              "maxAge": 86400
+            },
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [],
+                "earningsDate": []
+              },
+              "financialsChart": {
+                "yearly": [],
+                "quarterly": []
+              }
+            },
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 22.315,
+              "targetHighPrice": 15,
+              "targetLowPrice": 15,
+              "targetMeanPrice": 15,
+              "targetMedianPrice": 15,
+              "recommendationKey": "none",
+              "numberOfAnalystOpinions": 1,
+              "grossMargins": 0,
+              "ebitdaMargins": 0,
+              "operatingMargins": 0,
+              "profitMargins": 0,
+              "financialCurrency": null
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-assetProfile-BEKE.json
+++ b/tests/http/quoteSummary-assetProfile-BEKE.json
@@ -1,0 +1,198 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=assetProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "2kv93flg2qh3m"
+      ],
+      "x-yahoo-request-id": [
+        "2kv93flg2qh3m"
+      ],
+      "x-request-id": [
+        "be238be9-b2d1-4633-84ee-2c1709d98747"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "721"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:42 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "Building Fudao",
+              "address2": "No.11 Kaituo Road Haidian District",
+              "city": "Beijing",
+              "zip": "100085",
+              "country": "China",
+              "phone": "86 10 5810 4689",
+              "website": "http://ke.com",
+              "industry": "Real Estate Services",
+              "sector": "Real Estate",
+              "longBusinessSummary": "KE Holdings Inc. operates an integrated online and offline platform for housing transactions and services in the People's Republic of China. The company facilitates various housing transactions ranging from existing and new home sales and home rentals to home renovation, real estate financial solutions, and other services. It also owns and operates Lianjia, a real estate brokerage branded store. The company was founded in 2001 and is headquartered in Beijing, China.",
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Hui  Zuo",
+                  "age": 49,
+                  "title": "Founder & Chairman",
+                  "yearBorn": 1971,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Yongdong  Peng",
+                  "age": 41,
+                  "title": "CEO & Exec. Director",
+                  "yearBorn": 1979,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Tao  Xu",
+                  "age": 47,
+                  "title": "Chief Financial Officer",
+                  "yearBorn": 1973,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Wangang  Xu",
+                  "age": 55,
+                  "title": "Co-Chief Operating Officer",
+                  "yearBorn": 1965,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Yongqun  Wang",
+                  "age": 49,
+                  "title": "Co-Chief Operating Officer",
+                  "yearBorn": 1971,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Yigang  Shan",
+                  "age": 47,
+                  "title": "Exec. Director",
+                  "yearBorn": 1973,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-assetProfile-BFLY.json
+++ b/tests/http/quoteSummary-assetProfile-BFLY.json
@@ -1,0 +1,201 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=assetProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "86rhcq1g2qh3n"
+      ],
+      "x-yahoo-request-id": [
+        "86rhcq1g2qh3n"
+      ],
+      "x-request-id": [
+        "926b05a5-ecda-4a9a-8f53-c7087db71d83"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "925"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:42 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "530 Old Whitfield Street",
+              "city": "Guilford",
+              "state": "CT",
+              "zip": "06437",
+              "country": "United States",
+              "phone": "203-458-2514",
+              "website": "http://english.butterflynetwork.com",
+              "industry": "Medical Devices",
+              "sector": "Healthcare",
+              "longBusinessSummary": "Butterfly Network, Inc. develops medical imaging device for hospitals and organizations to scale their point of care ultrasound programs through a new suite of tools that enable ultrasound workflow mobile and system integrations simple and secure. The company's device provides diagnostic imaging and measurement of blood vessels and examines the cardiac, abdominal, urological, fetal, gynecological, and musculoskeletal systems. The company also offers Butterfly iQ, a handheld and single-probe whole body ultrasound system. The company was founded in 2011 and is based in Guilford, Connecticut.",
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Darius  Shahida",
+                  "age": 29,
+                  "title": "Chief Strategy Officer & Chief Bus. Devel. Officer",
+                  "yearBorn": 1991,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 413625,
+                    "fmt": "413.62k",
+                    "longFmt": "413,625"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Jonathan M. Rothberg",
+                  "age": 56,
+                  "title": "Founder & Chairman",
+                  "yearBorn": 1964,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Todd M. Fruchterman",
+                  "age": 50,
+                  "title": "Pres & CEO",
+                  "yearBorn": 1970,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Gregory C. Fergus",
+                  "age": 56,
+                  "title": "Board Member and Chief Commercial Officer",
+                  "yearBorn": 1964,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Michael J. Rothberg",
+                  "title": "Chief Financial Officer",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Elizabeth A. Whayland",
+                  "title": "Sec. & Director",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "compensationAsOfEpochDate": 1577750400,
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistory-BEKE.json
+++ b/tests/http/quoteSummary-balanceSheetHistory-BEKE.json
@@ -1,0 +1,492 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=balanceSheetHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "afae8q5g2qh3n"
+      ],
+      "x-yahoo-request-id": [
+        "afae8q5g2qh3n"
+      ],
+      "x-request-id": [
+        "73c8fa21-3092-4c64-9601-b43b86c33381"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1682"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:43 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 24319332000,
+                    "fmt": "24.32B",
+                    "longFmt": "24,319,332,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 1844595000,
+                    "fmt": "1.84B",
+                    "longFmt": "1,844,595,000"
+                  },
+                  "netReceivables": {
+                    "raw": 13169172000,
+                    "fmt": "13.17B",
+                    "longFmt": "13,169,172,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 12139612000,
+                    "fmt": "12.14B",
+                    "longFmt": "12,139,612,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 51912486000,
+                    "fmt": "51.91B",
+                    "longFmt": "51,912,486,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2333745000,
+                    "fmt": "2.33B",
+                    "longFmt": "2,333,745,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6759243000,
+                    "fmt": "6.76B",
+                    "longFmt": "6,759,243,000"
+                  },
+                  "goodWill": {
+                    "raw": 2477075000,
+                    "fmt": "2.48B",
+                    "longFmt": "2,477,075,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 2560442000,
+                    "fmt": "2.56B",
+                    "longFmt": "2,560,442,000"
+                  },
+                  "otherAssets": {
+                    "raw": 1222321000,
+                    "fmt": "1.22B",
+                    "longFmt": "1,222,321,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 520292000,
+                    "fmt": "520.29M",
+                    "longFmt": "520,292,000"
+                  },
+                  "totalAssets": {
+                    "raw": 67265312000,
+                    "fmt": "67.27B",
+                    "longFmt": "67,265,312,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 4475170000,
+                    "fmt": "4.48B",
+                    "longFmt": "4,475,170,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2291723000,
+                    "fmt": "2.29B",
+                    "longFmt": "2,291,723,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 8584074000,
+                    "fmt": "8.58B",
+                    "longFmt": "8,584,074,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 4897530000,
+                    "fmt": "4.9B",
+                    "longFmt": "4,897,530,000"
+                  },
+                  "otherLiab": {
+                    "raw": 120275000,
+                    "fmt": "120.28M",
+                    "longFmt": "120,275,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 87203000,
+                    "fmt": "87.2M",
+                    "longFmt": "87,203,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 27797675000,
+                    "fmt": "27.8B",
+                    "longFmt": "27,797,675,000"
+                  },
+                  "totalLiab": {
+                    "raw": 35729720000,
+                    "fmt": "35.73B",
+                    "longFmt": "35,729,720,000"
+                  },
+                  "commonStock": {
+                    "raw": 202000,
+                    "fmt": "202k",
+                    "longFmt": "202,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -11521905000,
+                    "fmt": "-11.52B",
+                    "longFmt": "-11,521,905,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 63308000,
+                    "fmt": "63.31M",
+                    "longFmt": "63,308,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 2533889000,
+                    "fmt": "2.53B",
+                    "longFmt": "2,533,889,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 63308000,
+                    "fmt": "63.31M",
+                    "longFmt": "63,308,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -8924506000,
+                    "fmt": "-8.92B",
+                    "longFmt": "-8,924,506,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -13962023000,
+                    "fmt": "-13.96B",
+                    "longFmt": "-13,962,023,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "cash": {
+                    "raw": 9115649000,
+                    "fmt": "9.12B",
+                    "longFmt": "9,115,649,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 2523199000,
+                    "fmt": "2.52B",
+                    "longFmt": "2,523,199,000"
+                  },
+                  "netReceivables": {
+                    "raw": 10369552000,
+                    "fmt": "10.37B",
+                    "longFmt": "10,369,552,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 4972534000,
+                    "fmt": "4.97B",
+                    "longFmt": "4,972,534,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 27374784000,
+                    "fmt": "27.37B",
+                    "longFmt": "27,374,784,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 418469000,
+                    "fmt": "418.47M",
+                    "longFmt": "418,469,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6089232000,
+                    "fmt": "6.09B",
+                    "longFmt": "6,089,232,000"
+                  },
+                  "goodWill": {
+                    "raw": 1135034000,
+                    "fmt": "1.14B",
+                    "longFmt": "1,135,034,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 196998000,
+                    "fmt": "197M",
+                    "longFmt": "196,998,000"
+                  },
+                  "otherAssets": {
+                    "raw": 3651747000,
+                    "fmt": "3.65B",
+                    "longFmt": "3,651,747,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 672622000,
+                    "fmt": "672.62M",
+                    "longFmt": "672,622,000"
+                  },
+                  "totalAssets": {
+                    "raw": 38866264000,
+                    "fmt": "38.87B",
+                    "longFmt": "38,866,264,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1573343000,
+                    "fmt": "1.57B",
+                    "longFmt": "1,573,343,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2414607000,
+                    "fmt": "2.41B",
+                    "longFmt": "2,414,607,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 4762200000,
+                    "fmt": "4.76B",
+                    "longFmt": "4,762,200,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 112900000,
+                    "fmt": "112.9M",
+                    "longFmt": "112,900,000"
+                  },
+                  "otherLiab": {
+                    "raw": 532931000,
+                    "fmt": "532.93M",
+                    "longFmt": "532,931,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 10467000,
+                    "fmt": "10.47M",
+                    "longFmt": "10,467,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 20572881000,
+                    "fmt": "20.57B",
+                    "longFmt": "20,572,881,000"
+                  },
+                  "totalLiab": {
+                    "raw": 24007724000,
+                    "fmt": "24.01B",
+                    "longFmt": "24,007,724,000"
+                  },
+                  "commonStock": {
+                    "raw": 189000,
+                    "fmt": "189k",
+                    "longFmt": "189,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -7814291000,
+                    "fmt": "-7.81B",
+                    "longFmt": "-7,814,291,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -134000,
+                    "fmt": "-134k",
+                    "longFmt": "-134,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -134000,
+                    "fmt": "-134k",
+                    "longFmt": "-134,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -7814236000,
+                    "fmt": "-7.81B",
+                    "longFmt": "-7,814,236,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -9146268000,
+                    "fmt": "-9.15B",
+                    "longFmt": "-9,146,268,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "cash": {
+                    "raw": 5236100000,
+                    "fmt": "5.24B",
+                    "longFmt": "5,236,100,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 7587433000,
+                    "fmt": "7.59B",
+                    "longFmt": "7,587,433,000"
+                  },
+                  "netReceivables": {
+                    "raw": 4676434000,
+                    "fmt": "4.68B",
+                    "longFmt": "4,676,434,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 6227975000,
+                    "fmt": "6.23B",
+                    "longFmt": "6,227,975,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 24067931000,
+                    "fmt": "24.07B",
+                    "longFmt": "24,067,931,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 379972000,
+                    "fmt": "379.97M",
+                    "longFmt": "379,972,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6002914000,
+                    "fmt": "6B",
+                    "longFmt": "6,002,914,000"
+                  },
+                  "goodWill": {
+                    "raw": 710983000,
+                    "fmt": "710.98M",
+                    "longFmt": "710,983,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 264726000,
+                    "fmt": "264.73M",
+                    "longFmt": "264,726,000"
+                  },
+                  "otherAssets": {
+                    "raw": 153409000,
+                    "fmt": "153.41M",
+                    "longFmt": "153,409,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 147535000,
+                    "fmt": "147.53M",
+                    "longFmt": "147,535,000"
+                  },
+                  "totalAssets": {
+                    "raw": 31579935000,
+                    "fmt": "31.58B",
+                    "longFmt": "31,579,935,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 370496000,
+                    "fmt": "370.5M",
+                    "longFmt": "370,496,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 4665524000,
+                    "fmt": "4.67B",
+                    "longFmt": "4,665,524,000"
+                  },
+                  "otherLiab": {
+                    "raw": 518091000,
+                    "fmt": "518.09M",
+                    "longFmt": "518,091,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 65836000,
+                    "fmt": "65.84M",
+                    "longFmt": "65,836,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 16047286000,
+                    "fmt": "16.05B",
+                    "longFmt": "16,047,286,000"
+                  },
+                  "totalLiab": {
+                    "raw": 19143150000,
+                    "fmt": "19.14B",
+                    "longFmt": "19,143,150,000"
+                  },
+                  "commonStock": {
+                    "raw": 178000,
+                    "fmt": "178k",
+                    "longFmt": "178,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -5226325000,
+                    "fmt": "-5.23B",
+                    "longFmt": "-5,226,325,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -327000,
+                    "fmt": "-327k",
+                    "longFmt": "-327,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -327000,
+                    "fmt": "-327k",
+                    "longFmt": "-327,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -5226474000,
+                    "fmt": "-5.23B",
+                    "longFmt": "-5,226,474,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -6202183000,
+                    "fmt": "-6.2B",
+                    "longFmt": "-6,202,183,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistory-BFLY.json
+++ b/tests/http/quoteSummary-balanceSheetHistory-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=balanceSheetHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "0l7sr3lg2qh3n"
+      ],
+      "x-yahoo-request-id": [
+        "0l7sr3lg2qh3n"
+      ],
+      "x-request-id": [
+        "3735695d-05a9-4c16-b056-d836f663c3ed"
+      ],
+      "content-length": [
+        "111"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:43 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistoryQuarterly-BEKE.json
+++ b/tests/http/quoteSummary-balanceSheetHistoryQuarterly-BEKE.json
@@ -1,0 +1,519 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=balanceSheetHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "65n4cf1g2qh3n"
+      ],
+      "x-yahoo-request-id": [
+        "65n4cf1g2qh3n"
+      ],
+      "x-request-id": [
+        "6bcef0bb-c75c-437f-b353-071111da1184"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1750"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:43 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 38046404000,
+                    "fmt": "38.05B",
+                    "longFmt": "38,046,404,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 13156851000,
+                    "fmt": "13.16B",
+                    "longFmt": "13,156,851,000"
+                  },
+                  "netReceivables": {
+                    "raw": 12955146000,
+                    "fmt": "12.96B",
+                    "longFmt": "12,955,146,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 10926407000,
+                    "fmt": "10.93B",
+                    "longFmt": "10,926,407,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 75696700000,
+                    "fmt": "75.7B",
+                    "longFmt": "75,696,700,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2461657000,
+                    "fmt": "2.46B",
+                    "longFmt": "2,461,657,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 7389774000,
+                    "fmt": "7.39B",
+                    "longFmt": "7,389,774,000"
+                  },
+                  "goodWill": {
+                    "raw": 2490155000,
+                    "fmt": "2.49B",
+                    "longFmt": "2,490,155,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 2062294000,
+                    "fmt": "2.06B",
+                    "longFmt": "2,062,294,000"
+                  },
+                  "otherAssets": {
+                    "raw": 873615000,
+                    "fmt": "873.62M",
+                    "longFmt": "873,615,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 530164000,
+                    "fmt": "530.16M",
+                    "longFmt": "530,164,000"
+                  },
+                  "totalAssets": {
+                    "raw": 90974195000,
+                    "fmt": "90.97B",
+                    "longFmt": "90,974,195,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 6499745000,
+                    "fmt": "6.5B",
+                    "longFmt": "6,499,745,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2411361000,
+                    "fmt": "2.41B",
+                    "longFmt": "2,411,361,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 9611704000,
+                    "fmt": "9.61B",
+                    "longFmt": "9,611,704,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 4793875000,
+                    "fmt": "4.79B",
+                    "longFmt": "4,793,875,000"
+                  },
+                  "otherLiab": {
+                    "raw": 22446000,
+                    "fmt": "22.45M",
+                    "longFmt": "22,446,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 26490000,
+                    "fmt": "26.49M",
+                    "longFmt": "26,490,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 31727200000,
+                    "fmt": "31.73B",
+                    "longFmt": "31,727,200,000"
+                  },
+                  "totalLiab": {
+                    "raw": 39843179000,
+                    "fmt": "39.84B",
+                    "longFmt": "39,843,179,000"
+                  },
+                  "commonStock": {
+                    "raw": 466000,
+                    "fmt": "466k",
+                    "longFmt": "466,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -9929807000,
+                    "fmt": "-9.93B",
+                    "longFmt": "-9,929,807,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -531354000,
+                    "fmt": "-531.35M",
+                    "longFmt": "-531,354,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 61565221000,
+                    "fmt": "61.57B",
+                    "longFmt": "61,565,221,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -531354000,
+                    "fmt": "-531.35M",
+                    "longFmt": "-531,354,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 51104526000,
+                    "fmt": "51.1B",
+                    "longFmt": "51,104,526,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 46552077000,
+                    "fmt": "46.55B",
+                    "longFmt": "46,552,077,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "cash": {
+                    "raw": 25079605000,
+                    "fmt": "25.08B",
+                    "longFmt": "25,079,605,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 5869529000,
+                    "fmt": "5.87B",
+                    "longFmt": "5,869,529,000"
+                  },
+                  "netReceivables": {
+                    "raw": 13068816000,
+                    "fmt": "13.07B",
+                    "longFmt": "13,068,816,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 12353005000,
+                    "fmt": "12.35B",
+                    "longFmt": "12,353,005,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 56925376000,
+                    "fmt": "56.93B",
+                    "longFmt": "56,925,376,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2466889000,
+                    "fmt": "2.47B",
+                    "longFmt": "2,466,889,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6911464000,
+                    "fmt": "6.91B",
+                    "longFmt": "6,911,464,000"
+                  },
+                  "goodWill": {
+                    "raw": 2490155000,
+                    "fmt": "2.49B",
+                    "longFmt": "2,490,155,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 2288794000,
+                    "fmt": "2.29B",
+                    "longFmt": "2,288,794,000"
+                  },
+                  "otherAssets": {
+                    "raw": 923040000,
+                    "fmt": "923.04M",
+                    "longFmt": "923,040,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 530164000,
+                    "fmt": "530.16M",
+                    "longFmt": "530,164,000"
+                  },
+                  "totalAssets": {
+                    "raw": 72005718000,
+                    "fmt": "72.01B",
+                    "longFmt": "72,005,718,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 5287577000,
+                    "fmt": "5.29B",
+                    "longFmt": "5,287,577,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2199275000,
+                    "fmt": "2.2B",
+                    "longFmt": "2,199,275,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 11037514000,
+                    "fmt": "11.04B",
+                    "longFmt": "11,037,514,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 4885370000,
+                    "fmt": "4.89B",
+                    "longFmt": "4,885,370,000"
+                  },
+                  "otherLiab": {
+                    "raw": 116203000,
+                    "fmt": "116.2M",
+                    "longFmt": "116,203,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 25846000,
+                    "fmt": "25.85M",
+                    "longFmt": "25,846,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 30175739000,
+                    "fmt": "30.18B",
+                    "longFmt": "30,175,739,000"
+                  },
+                  "totalLiab": {
+                    "raw": 38219015000,
+                    "fmt": "38.22B",
+                    "longFmt": "38,219,015,000"
+                  },
+                  "commonStock": {
+                    "raw": 205000,
+                    "fmt": "205k",
+                    "longFmt": "205,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -10004504000,
+                    "fmt": "-10B",
+                    "longFmt": "-10,004,504,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 213691000,
+                    "fmt": "213.69M",
+                    "longFmt": "213,691,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1769485000,
+                    "fmt": "1.77B",
+                    "longFmt": "1,769,485,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 213691000,
+                    "fmt": "213.69M",
+                    "longFmt": "213,691,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -8021123000,
+                    "fmt": "-8.02B",
+                    "longFmt": "-8,021,123,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -12800072000,
+                    "fmt": "-12.8B",
+                    "longFmt": "-12,800,072,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "cash": {
+                    "raw": 15538844000,
+                    "fmt": "15.54B",
+                    "longFmt": "15,538,844,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 7709598000,
+                    "fmt": "7.71B",
+                    "longFmt": "7,709,598,000"
+                  },
+                  "netReceivables": {
+                    "raw": 11799844000,
+                    "fmt": "11.8B",
+                    "longFmt": "11,799,844,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 10805983000,
+                    "fmt": "10.81B",
+                    "longFmt": "10,805,983,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 46380397000,
+                    "fmt": "46.38B",
+                    "longFmt": "46,380,397,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2347955000,
+                    "fmt": "2.35B",
+                    "longFmt": "2,347,955,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6700269000,
+                    "fmt": "6.7B",
+                    "longFmt": "6,700,269,000"
+                  },
+                  "goodWill": {
+                    "raw": 2477075000,
+                    "fmt": "2.48B",
+                    "longFmt": "2,477,075,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 2433454000,
+                    "fmt": "2.43B",
+                    "longFmt": "2,433,454,000"
+                  },
+                  "otherAssets": {
+                    "raw": 901375000,
+                    "fmt": "901.38M",
+                    "longFmt": "901,375,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 530164000,
+                    "fmt": "530.16M",
+                    "longFmt": "530,164,000"
+                  },
+                  "totalAssets": {
+                    "raw": 61240525000,
+                    "fmt": "61.24B",
+                    "longFmt": "61,240,525,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 3645940000,
+                    "fmt": "3.65B",
+                    "longFmt": "3,645,940,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 1767844000,
+                    "fmt": "1.77B",
+                    "longFmt": "1,767,844,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 8597488000,
+                    "fmt": "8.6B",
+                    "longFmt": "8,597,488,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 4980956000,
+                    "fmt": "4.98B",
+                    "longFmt": "4,980,956,000"
+                  },
+                  "otherLiab": {
+                    "raw": 120365000,
+                    "fmt": "120.36M",
+                    "longFmt": "120,365,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 84466000,
+                    "fmt": "84.47M",
+                    "longFmt": "84,466,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 22876987000,
+                    "fmt": "22.88B",
+                    "longFmt": "22,876,987,000"
+                  },
+                  "totalLiab": {
+                    "raw": 30855825000,
+                    "fmt": "30.86B",
+                    "longFmt": "30,855,825,000"
+                  },
+                  "commonStock": {
+                    "raw": 202000,
+                    "fmt": "202k",
+                    "longFmt": "202,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -12841072000,
+                    "fmt": "-12.84B",
+                    "longFmt": "-12,841,072,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 234320000,
+                    "fmt": "234.32M",
+                    "longFmt": "234,320,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1840586000,
+                    "fmt": "1.84B",
+                    "longFmt": "1,840,586,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 234320000,
+                    "fmt": "234.32M",
+                    "longFmt": "234,320,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -10765964000,
+                    "fmt": "-10.77B",
+                    "longFmt": "-10,765,964,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -15676493000,
+                    "fmt": "-15.68B",
+                    "longFmt": "-15,676,493,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1569801600,
+                    "fmt": "2019-09-30"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistoryQuarterly-BFLY.json
+++ b/tests/http/quoteSummary-balanceSheetHistoryQuarterly-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=balanceSheetHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "c25hpg1g2qh3n"
+      ],
+      "x-yahoo-request-id": [
+        "c25hpg1g2qh3n"
+      ],
+      "x-request-id": [
+        "cc29e7d1-b080-47d9-ae74-b1188b738c5c"
+      ],
+      "content-length": [
+        "120"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:43 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-calendarEvents-BEKE.json
+++ b/tests/http/quoteSummary-calendarEvents-BEKE.json
@@ -1,0 +1,90 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=calendarEvents"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "b0tjr2tg2qh3n"
+      ],
+      "x-yahoo-request-id": [
+        "b0tjr2tg2qh3n"
+      ],
+      "x-request-id": [
+        "c71704fd-0b26-4a37-b7da-48af6b6a8e41"
+      ],
+      "content-length": [
+        "244"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:43 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "3"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": [],
+                "earningsAverage": 0.13,
+                "earningsLow": 0.01,
+                "earningsHigh": 0.17,
+                "revenueAverage": 3082150000,
+                "revenueLow": 2998670000,
+                "revenueHigh": 3182420000
+              }
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-calendarEvents-BFLY.json
+++ b/tests/http/quoteSummary-calendarEvents-BFLY.json
@@ -1,0 +1,84 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=calendarEvents"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "a57c9llg2qh3o"
+      ],
+      "x-yahoo-request-id": [
+        "a57c9llg2qh3o"
+      ],
+      "x-request-id": [
+        "d609600c-4d8a-4ffa-a896-f12d633bb472"
+      ],
+      "content-length": [
+        "105"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:43 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": []
+              }
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistory-BEKE.json
+++ b/tests/http/quoteSummary-cashflowStatementHistory-BEKE.json
@@ -1,0 +1,382 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=cashflowStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "abs8kktg2qh3o"
+      ],
+      "x-yahoo-request-id": [
+        "abs8kktg2qh3o"
+      ],
+      "x-request-id": [
+        "0706e966-852f-43b6-b800-1f03e7af624d"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1246"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:43 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -2183546000,
+                    "fmt": "-2.18B",
+                    "longFmt": "-2,183,546,000"
+                  },
+                  "depreciation": {
+                    "raw": 1039318000,
+                    "fmt": "1.04B",
+                    "longFmt": "1,039,318,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 3018688000,
+                    "fmt": "3.02B",
+                    "longFmt": "3,018,688,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -5040865000,
+                    "fmt": "-5.04B",
+                    "longFmt": "-5,040,865,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 3009276000,
+                    "fmt": "3.01B",
+                    "longFmt": "3,009,276,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -412586000,
+                    "fmt": "-412.59M",
+                    "longFmt": "-412,586,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 112626000,
+                    "fmt": "112.63M",
+                    "longFmt": "112,626,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -703008000,
+                    "fmt": "-703.01M",
+                    "longFmt": "-703,008,000"
+                  },
+                  "investments": {
+                    "raw": -1133063000,
+                    "fmt": "-1.13B",
+                    "longFmt": "-1,133,063,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 91216000,
+                    "fmt": "91.22M",
+                    "longFmt": "91,216,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -3873722000,
+                    "fmt": "-3.87B",
+                    "longFmt": "-3,873,722,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 6758437000,
+                    "fmt": "6.76B",
+                    "longFmt": "6,758,437,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -8628000,
+                    "fmt": "-8.63M",
+                    "longFmt": "-8,628,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 23026396000,
+                    "fmt": "23.03B",
+                    "longFmt": "23,026,396,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -94922000,
+                    "fmt": "-94.92M",
+                    "longFmt": "-94,922,000"
+                  },
+                  "changeInCash": {
+                    "raw": 19170378000,
+                    "fmt": "19.17B",
+                    "longFmt": "19,170,378,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -347219000,
+                    "fmt": "-347.22M",
+                    "longFmt": "-347,219,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 232885000,
+                    "fmt": "232.88M",
+                    "longFmt": "232,885,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -467824000,
+                    "fmt": "-467.82M",
+                    "longFmt": "-467,824,000"
+                  },
+                  "depreciation": {
+                    "raw": 792294000,
+                    "fmt": "792.29M",
+                    "longFmt": "792,294,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -186336000,
+                    "fmt": "-186.34M",
+                    "longFmt": "-186,336,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -769062000,
+                    "fmt": "-769.06M",
+                    "longFmt": "-769,062,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 1157138000,
+                    "fmt": "1.16B",
+                    "longFmt": "1,157,138,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 2913832000,
+                    "fmt": "2.91B",
+                    "longFmt": "2,913,832,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 3216797000,
+                    "fmt": "3.22B",
+                    "longFmt": "3,216,797,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -542853000,
+                    "fmt": "-542.85M",
+                    "longFmt": "-542,853,000"
+                  },
+                  "investments": {
+                    "raw": 5239066000,
+                    "fmt": "5.24B",
+                    "longFmt": "5,239,066,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -2010792000,
+                    "fmt": "-2.01B",
+                    "longFmt": "-2,010,792,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 2609149000,
+                    "fmt": "2.61B",
+                    "longFmt": "2,609,149,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -124121000,
+                    "fmt": "-124.12M",
+                    "longFmt": "-124,121,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -437019000,
+                    "fmt": "-437.02M",
+                    "longFmt": "-437,019,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -1282408000,
+                    "fmt": "-1.28B",
+                    "longFmt": "-1,282,408,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 416000,
+                    "fmt": "416k",
+                    "longFmt": "416,000"
+                  },
+                  "changeInCash": {
+                    "raw": 4543954000,
+                    "fmt": "4.54B",
+                    "longFmt": "4,543,954,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -347219000,
+                    "fmt": "-347.22M",
+                    "longFmt": "-347,219,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 232885000,
+                    "fmt": "232.88M",
+                    "longFmt": "232,885,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -574430000,
+                    "fmt": "-574.43M",
+                    "longFmt": "-574,430,000"
+                  },
+                  "depreciation": {
+                    "raw": 811203000,
+                    "fmt": "811.2M",
+                    "longFmt": "811,203,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 164271000,
+                    "fmt": "164.27M",
+                    "longFmt": "164,271,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -498216000,
+                    "fmt": "-498.22M",
+                    "longFmt": "-498,216,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -764294000,
+                    "fmt": "-764.29M",
+                    "longFmt": "-764,294,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -5733411000,
+                    "fmt": "-5.73B",
+                    "longFmt": "-5,733,411,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -6456226000,
+                    "fmt": "-6.46B",
+                    "longFmt": "-6,456,226,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -575185000,
+                    "fmt": "-575.18M",
+                    "longFmt": "-575,185,000"
+                  },
+                  "investments": {
+                    "raw": -959123000,
+                    "fmt": "-959.12M",
+                    "longFmt": "-959,123,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -5000000,
+                    "fmt": "-5M",
+                    "longFmt": "-5,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -2783562000,
+                    "fmt": "-2.78B",
+                    "longFmt": "-2,783,562,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -127188000,
+                    "fmt": "-127.19M",
+                    "longFmt": "-127,188,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 973472000,
+                    "fmt": "973.47M",
+                    "longFmt": "973,472,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -437019000,
+                    "fmt": "-437.02M",
+                    "longFmt": "-437,019,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 9576284000,
+                    "fmt": "9.58B",
+                    "longFmt": "9,576,284,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -330000,
+                    "fmt": "-330k",
+                    "longFmt": "-330,000"
+                  },
+                  "changeInCash": {
+                    "raw": 336166000,
+                    "fmt": "336.17M",
+                    "longFmt": "336,166,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -347219000,
+                    "fmt": "-347.22M",
+                    "longFmt": "-347,219,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 232885000,
+                    "fmt": "232.88M",
+                    "longFmt": "232,885,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistory-BFLY.json
+++ b/tests/http/quoteSummary-cashflowStatementHistory-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=cashflowStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "0cg0gf9g2qh3o"
+      ],
+      "x-yahoo-request-id": [
+        "0cg0gf9g2qh3o"
+      ],
+      "x-request-id": [
+        "b27f5dd7-bf2c-4cec-a6e6-c5885fe16c79"
+      ],
+      "content-length": [
+        "112"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:44 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistory": {
+              "cashflowStatements": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-BEKE.json
+++ b/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-BEKE.json
@@ -1,0 +1,459 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=cashflowStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "dosf11tg2qh3o"
+      ],
+      "x-yahoo-request-id": [
+        "dosf11tg2qh3o"
+      ],
+      "x-request-id": [
+        "97d3d5eb-5a70-47d4-9343-9681a8c1f5f9"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1436"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:44 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 74697000,
+                    "fmt": "74.7M",
+                    "longFmt": "74,697,000"
+                  },
+                  "depreciation": {
+                    "raw": 303789000,
+                    "fmt": "303.79M",
+                    "longFmt": "303,789,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -746842000,
+                    "fmt": "-746.84M",
+                    "longFmt": "-746,842,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -3341525000,
+                    "fmt": "-3.34B",
+                    "longFmt": "-3,341,525,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 2217374000,
+                    "fmt": "2.22B",
+                    "longFmt": "2,217,374,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 5410498000,
+                    "fmt": "5.41B",
+                    "longFmt": "5,410,498,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 3213000000,
+                    "fmt": "3.21B",
+                    "longFmt": "3,213,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -566050000,
+                    "fmt": "-566.05M",
+                    "longFmt": "-566,050,000"
+                  },
+                  "investments": {
+                    "raw": -11199382000,
+                    "fmt": "-11.2B",
+                    "longFmt": "-11,199,382,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 4307818000,
+                    "fmt": "4.31B",
+                    "longFmt": "4,307,818,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -6945255000,
+                    "fmt": "-6.95B",
+                    "longFmt": "-6,945,255,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -105172000,
+                    "fmt": "-105.17M",
+                    "longFmt": "-105,172,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 324758000,
+                    "fmt": "324.76M",
+                    "longFmt": "324,758,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 16565408000,
+                    "fmt": "16.57B",
+                    "longFmt": "16,565,408,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -815884000,
+                    "fmt": "-815.88M",
+                    "longFmt": "-815,884,000"
+                  },
+                  "changeInCash": {
+                    "raw": 12017269000,
+                    "fmt": "12.02B",
+                    "longFmt": "12,017,269,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 16345822000,
+                    "fmt": "16.35B",
+                    "longFmt": "16,345,822,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "netIncome": {
+                    "raw": 2836568000,
+                    "fmt": "2.84B",
+                    "longFmt": "2,836,568,000"
+                  },
+                  "depreciation": {
+                    "raw": 272184000,
+                    "fmt": "272.18M",
+                    "longFmt": "272,184,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 2743463000,
+                    "fmt": "2.74B",
+                    "longFmt": "2,743,463,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -719861000,
+                    "fmt": "-719.86M",
+                    "longFmt": "-719,861,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 785185000,
+                    "fmt": "785.18M",
+                    "longFmt": "785,185,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 2426120000,
+                    "fmt": "2.43B",
+                    "longFmt": "2,426,120,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 9133566000,
+                    "fmt": "9.13B",
+                    "longFmt": "9,133,566,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": 149136000,
+                    "fmt": "149.14M",
+                    "longFmt": "149,136,000"
+                  },
+                  "investments": {
+                    "raw": 5786363000,
+                    "fmt": "5.79B",
+                    "longFmt": "5,786,363,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -2409715000,
+                    "fmt": "-2.41B",
+                    "longFmt": "-2,409,715,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 2751829000,
+                    "fmt": "2.75B",
+                    "longFmt": "2,751,829,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 898389000,
+                    "fmt": "898.39M",
+                    "longFmt": "898,389,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -569320000,
+                    "fmt": "-569.32M",
+                    "longFmt": "-569,320,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 329069000,
+                    "fmt": "329.07M",
+                    "longFmt": "329,069,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -14448000,
+                    "fmt": "-14.45M",
+                    "longFmt": "-14,448,000"
+                  },
+                  "changeInCash": {
+                    "raw": 12200016000,
+                    "fmt": "12.2B",
+                    "longFmt": "12,200,016,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 16345822000,
+                    "fmt": "16.35B",
+                    "longFmt": "16,345,822,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "netIncome": {
+                    "raw": -1228650000,
+                    "fmt": "-1.23B",
+                    "longFmt": "-1,228,650,000"
+                  },
+                  "depreciation": {
+                    "raw": 271845000,
+                    "fmt": "271.85M",
+                    "longFmt": "271,845,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 149055000,
+                    "fmt": "149.06M",
+                    "longFmt": "149,055,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 719861000,
+                    "fmt": "719.86M",
+                    "longFmt": "719,861,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -785185000,
+                    "fmt": "-785.18M",
+                    "longFmt": "-785,185,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -2426120000,
+                    "fmt": "-2.43B",
+                    "longFmt": "-2,426,120,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -4089101000,
+                    "fmt": "-4.09B",
+                    "longFmt": "-4,089,101,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -149136000,
+                    "fmt": "-149.14M",
+                    "longFmt": "-149,136,000"
+                  },
+                  "investments": {
+                    "raw": -5786363000,
+                    "fmt": "-5.79B",
+                    "longFmt": "-5,786,363,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -14819000,
+                    "fmt": "-14.82M",
+                    "longFmt": "-14,819,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -5176363000,
+                    "fmt": "-5.18B",
+                    "longFmt": "-5,176,363,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -898389000,
+                    "fmt": "-898.39M",
+                    "longFmt": "-898,389,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -569320000,
+                    "fmt": "-569.32M",
+                    "longFmt": "-569,320,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -898389000,
+                    "fmt": "-898.39M",
+                    "longFmt": "-898,389,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 131392000,
+                    "fmt": "131.39M",
+                    "longFmt": "131,392,000"
+                  },
+                  "changeInCash": {
+                    "raw": -10032461000,
+                    "fmt": "-10.03B",
+                    "longFmt": "-10,032,461,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 16345822000,
+                    "fmt": "16.35B",
+                    "longFmt": "16,345,822,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1569801600,
+                    "fmt": "2019-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 381354000,
+                    "fmt": "381.35M",
+                    "longFmt": "381,354,000"
+                  },
+                  "depreciation": {
+                    "raw": 308036000,
+                    "fmt": "308.04M",
+                    "longFmt": "308,036,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 56176000,
+                    "fmt": "56.18M",
+                    "longFmt": "56,176,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -1204448000,
+                    "fmt": "-1.2B",
+                    "longFmt": "-1,204,448,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 940491000,
+                    "fmt": "940.49M",
+                    "longFmt": "940,491,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 394199000,
+                    "fmt": "394.2M",
+                    "longFmt": "394,199,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 1257660000,
+                    "fmt": "1.26B",
+                    "longFmt": "1,257,660,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -123413000,
+                    "fmt": "-123.41M",
+                    "longFmt": "-123,413,000"
+                  },
+                  "investments": {
+                    "raw": 1040954000,
+                    "fmt": "1.04B",
+                    "longFmt": "1,040,954,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -4488000,
+                    "fmt": "-4.49M",
+                    "longFmt": "-4,488,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 132616000,
+                    "fmt": "132.62M",
+                    "longFmt": "132,616,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 64710000,
+                    "fmt": "64.71M",
+                    "longFmt": "64,710,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -569320000,
+                    "fmt": "-569.32M",
+                    "longFmt": "-569,320,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -2222516000,
+                    "fmt": "-2.22B",
+                    "longFmt": "-2,222,516,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 109779000,
+                    "fmt": "109.78M",
+                    "longFmt": "109,779,000"
+                  },
+                  "changeInCash": {
+                    "raw": -722461000,
+                    "fmt": "-722.46M",
+                    "longFmt": "-722,461,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -140074000,
+                    "fmt": "-140.07M",
+                    "longFmt": "-140,074,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 16345822000,
+                    "fmt": "16.35B",
+                    "longFmt": "16,345,822,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-BFLY.json
+++ b/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=cashflowStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "9idos9dg2qh3o"
+      ],
+      "x-yahoo-request-id": [
+        "9idos9dg2qh3o"
+      ],
+      "x-request-id": [
+        "610cde71-4ad1-4fa6-bfba-7957c5578f31"
+      ],
+      "content-length": [
+        "121"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:44 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-defaultKeyStatistics-BEKE.json
+++ b/tests/http/quoteSummary-defaultKeyStatistics-BEKE.json
@@ -1,0 +1,109 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=defaultKeyStatistics"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "1dms9c5g2qh3p"
+      ],
+      "x-yahoo-request-id": [
+        "1dms9c5g2qh3p"
+      ],
+      "x-request-id": [
+        "0993e0fa-0653-49f5-ac91-b82141a92fe5"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "469"
+      ],
+      "x-envoy-upstream-service-time": [
+        "5"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:44 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": 79355428864,
+              "forwardPE": 73.244446,
+              "profitMargins": -0.02313,
+              "floatShares": 389103285,
+              "sharesOutstanding": 1143379968,
+              "sharesShort": 11331624,
+              "sharesShortPriorMonth": 10275253,
+              "sharesShortPreviousMonthDate": 1609372800,
+              "dateShortInterest": 1611878400,
+              "sharesPercentSharesOut": 0.0095999995,
+              "heldPercentInsiders": 0.0090499995,
+              "heldPercentInstitutions": 0.14386,
+              "shortRatio": 3.25,
+              "category": null,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1577750400,
+              "nextFiscalYearEnd": 1640908800,
+              "mostRecentQuarter": 1601424000,
+              "earningsQuarterlyGrowth": -0.804,
+              "pegRatio": 117.17,
+              "lastSplitFactor": null,
+              "52WeekChange": 0.81623936,
+              "SandP52WeekChange": 0.16137505
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-defaultKeyStatistics-BFLY.json
+++ b/tests/http/quoteSummary-defaultKeyStatistics-BFLY.json
@@ -1,0 +1,89 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=defaultKeyStatistics"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "ba5rsr1g2qh3p"
+      ],
+      "x-yahoo-request-id": [
+        "ba5rsr1g2qh3p"
+      ],
+      "x-request-id": [
+        "fc936ba0-3207-437f-8d60-12a0cf986683"
+      ],
+      "content-length": [
+        "238"
+      ],
+      "x-envoy-upstream-service-time": [
+        "5"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:45 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "profitMargins": 0,
+              "category": null,
+              "fundFamily": null,
+              "legalType": null,
+              "lastSplitFactor": null,
+              "52WeekChange": 0,
+              "SandP52WeekChange": 0.16137505
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earnings-BEKE.json
+++ b/tests/http/quoteSummary-earnings-BEKE.json
@@ -1,0 +1,139 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=earnings"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "d6clrnhg2qh3p"
+      ],
+      "x-yahoo-request-id": [
+        "d6clrnhg2qh3p"
+      ],
+      "x-request-id": [
+        "8398cced-336c-4b57-9bb5-c921c912a18f"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "337"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:45 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [
+                  {
+                    "date": "3Q2020",
+                    "actual": 0.21,
+                    "estimate": 0.17
+                  }
+                ],
+                "currentQuarterEstimate": 0.13,
+                "currentQuarterEstimateDate": "4Q",
+                "currentQuarterEstimateYear": 2020,
+                "earningsDate": []
+              },
+              "financialsChart": {
+                "yearly": [
+                  {
+                    "date": 2017,
+                    "revenue": 25505698000,
+                    "earnings": -574430000
+                  },
+                  {
+                    "date": 2018,
+                    "revenue": 28646499000,
+                    "earnings": -467824000
+                  },
+                  {
+                    "date": 2019,
+                    "revenue": 46014906000,
+                    "earnings": -2183546000
+                  }
+                ],
+                "quarterly": [
+                  {
+                    "date": "3Q2019",
+                    "revenue": 12022659000,
+                    "earnings": 381354000
+                  },
+                  {
+                    "date": "1Q2020",
+                    "revenue": 7119759000,
+                    "earnings": -1228650000
+                  },
+                  {
+                    "date": "2Q2020",
+                    "revenue": 20141659000,
+                    "earnings": 2836568000
+                  },
+                  {
+                    "date": "3Q2020",
+                    "revenue": 20548915000,
+                    "earnings": 74697000
+                  }
+                ]
+              },
+              "financialCurrency": "CNY"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earnings-BFLY.json
+++ b/tests/http/quoteSummary-earnings-BFLY.json
@@ -1,0 +1,89 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=earnings"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "94lfnm9g2qh3p"
+      ],
+      "x-yahoo-request-id": [
+        "94lfnm9g2qh3p"
+      ],
+      "x-request-id": [
+        "1edeb2e8-9368-41a4-80e0-d2e554fafd72"
+      ],
+      "content-length": [
+        "170"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:45 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [],
+                "earningsDate": []
+              },
+              "financialsChart": {
+                "yearly": [],
+                "quarterly": []
+              }
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsHistory-BEKE.json
+++ b/tests/http/quoteSummary-earningsHistory-BEKE.json
@@ -1,0 +1,137 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=earningsHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "214nfv1g2qh3p"
+      ],
+      "x-yahoo-request-id": [
+        "214nfv1g2qh3p"
+      ],
+      "x-request-id": [
+        "4e0b1813-06b3-45cd-bf63-43b2cfdee153"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "252"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:45 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.21,
+                    "fmt": "0.21"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.17,
+                    "fmt": "0.17"
+                  },
+                  "epsDifference": {
+                    "raw": 0.04,
+                    "fmt": "0.04"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.235,
+                    "fmt": "23.50%"
+                  },
+                  "quarter": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsHistory-BFLY.json
+++ b/tests/http/quoteSummary-earningsHistory-BFLY.json
@@ -1,0 +1,122 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=earningsHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "ds90ab9g2qh3p"
+      ],
+      "x-yahoo-request-id": [
+        "ds90ab9g2qh3p"
+      ],
+      "x-request-id": [
+        "299f3e60-7caa-4d54-a9c7-34dac8bb082c"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "176"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:45 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsTrend-BEKE.json
+++ b/tests/http/quoteSummary-earningsTrend-BEKE.json
@@ -1,0 +1,539 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=earningsTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "5v227chg2qh3p"
+      ],
+      "x-yahoo-request-id": [
+        "5v227chg2qh3p"
+      ],
+      "x-request-id": [
+        "b808f656-6f9a-4d67-89f1-e8acd07825f3"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "849"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:45 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "2"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": "2020-12-31",
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "low": {
+                      "raw": 0.01,
+                      "fmt": "0.01"
+                    },
+                    "high": {
+                      "raw": 0.17,
+                      "fmt": "0.17"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 6,
+                      "fmt": "6",
+                      "longFmt": "6"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 3082150000,
+                      "fmt": "3.08B",
+                      "longFmt": "3,082,150,000"
+                    },
+                    "low": {
+                      "raw": 2998670000,
+                      "fmt": "3B",
+                      "longFmt": "2,998,670,000"
+                    },
+                    "high": {
+                      "raw": 3182420000,
+                      "fmt": "3.18B",
+                      "longFmt": "3,182,420,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 7,
+                      "fmt": "7",
+                      "longFmt": "7"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.11,
+                      "fmt": "0.11"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": "2021-03-31",
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "low": {
+                      "raw": 0.09,
+                      "fmt": "0.09"
+                    },
+                    "high": {
+                      "raw": 0.14,
+                      "fmt": "0.14"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 3,
+                      "fmt": "3",
+                      "longFmt": "3"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 2126150000,
+                      "fmt": "2.13B",
+                      "longFmt": "2,126,150,000"
+                    },
+                    "low": {
+                      "raw": 1891260000,
+                      "fmt": "1.89B",
+                      "longFmt": "1,891,260,000"
+                    },
+                    "high": {
+                      "raw": 2252600000,
+                      "fmt": "2.25B",
+                      "longFmt": "2,252,600,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 3,
+                      "fmt": "3",
+                      "longFmt": "3"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.08,
+                      "fmt": "0.08"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": "2020-12-31",
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "low": {
+                      "raw": 0.63,
+                      "fmt": "0.63"
+                    },
+                    "high": {
+                      "raw": 1.02,
+                      "fmt": "1.02"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 9,
+                      "fmt": "9",
+                      "longFmt": "9"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 10527000000,
+                      "fmt": "10.53B",
+                      "longFmt": "10,527,000,000"
+                    },
+                    "low": {
+                      "raw": 10400500000,
+                      "fmt": "10.4B",
+                      "longFmt": "10,400,500,000"
+                    },
+                    "high": {
+                      "raw": 10688500000,
+                      "fmt": "10.69B",
+                      "longFmt": "10,688,500,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 11,
+                      "fmt": "11",
+                      "longFmt": "11"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.74,
+                      "fmt": "0.74"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.67,
+                      "fmt": "0.67"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": "2021-12-31",
+                  "growth": {
+                    "raw": 0.2,
+                    "fmt": "20.00%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.9,
+                      "fmt": "0.9"
+                    },
+                    "low": {
+                      "raw": 0.64,
+                      "fmt": "0.64"
+                    },
+                    "high": {
+                      "raw": 0.99,
+                      "fmt": "0.99"
+                    },
+                    "yearAgoEps": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 9,
+                      "fmt": "9",
+                      "longFmt": "9"
+                    },
+                    "growth": {
+                      "raw": 0.2,
+                      "fmt": "20.00%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 13237800000,
+                      "fmt": "13.24B",
+                      "longFmt": "13,237,800,000"
+                    },
+                    "low": {
+                      "raw": 11327900000,
+                      "fmt": "11.33B",
+                      "longFmt": "11,327,900,000"
+                    },
+                    "high": {
+                      "raw": 14382900000,
+                      "fmt": "14.38B",
+                      "longFmt": "14,382,900,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 11,
+                      "fmt": "11",
+                      "longFmt": "11"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 10527000000,
+                      "fmt": "10.53B",
+                      "longFmt": "10,527,000,000"
+                    },
+                    "growth": {
+                      "raw": 0.258,
+                      "fmt": "25.80%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.9,
+                      "fmt": "0.9"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.9,
+                      "fmt": "0.9"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.9,
+                      "fmt": "0.9"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.89,
+                      "fmt": "0.89"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.88,
+                      "fmt": "0.88"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": 0.046,
+                    "fmt": "4.60%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsTrend-BFLY.json
+++ b/tests/http/quoteSummary-earningsTrend-BFLY.json
@@ -1,0 +1,520 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=earningsTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "ftavdhpg2qh3q"
+      ],
+      "x-yahoo-request-id": [
+        "ftavdhpg2qh3q"
+      ],
+      "x-request-id": [
+        "0f582b4c-8b61-4fe4-ac30-6e8cb6541361"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "385"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:46 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-financialData-BEKE.json
+++ b/tests/http/quoteSummary-financialData-BEKE.json
@@ -1,0 +1,99 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=financialData"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "24pqd7tg2qh3q"
+      ],
+      "x-yahoo-request-id": [
+        "24pqd7tg2qh3q"
+      ],
+      "x-request-id": [
+        "f9e4ebac-22ec-4ad9-ae4e-a7bc0c42e5b4"
+      ],
+      "content-length": [
+        "511"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:46 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 65.91,
+              "targetHighPrice": 90.48,
+              "targetLowPrice": 20.99,
+              "targetMeanPrice": 67.22,
+              "targetMedianPrice": 67.57,
+              "recommendationMean": 2.5,
+              "recommendationKey": "buy",
+              "numberOfAnalystOpinions": 10,
+              "quickRatio": 2.013,
+              "currentRatio": 2.386,
+              "debtToEquity": 26.427,
+              "grossProfits": 11268044000,
+              "revenueGrowth": 0.709,
+              "grossMargins": 0.22805999,
+              "ebitdaMargins": -0.00654,
+              "operatingMargins": 0,
+              "profitMargins": -0.02313,
+              "financialCurrency": "CNY"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-financialData-BFLY.json
+++ b/tests/http/quoteSummary-financialData-BFLY.json
@@ -1,0 +1,93 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=financialData"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "86i57nhg2qh3q"
+      ],
+      "x-yahoo-request-id": [
+        "86i57nhg2qh3q"
+      ],
+      "x-request-id": [
+        "80a7c3fd-379d-4301-880a-a5969d5398f6"
+      ],
+      "content-length": [
+        "354"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:46 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 22.315,
+              "targetHighPrice": 15,
+              "targetLowPrice": 15,
+              "targetMeanPrice": 15,
+              "targetMedianPrice": 15,
+              "recommendationKey": "none",
+              "numberOfAnalystOpinions": 1,
+              "grossMargins": 0,
+              "ebitdaMargins": 0,
+              "operatingMargins": 0,
+              "profitMargins": 0,
+              "financialCurrency": null
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-fundOwnership-BEKE.json
+++ b/tests/http/quoteSummary-fundOwnership-BEKE.json
@@ -1,0 +1,306 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=fundOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "2tcc5a5g2qh3q"
+      ],
+      "x-yahoo-request-id": [
+        "2tcc5a5g2qh3q"
+      ],
+      "x-request-id": [
+        "72d1e623-95e6-417e-a0ca-64464fd77cac"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "848"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:46 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Europacific Growth Fund",
+                  "pctHeld": {
+                    "raw": 0.005,
+                    "fmt": "0.50%"
+                  },
+                  "position": {
+                    "raw": 4457516,
+                    "fmt": "4.46M",
+                    "longFmt": "4,457,516"
+                  },
+                  "value": {
+                    "raw": 274315534,
+                    "fmt": "274.32M",
+                    "longFmt": "274,315,534"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "ARK ETF Tr-ARK Innovation ETF",
+                  "pctHeld": {
+                    "raw": 0.0049,
+                    "fmt": "0.49%"
+                  },
+                  "position": {
+                    "raw": 4358188,
+                    "fmt": "4.36M",
+                    "longFmt": "4,358,188"
+                  },
+                  "value": {
+                    "raw": 268202889,
+                    "fmt": "268.2M",
+                    "longFmt": "268,202,889"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "KraneShares CSI China Internet ETF",
+                  "pctHeld": {
+                    "raw": 0.0023999999,
+                    "fmt": "0.24%"
+                  },
+                  "position": {
+                    "raw": 2150250,
+                    "fmt": "2.15M",
+                    "longFmt": "2,150,250"
+                  },
+                  "value": {
+                    "raw": 131810325,
+                    "fmt": "131.81M",
+                    "longFmt": "131,810,325"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1604102400,
+                    "fmt": "2020-10-31"
+                  },
+                  "organization": "Vanguard International Stock Index-Total Intl Stock Indx",
+                  "pctHeld": {
+                    "raw": 0.0018000001,
+                    "fmt": "0.18%"
+                  },
+                  "position": {
+                    "raw": 1625494,
+                    "fmt": "1.63M",
+                    "longFmt": "1,625,494"
+                  },
+                  "value": {
+                    "raw": 113378206,
+                    "fmt": "113.38M",
+                    "longFmt": "113,378,206"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Fidelity OTC Portfolio",
+                  "pctHeld": {
+                    "raw": 0.0018000001,
+                    "fmt": "0.18%"
+                  },
+                  "position": {
+                    "raw": 1598717,
+                    "fmt": "1.6M",
+                    "longFmt": "1,598,717"
+                  },
+                  "value": {
+                    "raw": 98385044,
+                    "fmt": "98.39M",
+                    "longFmt": "98,385,044"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1604102400,
+                    "fmt": "2020-10-31"
+                  },
+                  "organization": "Vanguard International Stock Index-Emerging Markets Stk",
+                  "pctHeld": {
+                    "raw": 0.0016,
+                    "fmt": "0.16%"
+                  },
+                  "position": {
+                    "raw": 1440142,
+                    "fmt": "1.44M",
+                    "longFmt": "1,440,142"
+                  },
+                  "value": {
+                    "raw": 100449904,
+                    "fmt": "100.45M",
+                    "longFmt": "100,449,904"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "ARK ETF Tr-ARK Next Generation Internet ETF",
+                  "pctHeld": {
+                    "raw": 0.0014,
+                    "fmt": "0.14%"
+                  },
+                  "position": {
+                    "raw": 1285541,
+                    "fmt": "1.29M",
+                    "longFmt": "1,285,541"
+                  },
+                  "value": {
+                    "raw": 79112193,
+                    "fmt": "79.11M",
+                    "longFmt": "79,112,193"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "New World Fund, Inc.",
+                  "pctHeld": {
+                    "raw": 0.0013,
+                    "fmt": "0.13%"
+                  },
+                  "position": {
+                    "raw": 1116780,
+                    "fmt": "1.12M",
+                    "longFmt": "1,116,780"
+                  },
+                  "value": {
+                    "raw": 68726641,
+                    "fmt": "68.73M",
+                    "longFmt": "68,726,641"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Fundamental Investors Inc",
+                  "pctHeld": {
+                    "raw": 0.0011,
+                    "fmt": "0.11%"
+                  },
+                  "position": {
+                    "raw": 986393,
+                    "fmt": "986.39k",
+                    "longFmt": "986,393"
+                  },
+                  "value": {
+                    "raw": 60702625,
+                    "fmt": "60.7M",
+                    "longFmt": "60,702,625"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Fidelity Growth Company Fund",
+                  "pctHeld": {
+                    "raw": 0.0011,
+                    "fmt": "0.11%"
+                  },
+                  "position": {
+                    "raw": 974704,
+                    "fmt": "974.7k",
+                    "longFmt": "974,704"
+                  },
+                  "value": {
+                    "raw": 59983284,
+                    "fmt": "59.98M",
+                    "longFmt": "59,983,284"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-fundOwnership-BFLY.json
+++ b/tests/http/quoteSummary-fundOwnership-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=fundOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "22svjg1g2qh3r"
+      ],
+      "x-yahoo-request-id": [
+        "22svjg1g2qh3r"
+      ],
+      "x-request-id": [
+        "66a75f1e-b6d3-4122-b175-bc17fa292720"
+      ],
+      "content-length": [
+        "92"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:46 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistory-BEKE.json
+++ b/tests/http/quoteSummary-incomeStatementHistory-BEKE.json
@@ -1,0 +1,365 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=incomeStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "2jigv89g2qh3r"
+      ],
+      "x-yahoo-request-id": [
+        "2jigv89g2qh3r"
+      ],
+      "x-request-id": [
+        "ca110f6a-b0c6-4c17-9dd3-3f4f6e21fc8e"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1242"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:46 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 46014906000,
+                    "fmt": "46.01B",
+                    "longFmt": "46,014,906,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 34746862000,
+                    "fmt": "34.75B",
+                    "longFmt": "34,746,862,000"
+                  },
+                  "grossProfit": {
+                    "raw": 11268044000,
+                    "fmt": "11.27B",
+                    "longFmt": "11,268,044,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 1571154000,
+                    "fmt": "1.57B",
+                    "longFmt": "1,571,154,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 11482430000,
+                    "fmt": "11.48B",
+                    "longFmt": "11,482,430,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 47800446000,
+                    "fmt": "47.8B",
+                    "longFmt": "47,800,446,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -1785540000,
+                    "fmt": "-1.79B",
+                    "longFmt": "-1,785,540,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 509776000,
+                    "fmt": "509.78M",
+                    "longFmt": "509,776,000"
+                  },
+                  "ebit": {
+                    "raw": -1785540000,
+                    "fmt": "-1.79B",
+                    "longFmt": "-1,785,540,000"
+                  },
+                  "interestExpense": {
+                    "raw": -181099000,
+                    "fmt": "-181.1M",
+                    "longFmt": "-181,099,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -1275764000,
+                    "fmt": "-1.28B",
+                    "longFmt": "-1,275,764,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 904363000,
+                    "fmt": "904.36M",
+                    "longFmt": "904,363,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 87203000,
+                    "fmt": "87.2M",
+                    "longFmt": "87,203,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -2180127000,
+                    "fmt": "-2.18B",
+                    "longFmt": "-2,180,127,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -2183546000,
+                    "fmt": "-2.18B",
+                    "longFmt": "-2,183,546,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -4050074000,
+                    "fmt": "-4.05B",
+                    "longFmt": "-4,050,074,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 28646499000,
+                    "fmt": "28.65B",
+                    "longFmt": "28,646,499,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 21776523000,
+                    "fmt": "21.78B",
+                    "longFmt": "21,776,523,000"
+                  },
+                  "grossProfit": {
+                    "raw": 6869976000,
+                    "fmt": "6.87B",
+                    "longFmt": "6,869,976,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 670922000,
+                    "fmt": "670.92M",
+                    "longFmt": "670,922,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 7417059000,
+                    "fmt": "7.42B",
+                    "longFmt": "7,417,059,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 29864504000,
+                    "fmt": "29.86B",
+                    "longFmt": "29,864,504,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -1218005000,
+                    "fmt": "-1.22B",
+                    "longFmt": "-1,218,005,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 718940000,
+                    "fmt": "718.94M",
+                    "longFmt": "718,940,000"
+                  },
+                  "ebit": {
+                    "raw": -1218005000,
+                    "fmt": "-1.22B",
+                    "longFmt": "-1,218,005,000"
+                  },
+                  "interestExpense": {
+                    "raw": -43517000,
+                    "fmt": "-43.52M",
+                    "longFmt": "-43,517,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -499065000,
+                    "fmt": "-499.06M",
+                    "longFmt": "-499,065,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -71384000,
+                    "fmt": "-71.38M",
+                    "longFmt": "-71,384,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 10467000,
+                    "fmt": "10.47M",
+                    "longFmt": "10,467,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -427681000,
+                    "fmt": "-427.68M",
+                    "longFmt": "-427,681,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -467824000,
+                    "fmt": "-467.82M",
+                    "longFmt": "-467,824,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -2386005000,
+                    "fmt": "-2.39B",
+                    "longFmt": "-2,386,005,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 25505698000,
+                    "fmt": "25.51B",
+                    "longFmt": "25,505,698,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 20737641000,
+                    "fmt": "20.74B",
+                    "longFmt": "20,737,641,000"
+                  },
+                  "grossProfit": {
+                    "raw": 4768057000,
+                    "fmt": "4.77B",
+                    "longFmt": "4,768,057,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 251802000,
+                    "fmt": "251.8M",
+                    "longFmt": "251,802,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 5280146000,
+                    "fmt": "5.28B",
+                    "longFmt": "5,280,146,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 26269589000,
+                    "fmt": "26.27B",
+                    "longFmt": "26,269,589,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -763891000,
+                    "fmt": "-763.89M",
+                    "longFmt": "-763,891,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 625553000,
+                    "fmt": "625.55M",
+                    "longFmt": "625,553,000"
+                  },
+                  "ebit": {
+                    "raw": -763891000,
+                    "fmt": "-763.89M",
+                    "longFmt": "-763,891,000"
+                  },
+                  "interestExpense": {
+                    "raw": -43791000,
+                    "fmt": "-43.79M",
+                    "longFmt": "-43,791,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -138338000,
+                    "fmt": "-138.34M",
+                    "longFmt": "-138,338,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 399283000,
+                    "fmt": "399.28M",
+                    "longFmt": "399,283,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 65836000,
+                    "fmt": "65.84M",
+                    "longFmt": "65,836,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -537621000,
+                    "fmt": "-537.62M",
+                    "longFmt": "-537,621,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -574430000,
+                    "fmt": "-574.43M",
+                    "longFmt": "-574,430,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -1441879000,
+                    "fmt": "-1.44B",
+                    "longFmt": "-1,441,879,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistory-BFLY.json
+++ b/tests/http/quoteSummary-incomeStatementHistory-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=incomeStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "ab1gqalg2qh3r"
+      ],
+      "x-yahoo-request-id": [
+        "ab1gqalg2qh3r"
+      ],
+      "x-request-id": [
+        "556a1eab-78af-458c-aac1-2ffd9ded5bec"
+      ],
+      "content-length": [
+        "114"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:47 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistoryQuarterly-BEKE.json
+++ b/tests/http/quoteSummary-incomeStatementHistoryQuarterly-BEKE.json
@@ -1,0 +1,458 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=incomeStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "40m7g5hg2qh3r"
+      ],
+      "x-yahoo-request-id": [
+        "40m7g5hg2qh3r"
+      ],
+      "x-request-id": [
+        "e88a7405-91be-4963-b4a9-a5788b4ab258"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1462"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:47 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 20548915000,
+                    "fmt": "20.55B",
+                    "longFmt": "20,548,915,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 16165685000,
+                    "fmt": "16.17B",
+                    "longFmt": "16,165,685,000"
+                  },
+                  "grossProfit": {
+                    "raw": 4383230000,
+                    "fmt": "4.38B",
+                    "longFmt": "4,383,230,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 789089000,
+                    "fmt": "789.09M",
+                    "longFmt": "789,089,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 3675157000,
+                    "fmt": "3.68B",
+                    "longFmt": "3,675,157,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 20629931000,
+                    "fmt": "20.63B",
+                    "longFmt": "20,629,931,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -81016000,
+                    "fmt": "-81.02M",
+                    "longFmt": "-81,016,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 415348000,
+                    "fmt": "415.35M",
+                    "longFmt": "415,348,000"
+                  },
+                  "ebit": {
+                    "raw": -81016000,
+                    "fmt": "-81.02M",
+                    "longFmt": "-81,016,000"
+                  },
+                  "interestExpense": {
+                    "raw": -128157000,
+                    "fmt": "-128.16M",
+                    "longFmt": "-128,157,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 334332000,
+                    "fmt": "334.33M",
+                    "longFmt": "334,332,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 258991000,
+                    "fmt": "258.99M",
+                    "longFmt": "258,991,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 26490000,
+                    "fmt": "26.49M",
+                    "longFmt": "26,490,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 75341000,
+                    "fmt": "75.34M",
+                    "longFmt": "75,341,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 74697000,
+                    "fmt": "74.7M",
+                    "longFmt": "74,697,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -271446000,
+                    "fmt": "-271.45M",
+                    "longFmt": "-271,446,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 20141659000,
+                    "fmt": "20.14B",
+                    "longFmt": "20,141,659,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 13590784000,
+                    "fmt": "13.59B",
+                    "longFmt": "13,590,784,000"
+                  },
+                  "grossProfit": {
+                    "raw": 6550875000,
+                    "fmt": "6.55B",
+                    "longFmt": "6,550,875,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 523670000,
+                    "fmt": "523.67M",
+                    "longFmt": "523,670,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 2739831000,
+                    "fmt": "2.74B",
+                    "longFmt": "2,739,831,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 16854285000,
+                    "fmt": "16.85B",
+                    "longFmt": "16,854,285,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 3287374000,
+                    "fmt": "3.29B",
+                    "longFmt": "3,287,374,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 333154000,
+                    "fmt": "333.15M",
+                    "longFmt": "333,154,000"
+                  },
+                  "ebit": {
+                    "raw": 3287374000,
+                    "fmt": "3.29B",
+                    "longFmt": "3,287,374,000"
+                  },
+                  "interestExpense": {
+                    "raw": -128157000,
+                    "fmt": "-128.16M",
+                    "longFmt": "-128,157,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 3620528000,
+                    "fmt": "3.62B",
+                    "longFmt": "3,620,528,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 781715000,
+                    "fmt": "781.72M",
+                    "longFmt": "781,715,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 25846000,
+                    "fmt": "25.85M",
+                    "longFmt": "25,846,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 2838813000,
+                    "fmt": "2.84B",
+                    "longFmt": "2,838,813,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 2836568000,
+                    "fmt": "2.84B",
+                    "longFmt": "2,836,568,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 2120786000,
+                    "fmt": "2.12B",
+                    "longFmt": "2,120,786,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 7119759000,
+                    "fmt": "7.12B",
+                    "longFmt": "7,119,759,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 6618227000,
+                    "fmt": "6.62B",
+                    "longFmt": "6,618,227,000"
+                  },
+                  "grossProfit": {
+                    "raw": 501532000,
+                    "fmt": "501.53M",
+                    "longFmt": "501,532,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 450761000,
+                    "fmt": "450.76M",
+                    "longFmt": "450,761,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 1682124000,
+                    "fmt": "1.68B",
+                    "longFmt": "1,682,124,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 8751112000,
+                    "fmt": "8.75B",
+                    "longFmt": "8,751,112,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -1631353000,
+                    "fmt": "-1.63B",
+                    "longFmt": "-1,631,353,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 251105000,
+                    "fmt": "251.1M",
+                    "longFmt": "251,105,000"
+                  },
+                  "ebit": {
+                    "raw": -1631353000,
+                    "fmt": "-1.63B",
+                    "longFmt": "-1,631,353,000"
+                  },
+                  "interestExpense": {
+                    "raw": -50113000,
+                    "fmt": "-50.11M",
+                    "longFmt": "-50,113,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -1380248000,
+                    "fmt": "-1.38B",
+                    "longFmt": "-1,380,248,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -148861000,
+                    "fmt": "-148.86M",
+                    "longFmt": "-148,861,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 84466000,
+                    "fmt": "84.47M",
+                    "longFmt": "84,466,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -1231387000,
+                    "fmt": "-1.23B",
+                    "longFmt": "-1,231,387,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -1228650000,
+                    "fmt": "-1.23B",
+                    "longFmt": "-1,228,650,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -1921953000,
+                    "fmt": "-1.92B",
+                    "longFmt": "-1,921,953,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1569801600,
+                    "fmt": "2019-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 12022659000,
+                    "fmt": "12.02B",
+                    "longFmt": "12,022,659,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 9083190000,
+                    "fmt": "9.08B",
+                    "longFmt": "9,083,190,000"
+                  },
+                  "grossProfit": {
+                    "raw": 2939469000,
+                    "fmt": "2.94B",
+                    "longFmt": "2,939,469,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 436056000,
+                    "fmt": "436.06M",
+                    "longFmt": "436,056,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 2103745000,
+                    "fmt": "2.1B",
+                    "longFmt": "2,103,745,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 11622991000,
+                    "fmt": "11.62B",
+                    "longFmt": "11,622,991,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 399668000,
+                    "fmt": "399.67M",
+                    "longFmt": "399,668,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 301713000,
+                    "fmt": "301.71M",
+                    "longFmt": "301,713,000"
+                  },
+                  "ebit": {
+                    "raw": 399668000,
+                    "fmt": "399.67M",
+                    "longFmt": "399,668,000"
+                  },
+                  "interestExpense": {
+                    "raw": -34558000,
+                    "fmt": "-34.56M",
+                    "longFmt": "-34,558,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 701381000,
+                    "fmt": "701.38M",
+                    "longFmt": "701,381,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 317120000,
+                    "fmt": "317.12M",
+                    "longFmt": "317,120,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 84466000,
+                    "fmt": "84.47M",
+                    "longFmt": "84,466,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 384261000,
+                    "fmt": "384.26M",
+                    "longFmt": "384,261,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 381354000,
+                    "fmt": "381.35M",
+                    "longFmt": "381,354,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -76584000,
+                    "fmt": "-76.58M",
+                    "longFmt": "-76,584,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistoryQuarterly-BFLY.json
+++ b/tests/http/quoteSummary-incomeStatementHistoryQuarterly-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=incomeStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "8a4m2utg2qh3r"
+      ],
+      "x-yahoo-request-id": [
+        "8a4m2utg2qh3r"
+      ],
+      "x-request-id": [
+        "55ce1d72-0ef6-4532-892f-80761cba9133"
+      ],
+      "content-length": [
+        "123"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:47 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-indexTrend-BEKE.json
+++ b/tests/http/quoteSummary-indexTrend-BEKE.json
@@ -1,0 +1,109 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=indexTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "6imkitdg2qh3r"
+      ],
+      "x-yahoo-request-id": [
+        "6imkitdg2qh3r"
+      ],
+      "x-request-id": [
+        "ff8639e6-228c-4cfa-bbfa-4ba2d7f8c6da"
+      ],
+      "content-length": [
+        "321"
+      ],
+      "x-envoy-upstream-service-time": [
+        "5"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:47 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 5.56217,
+              "pegRatio": 0.991258,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.269
+                },
+                {
+                  "period": "+1q",
+                  "growth": 0.96099997
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.148
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.155
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0821053
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-indexTrend-BFLY.json
+++ b/tests/http/quoteSummary-indexTrend-BFLY.json
@@ -1,0 +1,109 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=indexTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "9d64t75g2qh3s"
+      ],
+      "x-yahoo-request-id": [
+        "9d64t75g2qh3s"
+      ],
+      "x-request-id": [
+        "81953c73-0265-4bef-a237-1b393d9ada50"
+      ],
+      "content-length": [
+        "321"
+      ],
+      "x-envoy-upstream-service-time": [
+        "5"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:47 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 5.56217,
+              "pegRatio": 0.991258,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.269
+                },
+                {
+                  "period": "+1q",
+                  "growth": 0.96099997
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.148
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.155
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0821053
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-industryTrend-BEKE.json
+++ b/tests/http/quoteSummary-industryTrend-BEKE.json
@@ -1,0 +1,83 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=industryTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "70b4qc1g2qh3s"
+      ],
+      "x-yahoo-request-id": [
+        "70b4qc1g2qh3s"
+      ],
+      "x-request-id": [
+        "947c0183-8528-4c00-810e-4fc457851cd9"
+      ],
+      "content-length": [
+        "102"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:47 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-industryTrend-BFLY.json
+++ b/tests/http/quoteSummary-industryTrend-BFLY.json
@@ -1,0 +1,83 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=industryTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "8e4sghlg2qh3s"
+      ],
+      "x-yahoo-request-id": [
+        "8e4sghlg2qh3s"
+      ],
+      "x-request-id": [
+        "a9991245-8abc-4956-bec8-a4a5df91a940"
+      ],
+      "content-length": [
+        "102"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:48 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderHolders-BEKE.json
+++ b/tests/http/quoteSummary-insiderHolders-BEKE.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=insiderHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "3m7lrv5g2qh3s"
+      ],
+      "x-yahoo-request-id": [
+        "3m7lrv5g2qh3s"
+      ],
+      "x-request-id": [
+        "70bf97ed-666a-400a-8988-475a53546de8"
+      ],
+      "content-length": [
+        "87"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:48 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "insiderHolders": {
+              "holders": [],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderHolders-BFLY.json
+++ b/tests/http/quoteSummary-insiderHolders-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=insiderHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "bn7uoklg2qh3s"
+      ],
+      "x-yahoo-request-id": [
+        "bn7uoklg2qh3s"
+      ],
+      "x-request-id": [
+        "56e55f50-f64f-4760-be84-e089f631f9bd"
+      ],
+      "content-length": [
+        "87"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:48 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "insiderHolders": {
+              "holders": [],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderTransactions-BEKE.json
+++ b/tests/http/quoteSummary-insiderTransactions-BEKE.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=insiderTransactions"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "bh47b2lg2qh3s"
+      ],
+      "x-yahoo-request-id": [
+        "bh47b2lg2qh3s"
+      ],
+      "x-request-id": [
+        "dd4c9389-46ba-4b8f-9b5d-98b218298b12"
+      ],
+      "content-length": [
+        "152"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:48 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=insiderTransactions"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderTransactions-BFLY.json
+++ b/tests/http/quoteSummary-insiderTransactions-BFLY.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=insiderTransactions"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "el48lqdg2qh3t"
+      ],
+      "x-yahoo-request-id": [
+        "el48lqdg2qh3t"
+      ],
+      "x-request-id": [
+        "aa06769c-b6d5-4de9-b338-54876747a81f"
+      ],
+      "content-length": [
+        "152"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:48 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=insiderTransactions"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-institutionOwnership-BEKE.json
+++ b/tests/http/quoteSummary-institutionOwnership-BEKE.json
@@ -1,0 +1,306 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=institutionOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "4t879ghg2qh3t"
+      ],
+      "x-yahoo-request-id": [
+        "4t879ghg2qh3t"
+      ],
+      "x-request-id": [
+        "65447612-95e2-4a03-b9b8-d1b7f7b0ae6a"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "801"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:48 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Baillie Gifford and Company",
+                  "pctHeld": {
+                    "raw": 0.0198,
+                    "fmt": "1.98%"
+                  },
+                  "position": {
+                    "raw": 17631431,
+                    "fmt": "17.63M",
+                    "longFmt": "17,631,431"
+                  },
+                  "value": {
+                    "raw": 1085038263,
+                    "fmt": "1.09B",
+                    "longFmt": "1,085,038,263"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "SC US (TTGP) Ltd",
+                  "pctHeld": {
+                    "raw": 0.0123000005,
+                    "fmt": "1.23%"
+                  },
+                  "position": {
+                    "raw": 10964911,
+                    "fmt": "10.96M",
+                    "longFmt": "10,964,911"
+                  },
+                  "value": {
+                    "raw": 672149044,
+                    "fmt": "672.15M",
+                    "longFmt": "672,149,044"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "FMR, LLC",
+                  "pctHeld": {
+                    "raw": 0.0089,
+                    "fmt": "0.89%"
+                  },
+                  "position": {
+                    "raw": 7903919,
+                    "fmt": "7.9M",
+                    "longFmt": "7,903,919"
+                  },
+                  "value": {
+                    "raw": 486407175,
+                    "fmt": "486.41M",
+                    "longFmt": "486,407,175"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Capital World Investors",
+                  "pctHeld": {
+                    "raw": 0.0088,
+                    "fmt": "0.88%"
+                  },
+                  "position": {
+                    "raw": 7821189,
+                    "fmt": "7.82M",
+                    "longFmt": "7,821,189"
+                  },
+                  "value": {
+                    "raw": 479438885,
+                    "fmt": "479.44M",
+                    "longFmt": "479,438,885"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Blackrock Inc.",
+                  "pctHeld": {
+                    "raw": 0.0074,
+                    "fmt": "0.74%"
+                  },
+                  "position": {
+                    "raw": 6536139,
+                    "fmt": "6.54M",
+                    "longFmt": "6,536,139"
+                  },
+                  "value": {
+                    "raw": 402233994,
+                    "fmt": "402.23M",
+                    "longFmt": "402,233,994"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Hillhouse Capital Advisors Ltd.",
+                  "pctHeld": {
+                    "raw": 0.0056,
+                    "fmt": "0.56%"
+                  },
+                  "position": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "value": {
+                    "raw": 306500000,
+                    "fmt": "306.5M",
+                    "longFmt": "306,500,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "D1 Capital Partners, LP",
+                  "pctHeld": {
+                    "raw": 0.0056,
+                    "fmt": "0.56%"
+                  },
+                  "position": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "value": {
+                    "raw": 306500000,
+                    "fmt": "306.5M",
+                    "longFmt": "306,500,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Credit Suisse Ag/",
+                  "pctHeld": {
+                    "raw": 0.0043,
+                    "fmt": "0.43%"
+                  },
+                  "position": {
+                    "raw": 3778354,
+                    "fmt": "3.78M",
+                    "longFmt": "3,778,354"
+                  },
+                  "value": {
+                    "raw": 231613100,
+                    "fmt": "231.61M",
+                    "longFmt": "231,613,100"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Group, Inc. (The)",
+                  "pctHeld": {
+                    "raw": 0.0042,
+                    "fmt": "0.42%"
+                  },
+                  "position": {
+                    "raw": 3750841,
+                    "fmt": "3.75M",
+                    "longFmt": "3,750,841"
+                  },
+                  "value": {
+                    "raw": 229926553,
+                    "fmt": "229.93M",
+                    "longFmt": "229,926,553"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Sumitomo Mitsui Trust Holdings, Inc.",
+                  "pctHeld": {
+                    "raw": 0.004,
+                    "fmt": "0.40%"
+                  },
+                  "position": {
+                    "raw": 3512686,
+                    "fmt": "3.51M",
+                    "longFmt": "3,512,686"
+                  },
+                  "value": {
+                    "raw": 216170696,
+                    "fmt": "216.17M",
+                    "longFmt": "216,170,696"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-institutionOwnership-BFLY.json
+++ b/tests/http/quoteSummary-institutionOwnership-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=institutionOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "71gj5clg2qh3t"
+      ],
+      "x-yahoo-request-id": [
+        "71gj5clg2qh3t"
+      ],
+      "x-request-id": [
+        "f6e95f94-69e1-4741-8e66-18675650d478"
+      ],
+      "content-length": [
+        "99"
+      ],
+      "x-envoy-upstream-service-time": [
+        "5"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:49 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorDirectHolders-BEKE.json
+++ b/tests/http/quoteSummary-majorDirectHolders-BEKE.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=majorDirectHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "79v4lvdg2qh3t"
+      ],
+      "x-yahoo-request-id": [
+        "79v4lvdg2qh3t"
+      ],
+      "x-request-id": [
+        "feabced7-bb52-42cd-84d8-d5ffed7c298e"
+      ],
+      "content-length": [
+        "91"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:49 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorDirectHolders-BFLY.json
+++ b/tests/http/quoteSummary-majorDirectHolders-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=majorDirectHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "f8a35g5g2qh3t"
+      ],
+      "x-yahoo-request-id": [
+        "f8a35g5g2qh3t"
+      ],
+      "x-request-id": [
+        "f1527fbe-56a4-4a5b-b9d8-5099fa88b244"
+      ],
+      "content-length": [
+        "91"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:49 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorHoldersBreakdown-BEKE.json
+++ b/tests/http/quoteSummary-majorHoldersBreakdown-BEKE.json
@@ -1,0 +1,85 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=majorHoldersBreakdown"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "1r74r59g2qh3t"
+      ],
+      "x-yahoo-request-id": [
+        "1r74r59g2qh3t"
+      ],
+      "x-request-id": [
+        "092c3142-7f31-40b7-8290-f61892a27801"
+      ],
+      "content-length": [
+        "213"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:49 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.0090499995,
+              "institutionsPercentHeld": 0.14386,
+              "institutionsFloatPercentHeld": 0.14517,
+              "institutionsCount": 234
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorHoldersBreakdown-BFLY.json
+++ b/tests/http/quoteSummary-majorHoldersBreakdown-BFLY.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=majorHoldersBreakdown"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "2s4lre9g2qh3u"
+      ],
+      "x-yahoo-request-id": [
+        "2s4lre9g2qh3u"
+      ],
+      "x-request-id": [
+        "cb056184-1c43-4d52-a8f3-8ddff101f1de"
+      ],
+      "content-length": [
+        "81"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:49 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorHoldersBreakdown": {
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-netSharePurchaseActivity-BEKE.json
+++ b/tests/http/quoteSummary-netSharePurchaseActivity-BEKE.json
@@ -1,0 +1,89 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=netSharePurchaseActivity"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "1h6ejehg2qh3u"
+      ],
+      "x-yahoo-request-id": [
+        "1h6ejehg2qh3u"
+      ],
+      "x-request-id": [
+        "328e9b00-c623-4c6b-8892-dbd69c321cac"
+      ],
+      "content-length": [
+        "246"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:50 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 0,
+              "buyInfoShares": 0,
+              "sellInfoCount": 0,
+              "netInfoCount": 0,
+              "netInfoShares": 0,
+              "netPercentInsiderShares": 0,
+              "totalInsiderShares": 10667953
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-netSharePurchaseActivity-BFLY.json
+++ b/tests/http/quoteSummary-netSharePurchaseActivity-BFLY.json
@@ -1,0 +1,88 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=netSharePurchaseActivity"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "32h1hc9g2qh3u"
+      ],
+      "x-yahoo-request-id": [
+        "32h1hc9g2qh3u"
+      ],
+      "x-request-id": [
+        "ddcce27b-62cf-489b-a9eb-a63f3db84b9f"
+      ],
+      "content-length": [
+        "209"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:50 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 0,
+              "buyInfoShares": 0,
+              "sellInfoCount": 0,
+              "netInfoCount": 0,
+              "netInfoShares": 0,
+              "totalInsiderShares": 0
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-price-BEKE.json
+++ b/tests/http/quoteSummary-price-BEKE.json
@@ -1,0 +1,116 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=price"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "7u91vrhg2qh3u"
+      ],
+      "x-yahoo-request-id": [
+        "7u91vrhg2qh3u"
+      ],
+      "x-request-id": [
+        "0a88ee7d-459a-48a3-b69c-d3c21f276b5a"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "455"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:50 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": -0.0220588,
+              "preMarketChange": -1.5,
+              "preMarketTime": 1613572197,
+              "preMarketPrice": 66.5,
+              "preMarketSource": "FREE_REALTIME",
+              "regularMarketChangePercent": -0.03073524,
+              "regularMarketChange": -2.0899963,
+              "regularMarketTime": 1613579385,
+              "priceHint": 2,
+              "regularMarketPrice": 65.91,
+              "regularMarketDayHigh": 67.82,
+              "regularMarketDayLow": 65.25,
+              "regularMarketVolume": 2665475,
+              "regularMarketPreviousClose": 68,
+              "regularMarketSource": "FREE_REALTIME",
+              "regularMarketOpen": 66.39,
+              "exchange": "NYQ",
+              "exchangeName": "NYSE",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "EQUITY",
+              "symbol": "BEKE",
+              "underlyingSymbol": null,
+              "shortName": "KE Holdings Inc",
+              "longName": "KE Holdings Inc.",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 77693394944
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-price-BFLY.json
+++ b/tests/http/quoteSummary-price-BFLY.json
@@ -1,0 +1,115 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=price"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "3nc1hg5g2qh3u"
+      ],
+      "x-yahoo-request-id": [
+        "3nc1hg5g2qh3u"
+      ],
+      "x-request-id": [
+        "a980ed48-2241-4321-984f-aadcaeb2263a"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "450"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:50 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": 0.0288889,
+              "preMarketChange": 0.65,
+              "preMarketTime": 1613572193,
+              "preMarketPrice": 23.15,
+              "preMarketSource": "FREE_REALTIME",
+              "regularMarketChangePercent": -0.008222198,
+              "regularMarketChange": -0.18499947,
+              "regularMarketTime": 1613579380,
+              "priceHint": 2,
+              "regularMarketPrice": 22.315,
+              "regularMarketDayHigh": 23.31,
+              "regularMarketDayLow": 22.1807,
+              "regularMarketVolume": 1508514,
+              "regularMarketPreviousClose": 22.5,
+              "regularMarketSource": "FREE_REALTIME",
+              "regularMarketOpen": 23.11,
+              "exchange": "NYQ",
+              "exchangeName": "NYSE",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "EQUITY",
+              "symbol": "BFLY",
+              "underlyingSymbol": null,
+              "shortName": "Butterfly Network, Inc. Class A",
+              "longName": "Butterfly Network, Inc.",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-quoteType-BEKE.json
+++ b/tests/http/quoteSummary-quoteType-BEKE.json
@@ -1,0 +1,93 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=quoteType"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "ehgo34hg2qh3u"
+      ],
+      "x-yahoo-request-id": [
+        "ehgo34hg2qh3u"
+      ],
+      "x-request-id": [
+        "35cafc5b-069d-4ccb-a1c1-567d72e75c70"
+      ],
+      "content-length": [
+        "424"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:50 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "quoteType": {
+              "exchange": "NYQ",
+              "quoteType": "EQUITY",
+              "symbol": "BEKE",
+              "underlyingSymbol": "BEKE",
+              "shortName": "KE Holdings Inc",
+              "longName": "KE Holdings Inc.",
+              "firstTradeDateEpochUtc": 1597325400,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "36c211a8-04c4-368b-8141-b3e0d4048354",
+              "messageBoardId": "finmb_665898843",
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-quoteType-BFLY.json
+++ b/tests/http/quoteSummary-quoteType-BFLY.json
@@ -1,0 +1,93 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=quoteType"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "3q8iqd9g2qh3u"
+      ],
+      "x-yahoo-request-id": [
+        "3q8iqd9g2qh3u"
+      ],
+      "x-request-id": [
+        "f41a98b9-f665-4294-9b84-f1a5b5ec4696"
+      ],
+      "content-length": [
+        "434"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:50 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "2"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "quoteType": {
+              "exchange": "NYQ",
+              "quoteType": "EQUITY",
+              "symbol": "BFLY",
+              "underlyingSymbol": "BFLY",
+              "shortName": "Butterfly Network, Inc. Class A",
+              "longName": "Butterfly Network, Inc.",
+              "firstTradeDateEpochUtc": 1594647000,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "5f9449d1-1162-3804-a742-88e2f8b5fb0e",
+              "messageBoardId": null,
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-recommendationTrend-BEKE.json
+++ b/tests/http/quoteSummary-recommendationTrend-BEKE.json
@@ -1,0 +1,115 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=recommendationTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "e1lim69g2qh3v"
+      ],
+      "x-yahoo-request-id": [
+        "e1lim69g2qh3v"
+      ],
+      "x-request-id": [
+        "a08c2349-2055-480e-bd08-e2e36b1bd7e8"
+      ],
+      "content-length": [
+        "380"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:50 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 2,
+                  "buy": 3,
+                  "hold": 5,
+                  "sell": 1,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 1,
+                  "buy": 3,
+                  "hold": 5,
+                  "sell": 1,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 0,
+                  "buy": 3,
+                  "hold": 5,
+                  "sell": 1,
+                  "strongSell": 0
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-recommendationTrend-BFLY.json
+++ b/tests/http/quoteSummary-recommendationTrend-BFLY.json
@@ -1,0 +1,115 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=recommendationTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "0o1jk4hg2qh3v"
+      ],
+      "x-yahoo-request-id": [
+        "0o1jk4hg2qh3v"
+      ],
+      "x-request-id": [
+        "1889444a-37f0-48b1-ba5a-109ec636446f"
+      ],
+      "content-length": [
+        "380"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:51 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-secFilings-BEKE.json
+++ b/tests/http/quoteSummary-secFilings-BEKE.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=secFilings"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "1f6ver9g2qh3v"
+      ],
+      "x-yahoo-request-id": [
+        "1f6ver9g2qh3v"
+      ],
+      "x-request-id": [
+        "f94bc82e-dc3d-49d2-bbdc-f6e7b5cf03ed"
+      ],
+      "content-length": [
+        "143"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:51 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=secFilings"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-secFilings-BFLY.json
+++ b/tests/http/quoteSummary-secFilings-BFLY.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=secFilings"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "batqj3tg2qh3v"
+      ],
+      "x-yahoo-request-id": [
+        "batqj3tg2qh3v"
+      ],
+      "x-request-id": [
+        "a2aeaa6c-9175-4fd0-9b40-441f1c59f5d6"
+      ],
+      "content-length": [
+        "143"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:51 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=secFilings"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryDetail-BEKE.json
+++ b/tests/http/quoteSummary-summaryDetail-BEKE.json
@@ -1,0 +1,114 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=summaryDetail"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "84m2anhg2qh3v"
+      ],
+      "x-yahoo-request-id": [
+        "84m2anhg2qh3v"
+      ],
+      "x-request-id": [
+        "ce9efedf-bc91-47bb-a98f-edfe149294f8"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "381"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:51 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 68,
+              "open": 66.39,
+              "dayLow": 65.25,
+              "dayHigh": 67.82,
+              "regularMarketPreviousClose": 68,
+              "regularMarketOpen": 66.39,
+              "regularMarketDayLow": 65.25,
+              "regularMarketDayHigh": 67.82,
+              "payoutRatio": 0,
+              "volume": 2665475,
+              "regularMarketVolume": 2665475,
+              "averageVolume": 3760300,
+              "averageVolume10days": 5531066,
+              "averageDailyVolume10Day": 5531066,
+              "bid": 66.05,
+              "ask": 66.24,
+              "bidSize": 900,
+              "askSize": 1000,
+              "marketCap": 77693394944,
+              "fiftyTwoWeekLow": 31.79,
+              "fiftyTwoWeekHigh": 79.4,
+              "fiftyDayAverage": 64.594246,
+              "twoHundredDayAverage": 61.68664,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryDetail-BFLY.json
+++ b/tests/http/quoteSummary-summaryDetail-BFLY.json
@@ -1,0 +1,112 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=summaryDetail"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "ccgb1rpg2qh40"
+      ],
+      "x-yahoo-request-id": [
+        "ccgb1rpg2qh40"
+      ],
+      "x-request-id": [
+        "5c7b94a7-5c71-4f29-9c11-fddab5b1b840"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "335"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:51 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 22.5,
+              "open": 23.11,
+              "dayLow": 22.1807,
+              "dayHigh": 23.31,
+              "regularMarketPreviousClose": 22.5,
+              "regularMarketOpen": 23.11,
+              "regularMarketDayLow": 22.1807,
+              "regularMarketDayHigh": 23.31,
+              "volume": 1508514,
+              "regularMarketVolume": 1508514,
+              "averageVolume": 2347300,
+              "averageVolume10days": 2347300,
+              "averageDailyVolume10Day": 2347300,
+              "bid": 22.68,
+              "ask": 22.71,
+              "bidSize": 900,
+              "askSize": 1200,
+              "fiftyTwoWeekLow": 21.95,
+              "fiftyTwoWeekHigh": 24.8,
+              "fiftyDayAverage": 22.5,
+              "twoHundredDayAverage": 22.5,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryProfile-BEKE.json
+++ b/tests/http/quoteSummary-summaryProfile-BEKE.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=summaryProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "6fenb8lg2qh40"
+      ],
+      "x-yahoo-request-id": [
+        "6fenb8lg2qh40"
+      ],
+      "x-request-id": [
+        "b699e0e0-e4a7-49a4-ab3b-fdb7262d5908"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "502"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:52 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryProfile": {
+              "address1": "Building Fudao",
+              "address2": "No.11 Kaituo Road Haidian District",
+              "city": "Beijing",
+              "zip": "100085",
+              "country": "China",
+              "phone": "86 10 5810 4689",
+              "website": "http://ke.com",
+              "industry": "Real Estate Services",
+              "sector": "Real Estate",
+              "longBusinessSummary": "KE Holdings Inc. operates an integrated online and offline platform for housing transactions and services in the People's Republic of China. The company facilitates various housing transactions ranging from existing and new home sales and home rentals to home renovation, real estate financial solutions, and other services. It also owns and operates Lianjia, a real estate brokerage branded store. The company was founded in 2001 and is headquartered in Beijing, China.",
+              "companyOfficers": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryProfile-BFLY.json
+++ b/tests/http/quoteSummary-summaryProfile-BFLY.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=summaryProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "an0o3lhg2qh40"
+      ],
+      "x-yahoo-request-id": [
+        "an0o3lhg2qh40"
+      ],
+      "x-request-id": [
+        "fdc1b2b5-dc60-41b6-8732-7c7a3318977e"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "582"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:52 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryProfile": {
+              "address1": "530 Old Whitfield Street",
+              "city": "Guilford",
+              "state": "CT",
+              "zip": "06437",
+              "country": "United States",
+              "phone": "203-458-2514",
+              "website": "http://english.butterflynetwork.com",
+              "industry": "Medical Devices",
+              "sector": "Healthcare",
+              "longBusinessSummary": "Butterfly Network, Inc. develops medical imaging device for hospitals and organizations to scale their point of care ultrasound programs through a new suite of tools that enable ultrasound workflow mobile and system integrations simple and secure. The company's device provides diagnostic imaging and measurement of blood vessels and examines the cardiac, abdominal, urological, fetal, gynecological, and musculoskeletal systems. The company also offers Butterfly iQ, a handheld and single-probe whole body ultrasound system. The company was founded in 2011 and is based in Guilford, Connecticut.",
+              "companyOfficers": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-upgradeDowngradeHistory-BEKE.json
+++ b/tests/http/quoteSummary-upgradeDowngradeHistory-BEKE.json
@@ -1,0 +1,90 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=upgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "39dcil5g2qh40"
+      ],
+      "x-yahoo-request-id": [
+        "39dcil5g2qh40"
+      ],
+      "x-request-id": [
+        "a5ce04e4-aeec-4862-8899-1ea970a296e3"
+      ],
+      "content-length": [
+        "195"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:52 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "upgradeDowngradeHistory": {
+              "history": [
+                {
+                  "epochGradeDate": 1609859636,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-upgradeDowngradeHistory-BFLY.json
+++ b/tests/http/quoteSummary-upgradeDowngradeHistory-BFLY.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=upgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "1n5fefpg2qh40"
+      ],
+      "x-yahoo-request-id": [
+        "1n5fefpg2qh40"
+      ],
+      "x-request-id": [
+        "a1b70336-77ec-4bb2-8d26-720462d2fcde"
+      ],
+      "content-length": [
+        "156"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:52 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=upgradeDowngradeHistory"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-BEKE.json
+++ b/tests/http/recommendationsBySymbol-BEKE.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/BEKE?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "95v5501g2qh3c"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "157"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:32 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "BEKE",
+            "recommendedSymbols": [
+              {
+                "symbol": "DOYU",
+                "score": 0.058686
+              },
+              {
+                "symbol": "API",
+                "score": 0.05831
+              },
+              {
+                "symbol": "FUTU",
+                "score": 0.057564
+              },
+              {
+                "symbol": "YSG",
+                "score": 0.056893
+              },
+              {
+                "symbol": "DADA",
+                "score": 0.055502
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-BFLY.json
+++ b/tests/http/recommendationsBySymbol-BFLY.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/BFLY?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "amr774hg2qh3c"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "161"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:32 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "BFLY",
+            "recommendedSymbols": [
+              {
+                "symbol": "LGVW",
+                "score": 0.028571
+              },
+              {
+                "symbol": "TGLO",
+                "score": 0.020148
+              },
+              {
+                "symbol": "AWEB",
+                "score": 0.018328
+              },
+              {
+                "symbol": "CMLF",
+                "score": 0.015492
+              },
+              {
+                "symbol": "EXPC",
+                "score": 0.014967
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/search-BEKE.json
+++ b/tests/http/search-BEKE.json
@@ -1,0 +1,186 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v1/finance/search?lang=en-US&region=US&quotesCount=6&newsCount=4&enableFuzzyQuery=false&quotesQueryId=tss_match_phrase_query&multiQuoteQueryId=multi_quote_single_token_query&newsQueryId=news_cie_vespa&enableCb=true&enableNavLinks=true&enableEnhancedTrivialQuery=true&q=BEKE"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=120, stale-while-revalidate=180"
+      ],
+      "y-rid": [
+        "7omig7pg2qh3l"
+      ],
+      "x-yahoo-request-id": [
+        "7omig7pg2qh3l"
+      ],
+      "x-request-id": [
+        "e542847b-c6cc-4b2d-afa2-4daaacc3afe3"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "973"
+      ],
+      "x-envoy-upstream-service-time": [
+        "74"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:41 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-search--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "explains": [],
+      "count": 10,
+      "quotes": [
+        {
+          "exchange": "NYQ",
+          "shortname": "KE Holdings Inc",
+          "quoteType": "EQUITY",
+          "symbol": "BEKE",
+          "index": "quotes",
+          "score": 3180600,
+          "typeDisp": "Equity",
+          "longname": "KE Holdings Inc.",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "PNK",
+          "shortname": "BEKEM METALS INC",
+          "quoteType": "EQUITY",
+          "symbol": "BKMM",
+          "index": "quotes",
+          "score": 20032,
+          "typeDisp": "Equity",
+          "longname": "Bekem Metals, Inc.",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "BRU",
+          "shortname": "TER BEKE",
+          "quoteType": "EQUITY",
+          "symbol": "TERB.BR",
+          "index": "quotes",
+          "score": 20030,
+          "typeDisp": "Equity",
+          "longname": "Ter Beke NV",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "OPR",
+          "shortname": "BEKE Mar 2021 80.000 call",
+          "quoteType": "OPTION",
+          "symbol": "BEKE210319C00080000",
+          "index": "quotes",
+          "score": 20006,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "OPR",
+          "shortname": "BEKE Jan 2023 80.000 call",
+          "quoteType": "OPTION",
+          "symbol": "BEKE230120C00080000",
+          "index": "quotes",
+          "score": 20004,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "OPR",
+          "shortname": "BEKE Apr 2021 115.000 call",
+          "quoteType": "OPTION",
+          "symbol": "BEKE210416C00115000",
+          "index": "quotes",
+          "score": 20003,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        }
+      ],
+      "news": [
+        {
+          "uuid": "3f33877f-d553-3330-be49-03f87c8cabc4",
+          "title": "Is the Options Market Predicting a Spike in KE Holdings (BEKE) Stock?",
+          "publisher": "Zacks",
+          "link": "https://finance.yahoo.com/news/options-market-predicting-spike-ke-134701283.html",
+          "providerPublishTime": 1610027221,
+          "type": "STORY"
+        },
+        {
+          "uuid": "533b5a72-a0b2-3fdf-a82f-a946f0905d74",
+          "title": "Why This 'Redfin of China' Should Be on Your Stock Watch List",
+          "publisher": "Motley Fool",
+          "link": "https://finance.yahoo.com/m/533b5a72-a0b2-3fdf-a82f-a946f0905d74/why-this-%27redfin-of-china%27.html",
+          "providerPublishTime": 1608126147,
+          "type": "STORY"
+        },
+        {
+          "uuid": "235e86f1-ba04-3066-8d49-be911ecab0d1",
+          "title": "JLL vs. BEKE: Which Stock Should Value Investors Buy Now?",
+          "publisher": "Zacks",
+          "link": "https://finance.yahoo.com/news/jll-vs-beke-stock-value-164004152.html",
+          "providerPublishTime": 1610037604,
+          "type": "STORY"
+        },
+        {
+          "uuid": "e45f1067-7704-3d7d-ad65-8a669633c34a",
+          "title": "Breakeven Is Near for KE Holdings Inc. (NYSE:BEKE)",
+          "publisher": "Simply Wall St.",
+          "link": "https://finance.yahoo.com/news/breakeven-near-ke-holdings-inc-052423184.html",
+          "providerPublishTime": 1613021063,
+          "type": "STORY"
+        }
+      ],
+      "nav": [],
+      "lists": [],
+      "researchReports": [],
+      "totalTime": 73,
+      "timeTakenForQuotes": 466,
+      "timeTakenForNews": 600,
+      "timeTakenForAlgowatchlist": 400,
+      "timeTakenForPredefinedScreener": 400,
+      "timeTakenForCrunchbase": 400,
+      "timeTakenForNav": 400,
+      "timeTakenForResearchReports": 0
+    }
+  }
+}

--- a/tests/http/search-BFLY.json
+++ b/tests/http/search-BFLY.json
@@ -1,0 +1,179 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v1/finance/search?lang=en-US&region=US&quotesCount=6&newsCount=4&enableFuzzyQuery=false&quotesQueryId=tss_match_phrase_query&multiQuoteQueryId=multi_quote_single_token_query&newsQueryId=news_cie_vespa&enableCb=true&enableNavLinks=true&enableEnhancedTrivialQuery=true&q=BFLY"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=120, stale-while-revalidate=180"
+      ],
+      "y-rid": [
+        "ee1ardlg2qh3l"
+      ],
+      "x-yahoo-request-id": [
+        "ee1ardlg2qh3l"
+      ],
+      "x-request-id": [
+        "141ceb71-2ada-4650-a42d-45f9f9f74b6c"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "945"
+      ],
+      "x-envoy-upstream-service-time": [
+        "35"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 16:29:41 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-search--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "explains": [],
+      "count": 10,
+      "quotes": [
+        {
+          "exchange": "NYQ",
+          "quoteType": "EQUITY",
+          "symbol": "BFLY",
+          "index": "quotes",
+          "score": 6852500,
+          "typeDisp": "Equity",
+          "longname": "Butterfly Network, Inc.",
+          "isYahooFinance": true,
+          "newListingDate": "2021-02-16"
+        },
+        {
+          "exchange": "NYQ",
+          "quoteType": "EQUITY",
+          "symbol": "BFLY-WT",
+          "index": "quotes",
+          "score": 20895,
+          "typeDisp": "Equity",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "OPR",
+          "quoteType": "OPTION",
+          "symbol": "BFLY210319P00025000",
+          "index": "quotes",
+          "score": 20891,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "OPR",
+          "quoteType": "OPTION",
+          "symbol": "BFLY210319P00015000",
+          "index": "quotes",
+          "score": 20243,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "OPR",
+          "quoteType": "OPTION",
+          "symbol": "BFLY210716P00035000",
+          "index": "quotes",
+          "score": 20039,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "OPR",
+          "quoteType": "OPTION",
+          "symbol": "BFLY210219P00012500",
+          "index": "quotes",
+          "score": 20023,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        }
+      ],
+      "news": [
+        {
+          "uuid": "72c5cf01-8a4d-3a4c-b14b-2de4c12217c6",
+          "title": "Butterfly Network Goes Public, Taking Portable Ultrasound Device Global",
+          "publisher": "IPO-Edge.com",
+          "link": "https://finance.yahoo.com/news/butterfly-network-goes-public-taking-110022864.html",
+          "providerPublishTime": 1613473222,
+          "type": "STORY"
+        },
+        {
+          "uuid": "6d1a2e8d-dc02-3e4c-abe4-b4816c8a7ea9",
+          "title": "Butterfly Network, a Global Leader in Democratizing Medical Imaging, Closes Business Combination and Will Begin Trading on the New York Stock Exchange",
+          "publisher": "PR Newswire",
+          "link": "https://finance.yahoo.com/news/butterfly-network-global-leader-democratizing-110000819.html",
+          "providerPublishTime": 1613473200,
+          "type": "STORY"
+        },
+        {
+          "uuid": "aee165c1-9b33-3afe-bf7c-ec0226f7ec4b",
+          "title": "Butterfly Network, a global leader in democratizing medical imaging, to be listed on NYSE through a merger with Longview Acquisition Corp.",
+          "publisher": "PR Newswire",
+          "link": "https://finance.yahoo.com/news/butterfly-network-global-leader-democratizing-120000797.html",
+          "providerPublishTime": 1605873600,
+          "type": "STORY"
+        },
+        {
+          "uuid": "d1980323-e654-3b3b-b9ff-280876c0f2d5",
+          "title": "SHAREHOLDER ALERT: WeissLaw LLP Investigates Longview Acquisition Corp.",
+          "publisher": "PR Newswire",
+          "link": "https://finance.yahoo.com/news/shareholder-alert-weisslaw-llp-investigates-011300059.html",
+          "providerPublishTime": 1605921180,
+          "type": "STORY"
+        }
+      ],
+      "nav": [],
+      "lists": [],
+      "researchReports": [],
+      "totalTime": 33,
+      "timeTakenForQuotes": 423,
+      "timeTakenForNews": 600,
+      "timeTakenForAlgowatchlist": 400,
+      "timeTakenForPredefinedScreener": 400,
+      "timeTakenForCrunchbase": 400,
+      "timeTakenForNav": 400,
+      "timeTakenForResearchReports": 0
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes the CI and tests by making a few properties on `quoteSummary`'s modules `majorHoldersBreakdown` and `netSharePurchaseActivity` optional.

## Changes
- Make everything except for `maxAge` optional for `majorHoldersBreakdown`
- Make `netPercentInsiderShares` optional for `netSharePurchaseActivity`

## Comments
- Now that the CI is passing again, we can continue to make the tests harsher and add more symbols.