### PR TITLE
feat(modules): add trendingSymbols module

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ recommendationTrend, secFilings, sectorTrend, summaryDetail, summaryProfile,
 symbol, topHoldings, upgradeDowngradeHistory),
 [`search`](./docs/modules/search.md),
 [`recommendationsBySymbol`](./docs/modules/recommendationsBySymbol.md), with more
+[`trendingSymbols`](./docs/modules/trendingSymbols.md),
 [coming soon](https://github.com/gadicc/node-yahoo-finance2/issues/8).
 
 See the [Full Documentation](./docs/README.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ const result = await yahooFinance.module(query, queryOpts, moduleOpts);
 1. [quoteSummary](./modules/quoteSummary.md) - comprehensive symbol info.
 1. [search](./modules/search.md) - symbol lookup, news and articles.
 1. [recommendationsBySymbol](./modules/recommendationsBySymbol.md) - similar symbols.
+1. [trendingSymbols](./modules/trendingSymbols.md) - symbols trending in a country.
 
 <a name="error-handling"></a>
 ## Error Handling

--- a/docs/modules/trendingSymbols.md
+++ b/docs/modules/trendingSymbols.md
@@ -1,0 +1,48 @@
+# trendingSymbols
+
+## Usage:
+
+```js
+import yahooFinance from 'yahoo-finance2';
+const queryOptions = { count: 5, lang: 'en-US' };
+const result = await yahooFinance.trendingSymbols('US', queryOptions);
+```
+Result:
+```js
+{
+  count: 5,
+  quotes: [
+    { symbol: 'TWLO' },
+    { symbol: 'RIOT' },
+    { symbol: 'LODE' },
+    { symbol: 'TLRY' },
+    { symbol: 'FSLY' }
+  ],
+  jobTimestamp: 1613600090081,
+  startInterval: 202102172100
+}
+```
+
+## API
+
+```js
+await yahooFinance.trendingSymbols(query, queryOptions, moduleOptions);
+```
+
+### Query
+
+The country name has to be an ISO2 code, either uppercase or lowercase. Most countries will not return data. Only `US`, `GB`, and a couple other will.
+
+### Query Options
+
+| Name     | Type   | Default | Description                                                       |
+| -------- | ------ | ------- | ----------------------------------------------------------------- |
+| `count`  | number | 5       | The max amount of symbols that can be returned.                   |
+| `lang`   | string | "en-US" |                                                                   |
+| `region` | string |         | The region/country. Will override the search country is provided. |
+
+**NOTE:** `corsDomain` seems to be a parameter for the API according to #8, but it does nothing. **It does not set the CORS domain.** Therefore, it is not a parameter.
+
+### Module Options
+
+See [Common Options](../README.md#common-options).

--- a/schema.json
+++ b/schema.json
@@ -5033,6 +5033,60 @@
       ],
       "type": "object"
     },
+    "TrendingSymbol": {
+      "additionalProperties": false,
+      "properties": {
+        "symbol": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "symbol"
+      ],
+      "type": "object"
+    },
+    "TrendingSymbolsOptions": {
+      "additionalProperties": false,
+      "properties": {
+        "count": {
+          "yahooFinanceType": "number"
+        },
+        "lang": {
+          "type": "string"
+        },
+        "region": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "TrendingSymbolsResult": {
+      "additionalProperties": false,
+      "properties": {
+        "count": {
+          "yahooFinanceType": "number"
+        },
+        "jobTimestamp": {
+          "yahooFinanceType": "number"
+        },
+        "quotes": {
+          "items": {
+            "$ref": "#/definitions/TrendingSymbol"
+          },
+          "type": "array"
+        },
+        "startInterval": {
+          "yahooFinanceType": "number"
+        }
+      },
+      "required": [
+        "count",
+        "quotes",
+        "jobTimestamp",
+        "startInterval"
+      ],
+      "type": "object"
+    },
     "TwoNumberRange": {
       "additionalProperties": false,
       "properties": {

--- a/src/index-common.ts
+++ b/src/index-common.ts
@@ -10,6 +10,7 @@ import quote from "./modules/quote";
 import quoteSummary from "./modules/quoteSummary";
 import search from "./modules/search";
 import recommendationsBySymbol from "./modules/recommendationsBySymbol";
+import trendingSymbols from "./modules/trendingSymbols";
 
 export default {
   _env: {},
@@ -23,4 +24,5 @@ export default {
   quoteSummary,
   search,
   recommendationsBySymbol,
+  trendingSymbols,
 };

--- a/src/modules/trendingSymbols.spec.ts
+++ b/src/modules/trendingSymbols.spec.ts
@@ -1,0 +1,15 @@
+import trendingSymbols from "./trendingSymbols";
+import testYf from "../../tests/testYf";
+
+const yf = testYf({ trendingSymbols });
+
+describe("trendingSymbols", () => {
+  it.each(["US", "GB", "IT", "AU"])(
+    "passes validation for country '%s'",
+    async (country) => {
+      await yf.trendingSymbols(country, undefined, {
+        devel: `trendingSymbols-${country}.json`,
+      });
+    }
+  );
+});

--- a/src/modules/trendingSymbols.ts
+++ b/src/modules/trendingSymbols.ts
@@ -1,0 +1,68 @@
+import type {
+  ModuleOptions,
+  ModuleOptionsWithValidateTrue,
+  ModuleOptionsWithValidateFalse,
+  ModuleThis,
+} from "../lib/moduleCommon";
+
+export interface TrendingSymbol {
+  symbol: string;
+}
+
+export interface TrendingSymbolsResult {
+  count: number;
+  quotes: TrendingSymbol[];
+  jobTimestamp: number;
+  startInterval: number;
+}
+
+export interface TrendingSymbolsOptions {
+  lang?: string;
+  region?: string;
+  count?: number;
+}
+
+const queryOptionsDefaults = {
+  lang: "en-US",
+  count: 5,
+};
+
+export default function trendingSymbols(
+  this: ModuleThis,
+  query: string,
+  queryOptionsOverrides?: TrendingSymbolsOptions,
+  moduleOptions?: ModuleOptionsWithValidateTrue
+): Promise<TrendingSymbolsResult>;
+
+export default function trendingSymbols(
+  this: ModuleThis,
+  query: string,
+  queryOptionsOverrides?: TrendingSymbolsOptions,
+  moduleOptions?: ModuleOptionsWithValidateFalse
+): Promise<any>;
+
+export default function trendingSymbols(
+  this: ModuleThis,
+  query: string,
+  queryOptionsOverrides?: TrendingSymbolsOptions,
+  moduleOptions?: ModuleOptions
+): Promise<any> {
+  return this._moduleExec({
+    moduleName: "trendingSymbols",
+    query: {
+      url: `https://query1.finance.yahoo.com/v1/finance/trending/${query}`,
+      schemaKey: "#/definitions/TrendingSymbolsOptions",
+      defaults: queryOptionsDefaults,
+      overrides: queryOptionsOverrides,
+    },
+    result: {
+      schemaKey: "#/definitions/TrendingSymbolsResult",
+      transformWith(result: any) {
+        if (!result.finance)
+          throw new Error("Unexpected result: " + JSON.stringify(result));
+        return result.finance.result[0];
+      },
+    },
+    moduleOptions,
+  });
+}

--- a/tests/http/quoteSummary-all-BEKE.json
+++ b/tests/http/quoteSummary-all-BEKE.json
@@ -1,0 +1,3469 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=assetProfile%2CbalanceSheetHistory%2CbalanceSheetHistoryQuarterly%2CcalendarEvents%2CcashflowStatementHistory%2CcashflowStatementHistoryQuarterly%2CdefaultKeyStatistics%2Cearnings%2CearningsHistory%2CearningsTrend%2CfinancialData%2CfundOwnership%2CfundPerformance%2CfundProfile%2CincomeStatementHistory%2CincomeStatementHistoryQuarterly%2CindexTrend%2CindustryTrend%2CinsiderHolders%2CinsiderTransactions%2CinstitutionOwnership%2CmajorDirectHolders%2CmajorHoldersBreakdown%2CnetSharePurchaseActivity%2Cprice%2CquoteType%2CrecommendationTrend%2CsecFilings%2CsectorTrend%2CsummaryDetail%2CsummaryProfile%2CtopHoldings%2CupgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "4lj5ashg2r54n"
+      ],
+      "x-yahoo-request-id": [
+        "4lj5ashg2r54n"
+      ],
+      "x-request-id": [
+        "629abae7-db77-4aef-80ac-ce6247cc14f9"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "13"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:35 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "Building Fudao",
+              "address2": "No.11 Kaituo Road Haidian District",
+              "city": "Beijing",
+              "zip": "100085",
+              "country": "China",
+              "phone": "86 10 5810 4689",
+              "website": "http://ke.com",
+              "industry": "Real Estate Services",
+              "sector": "Real Estate",
+              "longBusinessSummary": "KE Holdings Inc. operates an integrated online and offline platform for housing transactions and services in the People's Republic of China. The company facilitates various housing transactions ranging from existing and new home sales and home rentals to home renovation, real estate financial solutions, and other services. It also owns and operates Lianjia, a real estate brokerage branded store. The company was founded in 2001 and is headquartered in Beijing, China.",
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Hui  Zuo",
+                  "age": 49,
+                  "title": "Founder & Chairman",
+                  "yearBorn": 1971,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Yongdong  Peng",
+                  "age": 41,
+                  "title": "CEO & Exec. Director",
+                  "yearBorn": 1979,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Tao  Xu",
+                  "age": 47,
+                  "title": "Chief Financial Officer",
+                  "yearBorn": 1973,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Wangang  Xu",
+                  "age": 55,
+                  "title": "Co-Chief Operating Officer",
+                  "yearBorn": 1965,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Yongqun  Wang",
+                  "age": 49,
+                  "title": "Co-Chief Operating Officer",
+                  "yearBorn": 1971,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Yigang  Shan",
+                  "age": 47,
+                  "title": "Exec. Director",
+                  "yearBorn": 1973,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 2,
+                  "buy": 3,
+                  "hold": 5,
+                  "sell": 1,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 1,
+                  "buy": 3,
+                  "hold": 5,
+                  "sell": 1,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 0,
+                  "buy": 3,
+                  "hold": 5,
+                  "sell": 1,
+                  "strongSell": 0
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -2183546000,
+                    "fmt": "-2.18B",
+                    "longFmt": "-2,183,546,000"
+                  },
+                  "depreciation": {
+                    "raw": 1039318000,
+                    "fmt": "1.04B",
+                    "longFmt": "1,039,318,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 3018688000,
+                    "fmt": "3.02B",
+                    "longFmt": "3,018,688,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -5040865000,
+                    "fmt": "-5.04B",
+                    "longFmt": "-5,040,865,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 3009276000,
+                    "fmt": "3.01B",
+                    "longFmt": "3,009,276,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -412586000,
+                    "fmt": "-412.59M",
+                    "longFmt": "-412,586,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 112626000,
+                    "fmt": "112.63M",
+                    "longFmt": "112,626,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -703008000,
+                    "fmt": "-703.01M",
+                    "longFmt": "-703,008,000"
+                  },
+                  "investments": {
+                    "raw": -1133063000,
+                    "fmt": "-1.13B",
+                    "longFmt": "-1,133,063,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 91216000,
+                    "fmt": "91.22M",
+                    "longFmt": "91,216,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -3873722000,
+                    "fmt": "-3.87B",
+                    "longFmt": "-3,873,722,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 6758437000,
+                    "fmt": "6.76B",
+                    "longFmt": "6,758,437,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -8628000,
+                    "fmt": "-8.63M",
+                    "longFmt": "-8,628,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 23026396000,
+                    "fmt": "23.03B",
+                    "longFmt": "23,026,396,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -94922000,
+                    "fmt": "-94.92M",
+                    "longFmt": "-94,922,000"
+                  },
+                  "changeInCash": {
+                    "raw": 19170378000,
+                    "fmt": "19.17B",
+                    "longFmt": "19,170,378,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -347219000,
+                    "fmt": "-347.22M",
+                    "longFmt": "-347,219,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 232885000,
+                    "fmt": "232.88M",
+                    "longFmt": "232,885,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -467824000,
+                    "fmt": "-467.82M",
+                    "longFmt": "-467,824,000"
+                  },
+                  "depreciation": {
+                    "raw": 792294000,
+                    "fmt": "792.29M",
+                    "longFmt": "792,294,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -186336000,
+                    "fmt": "-186.34M",
+                    "longFmt": "-186,336,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -769062000,
+                    "fmt": "-769.06M",
+                    "longFmt": "-769,062,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 1157138000,
+                    "fmt": "1.16B",
+                    "longFmt": "1,157,138,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 2913832000,
+                    "fmt": "2.91B",
+                    "longFmt": "2,913,832,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 3216797000,
+                    "fmt": "3.22B",
+                    "longFmt": "3,216,797,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -542853000,
+                    "fmt": "-542.85M",
+                    "longFmt": "-542,853,000"
+                  },
+                  "investments": {
+                    "raw": 5239066000,
+                    "fmt": "5.24B",
+                    "longFmt": "5,239,066,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -2010792000,
+                    "fmt": "-2.01B",
+                    "longFmt": "-2,010,792,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 2609149000,
+                    "fmt": "2.61B",
+                    "longFmt": "2,609,149,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -124121000,
+                    "fmt": "-124.12M",
+                    "longFmt": "-124,121,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -437019000,
+                    "fmt": "-437.02M",
+                    "longFmt": "-437,019,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -1282408000,
+                    "fmt": "-1.28B",
+                    "longFmt": "-1,282,408,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 416000,
+                    "fmt": "416k",
+                    "longFmt": "416,000"
+                  },
+                  "changeInCash": {
+                    "raw": 4543954000,
+                    "fmt": "4.54B",
+                    "longFmt": "4,543,954,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -347219000,
+                    "fmt": "-347.22M",
+                    "longFmt": "-347,219,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 232885000,
+                    "fmt": "232.88M",
+                    "longFmt": "232,885,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -574430000,
+                    "fmt": "-574.43M",
+                    "longFmt": "-574,430,000"
+                  },
+                  "depreciation": {
+                    "raw": 811203000,
+                    "fmt": "811.2M",
+                    "longFmt": "811,203,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 164271000,
+                    "fmt": "164.27M",
+                    "longFmt": "164,271,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -498216000,
+                    "fmt": "-498.22M",
+                    "longFmt": "-498,216,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -764294000,
+                    "fmt": "-764.29M",
+                    "longFmt": "-764,294,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -5733411000,
+                    "fmt": "-5.73B",
+                    "longFmt": "-5,733,411,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -6456226000,
+                    "fmt": "-6.46B",
+                    "longFmt": "-6,456,226,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -575185000,
+                    "fmt": "-575.18M",
+                    "longFmt": "-575,185,000"
+                  },
+                  "investments": {
+                    "raw": -959123000,
+                    "fmt": "-959.12M",
+                    "longFmt": "-959,123,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -5000000,
+                    "fmt": "-5M",
+                    "longFmt": "-5,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -2783562000,
+                    "fmt": "-2.78B",
+                    "longFmt": "-2,783,562,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -127188000,
+                    "fmt": "-127.19M",
+                    "longFmt": "-127,188,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 973472000,
+                    "fmt": "973.47M",
+                    "longFmt": "973,472,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -437019000,
+                    "fmt": "-437.02M",
+                    "longFmt": "-437,019,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 9576284000,
+                    "fmt": "9.58B",
+                    "longFmt": "9,576,284,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -330000,
+                    "fmt": "-330k",
+                    "longFmt": "-330,000"
+                  },
+                  "changeInCash": {
+                    "raw": 336166000,
+                    "fmt": "336.17M",
+                    "longFmt": "336,166,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -347219000,
+                    "fmt": "-347.22M",
+                    "longFmt": "-347,219,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 232885000,
+                    "fmt": "232.88M",
+                    "longFmt": "232,885,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 5.56217,
+              "pegRatio": 0.991258,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.269
+                },
+                {
+                  "period": "+1q",
+                  "growth": 0.96099997
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.148
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.155
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0821053
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            },
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": 80156999680,
+              "forwardPE": 74.077774,
+              "profitMargins": -0.02313,
+              "floatShares": 389103285,
+              "sharesOutstanding": 1143379968,
+              "sharesShort": 11331624,
+              "sharesShortPriorMonth": 10275253,
+              "sharesShortPreviousMonthDate": 1609372800,
+              "dateShortInterest": 1611878400,
+              "sharesPercentSharesOut": 0.0095999995,
+              "heldPercentInsiders": 0.0090499995,
+              "heldPercentInstitutions": 0.14386,
+              "shortRatio": 3.25,
+              "category": null,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1577750400,
+              "nextFiscalYearEnd": 1640908800,
+              "mostRecentQuarter": 1601424000,
+              "earningsQuarterlyGrowth": -0.804,
+              "pegRatio": 117.17,
+              "lastSplitFactor": null,
+              "52WeekChange": 0.81623936,
+              "SandP52WeekChange": 0.16137505
+            },
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "quoteType": {
+              "exchange": "NYQ",
+              "quoteType": "EQUITY",
+              "symbol": "BEKE",
+              "underlyingSymbol": "BEKE",
+              "shortName": "KE Holdings Inc",
+              "longName": "KE Holdings Inc.",
+              "firstTradeDateEpochUtc": 1597325400,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "36c211a8-04c4-368b-8141-b3e0d4048354",
+              "messageBoardId": "finmb_665898843",
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            },
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 46014906000,
+                    "fmt": "46.01B",
+                    "longFmt": "46,014,906,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 34746862000,
+                    "fmt": "34.75B",
+                    "longFmt": "34,746,862,000"
+                  },
+                  "grossProfit": {
+                    "raw": 11268044000,
+                    "fmt": "11.27B",
+                    "longFmt": "11,268,044,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 1571154000,
+                    "fmt": "1.57B",
+                    "longFmt": "1,571,154,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 11482430000,
+                    "fmt": "11.48B",
+                    "longFmt": "11,482,430,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 47800446000,
+                    "fmt": "47.8B",
+                    "longFmt": "47,800,446,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -1785540000,
+                    "fmt": "-1.79B",
+                    "longFmt": "-1,785,540,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 509776000,
+                    "fmt": "509.78M",
+                    "longFmt": "509,776,000"
+                  },
+                  "ebit": {
+                    "raw": -1785540000,
+                    "fmt": "-1.79B",
+                    "longFmt": "-1,785,540,000"
+                  },
+                  "interestExpense": {
+                    "raw": -181099000,
+                    "fmt": "-181.1M",
+                    "longFmt": "-181,099,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -1275764000,
+                    "fmt": "-1.28B",
+                    "longFmt": "-1,275,764,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 904363000,
+                    "fmt": "904.36M",
+                    "longFmt": "904,363,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 87203000,
+                    "fmt": "87.2M",
+                    "longFmt": "87,203,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -2180127000,
+                    "fmt": "-2.18B",
+                    "longFmt": "-2,180,127,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -2183546000,
+                    "fmt": "-2.18B",
+                    "longFmt": "-2,183,546,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -4050074000,
+                    "fmt": "-4.05B",
+                    "longFmt": "-4,050,074,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 28646499000,
+                    "fmt": "28.65B",
+                    "longFmt": "28,646,499,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 21776523000,
+                    "fmt": "21.78B",
+                    "longFmt": "21,776,523,000"
+                  },
+                  "grossProfit": {
+                    "raw": 6869976000,
+                    "fmt": "6.87B",
+                    "longFmt": "6,869,976,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 670922000,
+                    "fmt": "670.92M",
+                    "longFmt": "670,922,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 7417059000,
+                    "fmt": "7.42B",
+                    "longFmt": "7,417,059,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 29864504000,
+                    "fmt": "29.86B",
+                    "longFmt": "29,864,504,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -1218005000,
+                    "fmt": "-1.22B",
+                    "longFmt": "-1,218,005,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 718940000,
+                    "fmt": "718.94M",
+                    "longFmt": "718,940,000"
+                  },
+                  "ebit": {
+                    "raw": -1218005000,
+                    "fmt": "-1.22B",
+                    "longFmt": "-1,218,005,000"
+                  },
+                  "interestExpense": {
+                    "raw": -43517000,
+                    "fmt": "-43.52M",
+                    "longFmt": "-43,517,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -499065000,
+                    "fmt": "-499.06M",
+                    "longFmt": "-499,065,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -71384000,
+                    "fmt": "-71.38M",
+                    "longFmt": "-71,384,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 10467000,
+                    "fmt": "10.47M",
+                    "longFmt": "10,467,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -427681000,
+                    "fmt": "-427.68M",
+                    "longFmt": "-427,681,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -467824000,
+                    "fmt": "-467.82M",
+                    "longFmt": "-467,824,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -2386005000,
+                    "fmt": "-2.39B",
+                    "longFmt": "-2,386,005,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 25505698000,
+                    "fmt": "25.51B",
+                    "longFmt": "25,505,698,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 20737641000,
+                    "fmt": "20.74B",
+                    "longFmt": "20,737,641,000"
+                  },
+                  "grossProfit": {
+                    "raw": 4768057000,
+                    "fmt": "4.77B",
+                    "longFmt": "4,768,057,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 251802000,
+                    "fmt": "251.8M",
+                    "longFmt": "251,802,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 5280146000,
+                    "fmt": "5.28B",
+                    "longFmt": "5,280,146,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 26269589000,
+                    "fmt": "26.27B",
+                    "longFmt": "26,269,589,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -763891000,
+                    "fmt": "-763.89M",
+                    "longFmt": "-763,891,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 625553000,
+                    "fmt": "625.55M",
+                    "longFmt": "625,553,000"
+                  },
+                  "ebit": {
+                    "raw": -763891000,
+                    "fmt": "-763.89M",
+                    "longFmt": "-763,891,000"
+                  },
+                  "interestExpense": {
+                    "raw": -43791000,
+                    "fmt": "-43.79M",
+                    "longFmt": "-43,791,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -138338000,
+                    "fmt": "-138.34M",
+                    "longFmt": "-138,338,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 399283000,
+                    "fmt": "399.28M",
+                    "longFmt": "399,283,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 65836000,
+                    "fmt": "65.84M",
+                    "longFmt": "65,836,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -537621000,
+                    "fmt": "-537.62M",
+                    "longFmt": "-537,621,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -574430000,
+                    "fmt": "-574.43M",
+                    "longFmt": "-574,430,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -1441879000,
+                    "fmt": "-1.44B",
+                    "longFmt": "-1,441,879,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            },
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 68,
+              "open": 66.39,
+              "dayLow": 65.25,
+              "dayHigh": 67.87,
+              "regularMarketPreviousClose": 68,
+              "regularMarketOpen": 66.39,
+              "regularMarketDayLow": 65.25,
+              "regularMarketDayHigh": 67.87,
+              "payoutRatio": 0,
+              "volume": 3772289,
+              "regularMarketVolume": 3772289,
+              "averageVolume": 3760300,
+              "averageVolume10days": 5531066,
+              "averageDailyVolume10Day": 5531066,
+              "bid": 66.62,
+              "ask": 67,
+              "bidSize": 1200,
+              "askSize": 1000,
+              "marketCap": 78589263872,
+              "fiftyTwoWeekLow": 31.79,
+              "fiftyTwoWeekHigh": 79.4,
+              "fiftyDayAverage": 64.594246,
+              "twoHundredDayAverage": 61.68664,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            },
+            "insiderHolders": {
+              "holders": [],
+              "maxAge": 1
+            },
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": [],
+                "earningsAverage": 0.13,
+                "earningsLow": 0.01,
+                "earningsHigh": 0.17,
+                "revenueAverage": 3082150000,
+                "revenueLow": 2998670000,
+                "revenueHigh": 3182420000
+              }
+            },
+            "upgradeDowngradeHistory": {
+              "history": [
+                {
+                  "epochGradeDate": 1609859636,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                }
+              ],
+              "maxAge": 86400
+            },
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": -0.0220588,
+              "preMarketChange": -1.5,
+              "preMarketTime": 1613572197,
+              "preMarketPrice": 66.5,
+              "preMarketSource": "FREE_REALTIME",
+              "postMarketChangePercent": -0.0032998535,
+              "postMarketChange": -0.22000122,
+              "postMarketTime": 1613599825,
+              "postMarketPrice": 66.45,
+              "postMarketSource": "FREE_REALTIME",
+              "regularMarketChangePercent": -0.01955885,
+              "regularMarketChange": -1.3300018,
+              "regularMarketTime": 1613595602,
+              "priceHint": 2,
+              "regularMarketPrice": 66.67,
+              "regularMarketDayHigh": 67.87,
+              "regularMarketDayLow": 65.25,
+              "regularMarketVolume": 3772289,
+              "averageDailyVolume10Day": 5531066,
+              "averageDailyVolume3Month": 3760300,
+              "regularMarketPreviousClose": 68,
+              "regularMarketSource": "DELAYED",
+              "regularMarketOpen": 66.39,
+              "exchange": "NYQ",
+              "exchangeName": "NYSE",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "POST",
+              "quoteType": "EQUITY",
+              "symbol": "BEKE",
+              "underlyingSymbol": null,
+              "shortName": "KE Holdings Inc",
+              "longName": "KE Holdings Inc.",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 78589263872
+            },
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 24319332000,
+                    "fmt": "24.32B",
+                    "longFmt": "24,319,332,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 1844595000,
+                    "fmt": "1.84B",
+                    "longFmt": "1,844,595,000"
+                  },
+                  "netReceivables": {
+                    "raw": 13169172000,
+                    "fmt": "13.17B",
+                    "longFmt": "13,169,172,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 12139612000,
+                    "fmt": "12.14B",
+                    "longFmt": "12,139,612,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 51912486000,
+                    "fmt": "51.91B",
+                    "longFmt": "51,912,486,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2333745000,
+                    "fmt": "2.33B",
+                    "longFmt": "2,333,745,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6759243000,
+                    "fmt": "6.76B",
+                    "longFmt": "6,759,243,000"
+                  },
+                  "goodWill": {
+                    "raw": 2477075000,
+                    "fmt": "2.48B",
+                    "longFmt": "2,477,075,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 2560442000,
+                    "fmt": "2.56B",
+                    "longFmt": "2,560,442,000"
+                  },
+                  "otherAssets": {
+                    "raw": 1222321000,
+                    "fmt": "1.22B",
+                    "longFmt": "1,222,321,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 520292000,
+                    "fmt": "520.29M",
+                    "longFmt": "520,292,000"
+                  },
+                  "totalAssets": {
+                    "raw": 67265312000,
+                    "fmt": "67.27B",
+                    "longFmt": "67,265,312,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 4475170000,
+                    "fmt": "4.48B",
+                    "longFmt": "4,475,170,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2291723000,
+                    "fmt": "2.29B",
+                    "longFmt": "2,291,723,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 8584074000,
+                    "fmt": "8.58B",
+                    "longFmt": "8,584,074,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 4897530000,
+                    "fmt": "4.9B",
+                    "longFmt": "4,897,530,000"
+                  },
+                  "otherLiab": {
+                    "raw": 120275000,
+                    "fmt": "120.28M",
+                    "longFmt": "120,275,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 87203000,
+                    "fmt": "87.2M",
+                    "longFmt": "87,203,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 27797675000,
+                    "fmt": "27.8B",
+                    "longFmt": "27,797,675,000"
+                  },
+                  "totalLiab": {
+                    "raw": 35729720000,
+                    "fmt": "35.73B",
+                    "longFmt": "35,729,720,000"
+                  },
+                  "commonStock": {
+                    "raw": 202000,
+                    "fmt": "202k",
+                    "longFmt": "202,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -11521905000,
+                    "fmt": "-11.52B",
+                    "longFmt": "-11,521,905,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 63308000,
+                    "fmt": "63.31M",
+                    "longFmt": "63,308,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 2533889000,
+                    "fmt": "2.53B",
+                    "longFmt": "2,533,889,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 63308000,
+                    "fmt": "63.31M",
+                    "longFmt": "63,308,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -8924506000,
+                    "fmt": "-8.92B",
+                    "longFmt": "-8,924,506,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -13962023000,
+                    "fmt": "-13.96B",
+                    "longFmt": "-13,962,023,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "cash": {
+                    "raw": 9115649000,
+                    "fmt": "9.12B",
+                    "longFmt": "9,115,649,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 2523199000,
+                    "fmt": "2.52B",
+                    "longFmt": "2,523,199,000"
+                  },
+                  "netReceivables": {
+                    "raw": 10369552000,
+                    "fmt": "10.37B",
+                    "longFmt": "10,369,552,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 4972534000,
+                    "fmt": "4.97B",
+                    "longFmt": "4,972,534,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 27374784000,
+                    "fmt": "27.37B",
+                    "longFmt": "27,374,784,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 418469000,
+                    "fmt": "418.47M",
+                    "longFmt": "418,469,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6089232000,
+                    "fmt": "6.09B",
+                    "longFmt": "6,089,232,000"
+                  },
+                  "goodWill": {
+                    "raw": 1135034000,
+                    "fmt": "1.14B",
+                    "longFmt": "1,135,034,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 196998000,
+                    "fmt": "197M",
+                    "longFmt": "196,998,000"
+                  },
+                  "otherAssets": {
+                    "raw": 3651747000,
+                    "fmt": "3.65B",
+                    "longFmt": "3,651,747,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 672622000,
+                    "fmt": "672.62M",
+                    "longFmt": "672,622,000"
+                  },
+                  "totalAssets": {
+                    "raw": 38866264000,
+                    "fmt": "38.87B",
+                    "longFmt": "38,866,264,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1573343000,
+                    "fmt": "1.57B",
+                    "longFmt": "1,573,343,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2414607000,
+                    "fmt": "2.41B",
+                    "longFmt": "2,414,607,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 4762200000,
+                    "fmt": "4.76B",
+                    "longFmt": "4,762,200,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 112900000,
+                    "fmt": "112.9M",
+                    "longFmt": "112,900,000"
+                  },
+                  "otherLiab": {
+                    "raw": 532931000,
+                    "fmt": "532.93M",
+                    "longFmt": "532,931,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 10467000,
+                    "fmt": "10.47M",
+                    "longFmt": "10,467,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 20572881000,
+                    "fmt": "20.57B",
+                    "longFmt": "20,572,881,000"
+                  },
+                  "totalLiab": {
+                    "raw": 24007724000,
+                    "fmt": "24.01B",
+                    "longFmt": "24,007,724,000"
+                  },
+                  "commonStock": {
+                    "raw": 189000,
+                    "fmt": "189k",
+                    "longFmt": "189,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -7814291000,
+                    "fmt": "-7.81B",
+                    "longFmt": "-7,814,291,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -134000,
+                    "fmt": "-134k",
+                    "longFmt": "-134,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -134000,
+                    "fmt": "-134k",
+                    "longFmt": "-134,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -7814236000,
+                    "fmt": "-7.81B",
+                    "longFmt": "-7,814,236,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -9146268000,
+                    "fmt": "-9.15B",
+                    "longFmt": "-9,146,268,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "cash": {
+                    "raw": 5236100000,
+                    "fmt": "5.24B",
+                    "longFmt": "5,236,100,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 7587433000,
+                    "fmt": "7.59B",
+                    "longFmt": "7,587,433,000"
+                  },
+                  "netReceivables": {
+                    "raw": 4676434000,
+                    "fmt": "4.68B",
+                    "longFmt": "4,676,434,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 6227975000,
+                    "fmt": "6.23B",
+                    "longFmt": "6,227,975,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 24067931000,
+                    "fmt": "24.07B",
+                    "longFmt": "24,067,931,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 379972000,
+                    "fmt": "379.97M",
+                    "longFmt": "379,972,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6002914000,
+                    "fmt": "6B",
+                    "longFmt": "6,002,914,000"
+                  },
+                  "goodWill": {
+                    "raw": 710983000,
+                    "fmt": "710.98M",
+                    "longFmt": "710,983,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 264726000,
+                    "fmt": "264.73M",
+                    "longFmt": "264,726,000"
+                  },
+                  "otherAssets": {
+                    "raw": 153409000,
+                    "fmt": "153.41M",
+                    "longFmt": "153,409,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 147535000,
+                    "fmt": "147.53M",
+                    "longFmt": "147,535,000"
+                  },
+                  "totalAssets": {
+                    "raw": 31579935000,
+                    "fmt": "31.58B",
+                    "longFmt": "31,579,935,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 370496000,
+                    "fmt": "370.5M",
+                    "longFmt": "370,496,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 4665524000,
+                    "fmt": "4.67B",
+                    "longFmt": "4,665,524,000"
+                  },
+                  "otherLiab": {
+                    "raw": 518091000,
+                    "fmt": "518.09M",
+                    "longFmt": "518,091,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 65836000,
+                    "fmt": "65.84M",
+                    "longFmt": "65,836,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 16047286000,
+                    "fmt": "16.05B",
+                    "longFmt": "16,047,286,000"
+                  },
+                  "totalLiab": {
+                    "raw": 19143150000,
+                    "fmt": "19.14B",
+                    "longFmt": "19,143,150,000"
+                  },
+                  "commonStock": {
+                    "raw": 178000,
+                    "fmt": "178k",
+                    "longFmt": "178,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -5226325000,
+                    "fmt": "-5.23B",
+                    "longFmt": "-5,226,325,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -327000,
+                    "fmt": "-327k",
+                    "longFmt": "-327,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -327000,
+                    "fmt": "-327k",
+                    "longFmt": "-327,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -5226474000,
+                    "fmt": "-5.23B",
+                    "longFmt": "-5,226,474,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -6202183000,
+                    "fmt": "-6.2B",
+                    "longFmt": "-6,202,183,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": "2020-12-31",
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "low": {
+                      "raw": 0.01,
+                      "fmt": "0.01"
+                    },
+                    "high": {
+                      "raw": 0.17,
+                      "fmt": "0.17"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 6,
+                      "fmt": "6",
+                      "longFmt": "6"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 3082150000,
+                      "fmt": "3.08B",
+                      "longFmt": "3,082,150,000"
+                    },
+                    "low": {
+                      "raw": 2998670000,
+                      "fmt": "3B",
+                      "longFmt": "2,998,670,000"
+                    },
+                    "high": {
+                      "raw": 3182420000,
+                      "fmt": "3.18B",
+                      "longFmt": "3,182,420,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 7,
+                      "fmt": "7",
+                      "longFmt": "7"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.11,
+                      "fmt": "0.11"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": "2021-03-31",
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "low": {
+                      "raw": 0.09,
+                      "fmt": "0.09"
+                    },
+                    "high": {
+                      "raw": 0.14,
+                      "fmt": "0.14"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 3,
+                      "fmt": "3",
+                      "longFmt": "3"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 2126150000,
+                      "fmt": "2.13B",
+                      "longFmt": "2,126,150,000"
+                    },
+                    "low": {
+                      "raw": 1891260000,
+                      "fmt": "1.89B",
+                      "longFmt": "1,891,260,000"
+                    },
+                    "high": {
+                      "raw": 2252600000,
+                      "fmt": "2.25B",
+                      "longFmt": "2,252,600,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 3,
+                      "fmt": "3",
+                      "longFmt": "3"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.08,
+                      "fmt": "0.08"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": "2020-12-31",
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "low": {
+                      "raw": 0.63,
+                      "fmt": "0.63"
+                    },
+                    "high": {
+                      "raw": 1.02,
+                      "fmt": "1.02"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 9,
+                      "fmt": "9",
+                      "longFmt": "9"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 10527000000,
+                      "fmt": "10.53B",
+                      "longFmt": "10,527,000,000"
+                    },
+                    "low": {
+                      "raw": 10400500000,
+                      "fmt": "10.4B",
+                      "longFmt": "10,400,500,000"
+                    },
+                    "high": {
+                      "raw": 10688500000,
+                      "fmt": "10.69B",
+                      "longFmt": "10,688,500,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 11,
+                      "fmt": "11",
+                      "longFmt": "11"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.74,
+                      "fmt": "0.74"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.67,
+                      "fmt": "0.67"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": "2021-12-31",
+                  "growth": {
+                    "raw": 0.2,
+                    "fmt": "20.00%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.9,
+                      "fmt": "0.9"
+                    },
+                    "low": {
+                      "raw": 0.64,
+                      "fmt": "0.64"
+                    },
+                    "high": {
+                      "raw": 0.99,
+                      "fmt": "0.99"
+                    },
+                    "yearAgoEps": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 9,
+                      "fmt": "9",
+                      "longFmt": "9"
+                    },
+                    "growth": {
+                      "raw": 0.2,
+                      "fmt": "20.00%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 13237800000,
+                      "fmt": "13.24B",
+                      "longFmt": "13,237,800,000"
+                    },
+                    "low": {
+                      "raw": 11327900000,
+                      "fmt": "11.33B",
+                      "longFmt": "11,327,900,000"
+                    },
+                    "high": {
+                      "raw": 14382900000,
+                      "fmt": "14.38B",
+                      "longFmt": "14,382,900,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 11,
+                      "fmt": "11",
+                      "longFmt": "11"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 10527000000,
+                      "fmt": "10.53B",
+                      "longFmt": "10,527,000,000"
+                    },
+                    "growth": {
+                      "raw": 0.258,
+                      "fmt": "25.80%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.9,
+                      "fmt": "0.9"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.9,
+                      "fmt": "0.9"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.9,
+                      "fmt": "0.9"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.89,
+                      "fmt": "0.89"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.88,
+                      "fmt": "0.88"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": 0.046,
+                    "fmt": "4.60%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            },
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Baillie Gifford and Company",
+                  "pctHeld": {
+                    "raw": 0.0198,
+                    "fmt": "1.98%"
+                  },
+                  "position": {
+                    "raw": 17631431,
+                    "fmt": "17.63M",
+                    "longFmt": "17,631,431"
+                  },
+                  "value": {
+                    "raw": 1085038263,
+                    "fmt": "1.09B",
+                    "longFmt": "1,085,038,263"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "SC US (TTGP) Ltd",
+                  "pctHeld": {
+                    "raw": 0.0123000005,
+                    "fmt": "1.23%"
+                  },
+                  "position": {
+                    "raw": 10964911,
+                    "fmt": "10.96M",
+                    "longFmt": "10,964,911"
+                  },
+                  "value": {
+                    "raw": 672149044,
+                    "fmt": "672.15M",
+                    "longFmt": "672,149,044"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "FMR, LLC",
+                  "pctHeld": {
+                    "raw": 0.0089,
+                    "fmt": "0.89%"
+                  },
+                  "position": {
+                    "raw": 7903919,
+                    "fmt": "7.9M",
+                    "longFmt": "7,903,919"
+                  },
+                  "value": {
+                    "raw": 486407175,
+                    "fmt": "486.41M",
+                    "longFmt": "486,407,175"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Capital World Investors",
+                  "pctHeld": {
+                    "raw": 0.0088,
+                    "fmt": "0.88%"
+                  },
+                  "position": {
+                    "raw": 7821189,
+                    "fmt": "7.82M",
+                    "longFmt": "7,821,189"
+                  },
+                  "value": {
+                    "raw": 479438885,
+                    "fmt": "479.44M",
+                    "longFmt": "479,438,885"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Blackrock Inc.",
+                  "pctHeld": {
+                    "raw": 0.0074,
+                    "fmt": "0.74%"
+                  },
+                  "position": {
+                    "raw": 6536139,
+                    "fmt": "6.54M",
+                    "longFmt": "6,536,139"
+                  },
+                  "value": {
+                    "raw": 402233994,
+                    "fmt": "402.23M",
+                    "longFmt": "402,233,994"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Hillhouse Capital Advisors Ltd.",
+                  "pctHeld": {
+                    "raw": 0.0056,
+                    "fmt": "0.56%"
+                  },
+                  "position": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "value": {
+                    "raw": 306500000,
+                    "fmt": "306.5M",
+                    "longFmt": "306,500,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "D1 Capital Partners, LP",
+                  "pctHeld": {
+                    "raw": 0.0056,
+                    "fmt": "0.56%"
+                  },
+                  "position": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "value": {
+                    "raw": 306500000,
+                    "fmt": "306.5M",
+                    "longFmt": "306,500,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Credit Suisse Ag/",
+                  "pctHeld": {
+                    "raw": 0.0043,
+                    "fmt": "0.43%"
+                  },
+                  "position": {
+                    "raw": 3778354,
+                    "fmt": "3.78M",
+                    "longFmt": "3,778,354"
+                  },
+                  "value": {
+                    "raw": 231613100,
+                    "fmt": "231.61M",
+                    "longFmt": "231,613,100"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Group, Inc. (The)",
+                  "pctHeld": {
+                    "raw": 0.0042,
+                    "fmt": "0.42%"
+                  },
+                  "position": {
+                    "raw": 3750841,
+                    "fmt": "3.75M",
+                    "longFmt": "3,750,841"
+                  },
+                  "value": {
+                    "raw": 229926553,
+                    "fmt": "229.93M",
+                    "longFmt": "229,926,553"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Sumitomo Mitsui Trust Holdings, Inc.",
+                  "pctHeld": {
+                    "raw": 0.004,
+                    "fmt": "0.40%"
+                  },
+                  "position": {
+                    "raw": 3512686,
+                    "fmt": "3.51M",
+                    "longFmt": "3,512,686"
+                  },
+                  "value": {
+                    "raw": 216170696,
+                    "fmt": "216.17M",
+                    "longFmt": "216,170,696"
+                  }
+                }
+              ]
+            },
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.0090499995,
+              "institutionsPercentHeld": 0.14386,
+              "institutionsFloatPercentHeld": 0.14517,
+              "institutionsCount": 234
+            },
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 38046404000,
+                    "fmt": "38.05B",
+                    "longFmt": "38,046,404,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 13156851000,
+                    "fmt": "13.16B",
+                    "longFmt": "13,156,851,000"
+                  },
+                  "netReceivables": {
+                    "raw": 12955146000,
+                    "fmt": "12.96B",
+                    "longFmt": "12,955,146,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 10926407000,
+                    "fmt": "10.93B",
+                    "longFmt": "10,926,407,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 75696700000,
+                    "fmt": "75.7B",
+                    "longFmt": "75,696,700,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2461657000,
+                    "fmt": "2.46B",
+                    "longFmt": "2,461,657,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 7389774000,
+                    "fmt": "7.39B",
+                    "longFmt": "7,389,774,000"
+                  },
+                  "goodWill": {
+                    "raw": 2490155000,
+                    "fmt": "2.49B",
+                    "longFmt": "2,490,155,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 2062294000,
+                    "fmt": "2.06B",
+                    "longFmt": "2,062,294,000"
+                  },
+                  "otherAssets": {
+                    "raw": 873615000,
+                    "fmt": "873.62M",
+                    "longFmt": "873,615,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 530164000,
+                    "fmt": "530.16M",
+                    "longFmt": "530,164,000"
+                  },
+                  "totalAssets": {
+                    "raw": 90974195000,
+                    "fmt": "90.97B",
+                    "longFmt": "90,974,195,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 6499745000,
+                    "fmt": "6.5B",
+                    "longFmt": "6,499,745,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2411361000,
+                    "fmt": "2.41B",
+                    "longFmt": "2,411,361,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 9611704000,
+                    "fmt": "9.61B",
+                    "longFmt": "9,611,704,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 4793875000,
+                    "fmt": "4.79B",
+                    "longFmt": "4,793,875,000"
+                  },
+                  "otherLiab": {
+                    "raw": 22446000,
+                    "fmt": "22.45M",
+                    "longFmt": "22,446,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 26490000,
+                    "fmt": "26.49M",
+                    "longFmt": "26,490,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 31727200000,
+                    "fmt": "31.73B",
+                    "longFmt": "31,727,200,000"
+                  },
+                  "totalLiab": {
+                    "raw": 39843179000,
+                    "fmt": "39.84B",
+                    "longFmt": "39,843,179,000"
+                  },
+                  "commonStock": {
+                    "raw": 466000,
+                    "fmt": "466k",
+                    "longFmt": "466,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -9929807000,
+                    "fmt": "-9.93B",
+                    "longFmt": "-9,929,807,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -531354000,
+                    "fmt": "-531.35M",
+                    "longFmt": "-531,354,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 61565221000,
+                    "fmt": "61.57B",
+                    "longFmt": "61,565,221,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -531354000,
+                    "fmt": "-531.35M",
+                    "longFmt": "-531,354,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 51104526000,
+                    "fmt": "51.1B",
+                    "longFmt": "51,104,526,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 46552077000,
+                    "fmt": "46.55B",
+                    "longFmt": "46,552,077,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "cash": {
+                    "raw": 25079605000,
+                    "fmt": "25.08B",
+                    "longFmt": "25,079,605,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 5869529000,
+                    "fmt": "5.87B",
+                    "longFmt": "5,869,529,000"
+                  },
+                  "netReceivables": {
+                    "raw": 13068816000,
+                    "fmt": "13.07B",
+                    "longFmt": "13,068,816,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 12353005000,
+                    "fmt": "12.35B",
+                    "longFmt": "12,353,005,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 56925376000,
+                    "fmt": "56.93B",
+                    "longFmt": "56,925,376,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2466889000,
+                    "fmt": "2.47B",
+                    "longFmt": "2,466,889,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6911464000,
+                    "fmt": "6.91B",
+                    "longFmt": "6,911,464,000"
+                  },
+                  "goodWill": {
+                    "raw": 2490155000,
+                    "fmt": "2.49B",
+                    "longFmt": "2,490,155,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 2288794000,
+                    "fmt": "2.29B",
+                    "longFmt": "2,288,794,000"
+                  },
+                  "otherAssets": {
+                    "raw": 923040000,
+                    "fmt": "923.04M",
+                    "longFmt": "923,040,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 530164000,
+                    "fmt": "530.16M",
+                    "longFmt": "530,164,000"
+                  },
+                  "totalAssets": {
+                    "raw": 72005718000,
+                    "fmt": "72.01B",
+                    "longFmt": "72,005,718,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 5287577000,
+                    "fmt": "5.29B",
+                    "longFmt": "5,287,577,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2199275000,
+                    "fmt": "2.2B",
+                    "longFmt": "2,199,275,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 11037514000,
+                    "fmt": "11.04B",
+                    "longFmt": "11,037,514,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 4885370000,
+                    "fmt": "4.89B",
+                    "longFmt": "4,885,370,000"
+                  },
+                  "otherLiab": {
+                    "raw": 116203000,
+                    "fmt": "116.2M",
+                    "longFmt": "116,203,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 25846000,
+                    "fmt": "25.85M",
+                    "longFmt": "25,846,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 30175739000,
+                    "fmt": "30.18B",
+                    "longFmt": "30,175,739,000"
+                  },
+                  "totalLiab": {
+                    "raw": 38219015000,
+                    "fmt": "38.22B",
+                    "longFmt": "38,219,015,000"
+                  },
+                  "commonStock": {
+                    "raw": 205000,
+                    "fmt": "205k",
+                    "longFmt": "205,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -10004504000,
+                    "fmt": "-10B",
+                    "longFmt": "-10,004,504,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 213691000,
+                    "fmt": "213.69M",
+                    "longFmt": "213,691,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1769485000,
+                    "fmt": "1.77B",
+                    "longFmt": "1,769,485,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 213691000,
+                    "fmt": "213.69M",
+                    "longFmt": "213,691,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -8021123000,
+                    "fmt": "-8.02B",
+                    "longFmt": "-8,021,123,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -12800072000,
+                    "fmt": "-12.8B",
+                    "longFmt": "-12,800,072,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "cash": {
+                    "raw": 15538844000,
+                    "fmt": "15.54B",
+                    "longFmt": "15,538,844,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 7709598000,
+                    "fmt": "7.71B",
+                    "longFmt": "7,709,598,000"
+                  },
+                  "netReceivables": {
+                    "raw": 11799844000,
+                    "fmt": "11.8B",
+                    "longFmt": "11,799,844,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 10805983000,
+                    "fmt": "10.81B",
+                    "longFmt": "10,805,983,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 46380397000,
+                    "fmt": "46.38B",
+                    "longFmt": "46,380,397,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2347955000,
+                    "fmt": "2.35B",
+                    "longFmt": "2,347,955,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6700269000,
+                    "fmt": "6.7B",
+                    "longFmt": "6,700,269,000"
+                  },
+                  "goodWill": {
+                    "raw": 2477075000,
+                    "fmt": "2.48B",
+                    "longFmt": "2,477,075,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 2433454000,
+                    "fmt": "2.43B",
+                    "longFmt": "2,433,454,000"
+                  },
+                  "otherAssets": {
+                    "raw": 901375000,
+                    "fmt": "901.38M",
+                    "longFmt": "901,375,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 530164000,
+                    "fmt": "530.16M",
+                    "longFmt": "530,164,000"
+                  },
+                  "totalAssets": {
+                    "raw": 61240525000,
+                    "fmt": "61.24B",
+                    "longFmt": "61,240,525,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 3645940000,
+                    "fmt": "3.65B",
+                    "longFmt": "3,645,940,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 1767844000,
+                    "fmt": "1.77B",
+                    "longFmt": "1,767,844,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 8597488000,
+                    "fmt": "8.6B",
+                    "longFmt": "8,597,488,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 4980956000,
+                    "fmt": "4.98B",
+                    "longFmt": "4,980,956,000"
+                  },
+                  "otherLiab": {
+                    "raw": 120365000,
+                    "fmt": "120.36M",
+                    "longFmt": "120,365,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 84466000,
+                    "fmt": "84.47M",
+                    "longFmt": "84,466,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 22876987000,
+                    "fmt": "22.88B",
+                    "longFmt": "22,876,987,000"
+                  },
+                  "totalLiab": {
+                    "raw": 30855825000,
+                    "fmt": "30.86B",
+                    "longFmt": "30,855,825,000"
+                  },
+                  "commonStock": {
+                    "raw": 202000,
+                    "fmt": "202k",
+                    "longFmt": "202,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -12841072000,
+                    "fmt": "-12.84B",
+                    "longFmt": "-12,841,072,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 234320000,
+                    "fmt": "234.32M",
+                    "longFmt": "234,320,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1840586000,
+                    "fmt": "1.84B",
+                    "longFmt": "1,840,586,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 234320000,
+                    "fmt": "234.32M",
+                    "longFmt": "234,320,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -10765964000,
+                    "fmt": "-10.77B",
+                    "longFmt": "-10,765,964,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -15676493000,
+                    "fmt": "-15.68B",
+                    "longFmt": "-15,676,493,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1569801600,
+                    "fmt": "2019-09-30"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.21,
+                    "fmt": "0.21"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.17,
+                    "fmt": "0.17"
+                  },
+                  "epsDifference": {
+                    "raw": 0.04,
+                    "fmt": "0.04"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.235,
+                    "fmt": "23.50%"
+                  },
+                  "quarter": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            },
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            },
+            "summaryProfile": {
+              "address1": "Building Fudao",
+              "address2": "No.11 Kaituo Road Haidian District",
+              "city": "Beijing",
+              "zip": "100085",
+              "country": "China",
+              "phone": "86 10 5810 4689",
+              "website": "http://ke.com",
+              "industry": "Real Estate Services",
+              "sector": "Real Estate",
+              "longBusinessSummary": "KE Holdings Inc. operates an integrated online and offline platform for housing transactions and services in the People's Republic of China. The company facilitates various housing transactions ranging from existing and new home sales and home rentals to home renovation, real estate financial solutions, and other services. It also owns and operates Lianjia, a real estate brokerage branded store. The company was founded in 2001 and is headquartered in Beijing, China.",
+              "companyOfficers": [],
+              "maxAge": 86400
+            },
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 0,
+              "buyInfoShares": 0,
+              "sellInfoCount": 0,
+              "netInfoCount": 0,
+              "netInfoShares": 0,
+              "netPercentInsiderShares": 0,
+              "totalInsiderShares": 10667953
+            },
+            "sectorTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 20548915000,
+                    "fmt": "20.55B",
+                    "longFmt": "20,548,915,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 16165685000,
+                    "fmt": "16.17B",
+                    "longFmt": "16,165,685,000"
+                  },
+                  "grossProfit": {
+                    "raw": 4383230000,
+                    "fmt": "4.38B",
+                    "longFmt": "4,383,230,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 789089000,
+                    "fmt": "789.09M",
+                    "longFmt": "789,089,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 3675157000,
+                    "fmt": "3.68B",
+                    "longFmt": "3,675,157,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 20629931000,
+                    "fmt": "20.63B",
+                    "longFmt": "20,629,931,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -81016000,
+                    "fmt": "-81.02M",
+                    "longFmt": "-81,016,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 415348000,
+                    "fmt": "415.35M",
+                    "longFmt": "415,348,000"
+                  },
+                  "ebit": {
+                    "raw": -81016000,
+                    "fmt": "-81.02M",
+                    "longFmt": "-81,016,000"
+                  },
+                  "interestExpense": {
+                    "raw": -128157000,
+                    "fmt": "-128.16M",
+                    "longFmt": "-128,157,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 334332000,
+                    "fmt": "334.33M",
+                    "longFmt": "334,332,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 258991000,
+                    "fmt": "258.99M",
+                    "longFmt": "258,991,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 26490000,
+                    "fmt": "26.49M",
+                    "longFmt": "26,490,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 75341000,
+                    "fmt": "75.34M",
+                    "longFmt": "75,341,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 74697000,
+                    "fmt": "74.7M",
+                    "longFmt": "74,697,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -271446000,
+                    "fmt": "-271.45M",
+                    "longFmt": "-271,446,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 20141659000,
+                    "fmt": "20.14B",
+                    "longFmt": "20,141,659,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 13590784000,
+                    "fmt": "13.59B",
+                    "longFmt": "13,590,784,000"
+                  },
+                  "grossProfit": {
+                    "raw": 6550875000,
+                    "fmt": "6.55B",
+                    "longFmt": "6,550,875,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 523670000,
+                    "fmt": "523.67M",
+                    "longFmt": "523,670,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 2739831000,
+                    "fmt": "2.74B",
+                    "longFmt": "2,739,831,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 16854285000,
+                    "fmt": "16.85B",
+                    "longFmt": "16,854,285,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 3287374000,
+                    "fmt": "3.29B",
+                    "longFmt": "3,287,374,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 333154000,
+                    "fmt": "333.15M",
+                    "longFmt": "333,154,000"
+                  },
+                  "ebit": {
+                    "raw": 3287374000,
+                    "fmt": "3.29B",
+                    "longFmt": "3,287,374,000"
+                  },
+                  "interestExpense": {
+                    "raw": -128157000,
+                    "fmt": "-128.16M",
+                    "longFmt": "-128,157,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 3620528000,
+                    "fmt": "3.62B",
+                    "longFmt": "3,620,528,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 781715000,
+                    "fmt": "781.72M",
+                    "longFmt": "781,715,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 25846000,
+                    "fmt": "25.85M",
+                    "longFmt": "25,846,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 2838813000,
+                    "fmt": "2.84B",
+                    "longFmt": "2,838,813,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 2836568000,
+                    "fmt": "2.84B",
+                    "longFmt": "2,836,568,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 2120786000,
+                    "fmt": "2.12B",
+                    "longFmt": "2,120,786,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 7119759000,
+                    "fmt": "7.12B",
+                    "longFmt": "7,119,759,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 6618227000,
+                    "fmt": "6.62B",
+                    "longFmt": "6,618,227,000"
+                  },
+                  "grossProfit": {
+                    "raw": 501532000,
+                    "fmt": "501.53M",
+                    "longFmt": "501,532,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 450761000,
+                    "fmt": "450.76M",
+                    "longFmt": "450,761,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 1682124000,
+                    "fmt": "1.68B",
+                    "longFmt": "1,682,124,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 8751112000,
+                    "fmt": "8.75B",
+                    "longFmt": "8,751,112,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -1631353000,
+                    "fmt": "-1.63B",
+                    "longFmt": "-1,631,353,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 251105000,
+                    "fmt": "251.1M",
+                    "longFmt": "251,105,000"
+                  },
+                  "ebit": {
+                    "raw": -1631353000,
+                    "fmt": "-1.63B",
+                    "longFmt": "-1,631,353,000"
+                  },
+                  "interestExpense": {
+                    "raw": -50113000,
+                    "fmt": "-50.11M",
+                    "longFmt": "-50,113,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -1380248000,
+                    "fmt": "-1.38B",
+                    "longFmt": "-1,380,248,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -148861000,
+                    "fmt": "-148.86M",
+                    "longFmt": "-148,861,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 84466000,
+                    "fmt": "84.47M",
+                    "longFmt": "84,466,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -1231387000,
+                    "fmt": "-1.23B",
+                    "longFmt": "-1,231,387,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -1228650000,
+                    "fmt": "-1.23B",
+                    "longFmt": "-1,228,650,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -1921953000,
+                    "fmt": "-1.92B",
+                    "longFmt": "-1,921,953,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1569801600,
+                    "fmt": "2019-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 12022659000,
+                    "fmt": "12.02B",
+                    "longFmt": "12,022,659,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 9083190000,
+                    "fmt": "9.08B",
+                    "longFmt": "9,083,190,000"
+                  },
+                  "grossProfit": {
+                    "raw": 2939469000,
+                    "fmt": "2.94B",
+                    "longFmt": "2,939,469,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 436056000,
+                    "fmt": "436.06M",
+                    "longFmt": "436,056,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 2103745000,
+                    "fmt": "2.1B",
+                    "longFmt": "2,103,745,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 11622991000,
+                    "fmt": "11.62B",
+                    "longFmt": "11,622,991,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 399668000,
+                    "fmt": "399.67M",
+                    "longFmt": "399,668,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 301713000,
+                    "fmt": "301.71M",
+                    "longFmt": "301,713,000"
+                  },
+                  "ebit": {
+                    "raw": 399668000,
+                    "fmt": "399.67M",
+                    "longFmt": "399,668,000"
+                  },
+                  "interestExpense": {
+                    "raw": -34558000,
+                    "fmt": "-34.56M",
+                    "longFmt": "-34,558,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 701381000,
+                    "fmt": "701.38M",
+                    "longFmt": "701,381,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 317120000,
+                    "fmt": "317.12M",
+                    "longFmt": "317,120,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 84466000,
+                    "fmt": "84.47M",
+                    "longFmt": "84,466,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 384261000,
+                    "fmt": "384.26M",
+                    "longFmt": "384,261,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 381354000,
+                    "fmt": "381.35M",
+                    "longFmt": "381,354,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -76584000,
+                    "fmt": "-76.58M",
+                    "longFmt": "-76,584,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 74697000,
+                    "fmt": "74.7M",
+                    "longFmt": "74,697,000"
+                  },
+                  "depreciation": {
+                    "raw": 303789000,
+                    "fmt": "303.79M",
+                    "longFmt": "303,789,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -746842000,
+                    "fmt": "-746.84M",
+                    "longFmt": "-746,842,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -3341525000,
+                    "fmt": "-3.34B",
+                    "longFmt": "-3,341,525,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 2217374000,
+                    "fmt": "2.22B",
+                    "longFmt": "2,217,374,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 5410498000,
+                    "fmt": "5.41B",
+                    "longFmt": "5,410,498,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 3213000000,
+                    "fmt": "3.21B",
+                    "longFmt": "3,213,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -566050000,
+                    "fmt": "-566.05M",
+                    "longFmt": "-566,050,000"
+                  },
+                  "investments": {
+                    "raw": -11199382000,
+                    "fmt": "-11.2B",
+                    "longFmt": "-11,199,382,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 4307818000,
+                    "fmt": "4.31B",
+                    "longFmt": "4,307,818,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -6945255000,
+                    "fmt": "-6.95B",
+                    "longFmt": "-6,945,255,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -105172000,
+                    "fmt": "-105.17M",
+                    "longFmt": "-105,172,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 324758000,
+                    "fmt": "324.76M",
+                    "longFmt": "324,758,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 16565408000,
+                    "fmt": "16.57B",
+                    "longFmt": "16,565,408,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -815884000,
+                    "fmt": "-815.88M",
+                    "longFmt": "-815,884,000"
+                  },
+                  "changeInCash": {
+                    "raw": 12017269000,
+                    "fmt": "12.02B",
+                    "longFmt": "12,017,269,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 16345822000,
+                    "fmt": "16.35B",
+                    "longFmt": "16,345,822,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "netIncome": {
+                    "raw": 2836568000,
+                    "fmt": "2.84B",
+                    "longFmt": "2,836,568,000"
+                  },
+                  "depreciation": {
+                    "raw": 272184000,
+                    "fmt": "272.18M",
+                    "longFmt": "272,184,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 2743463000,
+                    "fmt": "2.74B",
+                    "longFmt": "2,743,463,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -719861000,
+                    "fmt": "-719.86M",
+                    "longFmt": "-719,861,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 785185000,
+                    "fmt": "785.18M",
+                    "longFmt": "785,185,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 2426120000,
+                    "fmt": "2.43B",
+                    "longFmt": "2,426,120,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 9133566000,
+                    "fmt": "9.13B",
+                    "longFmt": "9,133,566,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": 149136000,
+                    "fmt": "149.14M",
+                    "longFmt": "149,136,000"
+                  },
+                  "investments": {
+                    "raw": 5786363000,
+                    "fmt": "5.79B",
+                    "longFmt": "5,786,363,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -2409715000,
+                    "fmt": "-2.41B",
+                    "longFmt": "-2,409,715,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 2751829000,
+                    "fmt": "2.75B",
+                    "longFmt": "2,751,829,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 898389000,
+                    "fmt": "898.39M",
+                    "longFmt": "898,389,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -569320000,
+                    "fmt": "-569.32M",
+                    "longFmt": "-569,320,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 329069000,
+                    "fmt": "329.07M",
+                    "longFmt": "329,069,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -14448000,
+                    "fmt": "-14.45M",
+                    "longFmt": "-14,448,000"
+                  },
+                  "changeInCash": {
+                    "raw": 12200016000,
+                    "fmt": "12.2B",
+                    "longFmt": "12,200,016,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 16345822000,
+                    "fmt": "16.35B",
+                    "longFmt": "16,345,822,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "netIncome": {
+                    "raw": -1228650000,
+                    "fmt": "-1.23B",
+                    "longFmt": "-1,228,650,000"
+                  },
+                  "depreciation": {
+                    "raw": 271845000,
+                    "fmt": "271.85M",
+                    "longFmt": "271,845,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 149055000,
+                    "fmt": "149.06M",
+                    "longFmt": "149,055,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 719861000,
+                    "fmt": "719.86M",
+                    "longFmt": "719,861,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -785185000,
+                    "fmt": "-785.18M",
+                    "longFmt": "-785,185,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -2426120000,
+                    "fmt": "-2.43B",
+                    "longFmt": "-2,426,120,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -4089101000,
+                    "fmt": "-4.09B",
+                    "longFmt": "-4,089,101,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -149136000,
+                    "fmt": "-149.14M",
+                    "longFmt": "-149,136,000"
+                  },
+                  "investments": {
+                    "raw": -5786363000,
+                    "fmt": "-5.79B",
+                    "longFmt": "-5,786,363,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -14819000,
+                    "fmt": "-14.82M",
+                    "longFmt": "-14,819,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -5176363000,
+                    "fmt": "-5.18B",
+                    "longFmt": "-5,176,363,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -898389000,
+                    "fmt": "-898.39M",
+                    "longFmt": "-898,389,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -569320000,
+                    "fmt": "-569.32M",
+                    "longFmt": "-569,320,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -898389000,
+                    "fmt": "-898.39M",
+                    "longFmt": "-898,389,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 131392000,
+                    "fmt": "131.39M",
+                    "longFmt": "131,392,000"
+                  },
+                  "changeInCash": {
+                    "raw": -10032461000,
+                    "fmt": "-10.03B",
+                    "longFmt": "-10,032,461,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 16345822000,
+                    "fmt": "16.35B",
+                    "longFmt": "16,345,822,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1569801600,
+                    "fmt": "2019-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 381354000,
+                    "fmt": "381.35M",
+                    "longFmt": "381,354,000"
+                  },
+                  "depreciation": {
+                    "raw": 308036000,
+                    "fmt": "308.04M",
+                    "longFmt": "308,036,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 56176000,
+                    "fmt": "56.18M",
+                    "longFmt": "56,176,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -1204448000,
+                    "fmt": "-1.2B",
+                    "longFmt": "-1,204,448,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 940491000,
+                    "fmt": "940.49M",
+                    "longFmt": "940,491,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 394199000,
+                    "fmt": "394.2M",
+                    "longFmt": "394,199,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 1257660000,
+                    "fmt": "1.26B",
+                    "longFmt": "1,257,660,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -123413000,
+                    "fmt": "-123.41M",
+                    "longFmt": "-123,413,000"
+                  },
+                  "investments": {
+                    "raw": 1040954000,
+                    "fmt": "1.04B",
+                    "longFmt": "1,040,954,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -4488000,
+                    "fmt": "-4.49M",
+                    "longFmt": "-4,488,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 132616000,
+                    "fmt": "132.62M",
+                    "longFmt": "132,616,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 64710000,
+                    "fmt": "64.71M",
+                    "longFmt": "64,710,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -569320000,
+                    "fmt": "-569.32M",
+                    "longFmt": "-569,320,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -2222516000,
+                    "fmt": "-2.22B",
+                    "longFmt": "-2,222,516,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 109779000,
+                    "fmt": "109.78M",
+                    "longFmt": "109,779,000"
+                  },
+                  "changeInCash": {
+                    "raw": -722461000,
+                    "fmt": "-722.46M",
+                    "longFmt": "-722,461,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -140074000,
+                    "fmt": "-140.07M",
+                    "longFmt": "-140,074,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 16345822000,
+                    "fmt": "16.35B",
+                    "longFmt": "16,345,822,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [
+                  {
+                    "date": "3Q2020",
+                    "actual": 0.21,
+                    "estimate": 0.17
+                  }
+                ],
+                "currentQuarterEstimate": 0.13,
+                "currentQuarterEstimateDate": "4Q",
+                "currentQuarterEstimateYear": 2020,
+                "earningsDate": []
+              },
+              "financialsChart": {
+                "yearly": [
+                  {
+                    "date": 2017,
+                    "revenue": 25505698000,
+                    "earnings": -574430000
+                  },
+                  {
+                    "date": 2018,
+                    "revenue": 28646499000,
+                    "earnings": -467824000
+                  },
+                  {
+                    "date": 2019,
+                    "revenue": 46014906000,
+                    "earnings": -2183546000
+                  }
+                ],
+                "quarterly": [
+                  {
+                    "date": "3Q2019",
+                    "revenue": 12022659000,
+                    "earnings": 381354000
+                  },
+                  {
+                    "date": "1Q2020",
+                    "revenue": 7119759000,
+                    "earnings": -1228650000
+                  },
+                  {
+                    "date": "2Q2020",
+                    "revenue": 20141659000,
+                    "earnings": 2836568000
+                  },
+                  {
+                    "date": "3Q2020",
+                    "revenue": 20548915000,
+                    "earnings": 74697000
+                  }
+                ]
+              },
+              "financialCurrency": "CNY"
+            },
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 66.67,
+              "targetHighPrice": 90.48,
+              "targetLowPrice": 20.99,
+              "targetMeanPrice": 67.22,
+              "targetMedianPrice": 67.57,
+              "recommendationMean": 2.5,
+              "recommendationKey": "buy",
+              "numberOfAnalystOpinions": 10,
+              "quickRatio": 2.013,
+              "currentRatio": 2.386,
+              "debtToEquity": 26.427,
+              "grossProfits": 11268044000,
+              "revenueGrowth": 0.709,
+              "grossMargins": 0.22805999,
+              "ebitdaMargins": -0.00654,
+              "operatingMargins": 0,
+              "profitMargins": -0.02313,
+              "financialCurrency": "CNY"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-all-BFLY.json
+++ b/tests/http/quoteSummary-all-BFLY.json
@@ -1,0 +1,956 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=assetProfile%2CbalanceSheetHistory%2CbalanceSheetHistoryQuarterly%2CcalendarEvents%2CcashflowStatementHistory%2CcashflowStatementHistoryQuarterly%2CdefaultKeyStatistics%2Cearnings%2CearningsHistory%2CearningsTrend%2CfinancialData%2CfundOwnership%2CfundPerformance%2CfundProfile%2CincomeStatementHistory%2CincomeStatementHistoryQuarterly%2CindexTrend%2CindustryTrend%2CinsiderHolders%2CinsiderTransactions%2CinstitutionOwnership%2CmajorDirectHolders%2CmajorHoldersBreakdown%2CnetSharePurchaseActivity%2Cprice%2CquoteType%2CrecommendationTrend%2CsecFilings%2CsectorTrend%2CsummaryDetail%2CsummaryProfile%2CtopHoldings%2CupgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "80rveg9g2r54n"
+      ],
+      "x-yahoo-request-id": [
+        "80rveg9g2r54n"
+      ],
+      "x-request-id": [
+        "7dbea9b8-49be-4693-849d-7d4e93a2fccd"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "10"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:35 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "530 Old Whitfield Street",
+              "city": "Guilford",
+              "state": "CT",
+              "zip": "06437",
+              "country": "United States",
+              "phone": "203-458-2514",
+              "website": "http://english.butterflynetwork.com",
+              "industry": "Medical Devices",
+              "sector": "Healthcare",
+              "longBusinessSummary": "Butterfly Network, Inc. develops medical imaging device for hospitals and organizations to scale their point of care ultrasound programs through a new suite of tools that enable ultrasound workflow mobile and system integrations simple and secure. The company's device provides diagnostic imaging and measurement of blood vessels and examines the cardiac, abdominal, urological, fetal, gynecological, and musculoskeletal systems. The company also offers Butterfly iQ, a handheld and single-probe whole body ultrasound system. The company was founded in 2011 and is based in Guilford, Connecticut.",
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Darius  Shahida",
+                  "age": 29,
+                  "title": "Chief Strategy Officer & Chief Bus. Devel. Officer",
+                  "yearBorn": 1991,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 413625,
+                    "fmt": "413.62k",
+                    "longFmt": "413,625"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Jonathan M. Rothberg",
+                  "age": 56,
+                  "title": "Founder & Chairman",
+                  "yearBorn": 1964,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Todd M. Fruchterman",
+                  "age": 50,
+                  "title": "Pres & CEO",
+                  "yearBorn": 1970,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Gregory C. Fergus",
+                  "age": 56,
+                  "title": "Board Member and Chief Commercial Officer",
+                  "yearBorn": 1964,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Michael J. Rothberg",
+                  "title": "Chief Financial Officer",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Elizabeth A. Whayland",
+                  "title": "Sec. & Director",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "compensationAsOfEpochDate": 1577750400,
+              "maxAge": 86400
+            },
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistory": {
+              "cashflowStatements": [],
+              "maxAge": 86400
+            },
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 5.56217,
+              "pegRatio": 0.991258,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.269
+                },
+                {
+                  "period": "+1q",
+                  "growth": 0.96099997
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.148
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.155
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0821053
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            },
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "profitMargins": 0,
+              "category": null,
+              "fundFamily": null,
+              "legalType": null,
+              "lastSplitFactor": null,
+              "52WeekChange": 0,
+              "SandP52WeekChange": 0.16137505
+            },
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "quoteType": {
+              "exchange": "NYQ",
+              "quoteType": "EQUITY",
+              "symbol": "BFLY",
+              "underlyingSymbol": "BFLY",
+              "shortName": "Butterfly Network, Inc. Class A",
+              "longName": "Butterfly Network, Inc.",
+              "firstTradeDateEpochUtc": 1594647000,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "5f9449d1-1162-3804-a742-88e2f8b5fb0e",
+              "messageBoardId": "finmb_275830634",
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            },
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [],
+              "maxAge": 86400
+            },
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            },
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 22.5,
+              "open": 23.11,
+              "dayLow": 21.98,
+              "dayHigh": 27.13,
+              "regularMarketPreviousClose": 22.5,
+              "regularMarketOpen": 23.11,
+              "regularMarketDayLow": 21.98,
+              "regularMarketDayHigh": 27.13,
+              "volume": 7029222,
+              "regularMarketVolume": 7029222,
+              "averageVolume": 2347300,
+              "averageVolume10days": 2347300,
+              "averageDailyVolume10Day": 2347300,
+              "bid": 25.95,
+              "ask": 26.4,
+              "bidSize": 1000,
+              "askSize": 800,
+              "fiftyTwoWeekLow": 21.95,
+              "fiftyTwoWeekHigh": 27.13,
+              "fiftyDayAverage": 22.5,
+              "twoHundredDayAverage": 22.5,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            },
+            "insiderHolders": {
+              "holders": [],
+              "maxAge": 1
+            },
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": []
+              }
+            },
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": 0.0288889,
+              "preMarketChange": 0.65,
+              "preMarketTime": 1613572193,
+              "preMarketPrice": 23.15,
+              "preMarketSource": "FREE_REALTIME",
+              "postMarketChangePercent": -0.011787052,
+              "postMarketChange": -0.30999947,
+              "postMarketTime": 1613599882,
+              "postMarketPrice": 25.99,
+              "postMarketSource": "FREE_REALTIME",
+              "regularMarketChangePercent": 0.168889,
+              "regularMarketChange": 3.8,
+              "regularMarketTime": 1613595602,
+              "priceHint": 2,
+              "regularMarketPrice": 26.3,
+              "regularMarketDayHigh": 27.13,
+              "regularMarketDayLow": 21.98,
+              "regularMarketVolume": 7029222,
+              "averageDailyVolume10Day": 2347300,
+              "averageDailyVolume3Month": 2347300,
+              "regularMarketPreviousClose": 22.5,
+              "regularMarketSource": "FREE_REALTIME",
+              "regularMarketOpen": 23.11,
+              "exchange": "NYQ",
+              "exchangeName": "NYSE",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "POST",
+              "quoteType": "EQUITY",
+              "symbol": "BFLY",
+              "underlyingSymbol": null,
+              "shortName": "Butterfly Network, Inc. Class A",
+              "longName": "Butterfly Network, Inc.",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null
+            },
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [],
+              "maxAge": 86400
+            },
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            },
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            },
+            "majorHoldersBreakdown": {
+              "maxAge": 1
+            },
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [],
+              "maxAge": 86400
+            },
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            },
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            },
+            "summaryProfile": {
+              "address1": "530 Old Whitfield Street",
+              "city": "Guilford",
+              "state": "CT",
+              "zip": "06437",
+              "country": "United States",
+              "phone": "203-458-2514",
+              "website": "http://english.butterflynetwork.com",
+              "industry": "Medical Devices",
+              "sector": "Healthcare",
+              "longBusinessSummary": "Butterfly Network, Inc. develops medical imaging device for hospitals and organizations to scale their point of care ultrasound programs through a new suite of tools that enable ultrasound workflow mobile and system integrations simple and secure. The company's device provides diagnostic imaging and measurement of blood vessels and examines the cardiac, abdominal, urological, fetal, gynecological, and musculoskeletal systems. The company also offers Butterfly iQ, a handheld and single-probe whole body ultrasound system. The company was founded in 2011 and is based in Guilford, Connecticut.",
+              "companyOfficers": [],
+              "maxAge": 86400
+            },
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 0,
+              "buyInfoShares": 0,
+              "sellInfoCount": 0,
+              "netInfoCount": 0,
+              "netInfoShares": 0,
+              "totalInsiderShares": 0
+            },
+            "sectorTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [],
+              "maxAge": 86400
+            },
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [],
+                "earningsDate": []
+              },
+              "financialsChart": {
+                "yearly": [],
+                "quarterly": []
+              }
+            },
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 26.3,
+              "targetHighPrice": 15,
+              "targetLowPrice": 15,
+              "targetMeanPrice": 15,
+              "targetMedianPrice": 15,
+              "recommendationKey": "none",
+              "numberOfAnalystOpinions": 1,
+              "grossMargins": 0,
+              "ebitdaMargins": 0,
+              "operatingMargins": 0,
+              "profitMargins": 0,
+              "financialCurrency": null
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-assetProfile-BEKE.json
+++ b/tests/http/quoteSummary-assetProfile-BEKE.json
@@ -1,0 +1,198 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=assetProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "7jhe5qhg2r54e"
+      ],
+      "x-yahoo-request-id": [
+        "7jhe5qhg2r54e"
+      ],
+      "x-request-id": [
+        "13234540-3a66-45de-8717-df8b4c81f505"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "721"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:26 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "Building Fudao",
+              "address2": "No.11 Kaituo Road Haidian District",
+              "city": "Beijing",
+              "zip": "100085",
+              "country": "China",
+              "phone": "86 10 5810 4689",
+              "website": "http://ke.com",
+              "industry": "Real Estate Services",
+              "sector": "Real Estate",
+              "longBusinessSummary": "KE Holdings Inc. operates an integrated online and offline platform for housing transactions and services in the People's Republic of China. The company facilitates various housing transactions ranging from existing and new home sales and home rentals to home renovation, real estate financial solutions, and other services. It also owns and operates Lianjia, a real estate brokerage branded store. The company was founded in 2001 and is headquartered in Beijing, China.",
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Hui  Zuo",
+                  "age": 49,
+                  "title": "Founder & Chairman",
+                  "yearBorn": 1971,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Yongdong  Peng",
+                  "age": 41,
+                  "title": "CEO & Exec. Director",
+                  "yearBorn": 1979,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Tao  Xu",
+                  "age": 47,
+                  "title": "Chief Financial Officer",
+                  "yearBorn": 1973,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Wangang  Xu",
+                  "age": 55,
+                  "title": "Co-Chief Operating Officer",
+                  "yearBorn": 1965,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Yongqun  Wang",
+                  "age": 49,
+                  "title": "Co-Chief Operating Officer",
+                  "yearBorn": 1971,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Yigang  Shan",
+                  "age": 47,
+                  "title": "Exec. Director",
+                  "yearBorn": 1973,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-assetProfile-BFLY.json
+++ b/tests/http/quoteSummary-assetProfile-BFLY.json
@@ -1,0 +1,201 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=assetProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "3nefn95g2r54f"
+      ],
+      "x-yahoo-request-id": [
+        "3nefn95g2r54f"
+      ],
+      "x-request-id": [
+        "b3d45dd7-3b2c-4201-b54c-e5a6a2702f2a"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "925"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:26 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "530 Old Whitfield Street",
+              "city": "Guilford",
+              "state": "CT",
+              "zip": "06437",
+              "country": "United States",
+              "phone": "203-458-2514",
+              "website": "http://english.butterflynetwork.com",
+              "industry": "Medical Devices",
+              "sector": "Healthcare",
+              "longBusinessSummary": "Butterfly Network, Inc. develops medical imaging device for hospitals and organizations to scale their point of care ultrasound programs through a new suite of tools that enable ultrasound workflow mobile and system integrations simple and secure. The company's device provides diagnostic imaging and measurement of blood vessels and examines the cardiac, abdominal, urological, fetal, gynecological, and musculoskeletal systems. The company also offers Butterfly iQ, a handheld and single-probe whole body ultrasound system. The company was founded in 2011 and is based in Guilford, Connecticut.",
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Darius  Shahida",
+                  "age": 29,
+                  "title": "Chief Strategy Officer & Chief Bus. Devel. Officer",
+                  "yearBorn": 1991,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 413625,
+                    "fmt": "413.62k",
+                    "longFmt": "413,625"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Jonathan M. Rothberg",
+                  "age": 56,
+                  "title": "Founder & Chairman",
+                  "yearBorn": 1964,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Todd M. Fruchterman",
+                  "age": 50,
+                  "title": "Pres & CEO",
+                  "yearBorn": 1970,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Gregory C. Fergus",
+                  "age": 56,
+                  "title": "Board Member and Chief Commercial Officer",
+                  "yearBorn": 1964,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Michael J. Rothberg",
+                  "title": "Chief Financial Officer",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Elizabeth A. Whayland",
+                  "title": "Sec. & Director",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "compensationAsOfEpochDate": 1577750400,
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistory-BEKE.json
+++ b/tests/http/quoteSummary-balanceSheetHistory-BEKE.json
@@ -1,0 +1,492 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=balanceSheetHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "180vds9g2r54f"
+      ],
+      "x-yahoo-request-id": [
+        "180vds9g2r54f"
+      ],
+      "x-request-id": [
+        "85541e67-4372-4273-962f-5d1ad3fddca5"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1682"
+      ],
+      "x-envoy-upstream-service-time": [
+        "5"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:26 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 24319332000,
+                    "fmt": "24.32B",
+                    "longFmt": "24,319,332,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 1844595000,
+                    "fmt": "1.84B",
+                    "longFmt": "1,844,595,000"
+                  },
+                  "netReceivables": {
+                    "raw": 13169172000,
+                    "fmt": "13.17B",
+                    "longFmt": "13,169,172,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 12139612000,
+                    "fmt": "12.14B",
+                    "longFmt": "12,139,612,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 51912486000,
+                    "fmt": "51.91B",
+                    "longFmt": "51,912,486,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2333745000,
+                    "fmt": "2.33B",
+                    "longFmt": "2,333,745,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6759243000,
+                    "fmt": "6.76B",
+                    "longFmt": "6,759,243,000"
+                  },
+                  "goodWill": {
+                    "raw": 2477075000,
+                    "fmt": "2.48B",
+                    "longFmt": "2,477,075,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 2560442000,
+                    "fmt": "2.56B",
+                    "longFmt": "2,560,442,000"
+                  },
+                  "otherAssets": {
+                    "raw": 1222321000,
+                    "fmt": "1.22B",
+                    "longFmt": "1,222,321,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 520292000,
+                    "fmt": "520.29M",
+                    "longFmt": "520,292,000"
+                  },
+                  "totalAssets": {
+                    "raw": 67265312000,
+                    "fmt": "67.27B",
+                    "longFmt": "67,265,312,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 4475170000,
+                    "fmt": "4.48B",
+                    "longFmt": "4,475,170,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2291723000,
+                    "fmt": "2.29B",
+                    "longFmt": "2,291,723,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 8584074000,
+                    "fmt": "8.58B",
+                    "longFmt": "8,584,074,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 4897530000,
+                    "fmt": "4.9B",
+                    "longFmt": "4,897,530,000"
+                  },
+                  "otherLiab": {
+                    "raw": 120275000,
+                    "fmt": "120.28M",
+                    "longFmt": "120,275,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 87203000,
+                    "fmt": "87.2M",
+                    "longFmt": "87,203,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 27797675000,
+                    "fmt": "27.8B",
+                    "longFmt": "27,797,675,000"
+                  },
+                  "totalLiab": {
+                    "raw": 35729720000,
+                    "fmt": "35.73B",
+                    "longFmt": "35,729,720,000"
+                  },
+                  "commonStock": {
+                    "raw": 202000,
+                    "fmt": "202k",
+                    "longFmt": "202,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -11521905000,
+                    "fmt": "-11.52B",
+                    "longFmt": "-11,521,905,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 63308000,
+                    "fmt": "63.31M",
+                    "longFmt": "63,308,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 2533889000,
+                    "fmt": "2.53B",
+                    "longFmt": "2,533,889,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 63308000,
+                    "fmt": "63.31M",
+                    "longFmt": "63,308,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -8924506000,
+                    "fmt": "-8.92B",
+                    "longFmt": "-8,924,506,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -13962023000,
+                    "fmt": "-13.96B",
+                    "longFmt": "-13,962,023,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "cash": {
+                    "raw": 9115649000,
+                    "fmt": "9.12B",
+                    "longFmt": "9,115,649,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 2523199000,
+                    "fmt": "2.52B",
+                    "longFmt": "2,523,199,000"
+                  },
+                  "netReceivables": {
+                    "raw": 10369552000,
+                    "fmt": "10.37B",
+                    "longFmt": "10,369,552,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 4972534000,
+                    "fmt": "4.97B",
+                    "longFmt": "4,972,534,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 27374784000,
+                    "fmt": "27.37B",
+                    "longFmt": "27,374,784,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 418469000,
+                    "fmt": "418.47M",
+                    "longFmt": "418,469,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6089232000,
+                    "fmt": "6.09B",
+                    "longFmt": "6,089,232,000"
+                  },
+                  "goodWill": {
+                    "raw": 1135034000,
+                    "fmt": "1.14B",
+                    "longFmt": "1,135,034,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 196998000,
+                    "fmt": "197M",
+                    "longFmt": "196,998,000"
+                  },
+                  "otherAssets": {
+                    "raw": 3651747000,
+                    "fmt": "3.65B",
+                    "longFmt": "3,651,747,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 672622000,
+                    "fmt": "672.62M",
+                    "longFmt": "672,622,000"
+                  },
+                  "totalAssets": {
+                    "raw": 38866264000,
+                    "fmt": "38.87B",
+                    "longFmt": "38,866,264,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1573343000,
+                    "fmt": "1.57B",
+                    "longFmt": "1,573,343,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2414607000,
+                    "fmt": "2.41B",
+                    "longFmt": "2,414,607,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 4762200000,
+                    "fmt": "4.76B",
+                    "longFmt": "4,762,200,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 112900000,
+                    "fmt": "112.9M",
+                    "longFmt": "112,900,000"
+                  },
+                  "otherLiab": {
+                    "raw": 532931000,
+                    "fmt": "532.93M",
+                    "longFmt": "532,931,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 10467000,
+                    "fmt": "10.47M",
+                    "longFmt": "10,467,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 20572881000,
+                    "fmt": "20.57B",
+                    "longFmt": "20,572,881,000"
+                  },
+                  "totalLiab": {
+                    "raw": 24007724000,
+                    "fmt": "24.01B",
+                    "longFmt": "24,007,724,000"
+                  },
+                  "commonStock": {
+                    "raw": 189000,
+                    "fmt": "189k",
+                    "longFmt": "189,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -7814291000,
+                    "fmt": "-7.81B",
+                    "longFmt": "-7,814,291,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -134000,
+                    "fmt": "-134k",
+                    "longFmt": "-134,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -134000,
+                    "fmt": "-134k",
+                    "longFmt": "-134,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -7814236000,
+                    "fmt": "-7.81B",
+                    "longFmt": "-7,814,236,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -9146268000,
+                    "fmt": "-9.15B",
+                    "longFmt": "-9,146,268,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "cash": {
+                    "raw": 5236100000,
+                    "fmt": "5.24B",
+                    "longFmt": "5,236,100,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 7587433000,
+                    "fmt": "7.59B",
+                    "longFmt": "7,587,433,000"
+                  },
+                  "netReceivables": {
+                    "raw": 4676434000,
+                    "fmt": "4.68B",
+                    "longFmt": "4,676,434,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 6227975000,
+                    "fmt": "6.23B",
+                    "longFmt": "6,227,975,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 24067931000,
+                    "fmt": "24.07B",
+                    "longFmt": "24,067,931,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 379972000,
+                    "fmt": "379.97M",
+                    "longFmt": "379,972,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6002914000,
+                    "fmt": "6B",
+                    "longFmt": "6,002,914,000"
+                  },
+                  "goodWill": {
+                    "raw": 710983000,
+                    "fmt": "710.98M",
+                    "longFmt": "710,983,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 264726000,
+                    "fmt": "264.73M",
+                    "longFmt": "264,726,000"
+                  },
+                  "otherAssets": {
+                    "raw": 153409000,
+                    "fmt": "153.41M",
+                    "longFmt": "153,409,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 147535000,
+                    "fmt": "147.53M",
+                    "longFmt": "147,535,000"
+                  },
+                  "totalAssets": {
+                    "raw": 31579935000,
+                    "fmt": "31.58B",
+                    "longFmt": "31,579,935,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 370496000,
+                    "fmt": "370.5M",
+                    "longFmt": "370,496,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 4665524000,
+                    "fmt": "4.67B",
+                    "longFmt": "4,665,524,000"
+                  },
+                  "otherLiab": {
+                    "raw": 518091000,
+                    "fmt": "518.09M",
+                    "longFmt": "518,091,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 65836000,
+                    "fmt": "65.84M",
+                    "longFmt": "65,836,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 16047286000,
+                    "fmt": "16.05B",
+                    "longFmt": "16,047,286,000"
+                  },
+                  "totalLiab": {
+                    "raw": 19143150000,
+                    "fmt": "19.14B",
+                    "longFmt": "19,143,150,000"
+                  },
+                  "commonStock": {
+                    "raw": 178000,
+                    "fmt": "178k",
+                    "longFmt": "178,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -5226325000,
+                    "fmt": "-5.23B",
+                    "longFmt": "-5,226,325,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -327000,
+                    "fmt": "-327k",
+                    "longFmt": "-327,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -327000,
+                    "fmt": "-327k",
+                    "longFmt": "-327,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -5226474000,
+                    "fmt": "-5.23B",
+                    "longFmt": "-5,226,474,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -6202183000,
+                    "fmt": "-6.2B",
+                    "longFmt": "-6,202,183,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistory-BFLY.json
+++ b/tests/http/quoteSummary-balanceSheetHistory-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=balanceSheetHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "ca6hvq5g2r54f"
+      ],
+      "x-yahoo-request-id": [
+        "ca6hvq5g2r54f"
+      ],
+      "x-request-id": [
+        "0d52a5be-ac2f-4dc0-98ff-a2ed57497f30"
+      ],
+      "content-length": [
+        "111"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:27 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistoryQuarterly-BEKE.json
+++ b/tests/http/quoteSummary-balanceSheetHistoryQuarterly-BEKE.json
@@ -1,0 +1,519 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=balanceSheetHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "f87nco5g2r54f"
+      ],
+      "x-yahoo-request-id": [
+        "f87nco5g2r54f"
+      ],
+      "x-request-id": [
+        "8953c877-8270-491b-aea6-9d24c3c9c9fe"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1750"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:27 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 38046404000,
+                    "fmt": "38.05B",
+                    "longFmt": "38,046,404,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 13156851000,
+                    "fmt": "13.16B",
+                    "longFmt": "13,156,851,000"
+                  },
+                  "netReceivables": {
+                    "raw": 12955146000,
+                    "fmt": "12.96B",
+                    "longFmt": "12,955,146,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 10926407000,
+                    "fmt": "10.93B",
+                    "longFmt": "10,926,407,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 75696700000,
+                    "fmt": "75.7B",
+                    "longFmt": "75,696,700,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2461657000,
+                    "fmt": "2.46B",
+                    "longFmt": "2,461,657,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 7389774000,
+                    "fmt": "7.39B",
+                    "longFmt": "7,389,774,000"
+                  },
+                  "goodWill": {
+                    "raw": 2490155000,
+                    "fmt": "2.49B",
+                    "longFmt": "2,490,155,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 2062294000,
+                    "fmt": "2.06B",
+                    "longFmt": "2,062,294,000"
+                  },
+                  "otherAssets": {
+                    "raw": 873615000,
+                    "fmt": "873.62M",
+                    "longFmt": "873,615,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 530164000,
+                    "fmt": "530.16M",
+                    "longFmt": "530,164,000"
+                  },
+                  "totalAssets": {
+                    "raw": 90974195000,
+                    "fmt": "90.97B",
+                    "longFmt": "90,974,195,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 6499745000,
+                    "fmt": "6.5B",
+                    "longFmt": "6,499,745,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2411361000,
+                    "fmt": "2.41B",
+                    "longFmt": "2,411,361,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 9611704000,
+                    "fmt": "9.61B",
+                    "longFmt": "9,611,704,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 4793875000,
+                    "fmt": "4.79B",
+                    "longFmt": "4,793,875,000"
+                  },
+                  "otherLiab": {
+                    "raw": 22446000,
+                    "fmt": "22.45M",
+                    "longFmt": "22,446,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 26490000,
+                    "fmt": "26.49M",
+                    "longFmt": "26,490,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 31727200000,
+                    "fmt": "31.73B",
+                    "longFmt": "31,727,200,000"
+                  },
+                  "totalLiab": {
+                    "raw": 39843179000,
+                    "fmt": "39.84B",
+                    "longFmt": "39,843,179,000"
+                  },
+                  "commonStock": {
+                    "raw": 466000,
+                    "fmt": "466k",
+                    "longFmt": "466,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -9929807000,
+                    "fmt": "-9.93B",
+                    "longFmt": "-9,929,807,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -531354000,
+                    "fmt": "-531.35M",
+                    "longFmt": "-531,354,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 61565221000,
+                    "fmt": "61.57B",
+                    "longFmt": "61,565,221,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -531354000,
+                    "fmt": "-531.35M",
+                    "longFmt": "-531,354,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 51104526000,
+                    "fmt": "51.1B",
+                    "longFmt": "51,104,526,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 46552077000,
+                    "fmt": "46.55B",
+                    "longFmt": "46,552,077,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "cash": {
+                    "raw": 25079605000,
+                    "fmt": "25.08B",
+                    "longFmt": "25,079,605,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 5869529000,
+                    "fmt": "5.87B",
+                    "longFmt": "5,869,529,000"
+                  },
+                  "netReceivables": {
+                    "raw": 13068816000,
+                    "fmt": "13.07B",
+                    "longFmt": "13,068,816,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 12353005000,
+                    "fmt": "12.35B",
+                    "longFmt": "12,353,005,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 56925376000,
+                    "fmt": "56.93B",
+                    "longFmt": "56,925,376,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2466889000,
+                    "fmt": "2.47B",
+                    "longFmt": "2,466,889,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6911464000,
+                    "fmt": "6.91B",
+                    "longFmt": "6,911,464,000"
+                  },
+                  "goodWill": {
+                    "raw": 2490155000,
+                    "fmt": "2.49B",
+                    "longFmt": "2,490,155,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 2288794000,
+                    "fmt": "2.29B",
+                    "longFmt": "2,288,794,000"
+                  },
+                  "otherAssets": {
+                    "raw": 923040000,
+                    "fmt": "923.04M",
+                    "longFmt": "923,040,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 530164000,
+                    "fmt": "530.16M",
+                    "longFmt": "530,164,000"
+                  },
+                  "totalAssets": {
+                    "raw": 72005718000,
+                    "fmt": "72.01B",
+                    "longFmt": "72,005,718,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 5287577000,
+                    "fmt": "5.29B",
+                    "longFmt": "5,287,577,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2199275000,
+                    "fmt": "2.2B",
+                    "longFmt": "2,199,275,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 11037514000,
+                    "fmt": "11.04B",
+                    "longFmt": "11,037,514,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 4885370000,
+                    "fmt": "4.89B",
+                    "longFmt": "4,885,370,000"
+                  },
+                  "otherLiab": {
+                    "raw": 116203000,
+                    "fmt": "116.2M",
+                    "longFmt": "116,203,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 25846000,
+                    "fmt": "25.85M",
+                    "longFmt": "25,846,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 30175739000,
+                    "fmt": "30.18B",
+                    "longFmt": "30,175,739,000"
+                  },
+                  "totalLiab": {
+                    "raw": 38219015000,
+                    "fmt": "38.22B",
+                    "longFmt": "38,219,015,000"
+                  },
+                  "commonStock": {
+                    "raw": 205000,
+                    "fmt": "205k",
+                    "longFmt": "205,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -10004504000,
+                    "fmt": "-10B",
+                    "longFmt": "-10,004,504,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 213691000,
+                    "fmt": "213.69M",
+                    "longFmt": "213,691,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1769485000,
+                    "fmt": "1.77B",
+                    "longFmt": "1,769,485,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 213691000,
+                    "fmt": "213.69M",
+                    "longFmt": "213,691,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -8021123000,
+                    "fmt": "-8.02B",
+                    "longFmt": "-8,021,123,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -12800072000,
+                    "fmt": "-12.8B",
+                    "longFmt": "-12,800,072,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "cash": {
+                    "raw": 15538844000,
+                    "fmt": "15.54B",
+                    "longFmt": "15,538,844,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 7709598000,
+                    "fmt": "7.71B",
+                    "longFmt": "7,709,598,000"
+                  },
+                  "netReceivables": {
+                    "raw": 11799844000,
+                    "fmt": "11.8B",
+                    "longFmt": "11,799,844,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 10805983000,
+                    "fmt": "10.81B",
+                    "longFmt": "10,805,983,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 46380397000,
+                    "fmt": "46.38B",
+                    "longFmt": "46,380,397,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2347955000,
+                    "fmt": "2.35B",
+                    "longFmt": "2,347,955,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6700269000,
+                    "fmt": "6.7B",
+                    "longFmt": "6,700,269,000"
+                  },
+                  "goodWill": {
+                    "raw": 2477075000,
+                    "fmt": "2.48B",
+                    "longFmt": "2,477,075,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 2433454000,
+                    "fmt": "2.43B",
+                    "longFmt": "2,433,454,000"
+                  },
+                  "otherAssets": {
+                    "raw": 901375000,
+                    "fmt": "901.38M",
+                    "longFmt": "901,375,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 530164000,
+                    "fmt": "530.16M",
+                    "longFmt": "530,164,000"
+                  },
+                  "totalAssets": {
+                    "raw": 61240525000,
+                    "fmt": "61.24B",
+                    "longFmt": "61,240,525,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 3645940000,
+                    "fmt": "3.65B",
+                    "longFmt": "3,645,940,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 1767844000,
+                    "fmt": "1.77B",
+                    "longFmt": "1,767,844,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 8597488000,
+                    "fmt": "8.6B",
+                    "longFmt": "8,597,488,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 4980956000,
+                    "fmt": "4.98B",
+                    "longFmt": "4,980,956,000"
+                  },
+                  "otherLiab": {
+                    "raw": 120365000,
+                    "fmt": "120.36M",
+                    "longFmt": "120,365,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 84466000,
+                    "fmt": "84.47M",
+                    "longFmt": "84,466,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 22876987000,
+                    "fmt": "22.88B",
+                    "longFmt": "22,876,987,000"
+                  },
+                  "totalLiab": {
+                    "raw": 30855825000,
+                    "fmt": "30.86B",
+                    "longFmt": "30,855,825,000"
+                  },
+                  "commonStock": {
+                    "raw": 202000,
+                    "fmt": "202k",
+                    "longFmt": "202,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -12841072000,
+                    "fmt": "-12.84B",
+                    "longFmt": "-12,841,072,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 234320000,
+                    "fmt": "234.32M",
+                    "longFmt": "234,320,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1840586000,
+                    "fmt": "1.84B",
+                    "longFmt": "1,840,586,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 234320000,
+                    "fmt": "234.32M",
+                    "longFmt": "234,320,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -10765964000,
+                    "fmt": "-10.77B",
+                    "longFmt": "-10,765,964,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -15676493000,
+                    "fmt": "-15.68B",
+                    "longFmt": "-15,676,493,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1569801600,
+                    "fmt": "2019-09-30"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistoryQuarterly-BFLY.json
+++ b/tests/http/quoteSummary-balanceSheetHistoryQuarterly-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=balanceSheetHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "dtj6itpg2r54f"
+      ],
+      "x-yahoo-request-id": [
+        "dtj6itpg2r54f"
+      ],
+      "x-request-id": [
+        "9a17070c-d03c-42ca-ab0f-812bed2eb519"
+      ],
+      "content-length": [
+        "120"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:27 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-calendarEvents-BEKE.json
+++ b/tests/http/quoteSummary-calendarEvents-BEKE.json
@@ -1,0 +1,90 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=calendarEvents"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "9cfn9mdg2r54f"
+      ],
+      "x-yahoo-request-id": [
+        "9cfn9mdg2r54f"
+      ],
+      "x-request-id": [
+        "abf11a82-4964-4ab6-a745-e8b2e438c907"
+      ],
+      "content-length": [
+        "244"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:27 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": [],
+                "earningsAverage": 0.13,
+                "earningsLow": 0.01,
+                "earningsHigh": 0.17,
+                "revenueAverage": 3082150000,
+                "revenueLow": 2998670000,
+                "revenueHigh": 3182420000
+              }
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-calendarEvents-BFLY.json
+++ b/tests/http/quoteSummary-calendarEvents-BFLY.json
@@ -1,0 +1,84 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=calendarEvents"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "be4u0glg2r54f"
+      ],
+      "x-yahoo-request-id": [
+        "be4u0glg2r54f"
+      ],
+      "x-request-id": [
+        "01c47fd6-e11f-4d13-a18a-6249cb828532"
+      ],
+      "content-length": [
+        "105"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:27 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": []
+              }
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistory-BEKE.json
+++ b/tests/http/quoteSummary-cashflowStatementHistory-BEKE.json
@@ -1,0 +1,382 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=cashflowStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "cort0jdg2r54g"
+      ],
+      "x-yahoo-request-id": [
+        "cort0jdg2r54g"
+      ],
+      "x-request-id": [
+        "c50ad953-6714-44be-b461-ac1235441505"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1246"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:28 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -2183546000,
+                    "fmt": "-2.18B",
+                    "longFmt": "-2,183,546,000"
+                  },
+                  "depreciation": {
+                    "raw": 1039318000,
+                    "fmt": "1.04B",
+                    "longFmt": "1,039,318,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 3018688000,
+                    "fmt": "3.02B",
+                    "longFmt": "3,018,688,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -5040865000,
+                    "fmt": "-5.04B",
+                    "longFmt": "-5,040,865,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 3009276000,
+                    "fmt": "3.01B",
+                    "longFmt": "3,009,276,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -412586000,
+                    "fmt": "-412.59M",
+                    "longFmt": "-412,586,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 112626000,
+                    "fmt": "112.63M",
+                    "longFmt": "112,626,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -703008000,
+                    "fmt": "-703.01M",
+                    "longFmt": "-703,008,000"
+                  },
+                  "investments": {
+                    "raw": -1133063000,
+                    "fmt": "-1.13B",
+                    "longFmt": "-1,133,063,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 91216000,
+                    "fmt": "91.22M",
+                    "longFmt": "91,216,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -3873722000,
+                    "fmt": "-3.87B",
+                    "longFmt": "-3,873,722,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 6758437000,
+                    "fmt": "6.76B",
+                    "longFmt": "6,758,437,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -8628000,
+                    "fmt": "-8.63M",
+                    "longFmt": "-8,628,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 23026396000,
+                    "fmt": "23.03B",
+                    "longFmt": "23,026,396,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -94922000,
+                    "fmt": "-94.92M",
+                    "longFmt": "-94,922,000"
+                  },
+                  "changeInCash": {
+                    "raw": 19170378000,
+                    "fmt": "19.17B",
+                    "longFmt": "19,170,378,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -347219000,
+                    "fmt": "-347.22M",
+                    "longFmt": "-347,219,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 232885000,
+                    "fmt": "232.88M",
+                    "longFmt": "232,885,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -467824000,
+                    "fmt": "-467.82M",
+                    "longFmt": "-467,824,000"
+                  },
+                  "depreciation": {
+                    "raw": 792294000,
+                    "fmt": "792.29M",
+                    "longFmt": "792,294,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -186336000,
+                    "fmt": "-186.34M",
+                    "longFmt": "-186,336,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -769062000,
+                    "fmt": "-769.06M",
+                    "longFmt": "-769,062,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 1157138000,
+                    "fmt": "1.16B",
+                    "longFmt": "1,157,138,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 2913832000,
+                    "fmt": "2.91B",
+                    "longFmt": "2,913,832,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 3216797000,
+                    "fmt": "3.22B",
+                    "longFmt": "3,216,797,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -542853000,
+                    "fmt": "-542.85M",
+                    "longFmt": "-542,853,000"
+                  },
+                  "investments": {
+                    "raw": 5239066000,
+                    "fmt": "5.24B",
+                    "longFmt": "5,239,066,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -2010792000,
+                    "fmt": "-2.01B",
+                    "longFmt": "-2,010,792,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 2609149000,
+                    "fmt": "2.61B",
+                    "longFmt": "2,609,149,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -124121000,
+                    "fmt": "-124.12M",
+                    "longFmt": "-124,121,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -437019000,
+                    "fmt": "-437.02M",
+                    "longFmt": "-437,019,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -1282408000,
+                    "fmt": "-1.28B",
+                    "longFmt": "-1,282,408,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 416000,
+                    "fmt": "416k",
+                    "longFmt": "416,000"
+                  },
+                  "changeInCash": {
+                    "raw": 4543954000,
+                    "fmt": "4.54B",
+                    "longFmt": "4,543,954,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -347219000,
+                    "fmt": "-347.22M",
+                    "longFmt": "-347,219,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 232885000,
+                    "fmt": "232.88M",
+                    "longFmt": "232,885,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -574430000,
+                    "fmt": "-574.43M",
+                    "longFmt": "-574,430,000"
+                  },
+                  "depreciation": {
+                    "raw": 811203000,
+                    "fmt": "811.2M",
+                    "longFmt": "811,203,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 164271000,
+                    "fmt": "164.27M",
+                    "longFmt": "164,271,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -498216000,
+                    "fmt": "-498.22M",
+                    "longFmt": "-498,216,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -764294000,
+                    "fmt": "-764.29M",
+                    "longFmt": "-764,294,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -5733411000,
+                    "fmt": "-5.73B",
+                    "longFmt": "-5,733,411,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -6456226000,
+                    "fmt": "-6.46B",
+                    "longFmt": "-6,456,226,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -575185000,
+                    "fmt": "-575.18M",
+                    "longFmt": "-575,185,000"
+                  },
+                  "investments": {
+                    "raw": -959123000,
+                    "fmt": "-959.12M",
+                    "longFmt": "-959,123,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -5000000,
+                    "fmt": "-5M",
+                    "longFmt": "-5,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -2783562000,
+                    "fmt": "-2.78B",
+                    "longFmt": "-2,783,562,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -127188000,
+                    "fmt": "-127.19M",
+                    "longFmt": "-127,188,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 973472000,
+                    "fmt": "973.47M",
+                    "longFmt": "973,472,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -437019000,
+                    "fmt": "-437.02M",
+                    "longFmt": "-437,019,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 9576284000,
+                    "fmt": "9.58B",
+                    "longFmt": "9,576,284,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -330000,
+                    "fmt": "-330k",
+                    "longFmt": "-330,000"
+                  },
+                  "changeInCash": {
+                    "raw": 336166000,
+                    "fmt": "336.17M",
+                    "longFmt": "336,166,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -347219000,
+                    "fmt": "-347.22M",
+                    "longFmt": "-347,219,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 232885000,
+                    "fmt": "232.88M",
+                    "longFmt": "232,885,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistory-BFLY.json
+++ b/tests/http/quoteSummary-cashflowStatementHistory-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=cashflowStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "6qnk55pg2r54g"
+      ],
+      "x-yahoo-request-id": [
+        "6qnk55pg2r54g"
+      ],
+      "x-request-id": [
+        "79e7607b-76e4-4d23-8fee-1844b69d89c6"
+      ],
+      "content-length": [
+        "112"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:27 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistory": {
+              "cashflowStatements": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-BEKE.json
+++ b/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-BEKE.json
@@ -1,0 +1,459 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=cashflowStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "av7pdtlg2r54g"
+      ],
+      "x-yahoo-request-id": [
+        "av7pdtlg2r54g"
+      ],
+      "x-request-id": [
+        "e8f46097-a1ea-4a6a-984c-258ed066fbcc"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1436"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:28 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 74697000,
+                    "fmt": "74.7M",
+                    "longFmt": "74,697,000"
+                  },
+                  "depreciation": {
+                    "raw": 303789000,
+                    "fmt": "303.79M",
+                    "longFmt": "303,789,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -746842000,
+                    "fmt": "-746.84M",
+                    "longFmt": "-746,842,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -3341525000,
+                    "fmt": "-3.34B",
+                    "longFmt": "-3,341,525,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 2217374000,
+                    "fmt": "2.22B",
+                    "longFmt": "2,217,374,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 5410498000,
+                    "fmt": "5.41B",
+                    "longFmt": "5,410,498,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 3213000000,
+                    "fmt": "3.21B",
+                    "longFmt": "3,213,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -566050000,
+                    "fmt": "-566.05M",
+                    "longFmt": "-566,050,000"
+                  },
+                  "investments": {
+                    "raw": -11199382000,
+                    "fmt": "-11.2B",
+                    "longFmt": "-11,199,382,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 4307818000,
+                    "fmt": "4.31B",
+                    "longFmt": "4,307,818,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -6945255000,
+                    "fmt": "-6.95B",
+                    "longFmt": "-6,945,255,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -105172000,
+                    "fmt": "-105.17M",
+                    "longFmt": "-105,172,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 324758000,
+                    "fmt": "324.76M",
+                    "longFmt": "324,758,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 16565408000,
+                    "fmt": "16.57B",
+                    "longFmt": "16,565,408,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -815884000,
+                    "fmt": "-815.88M",
+                    "longFmt": "-815,884,000"
+                  },
+                  "changeInCash": {
+                    "raw": 12017269000,
+                    "fmt": "12.02B",
+                    "longFmt": "12,017,269,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 16345822000,
+                    "fmt": "16.35B",
+                    "longFmt": "16,345,822,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "netIncome": {
+                    "raw": 2836568000,
+                    "fmt": "2.84B",
+                    "longFmt": "2,836,568,000"
+                  },
+                  "depreciation": {
+                    "raw": 272184000,
+                    "fmt": "272.18M",
+                    "longFmt": "272,184,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 2743463000,
+                    "fmt": "2.74B",
+                    "longFmt": "2,743,463,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -719861000,
+                    "fmt": "-719.86M",
+                    "longFmt": "-719,861,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 785185000,
+                    "fmt": "785.18M",
+                    "longFmt": "785,185,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 2426120000,
+                    "fmt": "2.43B",
+                    "longFmt": "2,426,120,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 9133566000,
+                    "fmt": "9.13B",
+                    "longFmt": "9,133,566,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": 149136000,
+                    "fmt": "149.14M",
+                    "longFmt": "149,136,000"
+                  },
+                  "investments": {
+                    "raw": 5786363000,
+                    "fmt": "5.79B",
+                    "longFmt": "5,786,363,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -2409715000,
+                    "fmt": "-2.41B",
+                    "longFmt": "-2,409,715,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 2751829000,
+                    "fmt": "2.75B",
+                    "longFmt": "2,751,829,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 898389000,
+                    "fmt": "898.39M",
+                    "longFmt": "898,389,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -569320000,
+                    "fmt": "-569.32M",
+                    "longFmt": "-569,320,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 329069000,
+                    "fmt": "329.07M",
+                    "longFmt": "329,069,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -14448000,
+                    "fmt": "-14.45M",
+                    "longFmt": "-14,448,000"
+                  },
+                  "changeInCash": {
+                    "raw": 12200016000,
+                    "fmt": "12.2B",
+                    "longFmt": "12,200,016,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 16345822000,
+                    "fmt": "16.35B",
+                    "longFmt": "16,345,822,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "netIncome": {
+                    "raw": -1228650000,
+                    "fmt": "-1.23B",
+                    "longFmt": "-1,228,650,000"
+                  },
+                  "depreciation": {
+                    "raw": 271845000,
+                    "fmt": "271.85M",
+                    "longFmt": "271,845,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 149055000,
+                    "fmt": "149.06M",
+                    "longFmt": "149,055,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 719861000,
+                    "fmt": "719.86M",
+                    "longFmt": "719,861,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -785185000,
+                    "fmt": "-785.18M",
+                    "longFmt": "-785,185,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -2426120000,
+                    "fmt": "-2.43B",
+                    "longFmt": "-2,426,120,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -4089101000,
+                    "fmt": "-4.09B",
+                    "longFmt": "-4,089,101,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -149136000,
+                    "fmt": "-149.14M",
+                    "longFmt": "-149,136,000"
+                  },
+                  "investments": {
+                    "raw": -5786363000,
+                    "fmt": "-5.79B",
+                    "longFmt": "-5,786,363,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -14819000,
+                    "fmt": "-14.82M",
+                    "longFmt": "-14,819,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -5176363000,
+                    "fmt": "-5.18B",
+                    "longFmt": "-5,176,363,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -898389000,
+                    "fmt": "-898.39M",
+                    "longFmt": "-898,389,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -569320000,
+                    "fmt": "-569.32M",
+                    "longFmt": "-569,320,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -898389000,
+                    "fmt": "-898.39M",
+                    "longFmt": "-898,389,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 131392000,
+                    "fmt": "131.39M",
+                    "longFmt": "131,392,000"
+                  },
+                  "changeInCash": {
+                    "raw": -10032461000,
+                    "fmt": "-10.03B",
+                    "longFmt": "-10,032,461,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 16345822000,
+                    "fmt": "16.35B",
+                    "longFmt": "16,345,822,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1569801600,
+                    "fmt": "2019-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 381354000,
+                    "fmt": "381.35M",
+                    "longFmt": "381,354,000"
+                  },
+                  "depreciation": {
+                    "raw": 308036000,
+                    "fmt": "308.04M",
+                    "longFmt": "308,036,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 56176000,
+                    "fmt": "56.18M",
+                    "longFmt": "56,176,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -1204448000,
+                    "fmt": "-1.2B",
+                    "longFmt": "-1,204,448,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 940491000,
+                    "fmt": "940.49M",
+                    "longFmt": "940,491,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 394199000,
+                    "fmt": "394.2M",
+                    "longFmt": "394,199,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 1257660000,
+                    "fmt": "1.26B",
+                    "longFmt": "1,257,660,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -123413000,
+                    "fmt": "-123.41M",
+                    "longFmt": "-123,413,000"
+                  },
+                  "investments": {
+                    "raw": 1040954000,
+                    "fmt": "1.04B",
+                    "longFmt": "1,040,954,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -4488000,
+                    "fmt": "-4.49M",
+                    "longFmt": "-4,488,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 132616000,
+                    "fmt": "132.62M",
+                    "longFmt": "132,616,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 64710000,
+                    "fmt": "64.71M",
+                    "longFmt": "64,710,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -569320000,
+                    "fmt": "-569.32M",
+                    "longFmt": "-569,320,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -2222516000,
+                    "fmt": "-2.22B",
+                    "longFmt": "-2,222,516,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 109779000,
+                    "fmt": "109.78M",
+                    "longFmt": "109,779,000"
+                  },
+                  "changeInCash": {
+                    "raw": -722461000,
+                    "fmt": "-722.46M",
+                    "longFmt": "-722,461,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -140074000,
+                    "fmt": "-140.07M",
+                    "longFmt": "-140,074,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 16345822000,
+                    "fmt": "16.35B",
+                    "longFmt": "16,345,822,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-BFLY.json
+++ b/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=cashflowStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "ed24m15g2r54g"
+      ],
+      "x-yahoo-request-id": [
+        "ed24m15g2r54g"
+      ],
+      "x-request-id": [
+        "7ab4d61f-f9b6-40c9-9e2b-9ffd2147b3c2"
+      ],
+      "content-length": [
+        "121"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:28 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-defaultKeyStatistics-BEKE.json
+++ b/tests/http/quoteSummary-defaultKeyStatistics-BEKE.json
@@ -1,0 +1,109 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=defaultKeyStatistics"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "62s0enlg2r54g"
+      ],
+      "x-yahoo-request-id": [
+        "62s0enlg2r54g"
+      ],
+      "x-request-id": [
+        "d0104789-21b4-484c-91e0-99622de68bb3"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "466"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:28 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": 80156999680,
+              "forwardPE": 74.077774,
+              "profitMargins": -0.02313,
+              "floatShares": 389103285,
+              "sharesOutstanding": 1143379968,
+              "sharesShort": 11331624,
+              "sharesShortPriorMonth": 10275253,
+              "sharesShortPreviousMonthDate": 1609372800,
+              "dateShortInterest": 1611878400,
+              "sharesPercentSharesOut": 0.0095999995,
+              "heldPercentInsiders": 0.0090499995,
+              "heldPercentInstitutions": 0.14386,
+              "shortRatio": 3.25,
+              "category": null,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1577750400,
+              "nextFiscalYearEnd": 1640908800,
+              "mostRecentQuarter": 1601424000,
+              "earningsQuarterlyGrowth": -0.804,
+              "pegRatio": 117.17,
+              "lastSplitFactor": null,
+              "52WeekChange": 0.81623936,
+              "SandP52WeekChange": 0.16137505
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-defaultKeyStatistics-BFLY.json
+++ b/tests/http/quoteSummary-defaultKeyStatistics-BFLY.json
@@ -1,0 +1,89 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=defaultKeyStatistics"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "2lcq86pg2r54g"
+      ],
+      "x-yahoo-request-id": [
+        "2lcq86pg2r54g"
+      ],
+      "x-request-id": [
+        "e67f503c-1e79-454d-8a6b-a82eb42ab8ea"
+      ],
+      "content-length": [
+        "238"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:28 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "profitMargins": 0,
+              "category": null,
+              "fundFamily": null,
+              "legalType": null,
+              "lastSplitFactor": null,
+              "52WeekChange": 0,
+              "SandP52WeekChange": 0.16137505
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earnings-BEKE.json
+++ b/tests/http/quoteSummary-earnings-BEKE.json
@@ -1,0 +1,139 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=earnings"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "0jv9g99g2r54h"
+      ],
+      "x-yahoo-request-id": [
+        "0jv9g99g2r54h"
+      ],
+      "x-request-id": [
+        "053211ea-51c1-47c7-8490-5207b64b24f5"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "337"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:28 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [
+                  {
+                    "date": "3Q2020",
+                    "actual": 0.21,
+                    "estimate": 0.17
+                  }
+                ],
+                "currentQuarterEstimate": 0.13,
+                "currentQuarterEstimateDate": "4Q",
+                "currentQuarterEstimateYear": 2020,
+                "earningsDate": []
+              },
+              "financialsChart": {
+                "yearly": [
+                  {
+                    "date": 2017,
+                    "revenue": 25505698000,
+                    "earnings": -574430000
+                  },
+                  {
+                    "date": 2018,
+                    "revenue": 28646499000,
+                    "earnings": -467824000
+                  },
+                  {
+                    "date": 2019,
+                    "revenue": 46014906000,
+                    "earnings": -2183546000
+                  }
+                ],
+                "quarterly": [
+                  {
+                    "date": "3Q2019",
+                    "revenue": 12022659000,
+                    "earnings": 381354000
+                  },
+                  {
+                    "date": "1Q2020",
+                    "revenue": 7119759000,
+                    "earnings": -1228650000
+                  },
+                  {
+                    "date": "2Q2020",
+                    "revenue": 20141659000,
+                    "earnings": 2836568000
+                  },
+                  {
+                    "date": "3Q2020",
+                    "revenue": 20548915000,
+                    "earnings": 74697000
+                  }
+                ]
+              },
+              "financialCurrency": "CNY"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earnings-BFLY.json
+++ b/tests/http/quoteSummary-earnings-BFLY.json
@@ -1,0 +1,89 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=earnings"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "dckfufdg2r54h"
+      ],
+      "x-yahoo-request-id": [
+        "dckfufdg2r54h"
+      ],
+      "x-request-id": [
+        "b99f5325-bd36-4572-ac2d-491275d18ce4"
+      ],
+      "content-length": [
+        "170"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:28 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [],
+                "earningsDate": []
+              },
+              "financialsChart": {
+                "yearly": [],
+                "quarterly": []
+              }
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsHistory-BEKE.json
+++ b/tests/http/quoteSummary-earningsHistory-BEKE.json
@@ -1,0 +1,137 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=earningsHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "07ovqadg2r54h"
+      ],
+      "x-yahoo-request-id": [
+        "07ovqadg2r54h"
+      ],
+      "x-request-id": [
+        "f510de2e-c877-44e0-9066-175053d5c263"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "252"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:29 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.21,
+                    "fmt": "0.21"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.17,
+                    "fmt": "0.17"
+                  },
+                  "epsDifference": {
+                    "raw": 0.04,
+                    "fmt": "0.04"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.235,
+                    "fmt": "23.50%"
+                  },
+                  "quarter": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsHistory-BFLY.json
+++ b/tests/http/quoteSummary-earningsHistory-BFLY.json
@@ -1,0 +1,122 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=earningsHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "fnbl4bhg2r54h"
+      ],
+      "x-yahoo-request-id": [
+        "fnbl4bhg2r54h"
+      ],
+      "x-request-id": [
+        "c5e505ad-27d5-4cfb-800d-5b7cb32fde40"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "176"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:29 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {},
+                  "epsEstimate": {},
+                  "epsDifference": {},
+                  "surprisePercent": {},
+                  "quarter": {},
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsTrend-BEKE.json
+++ b/tests/http/quoteSummary-earningsTrend-BEKE.json
@@ -1,0 +1,539 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=earningsTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "9eup0rhg2r54h"
+      ],
+      "x-yahoo-request-id": [
+        "9eup0rhg2r54h"
+      ],
+      "x-request-id": [
+        "6a76cad2-8098-9574-8fba-b25b5be1c58c"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "849"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:29 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": "2020-12-31",
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "low": {
+                      "raw": 0.01,
+                      "fmt": "0.01"
+                    },
+                    "high": {
+                      "raw": 0.17,
+                      "fmt": "0.17"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 6,
+                      "fmt": "6",
+                      "longFmt": "6"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 3082150000,
+                      "fmt": "3.08B",
+                      "longFmt": "3,082,150,000"
+                    },
+                    "low": {
+                      "raw": 2998670000,
+                      "fmt": "3B",
+                      "longFmt": "2,998,670,000"
+                    },
+                    "high": {
+                      "raw": 3182420000,
+                      "fmt": "3.18B",
+                      "longFmt": "3,182,420,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 7,
+                      "fmt": "7",
+                      "longFmt": "7"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.13,
+                      "fmt": "0.13"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.11,
+                      "fmt": "0.11"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": "2021-03-31",
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "low": {
+                      "raw": 0.09,
+                      "fmt": "0.09"
+                    },
+                    "high": {
+                      "raw": 0.14,
+                      "fmt": "0.14"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 3,
+                      "fmt": "3",
+                      "longFmt": "3"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 2126150000,
+                      "fmt": "2.13B",
+                      "longFmt": "2,126,150,000"
+                    },
+                    "low": {
+                      "raw": 1891260000,
+                      "fmt": "1.89B",
+                      "longFmt": "1,891,260,000"
+                    },
+                    "high": {
+                      "raw": 2252600000,
+                      "fmt": "2.25B",
+                      "longFmt": "2,252,600,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 3,
+                      "fmt": "3",
+                      "longFmt": "3"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.08,
+                      "fmt": "0.08"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": "2020-12-31",
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "low": {
+                      "raw": 0.63,
+                      "fmt": "0.63"
+                    },
+                    "high": {
+                      "raw": 1.02,
+                      "fmt": "1.02"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 9,
+                      "fmt": "9",
+                      "longFmt": "9"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 10527000000,
+                      "fmt": "10.53B",
+                      "longFmt": "10,527,000,000"
+                    },
+                    "low": {
+                      "raw": 10400500000,
+                      "fmt": "10.4B",
+                      "longFmt": "10,400,500,000"
+                    },
+                    "high": {
+                      "raw": 10688500000,
+                      "fmt": "10.69B",
+                      "longFmt": "10,688,500,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 11,
+                      "fmt": "11",
+                      "longFmt": "11"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.74,
+                      "fmt": "0.74"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.67,
+                      "fmt": "0.67"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": "2021-12-31",
+                  "growth": {
+                    "raw": 0.2,
+                    "fmt": "20.00%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.9,
+                      "fmt": "0.9"
+                    },
+                    "low": {
+                      "raw": 0.64,
+                      "fmt": "0.64"
+                    },
+                    "high": {
+                      "raw": 0.99,
+                      "fmt": "0.99"
+                    },
+                    "yearAgoEps": {
+                      "raw": 0.75,
+                      "fmt": "0.75"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 9,
+                      "fmt": "9",
+                      "longFmt": "9"
+                    },
+                    "growth": {
+                      "raw": 0.2,
+                      "fmt": "20.00%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 13237800000,
+                      "fmt": "13.24B",
+                      "longFmt": "13,237,800,000"
+                    },
+                    "low": {
+                      "raw": 11327900000,
+                      "fmt": "11.33B",
+                      "longFmt": "11,327,900,000"
+                    },
+                    "high": {
+                      "raw": 14382900000,
+                      "fmt": "14.38B",
+                      "longFmt": "14,382,900,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 11,
+                      "fmt": "11",
+                      "longFmt": "11"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 10527000000,
+                      "fmt": "10.53B",
+                      "longFmt": "10,527,000,000"
+                    },
+                    "growth": {
+                      "raw": 0.258,
+                      "fmt": "25.80%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.9,
+                      "fmt": "0.9"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.9,
+                      "fmt": "0.9"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.9,
+                      "fmt": "0.9"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.89,
+                      "fmt": "0.89"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.88,
+                      "fmt": "0.88"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": 0.046,
+                    "fmt": "4.60%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsTrend-BFLY.json
+++ b/tests/http/quoteSummary-earningsTrend-BFLY.json
@@ -1,0 +1,520 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=earningsTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "4pbpr4lg2r54h"
+      ],
+      "x-yahoo-request-id": [
+        "4pbpr4lg2r54h"
+      ],
+      "x-request-id": [
+        "42be15ed-93ef-4d00-ac07-822384ca0ef6"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "385"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:29 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-financialData-BEKE.json
+++ b/tests/http/quoteSummary-financialData-BEKE.json
@@ -1,0 +1,99 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=financialData"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "2at7fk1g2r54h"
+      ],
+      "x-yahoo-request-id": [
+        "2at7fk1g2r54h"
+      ],
+      "x-request-id": [
+        "4783f3bc-9e4b-409b-acbc-4b0b904027bf"
+      ],
+      "content-length": [
+        "511"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:29 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 66.67,
+              "targetHighPrice": 90.48,
+              "targetLowPrice": 20.99,
+              "targetMeanPrice": 67.22,
+              "targetMedianPrice": 67.57,
+              "recommendationMean": 2.5,
+              "recommendationKey": "buy",
+              "numberOfAnalystOpinions": 10,
+              "quickRatio": 2.013,
+              "currentRatio": 2.386,
+              "debtToEquity": 26.427,
+              "grossProfits": 11268044000,
+              "revenueGrowth": 0.709,
+              "grossMargins": 0.22805999,
+              "ebitdaMargins": -0.00654,
+              "operatingMargins": 0,
+              "profitMargins": -0.02313,
+              "financialCurrency": "CNY"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-financialData-BFLY.json
+++ b/tests/http/quoteSummary-financialData-BFLY.json
@@ -1,0 +1,93 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=financialData"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "bgffuulg2r54h"
+      ],
+      "x-yahoo-request-id": [
+        "bgffuulg2r54h"
+      ],
+      "x-request-id": [
+        "32fa922b-a204-456a-8f62-18e0cb8b1291"
+      ],
+      "content-length": [
+        "352"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:29 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "2"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 26.3,
+              "targetHighPrice": 15,
+              "targetLowPrice": 15,
+              "targetMeanPrice": 15,
+              "targetMedianPrice": 15,
+              "recommendationKey": "none",
+              "numberOfAnalystOpinions": 1,
+              "grossMargins": 0,
+              "ebitdaMargins": 0,
+              "operatingMargins": 0,
+              "profitMargins": 0,
+              "financialCurrency": null
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-fundOwnership-BEKE.json
+++ b/tests/http/quoteSummary-fundOwnership-BEKE.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=fundOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "chldld5g2r54i"
+      ],
+      "x-yahoo-request-id": [
+        "chldld5g2r54i"
+      ],
+      "x-request-id": [
+        "a28cab2b-65d6-4235-bb3b-40c8ca7075c0"
+      ],
+      "content-length": [
+        "92"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:29 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-fundOwnership-BFLY.json
+++ b/tests/http/quoteSummary-fundOwnership-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=fundOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "0020i49g2r54i"
+      ],
+      "x-yahoo-request-id": [
+        "0020i49g2r54i"
+      ],
+      "x-request-id": [
+        "0b231023-b053-4048-b178-5d118b5fba64"
+      ],
+      "content-length": [
+        "92"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:29 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistory-BEKE.json
+++ b/tests/http/quoteSummary-incomeStatementHistory-BEKE.json
@@ -1,0 +1,365 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=incomeStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "3ikuiotg2r54i"
+      ],
+      "x-yahoo-request-id": [
+        "3ikuiotg2r54i"
+      ],
+      "x-request-id": [
+        "f48a9069-aafa-43ed-9552-d8d63ecc9deb"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1242"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:29 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 46014906000,
+                    "fmt": "46.01B",
+                    "longFmt": "46,014,906,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 34746862000,
+                    "fmt": "34.75B",
+                    "longFmt": "34,746,862,000"
+                  },
+                  "grossProfit": {
+                    "raw": 11268044000,
+                    "fmt": "11.27B",
+                    "longFmt": "11,268,044,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 1571154000,
+                    "fmt": "1.57B",
+                    "longFmt": "1,571,154,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 11482430000,
+                    "fmt": "11.48B",
+                    "longFmt": "11,482,430,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 47800446000,
+                    "fmt": "47.8B",
+                    "longFmt": "47,800,446,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -1785540000,
+                    "fmt": "-1.79B",
+                    "longFmt": "-1,785,540,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 509776000,
+                    "fmt": "509.78M",
+                    "longFmt": "509,776,000"
+                  },
+                  "ebit": {
+                    "raw": -1785540000,
+                    "fmt": "-1.79B",
+                    "longFmt": "-1,785,540,000"
+                  },
+                  "interestExpense": {
+                    "raw": -181099000,
+                    "fmt": "-181.1M",
+                    "longFmt": "-181,099,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -1275764000,
+                    "fmt": "-1.28B",
+                    "longFmt": "-1,275,764,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 904363000,
+                    "fmt": "904.36M",
+                    "longFmt": "904,363,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 87203000,
+                    "fmt": "87.2M",
+                    "longFmt": "87,203,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -2180127000,
+                    "fmt": "-2.18B",
+                    "longFmt": "-2,180,127,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -2183546000,
+                    "fmt": "-2.18B",
+                    "longFmt": "-2,183,546,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -4050074000,
+                    "fmt": "-4.05B",
+                    "longFmt": "-4,050,074,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 28646499000,
+                    "fmt": "28.65B",
+                    "longFmt": "28,646,499,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 21776523000,
+                    "fmt": "21.78B",
+                    "longFmt": "21,776,523,000"
+                  },
+                  "grossProfit": {
+                    "raw": 6869976000,
+                    "fmt": "6.87B",
+                    "longFmt": "6,869,976,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 670922000,
+                    "fmt": "670.92M",
+                    "longFmt": "670,922,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 7417059000,
+                    "fmt": "7.42B",
+                    "longFmt": "7,417,059,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 29864504000,
+                    "fmt": "29.86B",
+                    "longFmt": "29,864,504,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -1218005000,
+                    "fmt": "-1.22B",
+                    "longFmt": "-1,218,005,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 718940000,
+                    "fmt": "718.94M",
+                    "longFmt": "718,940,000"
+                  },
+                  "ebit": {
+                    "raw": -1218005000,
+                    "fmt": "-1.22B",
+                    "longFmt": "-1,218,005,000"
+                  },
+                  "interestExpense": {
+                    "raw": -43517000,
+                    "fmt": "-43.52M",
+                    "longFmt": "-43,517,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -499065000,
+                    "fmt": "-499.06M",
+                    "longFmt": "-499,065,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -71384000,
+                    "fmt": "-71.38M",
+                    "longFmt": "-71,384,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 10467000,
+                    "fmt": "10.47M",
+                    "longFmt": "10,467,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -427681000,
+                    "fmt": "-427.68M",
+                    "longFmt": "-427,681,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -467824000,
+                    "fmt": "-467.82M",
+                    "longFmt": "-467,824,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -2386005000,
+                    "fmt": "-2.39B",
+                    "longFmt": "-2,386,005,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 25505698000,
+                    "fmt": "25.51B",
+                    "longFmt": "25,505,698,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 20737641000,
+                    "fmt": "20.74B",
+                    "longFmt": "20,737,641,000"
+                  },
+                  "grossProfit": {
+                    "raw": 4768057000,
+                    "fmt": "4.77B",
+                    "longFmt": "4,768,057,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 251802000,
+                    "fmt": "251.8M",
+                    "longFmt": "251,802,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 5280146000,
+                    "fmt": "5.28B",
+                    "longFmt": "5,280,146,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 26269589000,
+                    "fmt": "26.27B",
+                    "longFmt": "26,269,589,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -763891000,
+                    "fmt": "-763.89M",
+                    "longFmt": "-763,891,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 625553000,
+                    "fmt": "625.55M",
+                    "longFmt": "625,553,000"
+                  },
+                  "ebit": {
+                    "raw": -763891000,
+                    "fmt": "-763.89M",
+                    "longFmt": "-763,891,000"
+                  },
+                  "interestExpense": {
+                    "raw": -43791000,
+                    "fmt": "-43.79M",
+                    "longFmt": "-43,791,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -138338000,
+                    "fmt": "-138.34M",
+                    "longFmt": "-138,338,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 399283000,
+                    "fmt": "399.28M",
+                    "longFmt": "399,283,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 65836000,
+                    "fmt": "65.84M",
+                    "longFmt": "65,836,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -537621000,
+                    "fmt": "-537.62M",
+                    "longFmt": "-537,621,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -574430000,
+                    "fmt": "-574.43M",
+                    "longFmt": "-574,430,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -1441879000,
+                    "fmt": "-1.44B",
+                    "longFmt": "-1,441,879,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistory-BFLY.json
+++ b/tests/http/quoteSummary-incomeStatementHistory-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=incomeStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "a2gplkdg2r54i"
+      ],
+      "x-yahoo-request-id": [
+        "a2gplkdg2r54i"
+      ],
+      "x-request-id": [
+        "b57b4e47-b6c6-417a-b079-d76d19d99ac9"
+      ],
+      "content-length": [
+        "114"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:30 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistoryQuarterly-BEKE.json
+++ b/tests/http/quoteSummary-incomeStatementHistoryQuarterly-BEKE.json
@@ -1,0 +1,458 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=incomeStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "0svdkd9g2r54i"
+      ],
+      "x-yahoo-request-id": [
+        "0svdkd9g2r54i"
+      ],
+      "x-request-id": [
+        "a030459a-7f64-4786-8f16-f20b3fcd21e0"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1462"
+      ],
+      "x-envoy-upstream-service-time": [
+        "8"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:30 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 20548915000,
+                    "fmt": "20.55B",
+                    "longFmt": "20,548,915,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 16165685000,
+                    "fmt": "16.17B",
+                    "longFmt": "16,165,685,000"
+                  },
+                  "grossProfit": {
+                    "raw": 4383230000,
+                    "fmt": "4.38B",
+                    "longFmt": "4,383,230,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 789089000,
+                    "fmt": "789.09M",
+                    "longFmt": "789,089,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 3675157000,
+                    "fmt": "3.68B",
+                    "longFmt": "3,675,157,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 20629931000,
+                    "fmt": "20.63B",
+                    "longFmt": "20,629,931,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -81016000,
+                    "fmt": "-81.02M",
+                    "longFmt": "-81,016,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 415348000,
+                    "fmt": "415.35M",
+                    "longFmt": "415,348,000"
+                  },
+                  "ebit": {
+                    "raw": -81016000,
+                    "fmt": "-81.02M",
+                    "longFmt": "-81,016,000"
+                  },
+                  "interestExpense": {
+                    "raw": -128157000,
+                    "fmt": "-128.16M",
+                    "longFmt": "-128,157,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 334332000,
+                    "fmt": "334.33M",
+                    "longFmt": "334,332,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 258991000,
+                    "fmt": "258.99M",
+                    "longFmt": "258,991,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 26490000,
+                    "fmt": "26.49M",
+                    "longFmt": "26,490,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 75341000,
+                    "fmt": "75.34M",
+                    "longFmt": "75,341,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 74697000,
+                    "fmt": "74.7M",
+                    "longFmt": "74,697,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -271446000,
+                    "fmt": "-271.45M",
+                    "longFmt": "-271,446,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 20141659000,
+                    "fmt": "20.14B",
+                    "longFmt": "20,141,659,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 13590784000,
+                    "fmt": "13.59B",
+                    "longFmt": "13,590,784,000"
+                  },
+                  "grossProfit": {
+                    "raw": 6550875000,
+                    "fmt": "6.55B",
+                    "longFmt": "6,550,875,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 523670000,
+                    "fmt": "523.67M",
+                    "longFmt": "523,670,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 2739831000,
+                    "fmt": "2.74B",
+                    "longFmt": "2,739,831,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 16854285000,
+                    "fmt": "16.85B",
+                    "longFmt": "16,854,285,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 3287374000,
+                    "fmt": "3.29B",
+                    "longFmt": "3,287,374,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 333154000,
+                    "fmt": "333.15M",
+                    "longFmt": "333,154,000"
+                  },
+                  "ebit": {
+                    "raw": 3287374000,
+                    "fmt": "3.29B",
+                    "longFmt": "3,287,374,000"
+                  },
+                  "interestExpense": {
+                    "raw": -128157000,
+                    "fmt": "-128.16M",
+                    "longFmt": "-128,157,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 3620528000,
+                    "fmt": "3.62B",
+                    "longFmt": "3,620,528,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 781715000,
+                    "fmt": "781.72M",
+                    "longFmt": "781,715,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 25846000,
+                    "fmt": "25.85M",
+                    "longFmt": "25,846,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 2838813000,
+                    "fmt": "2.84B",
+                    "longFmt": "2,838,813,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 2836568000,
+                    "fmt": "2.84B",
+                    "longFmt": "2,836,568,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 2120786000,
+                    "fmt": "2.12B",
+                    "longFmt": "2,120,786,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 7119759000,
+                    "fmt": "7.12B",
+                    "longFmt": "7,119,759,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 6618227000,
+                    "fmt": "6.62B",
+                    "longFmt": "6,618,227,000"
+                  },
+                  "grossProfit": {
+                    "raw": 501532000,
+                    "fmt": "501.53M",
+                    "longFmt": "501,532,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 450761000,
+                    "fmt": "450.76M",
+                    "longFmt": "450,761,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 1682124000,
+                    "fmt": "1.68B",
+                    "longFmt": "1,682,124,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 8751112000,
+                    "fmt": "8.75B",
+                    "longFmt": "8,751,112,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -1631353000,
+                    "fmt": "-1.63B",
+                    "longFmt": "-1,631,353,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 251105000,
+                    "fmt": "251.1M",
+                    "longFmt": "251,105,000"
+                  },
+                  "ebit": {
+                    "raw": -1631353000,
+                    "fmt": "-1.63B",
+                    "longFmt": "-1,631,353,000"
+                  },
+                  "interestExpense": {
+                    "raw": -50113000,
+                    "fmt": "-50.11M",
+                    "longFmt": "-50,113,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -1380248000,
+                    "fmt": "-1.38B",
+                    "longFmt": "-1,380,248,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -148861000,
+                    "fmt": "-148.86M",
+                    "longFmt": "-148,861,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 84466000,
+                    "fmt": "84.47M",
+                    "longFmt": "84,466,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -1231387000,
+                    "fmt": "-1.23B",
+                    "longFmt": "-1,231,387,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -1228650000,
+                    "fmt": "-1.23B",
+                    "longFmt": "-1,228,650,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -1921953000,
+                    "fmt": "-1.92B",
+                    "longFmt": "-1,921,953,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1569801600,
+                    "fmt": "2019-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 12022659000,
+                    "fmt": "12.02B",
+                    "longFmt": "12,022,659,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 9083190000,
+                    "fmt": "9.08B",
+                    "longFmt": "9,083,190,000"
+                  },
+                  "grossProfit": {
+                    "raw": 2939469000,
+                    "fmt": "2.94B",
+                    "longFmt": "2,939,469,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 436056000,
+                    "fmt": "436.06M",
+                    "longFmt": "436,056,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 2103745000,
+                    "fmt": "2.1B",
+                    "longFmt": "2,103,745,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 11622991000,
+                    "fmt": "11.62B",
+                    "longFmt": "11,622,991,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 399668000,
+                    "fmt": "399.67M",
+                    "longFmt": "399,668,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 301713000,
+                    "fmt": "301.71M",
+                    "longFmt": "301,713,000"
+                  },
+                  "ebit": {
+                    "raw": 399668000,
+                    "fmt": "399.67M",
+                    "longFmt": "399,668,000"
+                  },
+                  "interestExpense": {
+                    "raw": -34558000,
+                    "fmt": "-34.56M",
+                    "longFmt": "-34,558,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 701381000,
+                    "fmt": "701.38M",
+                    "longFmt": "701,381,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 317120000,
+                    "fmt": "317.12M",
+                    "longFmt": "317,120,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 84466000,
+                    "fmt": "84.47M",
+                    "longFmt": "84,466,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 384261000,
+                    "fmt": "384.26M",
+                    "longFmt": "384,261,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 381354000,
+                    "fmt": "381.35M",
+                    "longFmt": "381,354,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -76584000,
+                    "fmt": "-76.58M",
+                    "longFmt": "-76,584,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistoryQuarterly-BFLY.json
+++ b/tests/http/quoteSummary-incomeStatementHistoryQuarterly-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=incomeStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "0kaqb51g2r54i"
+      ],
+      "x-yahoo-request-id": [
+        "0kaqb51g2r54i"
+      ],
+      "x-request-id": [
+        "efc076d0-d0fc-4bc6-9a51-86cafa25daef"
+      ],
+      "content-length": [
+        "123"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:30 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-indexTrend-BEKE.json
+++ b/tests/http/quoteSummary-indexTrend-BEKE.json
@@ -1,0 +1,109 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=indexTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "17mbsslg2r54j"
+      ],
+      "x-yahoo-request-id": [
+        "17mbsslg2r54j"
+      ],
+      "x-request-id": [
+        "9f8bc136-dd4d-4f98-8ab9-c0d59160aee6"
+      ],
+      "content-length": [
+        "321"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:30 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 5.56217,
+              "pegRatio": 0.991258,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.269
+                },
+                {
+                  "period": "+1q",
+                  "growth": 0.96099997
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.148
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.155
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0821053
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-indexTrend-BFLY.json
+++ b/tests/http/quoteSummary-indexTrend-BFLY.json
@@ -1,0 +1,109 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=indexTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "0l24c3pg2r54j"
+      ],
+      "x-yahoo-request-id": [
+        "0l24c3pg2r54j"
+      ],
+      "x-request-id": [
+        "79726e3f-6cb3-4c3a-9fe4-7679b51db1f9"
+      ],
+      "content-length": [
+        "321"
+      ],
+      "x-envoy-upstream-service-time": [
+        "5"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:31 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 5.56217,
+              "pegRatio": 0.991258,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.269
+                },
+                {
+                  "period": "+1q",
+                  "growth": 0.96099997
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.148
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.155
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0821053
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-industryTrend-BEKE.json
+++ b/tests/http/quoteSummary-industryTrend-BEKE.json
@@ -1,0 +1,83 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=industryTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "dllac8pg2r54j"
+      ],
+      "x-yahoo-request-id": [
+        "dllac8pg2r54j"
+      ],
+      "x-request-id": [
+        "5b03d92f-24f1-4a2e-94a6-6f16d3fee5ad"
+      ],
+      "content-length": [
+        "102"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:31 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-industryTrend-BFLY.json
+++ b/tests/http/quoteSummary-industryTrend-BFLY.json
@@ -1,0 +1,83 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=industryTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "cqvvvklg2r54j"
+      ],
+      "x-yahoo-request-id": [
+        "cqvvvklg2r54j"
+      ],
+      "x-request-id": [
+        "75f61b1b-10d2-4c61-887a-c7b8928eb9f8"
+      ],
+      "content-length": [
+        "102"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:31 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderHolders-BEKE.json
+++ b/tests/http/quoteSummary-insiderHolders-BEKE.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=insiderHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "3m128atg2r54j"
+      ],
+      "x-yahoo-request-id": [
+        "3m128atg2r54j"
+      ],
+      "x-request-id": [
+        "f72389e6-b8d8-44ff-b137-fe674be4b36c"
+      ],
+      "content-length": [
+        "87"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:31 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "insiderHolders": {
+              "holders": [],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderHolders-BFLY.json
+++ b/tests/http/quoteSummary-insiderHolders-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=insiderHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "5n6vbk1g2r54j"
+      ],
+      "x-yahoo-request-id": [
+        "5n6vbk1g2r54j"
+      ],
+      "x-request-id": [
+        "a8fe9cfa-06d0-4590-9377-6900b31f5786"
+      ],
+      "content-length": [
+        "87"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:31 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "insiderHolders": {
+              "holders": [],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderTransactions-BEKE.json
+++ b/tests/http/quoteSummary-insiderTransactions-BEKE.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=insiderTransactions"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "3gq0n01g2r54k"
+      ],
+      "x-yahoo-request-id": [
+        "3gq0n01g2r54k"
+      ],
+      "x-request-id": [
+        "e239c5f7-81fc-41b4-ab11-356542158bbf"
+      ],
+      "content-length": [
+        "152"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:31 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=insiderTransactions"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderTransactions-BFLY.json
+++ b/tests/http/quoteSummary-insiderTransactions-BFLY.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=insiderTransactions"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "3l1qt35g2r54k"
+      ],
+      "x-yahoo-request-id": [
+        "3l1qt35g2r54k"
+      ],
+      "x-request-id": [
+        "0c1c0b07-d065-40ac-9047-7ef859ac4f37"
+      ],
+      "content-length": [
+        "152"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:31 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=insiderTransactions"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-institutionOwnership-BEKE.json
+++ b/tests/http/quoteSummary-institutionOwnership-BEKE.json
@@ -1,0 +1,306 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=institutionOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "bg12bktg2r54k"
+      ],
+      "x-yahoo-request-id": [
+        "bg12bktg2r54k"
+      ],
+      "x-request-id": [
+        "cdc85605-4b65-43da-8163-ea85e4a78b69"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "801"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:31 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Baillie Gifford and Company",
+                  "pctHeld": {
+                    "raw": 0.0198,
+                    "fmt": "1.98%"
+                  },
+                  "position": {
+                    "raw": 17631431,
+                    "fmt": "17.63M",
+                    "longFmt": "17,631,431"
+                  },
+                  "value": {
+                    "raw": 1085038263,
+                    "fmt": "1.09B",
+                    "longFmt": "1,085,038,263"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "SC US (TTGP) Ltd",
+                  "pctHeld": {
+                    "raw": 0.0123000005,
+                    "fmt": "1.23%"
+                  },
+                  "position": {
+                    "raw": 10964911,
+                    "fmt": "10.96M",
+                    "longFmt": "10,964,911"
+                  },
+                  "value": {
+                    "raw": 672149044,
+                    "fmt": "672.15M",
+                    "longFmt": "672,149,044"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "FMR, LLC",
+                  "pctHeld": {
+                    "raw": 0.0089,
+                    "fmt": "0.89%"
+                  },
+                  "position": {
+                    "raw": 7903919,
+                    "fmt": "7.9M",
+                    "longFmt": "7,903,919"
+                  },
+                  "value": {
+                    "raw": 486407175,
+                    "fmt": "486.41M",
+                    "longFmt": "486,407,175"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Capital World Investors",
+                  "pctHeld": {
+                    "raw": 0.0088,
+                    "fmt": "0.88%"
+                  },
+                  "position": {
+                    "raw": 7821189,
+                    "fmt": "7.82M",
+                    "longFmt": "7,821,189"
+                  },
+                  "value": {
+                    "raw": 479438885,
+                    "fmt": "479.44M",
+                    "longFmt": "479,438,885"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Blackrock Inc.",
+                  "pctHeld": {
+                    "raw": 0.0074,
+                    "fmt": "0.74%"
+                  },
+                  "position": {
+                    "raw": 6536139,
+                    "fmt": "6.54M",
+                    "longFmt": "6,536,139"
+                  },
+                  "value": {
+                    "raw": 402233994,
+                    "fmt": "402.23M",
+                    "longFmt": "402,233,994"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Hillhouse Capital Advisors Ltd.",
+                  "pctHeld": {
+                    "raw": 0.0056,
+                    "fmt": "0.56%"
+                  },
+                  "position": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "value": {
+                    "raw": 306500000,
+                    "fmt": "306.5M",
+                    "longFmt": "306,500,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "D1 Capital Partners, LP",
+                  "pctHeld": {
+                    "raw": 0.0056,
+                    "fmt": "0.56%"
+                  },
+                  "position": {
+                    "raw": 5000000,
+                    "fmt": "5M",
+                    "longFmt": "5,000,000"
+                  },
+                  "value": {
+                    "raw": 306500000,
+                    "fmt": "306.5M",
+                    "longFmt": "306,500,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Credit Suisse Ag/",
+                  "pctHeld": {
+                    "raw": 0.0043,
+                    "fmt": "0.43%"
+                  },
+                  "position": {
+                    "raw": 3778354,
+                    "fmt": "3.78M",
+                    "longFmt": "3,778,354"
+                  },
+                  "value": {
+                    "raw": 231613100,
+                    "fmt": "231.61M",
+                    "longFmt": "231,613,100"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Group, Inc. (The)",
+                  "pctHeld": {
+                    "raw": 0.0042,
+                    "fmt": "0.42%"
+                  },
+                  "position": {
+                    "raw": 3750841,
+                    "fmt": "3.75M",
+                    "longFmt": "3,750,841"
+                  },
+                  "value": {
+                    "raw": 229926553,
+                    "fmt": "229.93M",
+                    "longFmt": "229,926,553"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Sumitomo Mitsui Trust Holdings, Inc.",
+                  "pctHeld": {
+                    "raw": 0.004,
+                    "fmt": "0.40%"
+                  },
+                  "position": {
+                    "raw": 3512686,
+                    "fmt": "3.51M",
+                    "longFmt": "3,512,686"
+                  },
+                  "value": {
+                    "raw": 216170696,
+                    "fmt": "216.17M",
+                    "longFmt": "216,170,696"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-institutionOwnership-BFLY.json
+++ b/tests/http/quoteSummary-institutionOwnership-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=institutionOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "8rhctshg2r54k"
+      ],
+      "x-yahoo-request-id": [
+        "8rhctshg2r54k"
+      ],
+      "x-request-id": [
+        "e19d4b36-5504-4b18-8bdf-7d18cd9f3d4c"
+      ],
+      "content-length": [
+        "99"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:32 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorDirectHolders-BEKE.json
+++ b/tests/http/quoteSummary-majorDirectHolders-BEKE.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=majorDirectHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "36dspgtg2r54k"
+      ],
+      "x-yahoo-request-id": [
+        "36dspgtg2r54k"
+      ],
+      "x-request-id": [
+        "622f5950-f488-4404-adb5-991550417d6f"
+      ],
+      "content-length": [
+        "91"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:32 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorDirectHolders-BFLY.json
+++ b/tests/http/quoteSummary-majorDirectHolders-BFLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=majorDirectHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "6s6hap1g2r54k"
+      ],
+      "x-yahoo-request-id": [
+        "6s6hap1g2r54k"
+      ],
+      "x-request-id": [
+        "d30c43fc-f932-42d3-a5c8-81a077bf430e"
+      ],
+      "content-length": [
+        "91"
+      ],
+      "x-envoy-upstream-service-time": [
+        "5"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:32 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorHoldersBreakdown-BEKE.json
+++ b/tests/http/quoteSummary-majorHoldersBreakdown-BEKE.json
@@ -1,0 +1,85 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=majorHoldersBreakdown"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "06pa461g2r54k"
+      ],
+      "x-yahoo-request-id": [
+        "06pa461g2r54k"
+      ],
+      "x-request-id": [
+        "f71d3d52-7343-4771-b03f-3af1fe743241"
+      ],
+      "content-length": [
+        "213"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:32 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "2"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.0090499995,
+              "institutionsPercentHeld": 0.14386,
+              "institutionsFloatPercentHeld": 0.14517,
+              "institutionsCount": 234
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorHoldersBreakdown-BFLY.json
+++ b/tests/http/quoteSummary-majorHoldersBreakdown-BFLY.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=majorHoldersBreakdown"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "0csbdp9g2r54l"
+      ],
+      "x-yahoo-request-id": [
+        "0csbdp9g2r54l"
+      ],
+      "x-request-id": [
+        "69d9622d-01db-4ac9-8207-8cd2dfba701e"
+      ],
+      "content-length": [
+        "81"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:32 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorHoldersBreakdown": {
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-netSharePurchaseActivity-BEKE.json
+++ b/tests/http/quoteSummary-netSharePurchaseActivity-BEKE.json
@@ -1,0 +1,89 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=netSharePurchaseActivity"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "152keblg2r54l"
+      ],
+      "x-yahoo-request-id": [
+        "152keblg2r54l"
+      ],
+      "x-request-id": [
+        "ab244d7f-1866-47eb-8f41-b60a86aee3f9"
+      ],
+      "content-length": [
+        "246"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:33 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 0,
+              "buyInfoShares": 0,
+              "sellInfoCount": 0,
+              "netInfoCount": 0,
+              "netInfoShares": 0,
+              "netPercentInsiderShares": 0,
+              "totalInsiderShares": 10667953
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-netSharePurchaseActivity-BFLY.json
+++ b/tests/http/quoteSummary-netSharePurchaseActivity-BFLY.json
@@ -1,0 +1,88 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=netSharePurchaseActivity"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "2885ho5g2r54l"
+      ],
+      "x-yahoo-request-id": [
+        "2885ho5g2r54l"
+      ],
+      "x-request-id": [
+        "048594b6-b65d-4fa1-af59-edd92a66f19a"
+      ],
+      "content-length": [
+        "209"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:33 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 0,
+              "buyInfoShares": 0,
+              "sellInfoCount": 0,
+              "netInfoCount": 0,
+              "netInfoShares": 0,
+              "totalInsiderShares": 0
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-price-BEKE.json
+++ b/tests/http/quoteSummary-price-BEKE.json
@@ -1,0 +1,121 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=price"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "6i5k5jtg2r54l"
+      ],
+      "x-yahoo-request-id": [
+        "6i5k5jtg2r54l"
+      ],
+      "x-request-id": [
+        "22cf092f-2e5c-4532-964d-f170b2ef9530"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "486"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:33 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": -0.0220588,
+              "preMarketChange": -1.5,
+              "preMarketTime": 1613572197,
+              "preMarketPrice": 66.5,
+              "preMarketSource": "FREE_REALTIME",
+              "postMarketChangePercent": -0.0032998535,
+              "postMarketChange": -0.22000122,
+              "postMarketTime": 1613599825,
+              "postMarketPrice": 66.45,
+              "postMarketSource": "FREE_REALTIME",
+              "regularMarketChangePercent": -0.01955885,
+              "regularMarketChange": -1.3300018,
+              "regularMarketTime": 1613595602,
+              "priceHint": 2,
+              "regularMarketPrice": 66.67,
+              "regularMarketDayHigh": 67.87,
+              "regularMarketDayLow": 65.25,
+              "regularMarketVolume": 3772289,
+              "regularMarketPreviousClose": 68,
+              "regularMarketSource": "DELAYED",
+              "regularMarketOpen": 66.39,
+              "exchange": "NYQ",
+              "exchangeName": "NYSE",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "POST",
+              "quoteType": "EQUITY",
+              "symbol": "BEKE",
+              "underlyingSymbol": null,
+              "shortName": "KE Holdings Inc",
+              "longName": "KE Holdings Inc.",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 78589263872
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-price-BFLY.json
+++ b/tests/http/quoteSummary-price-BFLY.json
@@ -1,0 +1,120 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=price"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "8e7lg8hg2r54l"
+      ],
+      "x-yahoo-request-id": [
+        "8e7lg8hg2r54l"
+      ],
+      "x-request-id": [
+        "9a749ae0-7afc-4182-8067-e79c0de83d3d"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "478"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:33 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": 0.0288889,
+              "preMarketChange": 0.65,
+              "preMarketTime": 1613572193,
+              "preMarketPrice": 23.15,
+              "preMarketSource": "FREE_REALTIME",
+              "postMarketChangePercent": -0.011787052,
+              "postMarketChange": -0.30999947,
+              "postMarketTime": 1613599882,
+              "postMarketPrice": 25.99,
+              "postMarketSource": "FREE_REALTIME",
+              "regularMarketChangePercent": 0.168889,
+              "regularMarketChange": 3.8,
+              "regularMarketTime": 1613595602,
+              "priceHint": 2,
+              "regularMarketPrice": 26.3,
+              "regularMarketDayHigh": 27.13,
+              "regularMarketDayLow": 21.98,
+              "regularMarketVolume": 7029222,
+              "regularMarketPreviousClose": 22.5,
+              "regularMarketSource": "FREE_REALTIME",
+              "regularMarketOpen": 23.11,
+              "exchange": "NYQ",
+              "exchangeName": "NYSE",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "POST",
+              "quoteType": "EQUITY",
+              "symbol": "BFLY",
+              "underlyingSymbol": null,
+              "shortName": "Butterfly Network, Inc. Class A",
+              "longName": "Butterfly Network, Inc.",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-quoteType-BEKE.json
+++ b/tests/http/quoteSummary-quoteType-BEKE.json
@@ -1,0 +1,93 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=quoteType"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "7m275f1g2r54l"
+      ],
+      "x-yahoo-request-id": [
+        "7m275f1g2r54l"
+      ],
+      "x-request-id": [
+        "7e62cd94-9f8c-4e8a-a923-d3afe59fe421"
+      ],
+      "content-length": [
+        "424"
+      ],
+      "x-envoy-upstream-service-time": [
+        "1"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:33 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "quoteType": {
+              "exchange": "NYQ",
+              "quoteType": "EQUITY",
+              "symbol": "BEKE",
+              "underlyingSymbol": "BEKE",
+              "shortName": "KE Holdings Inc",
+              "longName": "KE Holdings Inc.",
+              "firstTradeDateEpochUtc": 1597325400,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "36c211a8-04c4-368b-8141-b3e0d4048354",
+              "messageBoardId": "finmb_665898843",
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-quoteType-BFLY.json
+++ b/tests/http/quoteSummary-quoteType-BFLY.json
@@ -1,0 +1,93 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=quoteType"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "almb9ndg2r54l"
+      ],
+      "x-yahoo-request-id": [
+        "almb9ndg2r54l"
+      ],
+      "x-request-id": [
+        "a96d5b18-0e9c-434f-ac03-4e3803e69f06"
+      ],
+      "content-length": [
+        "447"
+      ],
+      "x-envoy-upstream-service-time": [
+        "1"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:33 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "quoteType": {
+              "exchange": "NYQ",
+              "quoteType": "EQUITY",
+              "symbol": "BFLY",
+              "underlyingSymbol": "BFLY",
+              "shortName": "Butterfly Network, Inc. Class A",
+              "longName": "Butterfly Network, Inc.",
+              "firstTradeDateEpochUtc": 1594647000,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "5f9449d1-1162-3804-a742-88e2f8b5fb0e",
+              "messageBoardId": "finmb_275830634",
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-recommendationTrend-BEKE.json
+++ b/tests/http/quoteSummary-recommendationTrend-BEKE.json
@@ -1,0 +1,115 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=recommendationTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "37r4qq5g2r54m"
+      ],
+      "x-yahoo-request-id": [
+        "37r4qq5g2r54m"
+      ],
+      "x-request-id": [
+        "42a50e3a-1a13-41bb-8fb9-1a96afd2948b"
+      ],
+      "content-length": [
+        "380"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:34 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 2,
+                  "buy": 3,
+                  "hold": 5,
+                  "sell": 1,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 1,
+                  "buy": 3,
+                  "hold": 5,
+                  "sell": 1,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 0,
+                  "buy": 3,
+                  "hold": 5,
+                  "sell": 1,
+                  "strongSell": 0
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-recommendationTrend-BFLY.json
+++ b/tests/http/quoteSummary-recommendationTrend-BFLY.json
@@ -1,0 +1,115 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=recommendationTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "00sa1ptg2r54m"
+      ],
+      "x-yahoo-request-id": [
+        "00sa1ptg2r54m"
+      ],
+      "x-request-id": [
+        "e74cd65f-32ad-45b6-a126-4d112a015d01"
+      ],
+      "content-length": [
+        "380"
+      ],
+      "x-envoy-upstream-service-time": [
+        "1"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:33 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-secFilings-BEKE.json
+++ b/tests/http/quoteSummary-secFilings-BEKE.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=secFilings"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "6rppfe9g2r54m"
+      ],
+      "x-yahoo-request-id": [
+        "6rppfe9g2r54m"
+      ],
+      "x-request-id": [
+        "5121a433-43aa-4c0f-b0fb-1cc7c2ca988a"
+      ],
+      "content-length": [
+        "143"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:34 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=secFilings"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-secFilings-BFLY.json
+++ b/tests/http/quoteSummary-secFilings-BFLY.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=secFilings"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "038kcs5g2r54m"
+      ],
+      "x-yahoo-request-id": [
+        "038kcs5g2r54m"
+      ],
+      "x-request-id": [
+        "aa05bf77-72ca-4186-9cce-d78cf67cf6f2"
+      ],
+      "content-length": [
+        "143"
+      ],
+      "x-envoy-upstream-service-time": [
+        "6"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:34 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=secFilings"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryDetail-BEKE.json
+++ b/tests/http/quoteSummary-summaryDetail-BEKE.json
@@ -1,0 +1,114 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=summaryDetail"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "djnridpg2r54m"
+      ],
+      "x-yahoo-request-id": [
+        "djnridpg2r54m"
+      ],
+      "x-request-id": [
+        "d72fcc93-b426-4731-ba7b-1c8b0385c65c"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "385"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:34 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 68,
+              "open": 66.39,
+              "dayLow": 65.25,
+              "dayHigh": 67.87,
+              "regularMarketPreviousClose": 68,
+              "regularMarketOpen": 66.39,
+              "regularMarketDayLow": 65.25,
+              "regularMarketDayHigh": 67.87,
+              "payoutRatio": 0,
+              "volume": 3772289,
+              "regularMarketVolume": 3772289,
+              "averageVolume": 3760300,
+              "averageVolume10days": 5531066,
+              "averageDailyVolume10Day": 5531066,
+              "bid": 66.62,
+              "ask": 67,
+              "bidSize": 1200,
+              "askSize": 1000,
+              "marketCap": 78589263872,
+              "fiftyTwoWeekLow": 31.79,
+              "fiftyTwoWeekHigh": 79.4,
+              "fiftyDayAverage": 64.594246,
+              "twoHundredDayAverage": 61.68664,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryDetail-BFLY.json
+++ b/tests/http/quoteSummary-summaryDetail-BFLY.json
@@ -1,0 +1,112 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=summaryDetail"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "at8ot5lg2r54m"
+      ],
+      "x-yahoo-request-id": [
+        "at8ot5lg2r54m"
+      ],
+      "x-request-id": [
+        "dad44d28-db13-474d-ab8a-32c333a3b786"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "331"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:34 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 22.5,
+              "open": 23.11,
+              "dayLow": 21.98,
+              "dayHigh": 27.13,
+              "regularMarketPreviousClose": 22.5,
+              "regularMarketOpen": 23.11,
+              "regularMarketDayLow": 21.98,
+              "regularMarketDayHigh": 27.13,
+              "volume": 7029222,
+              "regularMarketVolume": 7029222,
+              "averageVolume": 2347300,
+              "averageVolume10days": 2347300,
+              "averageDailyVolume10Day": 2347300,
+              "bid": 25.95,
+              "ask": 26.4,
+              "bidSize": 1000,
+              "askSize": 800,
+              "fiftyTwoWeekLow": 21.95,
+              "fiftyTwoWeekHigh": 27.13,
+              "fiftyDayAverage": 22.5,
+              "twoHundredDayAverage": 22.5,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryProfile-BEKE.json
+++ b/tests/http/quoteSummary-summaryProfile-BEKE.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=summaryProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "044omo5g2r54m"
+      ],
+      "x-yahoo-request-id": [
+        "044omo5g2r54m"
+      ],
+      "x-request-id": [
+        "81b56ef8-6d74-471a-a616-8617d55772a6"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "502"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:34 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryProfile": {
+              "address1": "Building Fudao",
+              "address2": "No.11 Kaituo Road Haidian District",
+              "city": "Beijing",
+              "zip": "100085",
+              "country": "China",
+              "phone": "86 10 5810 4689",
+              "website": "http://ke.com",
+              "industry": "Real Estate Services",
+              "sector": "Real Estate",
+              "longBusinessSummary": "KE Holdings Inc. operates an integrated online and offline platform for housing transactions and services in the People's Republic of China. The company facilitates various housing transactions ranging from existing and new home sales and home rentals to home renovation, real estate financial solutions, and other services. It also owns and operates Lianjia, a real estate brokerage branded store. The company was founded in 2001 and is headquartered in Beijing, China.",
+              "companyOfficers": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryProfile-BFLY.json
+++ b/tests/http/quoteSummary-summaryProfile-BFLY.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=summaryProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "y-rid": [
+        "4it0uhdg2r54n"
+      ],
+      "x-yahoo-request-id": [
+        "4it0uhdg2r54n"
+      ],
+      "x-request-id": [
+        "d7df8f42-7e6b-4d63-8610-05d5ba0c176b"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "582"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:34 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryProfile": {
+              "address1": "530 Old Whitfield Street",
+              "city": "Guilford",
+              "state": "CT",
+              "zip": "06437",
+              "country": "United States",
+              "phone": "203-458-2514",
+              "website": "http://english.butterflynetwork.com",
+              "industry": "Medical Devices",
+              "sector": "Healthcare",
+              "longBusinessSummary": "Butterfly Network, Inc. develops medical imaging device for hospitals and organizations to scale their point of care ultrasound programs through a new suite of tools that enable ultrasound workflow mobile and system integrations simple and secure. The company's device provides diagnostic imaging and measurement of blood vessels and examines the cardiac, abdominal, urological, fetal, gynecological, and musculoskeletal systems. The company also offers Butterfly iQ, a handheld and single-probe whole body ultrasound system. The company was founded in 2011 and is based in Guilford, Connecticut.",
+              "companyOfficers": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-upgradeDowngradeHistory-BEKE.json
+++ b/tests/http/quoteSummary-upgradeDowngradeHistory-BEKE.json
@@ -1,0 +1,90 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BEKE?formatted=false&modules=upgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "f2v1icpg2r54n"
+      ],
+      "x-yahoo-request-id": [
+        "f2v1icpg2r54n"
+      ],
+      "x-request-id": [
+        "e694bfb7-8c29-4697-9ed6-ad532768c3e0"
+      ],
+      "content-length": [
+        "195"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:34 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "upgradeDowngradeHistory": {
+              "history": [
+                {
+                  "epochGradeDate": 1609859636,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-upgradeDowngradeHistory-BFLY.json
+++ b/tests/http/quoteSummary-upgradeDowngradeHistory-BFLY.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BFLY?formatted=false&modules=upgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "e67ho05g2r54n"
+      ],
+      "x-yahoo-request-id": [
+        "e67ho05g2r54n"
+      ],
+      "x-request-id": [
+        "c048ca07-e73e-4c9d-9098-cfbda7fd8065"
+      ],
+      "content-length": [
+        "156"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:35 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=upgradeDowngradeHistory"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-BEKE.json
+++ b/tests/http/recommendationsBySymbol-BEKE.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/BEKE?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "3mta2mlg2r54e"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "157"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:26 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "BEKE",
+            "recommendedSymbols": [
+              {
+                "symbol": "DOYU",
+                "score": 0.058686
+              },
+              {
+                "symbol": "API",
+                "score": 0.05831
+              },
+              {
+                "symbol": "FUTU",
+                "score": 0.057564
+              },
+              {
+                "symbol": "YSG",
+                "score": 0.056893
+              },
+              {
+                "symbol": "DADA",
+                "score": 0.055502
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-BFLY.json
+++ b/tests/http/recommendationsBySymbol-BFLY.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/BFLY?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "54gri35g2r54e"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "161"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:26 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "BFLY",
+            "recommendedSymbols": [
+              {
+                "symbol": "LGVW",
+                "score": 0.028571
+              },
+              {
+                "symbol": "TGLO",
+                "score": 0.020148
+              },
+              {
+                "symbol": "AWEB",
+                "score": 0.018328
+              },
+              {
+                "symbol": "CMLF",
+                "score": 0.015492
+              },
+              {
+                "symbol": "EXPC",
+                "score": 0.014967
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/search-BEKE.json
+++ b/tests/http/search-BEKE.json
@@ -1,0 +1,186 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v1/finance/search?lang=en-US&region=US&quotesCount=6&newsCount=4&enableFuzzyQuery=false&quotesQueryId=tss_match_phrase_query&multiQuoteQueryId=multi_quote_single_token_query&newsQueryId=news_cie_vespa&enableCb=true&enableNavLinks=true&enableEnhancedTrivialQuery=true&q=BEKE"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=120, stale-while-revalidate=180"
+      ],
+      "y-rid": [
+        "bdg691dg2r54e"
+      ],
+      "x-yahoo-request-id": [
+        "bdg691dg2r54e"
+      ],
+      "x-request-id": [
+        "4eaea6d4-9e0c-48e3-8186-cf2b0a1f67c0"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "975"
+      ],
+      "x-envoy-upstream-service-time": [
+        "34"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:25 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-search--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "explains": [],
+      "count": 10,
+      "quotes": [
+        {
+          "exchange": "NYQ",
+          "shortname": "KE Holdings Inc",
+          "quoteType": "EQUITY",
+          "symbol": "BEKE",
+          "index": "quotes",
+          "score": 3219100,
+          "typeDisp": "Equity",
+          "longname": "KE Holdings Inc.",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "PNK",
+          "shortname": "BEKEM METALS INC",
+          "quoteType": "EQUITY",
+          "symbol": "BKMM",
+          "index": "quotes",
+          "score": 20034,
+          "typeDisp": "Equity",
+          "longname": "Bekem Metals, Inc.",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "BRU",
+          "shortname": "TER BEKE",
+          "quoteType": "EQUITY",
+          "symbol": "TERB.BR",
+          "index": "quotes",
+          "score": 20026,
+          "typeDisp": "Equity",
+          "longname": "Ter Beke NV",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "OPR",
+          "shortname": "BEKE Mar 2021 80.000 call",
+          "quoteType": "OPTION",
+          "symbol": "BEKE210319C00080000",
+          "index": "quotes",
+          "score": 20006,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "OPR",
+          "shortname": "BEKE Jan 2023 80.000 call",
+          "quoteType": "OPTION",
+          "symbol": "BEKE230120C00080000",
+          "index": "quotes",
+          "score": 20004,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "OPR",
+          "shortname": "BEKE Apr 2021 115.000 call",
+          "quoteType": "OPTION",
+          "symbol": "BEKE210416C00115000",
+          "index": "quotes",
+          "score": 20003,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        }
+      ],
+      "news": [
+        {
+          "uuid": "3f33877f-d553-3330-be49-03f87c8cabc4",
+          "title": "Is the Options Market Predicting a Spike in KE Holdings (BEKE) Stock?",
+          "publisher": "Zacks",
+          "link": "https://finance.yahoo.com/news/options-market-predicting-spike-ke-134701283.html",
+          "providerPublishTime": 1610027221,
+          "type": "STORY"
+        },
+        {
+          "uuid": "533b5a72-a0b2-3fdf-a82f-a946f0905d74",
+          "title": "Why This 'Redfin of China' Should Be on Your Stock Watch List",
+          "publisher": "Motley Fool",
+          "link": "https://finance.yahoo.com/m/533b5a72-a0b2-3fdf-a82f-a946f0905d74/why-this-%27redfin-of-china%27.html",
+          "providerPublishTime": 1608126147,
+          "type": "STORY"
+        },
+        {
+          "uuid": "235e86f1-ba04-3066-8d49-be911ecab0d1",
+          "title": "JLL vs. BEKE: Which Stock Should Value Investors Buy Now?",
+          "publisher": "Zacks",
+          "link": "https://finance.yahoo.com/news/jll-vs-beke-stock-value-164004152.html",
+          "providerPublishTime": 1610037604,
+          "type": "STORY"
+        },
+        {
+          "uuid": "e45f1067-7704-3d7d-ad65-8a669633c34a",
+          "title": "Breakeven Is Near for KE Holdings Inc. (NYSE:BEKE)",
+          "publisher": "Simply Wall St.",
+          "link": "https://finance.yahoo.com/news/breakeven-near-ke-holdings-inc-052423184.html",
+          "providerPublishTime": 1613021063,
+          "type": "STORY"
+        }
+      ],
+      "nav": [],
+      "lists": [],
+      "researchReports": [],
+      "totalTime": 32,
+      "timeTakenForQuotes": 422,
+      "timeTakenForNews": 600,
+      "timeTakenForAlgowatchlist": 400,
+      "timeTakenForPredefinedScreener": 400,
+      "timeTakenForCrunchbase": 400,
+      "timeTakenForNav": 400,
+      "timeTakenForResearchReports": 0
+    }
+  }
+}

--- a/tests/http/search-BFLY.json
+++ b/tests/http/search-BFLY.json
@@ -1,0 +1,179 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v1/finance/search?lang=en-US&region=US&quotesCount=6&newsCount=4&enableFuzzyQuery=false&quotesQueryId=tss_match_phrase_query&multiQuoteQueryId=multi_quote_single_token_query&newsQueryId=news_cie_vespa&enableCb=true&enableNavLinks=true&enableEnhancedTrivialQuery=true&q=BFLY"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=120, stale-while-revalidate=180"
+      ],
+      "y-rid": [
+        "5qm5e95g2r54e"
+      ],
+      "x-yahoo-request-id": [
+        "5qm5e95g2r54e"
+      ],
+      "x-request-id": [
+        "ad935553-dfda-40c5-b8b1-26a025ee7f86"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "949"
+      ],
+      "x-envoy-upstream-service-time": [
+        "30"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:11:26 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-search--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "explains": [],
+      "count": 10,
+      "quotes": [
+        {
+          "exchange": "NYQ",
+          "quoteType": "EQUITY",
+          "symbol": "BFLY",
+          "index": "quotes",
+          "score": 7715300,
+          "typeDisp": "Equity",
+          "longname": "Butterfly Network, Inc.",
+          "isYahooFinance": true,
+          "newListingDate": "2021-02-16"
+        },
+        {
+          "exchange": "NYQ",
+          "quoteType": "EQUITY",
+          "symbol": "BFLY-WT",
+          "index": "quotes",
+          "score": 21046,
+          "typeDisp": "Equity",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "OPR",
+          "quoteType": "OPTION",
+          "symbol": "BFLY210319P00025000",
+          "index": "quotes",
+          "score": 20896,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "OPR",
+          "quoteType": "OPTION",
+          "symbol": "BFLY210319P00015000",
+          "index": "quotes",
+          "score": 20244,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "OPR",
+          "quoteType": "OPTION",
+          "symbol": "BFLY210716P00035000",
+          "index": "quotes",
+          "score": 20039,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "OPR",
+          "quoteType": "OPTION",
+          "symbol": "BFLY210219P00012500",
+          "index": "quotes",
+          "score": 20024,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        }
+      ],
+      "news": [
+        {
+          "uuid": "72c5cf01-8a4d-3a4c-b14b-2de4c12217c6",
+          "title": "Butterfly Network Goes Public, Taking Portable Ultrasound Device Global",
+          "publisher": "IPO-Edge.com",
+          "link": "https://finance.yahoo.com/news/butterfly-network-goes-public-taking-110022864.html",
+          "providerPublishTime": 1613473222,
+          "type": "STORY"
+        },
+        {
+          "uuid": "6d1a2e8d-dc02-3e4c-abe4-b4816c8a7ea9",
+          "title": "Butterfly Network, a Global Leader in Democratizing Medical Imaging, Closes Business Combination and Will Begin Trading on the New York Stock Exchange",
+          "publisher": "PR Newswire",
+          "link": "https://finance.yahoo.com/news/butterfly-network-global-leader-democratizing-110000819.html",
+          "providerPublishTime": 1613473200,
+          "type": "STORY"
+        },
+        {
+          "uuid": "aee165c1-9b33-3afe-bf7c-ec0226f7ec4b",
+          "title": "Butterfly Network, a global leader in democratizing medical imaging, to be listed on NYSE through a merger with Longview Acquisition Corp.",
+          "publisher": "PR Newswire",
+          "link": "https://finance.yahoo.com/news/butterfly-network-global-leader-democratizing-120000797.html",
+          "providerPublishTime": 1605873600,
+          "type": "STORY"
+        },
+        {
+          "uuid": "d1980323-e654-3b3b-b9ff-280876c0f2d5",
+          "title": "SHAREHOLDER ALERT: WeissLaw LLP Investigates Longview Acquisition Corp.",
+          "publisher": "PR Newswire",
+          "link": "https://finance.yahoo.com/news/shareholder-alert-weisslaw-llp-investigates-011300059.html",
+          "providerPublishTime": 1605921180,
+          "type": "STORY"
+        }
+      ],
+      "nav": [],
+      "lists": [],
+      "researchReports": [],
+      "totalTime": 29,
+      "timeTakenForQuotes": 419,
+      "timeTakenForNews": 600,
+      "timeTakenForAlgowatchlist": 400,
+      "timeTakenForPredefinedScreener": 400,
+      "timeTakenForCrunchbase": 400,
+      "timeTakenForNav": 400,
+      "timeTakenForResearchReports": 0
+    }
+  }
+}

--- a/tests/http/trendingSymbols-AU.json
+++ b/tests/http/trendingSymbols-AU.json
@@ -1,0 +1,80 @@
+{
+  "request": {
+    "url": "https://query1.finance.yahoo.com/v1/finance/trending/AU?lang=en-US&count=5"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "7323hs5g2r6rs"
+      ],
+      "cache-control": [
+        "max-age=300, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "137"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:41:00 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "count": 1,
+            "quotes": [
+              {
+                "symbol": "^DJI"
+              }
+            ],
+            "jobTimestamp": 1613600089614,
+            "startInterval": 202102172100
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/trendingSymbols-GB.json
+++ b/tests/http/trendingSymbols-GB.json
@@ -1,0 +1,92 @@
+{
+  "request": {
+    "url": "https://query1.finance.yahoo.com/v1/finance/trending/GB?lang=en-US&count=5"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "8qobpepg2r6rs"
+      ],
+      "cache-control": [
+        "max-age=300, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "167"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:41:00 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "count": 5,
+            "quotes": [
+              {
+                "symbol": "RIOT"
+              },
+              {
+                "symbol": "BTC-USD"
+              },
+              {
+                "symbol": "BTC-GBP"
+              },
+              {
+                "symbol": "ARBKF"
+              },
+              {
+                "symbol": "QS"
+              }
+            ],
+            "jobTimestamp": 1613600089547,
+            "startInterval": 202102172100
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/trendingSymbols-IT.json
+++ b/tests/http/trendingSymbols-IT.json
@@ -1,0 +1,83 @@
+{
+  "request": {
+    "url": "https://query1.finance.yahoo.com/v1/finance/trending/IT?lang=en-US&count=5"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "7m0nuadg2r6rs"
+      ],
+      "cache-control": [
+        "max-age=300, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "147"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:41:00 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "count": 2,
+            "quotes": [
+              {
+                "symbol": "AAPL"
+              },
+              {
+                "symbol": "TSLA"
+              }
+            ],
+            "jobTimestamp": 1613596601399,
+            "startInterval": 202102172000
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/trendingSymbols-US.json
+++ b/tests/http/trendingSymbols-US.json
@@ -1,0 +1,92 @@
+{
+  "request": {
+    "url": "https://query1.finance.yahoo.com/v1/finance/trending/US?lang=en-US&count=5"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "9r2jfclg2r6rs"
+      ],
+      "cache-control": [
+        "max-age=300, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "162"
+      ],
+      "date": [
+        "Wed, 17 Feb 2021 22:41:00 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "count": 5,
+            "quotes": [
+              {
+                "symbol": "TWLO"
+              },
+              {
+                "symbol": "RIOT"
+              },
+              {
+                "symbol": "LODE"
+              },
+              {
+                "symbol": "TLRY"
+              },
+              {
+                "symbol": "FSLY"
+              }
+            ],
+            "jobTimestamp": 1613600090081,
+            "startInterval": 202102172100
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}


### PR DESCRIPTION
# New module `trendingSymbols`
This PR adds a new module :tada:, `trendingSymbols`! It provides the symbols that are trending in your region (country in this case, as far as I can tell).

## Changes
- Add new module `trendingSymbols`
- Add tests for the module
- Add docs for the module

## Endpoint Params
`count` - max number of symbols that can be returned.
`lang` - does nothing???
`region` - overrides the search country, alternative to passing the query.
`corsDomain` (**not added**) - This was provided in #8, but does not actually set the cors domain, so it is not added in the PR (better not to add it than to release a new major version for removing it).

## Tests
Tests will not pass until #64 is merged, but tests for the module pass.

## Example usage
```ts
import yahooFinance from 'yahoo-finance2';
yahooFinance.trendingSymbols('US', { count: 5, lang: 'en-US' }); // default queryOptions
```

@gadicc What are your thoughts on this? Anything to change?