### PR TITLE
chore(tests): More it() to it.each()

### DIFF
--- a/src/modules/quote.spec.ts
+++ b/src/modules/quote.spec.ts
@@ -1,11 +1,7 @@
 import quote from "./quote";
-import { testSymbols as testSymbolsOriginal } from "../../tests/symbols";
+import { testSymbols } from "../../tests/symbols";
 import testYf from "../../tests/testYf";
-
-const testSymbols = [
-  ...testSymbolsOriginal,
-  "AZT.OL", // Far less properties than other symbols (#42)
-];
+import { zip } from "../../tests/utils/zip";
 
 const yf = testYf({ quote });
 
@@ -28,19 +24,22 @@ describe("quote", () => {
     ).not.toThrow();
   });
 
-  it("returns an array for an array", async () => {
-    const devel = "quote-AAPL-BABA.json";
-    const results = await yf.quote(["AAPL", "BABA"], {}, { devel });
-    expect(results.length).toBe(2);
-    expect(results[0].symbol).toBe("AAPL");
-    expect(results[1].symbol).toBe("BABA");
-  });
+  it.each(zip(testSymbols, testSymbols.slice().reverse()))(
+    "returns an array for an array ('%s', '%s')",
+    async (symbol1, symbol2) => {
+      const devel = `quote-${symbol1}-${symbol2}.json`;
+      const results = await yf.quote([symbol1, symbol2], {}, { devel });
+      expect(results.length).toBe(2);
+      expect(results[0].symbol).toBe(symbol1);
+      expect(results[1].symbol).toBe(symbol2);
+    }
+  );
 
-  it("returns single for a string", async () => {
-    const devel = "quote-AAPL.json";
-    const result = await yf.quote("AAPL", {}, { devel });
+  it.each(testSymbols)("returns single for a string ('%s')", async (symbol) => {
+    const devel = `quote-${symbol}.json`;
+    const result = await yf.quote(symbol, {}, { devel });
     expect(Array.isArray(result)).toBe(false);
-    expect(result.symbol).toBe("AAPL");
+    expect(result.symbol).toBe(symbol);
   });
 
   if (process.env.FETCH_DEVEL !== "nocache")

--- a/src/modules/recommendationsBySymbol.spec.ts
+++ b/src/modules/recommendationsBySymbol.spec.ts
@@ -4,6 +4,7 @@ import { testSymbols } from "../../tests/symbols";
 import _env from "../env-node";
 import _fetch from "../lib/yahooFinanceFetch";
 import _moduleExec from "../lib/moduleExec";
+import { zip } from "../../tests/utils/zip";
 
 const yf = {
   _env,
@@ -14,41 +15,48 @@ const yf = {
 };
 
 describe("recommendationsBySymbol", () => {
+  const symbolsToSkip = [
+    "ADH", // 404 Not Found
+  ];
+  const symbols = testSymbols.filter((s) => !symbolsToSkip.includes(s));
+
   // make sure it passes validation for some symbols
   describe("passes validation", () => {
-    const symbolsToSkip = [
-      "ADH", // 404 Not Found
-    ];
-    const symbols = testSymbols.filter((s) => !symbolsToSkip.includes(s));
     it.each(symbols)("for symbol '%s'", async (symbol) => {
       const devel = `recommendationsBySymbol-${symbol}.json`;
       await yf.recommendationsBySymbol(symbol, {}, { devel });
     });
-  });
 
-  // make sure it passes validation for multiple symbols
-  it(`passes validation for multiple symbols ("AAPL" and "BMW.DE")`, async () => {
-    const devel = `recommendationsBySymbol-AAPL-BMW.DE.json`;
-    await yf.recommendationsBySymbol(["AAPL", "BMW.DE"], {}, { devel });
-  });
-
-  it("returns an array for an array", async () => {
-    const devel = "recommendationsBySymbol-AAPL-BMW.DE.json";
-    const results = await yf.recommendationsBySymbol(
-      ["AAPL", "BMW.DE"],
-      {},
-      { devel }
+    // make sure it passes validation for multiple symbols
+    it.each(zip(symbols, symbols.slice().reverse()))(
+      "for multiple symbols ('%s' and '%s')",
+      async (symbol1, symbol2) => {
+        const devel = `recommendationsBySymbol-${symbol1}-${symbol2}.json`;
+        await yf.recommendationsBySymbol([symbol1, symbol2], {}, { devel });
+      }
     );
-    expect(results.length).toBe(2);
-    expect(results[0].symbol).toBe("AAPL");
-    expect(results[1].symbol).toBe("BMW.DE");
   });
 
-  it("returns single for a string", async () => {
-    const devel = "recommendationsBySymbol-AAPL.json";
-    const result = await yf.recommendationsBySymbol("AAPL", {}, { devel });
+  it.each(zip(symbols, symbols.slice().reverse()))(
+    "returns an array for an array ('%s', '%s')",
+    async (symbol1, symbol2) => {
+      const devel = `recommendationsBySymbol-${symbol1}-${symbol2}.json`;
+      const results = await yf.recommendationsBySymbol(
+        [symbol1, symbol2],
+        {},
+        { devel }
+      );
+      expect(results.length).toBe(2);
+      expect(results[0].symbol).toBe(symbol1);
+      expect(results[1].symbol).toBe(symbol2);
+    }
+  );
+
+  it.each(symbols)("returns single for a string ('%s')", async (symbol) => {
+    const devel = `recommendationsBySymbol-${symbol}.json`;
+    const result = await yf.recommendationsBySymbol(symbol, {}, { devel });
     expect(Array.isArray(result)).toBe(false);
-    expect(result.symbol).toBe("AAPL");
+    expect(result.symbol).toBe(symbol);
   });
 
   if (process.env.FETCH_DEVEL !== "nocache")

--- a/tests/http/quote-0P000071W8.TO-AAPL.json
+++ b/tests/http/quote-0P000071W8.TO-AAPL.json
@@ -1,0 +1,197 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=0P000071W8.TO%2CAAPL"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "9n0kgstg2tgsp"
+      ],
+      "x-yahoo-request-id": [
+        "9n0kgstg2tgsp"
+      ],
+      "x-request-id": [
+        "4b7c3558-98c1-4fba-8dbf-b797fb191a5e"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1248"
+      ],
+      "x-envoy-upstream-service-time": [
+        "8"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:25 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "MUTUALFUND",
+            "quoteSourceName": "Delayed Quote",
+            "triggerable": true,
+            "currency": "CAD",
+            "gmtOffSetMilliseconds": -18000000,
+            "esgPopulated": false,
+            "exchange": "TOR",
+            "shortName": "TD U.S. Index Fund - e",
+            "longName": "TD U.S. Index Fund - e",
+            "exchangeTimezoneName": "America/Toronto",
+            "market": "ca_market",
+            "exchangeTimezoneShortName": "EST",
+            "tradeable": false,
+            "ytdReturn": 18.12,
+            "trailingThreeMonthReturns": 7.59,
+            "fiftyDayAverage": 86.81087,
+            "fiftyDayAverageChange": 2.56913,
+            "fiftyDayAverageChangePercent": 0.029594567,
+            "twoHundredDayAverage": 82.695,
+            "twoHundredDayAverageChange": 6.6849976,
+            "twoHundredDayAverageChangePercent": 0.0808392,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 15,
+            "firstTradeDateMilliseconds": 1344519000000,
+            "priceHint": 2,
+            "marketState": "REGULAR",
+            "regularMarketChange": -0.20999908,
+            "regularMarketChangePercent": -0.23440015,
+            "regularMarketTime": 1613592000,
+            "regularMarketPrice": 89.38,
+            "regularMarketPreviousClose": 89.59,
+            "fullExchangeName": "Toronto",
+            "averageDailyVolume3Month": 0,
+            "averageDailyVolume10Day": 0,
+            "fiftyTwoWeekLowChange": 32.199997,
+            "fiftyTwoWeekLowChangePercent": 0.5631339,
+            "fiftyTwoWeekRange": "57.18 - 89.59",
+            "fiftyTwoWeekHighChange": -0.20999908,
+            "fiftyTwoWeekHighChangePercent": -0.0023440016,
+            "fiftyTwoWeekLow": 57.18,
+            "fiftyTwoWeekHigh": 89.59,
+            "symbol": "0P000071W8.TO"
+          },
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "gmtOffSetMilliseconds": -18000000,
+            "esgPopulated": false,
+            "exchange": "NMS",
+            "shortName": "Apple Inc.",
+            "longName": "Apple Inc.",
+            "messageBoardId": "finmb_24937",
+            "exchangeTimezoneName": "America/New_York",
+            "market": "us_market",
+            "exchangeTimezoneShortName": "EST",
+            "tradeable": false,
+            "earningsTimestamp": 1611765000,
+            "earningsTimestampStart": 1619607540,
+            "earningsTimestampEnd": 1620043200,
+            "trailingAnnualDividendRate": 0.807,
+            "trailingPE": 34.906425,
+            "trailingAnnualDividendYield": 0.006167839,
+            "epsTrailingTwelveMonths": 3.687,
+            "epsForward": 4.68,
+            "epsCurrentYear": 4.45,
+            "priceEpsCurrentYear": 28.921349,
+            "sharesOutstanding": 16788100096,
+            "bookValue": 3.936,
+            "fiftyDayAverage": 133.76273,
+            "fiftyDayAverageChange": -5.062729,
+            "fiftyDayAverageChangePercent": -0.037848577,
+            "twoHundredDayAverage": 122.09259,
+            "twoHundredDayAverageChange": 6.6074066,
+            "twoHundredDayAverageChangePercent": 0.054118,
+            "marketCap": 2160628465664,
+            "forwardPE": 27.5,
+            "priceToBook": 32.69817,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "firstTradeDateMilliseconds": 345479400000,
+            "priceHint": 2,
+            "marketState": "REGULAR",
+            "regularMarketChange": -2.1399994,
+            "regularMarketChangePercent": -1.6355851,
+            "regularMarketTime": 1613677463,
+            "regularMarketPrice": 128.7,
+            "regularMarketDayHigh": 129.68,
+            "regularMarketDayRange": "127.41 - 129.68",
+            "regularMarketDayLow": 127.41,
+            "regularMarketVolume": 73643177,
+            "regularMarketPreviousClose": 130.84,
+            "bid": 128.73,
+            "ask": 128.74,
+            "bidSize": 8,
+            "askSize": 18,
+            "fullExchangeName": "NasdaqGS",
+            "financialCurrency": "USD",
+            "regularMarketOpen": 129.2,
+            "averageDailyVolume3Month": 103041345,
+            "averageDailyVolume10Day": 74862557,
+            "fiftyTwoWeekLowChange": 75.5475,
+            "fiftyTwoWeekLowChangePercent": 1.4213349,
+            "fiftyTwoWeekRange": "53.1525 - 145.09",
+            "fiftyTwoWeekHighChange": -16.39,
+            "fiftyTwoWeekHighChangePercent": -0.11296436,
+            "fiftyTwoWeekLow": 53.1525,
+            "fiftyTwoWeekHigh": 145.09,
+            "dividendDate": 1613001600,
+            "displayName": "Apple",
+            "symbol": "AAPL"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-AAPL-0P000071W8.TO.json
+++ b/tests/http/quote-AAPL-0P000071W8.TO.json
@@ -1,0 +1,197 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=AAPL%2C0P000071W8.TO"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "7lhfp0tg2tgsm"
+      ],
+      "x-yahoo-request-id": [
+        "7lhfp0tg2tgsm"
+      ],
+      "x-request-id": [
+        "412cbfa8-464e-4421-a5f4-2f5c5edda335"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1263"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:22 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "marketState": "REGULAR",
+            "regularMarketChange": -2.1149902,
+            "regularMarketChangePercent": -1.6164707,
+            "regularMarketTime": 1613677461,
+            "regularMarketPrice": 128.725,
+            "regularMarketDayHigh": 129.68,
+            "regularMarketDayRange": "127.41 - 129.68",
+            "regularMarketDayLow": 127.41,
+            "regularMarketVolume": 73640163,
+            "regularMarketPreviousClose": 130.84,
+            "bid": 128.73,
+            "ask": 128.74,
+            "bidSize": 8,
+            "askSize": 18,
+            "fullExchangeName": "NasdaqGS",
+            "financialCurrency": "USD",
+            "regularMarketOpen": 129.2,
+            "averageDailyVolume3Month": 103041345,
+            "averageDailyVolume10Day": 74862557,
+            "fiftyTwoWeekLowChange": 75.57251,
+            "fiftyTwoWeekLowChangePercent": 1.4218054,
+            "fiftyTwoWeekRange": "53.1525 - 145.09",
+            "fiftyTwoWeekHighChange": -16.36499,
+            "fiftyTwoWeekHighChangePercent": -0.11279199,
+            "fiftyTwoWeekLow": 53.1525,
+            "fiftyTwoWeekHigh": 145.09,
+            "dividendDate": 1613001600,
+            "earningsTimestamp": 1611765000,
+            "earningsTimestampStart": 1619607540,
+            "earningsTimestampEnd": 1620043200,
+            "trailingAnnualDividendRate": 0.807,
+            "trailingPE": 34.913208,
+            "trailingAnnualDividendYield": 0.006167839,
+            "epsTrailingTwelveMonths": 3.687,
+            "epsForward": 4.68,
+            "epsCurrentYear": 4.45,
+            "priceEpsCurrentYear": 28.92697,
+            "sharesOutstanding": 16788100096,
+            "bookValue": 3.936,
+            "fiftyDayAverage": 133.76273,
+            "fiftyDayAverageChange": -5.0377197,
+            "fiftyDayAverageChangePercent": -0.037661612,
+            "twoHundredDayAverage": 122.09259,
+            "twoHundredDayAverageChange": 6.632416,
+            "twoHundredDayAverageChangePercent": 0.054322835,
+            "marketCap": 2161048289280,
+            "forwardPE": 27.505344,
+            "priceToBook": 32.70452,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "firstTradeDateMilliseconds": 345479400000,
+            "priceHint": 2,
+            "tradeable": false,
+            "exchange": "NMS",
+            "shortName": "Apple Inc.",
+            "longName": "Apple Inc.",
+            "messageBoardId": "finmb_24937",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "displayName": "Apple",
+            "symbol": "AAPL"
+          },
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "MUTUALFUND",
+            "quoteSourceName": "Delayed Quote",
+            "triggerable": true,
+            "currency": "CAD",
+            "marketState": "REGULAR",
+            "regularMarketChange": -0.20999908,
+            "regularMarketChangePercent": -0.23440015,
+            "regularMarketTime": 1613592000,
+            "regularMarketPrice": 89.38,
+            "regularMarketPreviousClose": 89.59,
+            "fullExchangeName": "Toronto",
+            "averageDailyVolume3Month": 0,
+            "averageDailyVolume10Day": 0,
+            "fiftyTwoWeekLowChange": 32.199997,
+            "fiftyTwoWeekLowChangePercent": 0.5631339,
+            "fiftyTwoWeekRange": "57.18 - 89.59",
+            "fiftyTwoWeekHighChange": -0.20999908,
+            "fiftyTwoWeekHighChangePercent": -0.0023440016,
+            "fiftyTwoWeekLow": 57.18,
+            "fiftyTwoWeekHigh": 89.59,
+            "ytdReturn": 18.12,
+            "trailingThreeMonthReturns": 7.59,
+            "fiftyDayAverage": 86.81087,
+            "fiftyDayAverageChange": 2.56913,
+            "fiftyDayAverageChangePercent": 0.029594567,
+            "twoHundredDayAverage": 82.695,
+            "twoHundredDayAverageChange": 6.6849976,
+            "twoHundredDayAverageChangePercent": 0.0808392,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 15,
+            "firstTradeDateMilliseconds": 1344519000000,
+            "priceHint": 2,
+            "tradeable": false,
+            "exchange": "TOR",
+            "shortName": "TD U.S. Index Fund - e",
+            "longName": "TD U.S. Index Fund - e",
+            "exchangeTimezoneName": "America/Toronto",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "ca_market",
+            "esgPopulated": false,
+            "symbol": "0P000071W8.TO"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-ADH-QQQ.json
+++ b/tests/http/quote-ADH-QQQ.json
@@ -1,0 +1,175 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=ADH%2CQQQ"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "ehd66nhg2tgsm"
+      ],
+      "x-yahoo-request-id": [
+        "ehd66nhg2tgsm"
+      ],
+      "x-request-id": [
+        "0cf572e4-084d-4ba3-91ee-adcd3d9e20a2"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1040"
+      ],
+      "x-envoy-upstream-service-time": [
+        "6"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:22 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "MUTUALFUND",
+            "quoteSourceName": "Delayed Quote",
+            "triggerable": false,
+            "priceHint": 2,
+            "regularMarketTime": 1561759658,
+            "fiftyDayAverage": 6.794706,
+            "twoHundredDayAverage": 6.402117,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "marketState": "REGULAR",
+            "exchange": "YHD",
+            "shortName": "54688",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "firstTradeDateMilliseconds": 1152538200000,
+            "fullExchangeName": "YHD",
+            "averageDailyVolume3Month": 212721,
+            "averageDailyVolume10Day": 100595,
+            "fiftyTwoWeekRange": "5.6 - 9.24",
+            "fiftyTwoWeekLow": 5.6,
+            "fiftyTwoWeekHigh": 9.24,
+            "symbol": "ADH"
+          },
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "ETF",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "priceHint": 2,
+            "regularMarketChange": -2.0099792,
+            "regularMarketChangePercent": -0.6019164,
+            "regularMarketTime": 1613677458,
+            "regularMarketPrice": 331.92,
+            "regularMarketDayHigh": 333.8661,
+            "regularMarketDayRange": "328.36 - 333.8661",
+            "regularMarketDayLow": 328.36,
+            "regularMarketVolume": 23573233,
+            "regularMarketPreviousClose": 333.93,
+            "bid": 331.87,
+            "ask": 331.83,
+            "bidSize": 18,
+            "askSize": 11,
+            "sharesOutstanding": 393100000,
+            "bookValue": 188.775,
+            "fiftyDayAverage": 322.49728,
+            "fiftyDayAverageChange": 9.4227295,
+            "fiftyDayAverageChangePercent": 0.029218012,
+            "twoHundredDayAverage": 295.23254,
+            "twoHundredDayAverageChange": 36.68747,
+            "twoHundredDayAverageChangePercent": 0.12426635,
+            "marketCap": 130477760512,
+            "priceToBook": 1.7582839,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "marketState": "REGULAR",
+            "exchange": "NMS",
+            "shortName": "Invesco QQQ Trust, Series 1",
+            "longName": "Invesco QQQ Trust",
+            "messageBoardId": "finmb_8108558",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "firstTradeDateMilliseconds": 921076200000,
+            "fullExchangeName": "NasdaqGS",
+            "financialCurrency": "USD",
+            "regularMarketOpen": 330.23,
+            "averageDailyVolume3Month": 28331339,
+            "averageDailyVolume10Day": 23851857,
+            "fiftyTwoWeekLowChange": 166.99002,
+            "fiftyTwoWeekLowChangePercent": 1.0124903,
+            "fiftyTwoWeekRange": "164.93 - 338.19",
+            "fiftyTwoWeekHighChange": -6.269989,
+            "fiftyTwoWeekHighChangePercent": -0.018539842,
+            "fiftyTwoWeekLow": 164.93,
+            "fiftyTwoWeekHigh": 338.19,
+            "trailingAnnualDividendRate": 1.54,
+            "trailingPE": 85.21695,
+            "trailingAnnualDividendYield": 0.004611745,
+            "ytdReturn": 0.31,
+            "trailingThreeMonthReturns": 16.98,
+            "trailingThreeMonthNavReturns": 17.08,
+            "epsTrailingTwelveMonths": 3.895,
+            "symbol": "QQQ"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-AFRAF-BABA.json
+++ b/tests/http/quote-AFRAF-BABA.json
@@ -1,0 +1,209 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=AFRAF%2CBABA"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "cbe2sptg2tgsm"
+      ],
+      "x-yahoo-request-id": [
+        "cbe2sptg2tgsm"
+      ],
+      "x-request-id": [
+        "b2398f2c-5b97-4627-9f14-42cf4bc69cb9"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1293"
+      ],
+      "x-envoy-upstream-service-time": [
+        "19"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:22 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Delayed Quote",
+            "triggerable": false,
+            "currency": "USD",
+            "firstTradeDateMilliseconds": 1331731800000,
+            "priceHint": 2,
+            "regularMarketChange": -0.21499968,
+            "regularMarketChangePercent": -3.61344,
+            "regularMarketTime": 1613661689,
+            "regularMarketPrice": 5.735,
+            "regularMarketDayHigh": 5.735,
+            "regularMarketDayRange": "5.735 - 5.735",
+            "regularMarketDayLow": 5.735,
+            "regularMarketVolume": 210,
+            "regularMarketPreviousClose": 5.95,
+            "bid": 0,
+            "ask": 0,
+            "bidSize": 0,
+            "askSize": 0,
+            "fullExchangeName": "Other OTC",
+            "financialCurrency": "EUR",
+            "regularMarketOpen": 5.735,
+            "averageDailyVolume3Month": 2700,
+            "averageDailyVolume10Day": 1857,
+            "fiftyTwoWeekLowChange": 2.4650002,
+            "fiftyTwoWeekLowChangePercent": 0.7538227,
+            "fiftyTwoWeekRange": "3.27 - 10.95",
+            "fiftyTwoWeekHighChange": -5.2149997,
+            "fiftyTwoWeekHighChangePercent": -0.47625569,
+            "fiftyTwoWeekLow": 3.27,
+            "fiftyTwoWeekHigh": 10.95,
+            "dividendDate": 1216252800,
+            "epsTrailingTwelveMonths": -1.903,
+            "sharesOutstanding": 427432000,
+            "bookValue": 8.847,
+            "fiftyDayAverage": 5.971212,
+            "fiftyDayAverageChange": -0.23621178,
+            "fiftyDayAverageChangePercent": -0.039558433,
+            "twoHundredDayAverage": 4.960219,
+            "twoHundredDayAverageChange": 0.7747812,
+            "twoHundredDayAverageChangePercent": 0.156199,
+            "marketCap": 2389229568,
+            "priceToBook": 0.64824235,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "exchange": "PNK",
+            "shortName": "AIR FRANCE-KLM",
+            "longName": "Air France-KLM SA",
+            "messageBoardId": "finmb_4463198",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "marketState": "REGULAR",
+            "symbol": "AFRAF"
+          },
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "firstTradeDateMilliseconds": 1411133400000,
+            "priceHint": 2,
+            "regularMarketChange": -5.899994,
+            "regularMarketChangePercent": -2.178486,
+            "regularMarketTime": 1613677455,
+            "regularMarketPrice": 264.93,
+            "regularMarketDayHigh": 265.425,
+            "regularMarketDayRange": "262.33 - 265.425",
+            "regularMarketDayLow": 262.33,
+            "regularMarketVolume": 9700864,
+            "regularMarketPreviousClose": 270.83,
+            "bid": 265.08,
+            "ask": 265.15,
+            "bidSize": 8,
+            "askSize": 10,
+            "fullExchangeName": "NYSE",
+            "financialCurrency": "CNY",
+            "regularMarketOpen": 265.23,
+            "averageDailyVolume3Month": 23712808,
+            "averageDailyVolume10Day": 12949357,
+            "fiftyTwoWeekLowChange": 94.979996,
+            "fiftyTwoWeekLowChangePercent": 0.55887026,
+            "fiftyTwoWeekRange": "169.95 - 319.32",
+            "fiftyTwoWeekHighChange": -54.390015,
+            "fiftyTwoWeekHighChangePercent": -0.17033075,
+            "fiftyTwoWeekLow": 169.95,
+            "fiftyTwoWeekHigh": 319.32,
+            "earningsTimestamp": 1612249320,
+            "earningsTimestampStart": 1612249320,
+            "earningsTimestampEnd": 1612249320,
+            "trailingPE": 28.456497,
+            "epsTrailingTwelveMonths": 9.31,
+            "epsForward": 12.09,
+            "epsCurrentYear": 10.39,
+            "priceEpsCurrentYear": 25.498554,
+            "sharesOutstanding": 2705639936,
+            "bookValue": 24.798,
+            "fiftyDayAverage": 252.51848,
+            "fiftyDayAverageChange": 12.411514,
+            "fiftyDayAverageChangePercent": 0.049150914,
+            "twoHundredDayAverage": 270.33395,
+            "twoHundredDayAverageChange": -5.403961,
+            "twoHundredDayAverageChangePercent": -0.019989947,
+            "marketCap": 731055718400,
+            "forwardPE": 21.91315,
+            "priceToBook": 10.683522,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "exchange": "NYQ",
+            "shortName": "Alibaba Group Holding Limited",
+            "longName": "Alibaba Group Holding Limited",
+            "messageBoardId": "finmb_42083601",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "marketState": "REGULAR",
+            "displayName": "Alibaba",
+            "symbol": "BABA"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-AMZN-OCDO.L.json
+++ b/tests/http/quote-AMZN-OCDO.L.json
@@ -1,0 +1,211 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=AMZN%2COCDO.L"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "22salupg2tgsn"
+      ],
+      "x-yahoo-request-id": [
+        "22salupg2tgsn"
+      ],
+      "x-request-id": [
+        "fb17b93c-db22-402e-b001-af59718cead3"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1345"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:22 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "sharesOutstanding": 500889984,
+            "bookValue": 185.694,
+            "fiftyDayAverage": 3245.279,
+            "fiftyDayAverageChange": 78.87085,
+            "fiftyDayAverageChangePercent": 0.024303257,
+            "twoHundredDayAverage": 3207.455,
+            "twoHundredDayAverageChange": 116.694824,
+            "twoHundredDayAverageChangePercent": 0.036382373,
+            "marketCap": 1673925492736,
+            "forwardPE": 50.02483,
+            "priceToBook": 17.901224,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "regularMarketChange": 15.51001,
+            "regularMarketChangePercent": 0.46877298,
+            "regularMarketTime": 1613677436,
+            "regularMarketPrice": 3324.15,
+            "regularMarketDayHigh": 3338,
+            "regularMarketDayRange": "3273.94 - 3338.0",
+            "regularMarketDayLow": 3273.94,
+            "regularMarketVolume": 2228095,
+            "regularMarketPreviousClose": 3308.64,
+            "bid": 3325.74,
+            "ask": 3328.6,
+            "bidSize": 9,
+            "askSize": 9,
+            "fullExchangeName": "NasdaqGS",
+            "financialCurrency": "USD",
+            "regularMarketOpen": 3282.42,
+            "averageDailyVolume3Month": 3634800,
+            "averageDailyVolume10Day": 2731628,
+            "fiftyTwoWeekLowChange": 1698.1199,
+            "fiftyTwoWeekLowChangePercent": 1.0443349,
+            "fiftyTwoWeekRange": "1626.03 - 3552.25",
+            "fiftyTwoWeekHighChange": -228.1001,
+            "fiftyTwoWeekHighChangePercent": -0.06421285,
+            "fiftyTwoWeekLow": 1626.03,
+            "fiftyTwoWeekHigh": 3552.25,
+            "earningsTimestamp": 1612281780,
+            "earningsTimestampStart": 1619640000,
+            "earningsTimestampEnd": 1620072000,
+            "trailingPE": 79.46808,
+            "epsTrailingTwelveMonths": 41.83,
+            "epsForward": 66.45,
+            "epsCurrentYear": 47.62,
+            "priceEpsCurrentYear": 69.805756,
+            "firstTradeDateMilliseconds": 863703000000,
+            "priceHint": 2,
+            "exchange": "NMS",
+            "shortName": "Amazon.com, Inc.",
+            "longName": "Amazon.com, Inc.",
+            "messageBoardId": "finmb_18749",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "marketState": "REGULAR",
+            "displayName": "Amazon.com",
+            "symbol": "AMZN"
+          },
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Delayed Quote",
+            "triggerable": false,
+            "currency": "GBp",
+            "sharesOutstanding": 748801984,
+            "bookValue": 2.394,
+            "fiftyDayAverage": 2614.5881,
+            "fiftyDayAverageChange": -46.588135,
+            "fiftyDayAverageChangePercent": -0.017818537,
+            "twoHundredDayAverage": 2443.1,
+            "twoHundredDayAverageChange": 124.8999,
+            "twoHundredDayAverageChangePercent": 0.05112353,
+            "marketCap": 19229235200,
+            "priceToBook": 1072.6816,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 20,
+            "tradeable": false,
+            "regularMarketChange": -25,
+            "regularMarketChangePercent": -0.9641342,
+            "regularMarketTime": 1613666318,
+            "regularMarketPrice": 2568,
+            "regularMarketDayHigh": 2598,
+            "regularMarketDayRange": "2528.0 - 2598.0",
+            "regularMarketDayLow": 2528,
+            "regularMarketVolume": 885289,
+            "regularMarketPreviousClose": 2593,
+            "bid": 2551,
+            "ask": 2553,
+            "bidSize": 0,
+            "askSize": 0,
+            "fullExchangeName": "LSE",
+            "financialCurrency": "GBP",
+            "regularMarketOpen": 2570,
+            "averageDailyVolume3Month": 1636988,
+            "averageDailyVolume10Day": 1293261,
+            "fiftyTwoWeekLowChange": 1573.988,
+            "fiftyTwoWeekLowChangePercent": 1.5834699,
+            "fiftyTwoWeekRange": "994.012 - 2914.0",
+            "fiftyTwoWeekHighChange": -346,
+            "fiftyTwoWeekHighChangePercent": -0.11873713,
+            "fiftyTwoWeekLow": 994.012,
+            "fiftyTwoWeekHigh": 2914,
+            "earningsTimestamp": 1612836000,
+            "earningsTimestampStart": 1612836000,
+            "earningsTimestampEnd": 1612836000,
+            "epsTrailingTwelveMonths": -17.5,
+            "firstTradeDateMilliseconds": 1279695600000,
+            "priceHint": 2,
+            "exchange": "LSE",
+            "shortName": "OCADO GROUP PLC ORD 2P",
+            "longName": "Ocado Group plc",
+            "messageBoardId": "finmb_109303666",
+            "exchangeTimezoneName": "Europe/London",
+            "exchangeTimezoneShortName": "GMT",
+            "gmtOffSetMilliseconds": 0,
+            "market": "gb_market",
+            "esgPopulated": false,
+            "marketState": "POSTPOST",
+            "symbol": "OCDO.L"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-AZT.OL-UNIR.MI.json
+++ b/tests/http/quote-AZT.OL-UNIR.MI.json
@@ -1,0 +1,196 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=AZT.OL%2CUNIR.MI"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "b02i3mpg2tgsn"
+      ],
+      "x-yahoo-request-id": [
+        "b02i3mpg2tgsn"
+      ],
+      "x-request-id": [
+        "be1ac632-388f-4efa-b551-1fb92e3136d8"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1138"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:22 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "triggerable": false,
+            "gmtOffSetMilliseconds": 3600000,
+            "market": "no_market",
+            "esgPopulated": false,
+            "currency": "NOK",
+            "tradeable": false,
+            "sharesOutstanding": 48334700,
+            "bookValue": 4.018,
+            "regularMarketChange": 0.19999695,
+            "regularMarketChangePercent": 0.27777356,
+            "regularMarketTime": 1613661913,
+            "regularMarketPrice": 72.2,
+            "regularMarketDayHigh": 73,
+            "regularMarketDayRange": "71.2 - 73.0",
+            "regularMarketDayLow": 71.2,
+            "regularMarketVolume": 587033,
+            "regularMarketPreviousClose": 72,
+            "bid": 71.8,
+            "ask": 74.8,
+            "fullExchangeName": "Oslo",
+            "financialCurrency": "NOK",
+            "regularMarketOpen": 72,
+            "fiftyTwoWeekLowChange": 1,
+            "fiftyTwoWeekLowChangePercent": 0.014044944,
+            "fiftyTwoWeekRange": "71.2 - 73.0",
+            "fiftyTwoWeekHighChange": -0.80000305,
+            "fiftyTwoWeekHighChangePercent": -0.010958946,
+            "fiftyTwoWeekLow": 71.2,
+            "fiftyTwoWeekHigh": 73,
+            "earningsTimestamp": 1611801000,
+            "earningsTimestampStart": 1611801000,
+            "earningsTimestampEnd": 1611801000,
+            "trailingPE": 41.97674,
+            "epsTrailingTwelveMonths": 1.72,
+            "marketCap": 3489765120,
+            "priceToBook": 17.969137,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "priceHint": 2,
+            "exchange": "OSL",
+            "shortName": "ARCTICZYMES TECH",
+            "longName": "ArcticZymes Technologies ASA",
+            "messageBoardId": "finmb_13529463",
+            "exchangeTimezoneName": "Europe/Oslo",
+            "exchangeTimezoneShortName": "CET",
+            "marketState": "POSTPOST",
+            "symbol": "AZT.OL"
+          },
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "triggerable": false,
+            "gmtOffSetMilliseconds": 3600000,
+            "market": "it_market",
+            "esgPopulated": false,
+            "currency": "EUR",
+            "tradeable": false,
+            "sharesOutstanding": 20208400,
+            "bookValue": 6.862,
+            "fiftyDayAverage": 13.915882,
+            "fiftyDayAverageChange": 1.0441179,
+            "fiftyDayAverageChangePercent": 0.07503067,
+            "twoHundredDayAverage": 11.860647,
+            "twoHundredDayAverageChangePercent": 0.26131397,
+            "firstTradeDateMilliseconds": 1491289200000,
+            "regularMarketChange": -0.3000002,
+            "regularMarketChangePercent": -1.9659253,
+            "regularMarketTime": 1613666126,
+            "regularMarketPrice": 14.96,
+            "regularMarketDayHigh": 15.66,
+            "regularMarketDayRange": "14.94 - 15.66",
+            "regularMarketDayLow": 14.94,
+            "regularMarketVolume": 464206,
+            "regularMarketPreviousClose": 15.26,
+            "bid": 14.92,
+            "ask": 15.34,
+            "bidSize": 0,
+            "askSize": 0,
+            "fullExchangeName": "Milan",
+            "financialCurrency": "EUR",
+            "regularMarketOpen": 15.28,
+            "averageDailyVolume3Month": 303653,
+            "averageDailyVolume10Day": 280428,
+            "fiftyTwoWeekLowChange": 9.93,
+            "fiftyTwoWeekLowChangePercent": 1.9741551,
+            "fiftyTwoWeekRange": "5.03 - 15.96",
+            "fiftyTwoWeekHighChange": -1,
+            "fiftyTwoWeekHighChangePercent": -0.06265664,
+            "fiftyTwoWeekLow": 5.03,
+            "fiftyTwoWeekHigh": 15.96,
+            "earningsTimestamp": 1620298740,
+            "earningsTimestampStart": 1620298740,
+            "earningsTimestampEnd": 1620298740,
+            "trailingAnnualDividendRate": 1.07,
+            "trailingPE": 5.1926413,
+            "trailingAnnualDividendYield": 0.07011796,
+            "epsTrailingTwelveMonths": 2.881,
+            "twoHundredDayAverageChange": 3.0993528,
+            "marketCap": 302317664,
+            "priceToBook": 2.1801224,
+            "sourceInterval": 20,
+            "exchangeDataDelayedBy": 0,
+            "priceHint": 2,
+            "exchange": "MIL",
+            "shortName": "UNIEURO",
+            "longName": "Unieuro S.p.A.",
+            "messageBoardId": "finmb_931146",
+            "exchangeTimezoneName": "Europe/Rome",
+            "exchangeTimezoneShortName": "CET",
+            "marketState": "POSTPOST",
+            "symbol": "UNIR.MI"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-BABA-AFRAF.json
+++ b/tests/http/quote-BABA-AFRAF.json
@@ -1,0 +1,209 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=BABA%2CAFRAF"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "88oddehg2tgso"
+      ],
+      "x-yahoo-request-id": [
+        "88oddehg2tgso"
+      ],
+      "x-request-id": [
+        "190aeb68-60f5-4c94-a392-67c01fbdb8e4"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1296"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:24 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "tradeable": false,
+            "fiftyTwoWeekLowChange": 94.979996,
+            "fiftyTwoWeekLowChangePercent": 0.55887026,
+            "fiftyTwoWeekRange": "169.95 - 319.32",
+            "fiftyTwoWeekHighChange": -54.390015,
+            "fiftyTwoWeekHighChangePercent": -0.17033075,
+            "fiftyTwoWeekLow": 169.95,
+            "fiftyTwoWeekHigh": 319.32,
+            "earningsTimestamp": 1612249320,
+            "earningsTimestampStart": 1612249320,
+            "earningsTimestampEnd": 1612249320,
+            "trailingPE": 28.456497,
+            "epsTrailingTwelveMonths": 9.31,
+            "epsForward": 12.09,
+            "epsCurrentYear": 10.39,
+            "priceEpsCurrentYear": 25.498554,
+            "sharesOutstanding": 2705639936,
+            "bookValue": 24.798,
+            "fiftyDayAverage": 252.51848,
+            "fiftyDayAverageChange": 12.411514,
+            "fiftyDayAverageChangePercent": 0.049150914,
+            "twoHundredDayAverage": 270.33395,
+            "twoHundredDayAverageChange": -5.403961,
+            "twoHundredDayAverageChangePercent": -0.019989947,
+            "marketCap": 731055718400,
+            "forwardPE": 21.91315,
+            "priceToBook": 10.683522,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "firstTradeDateMilliseconds": 1411133400000,
+            "priceHint": 2,
+            "regularMarketChange": -5.899994,
+            "regularMarketChangePercent": -2.178486,
+            "regularMarketTime": 1613677455,
+            "regularMarketPrice": 264.93,
+            "regularMarketDayHigh": 265.425,
+            "regularMarketDayRange": "262.33 - 265.425",
+            "regularMarketDayLow": 262.33,
+            "regularMarketVolume": 9700868,
+            "regularMarketPreviousClose": 270.83,
+            "bid": 265.08,
+            "ask": 265.15,
+            "bidSize": 8,
+            "askSize": 10,
+            "fullExchangeName": "NYSE",
+            "financialCurrency": "CNY",
+            "regularMarketOpen": 265.23,
+            "averageDailyVolume3Month": 23712808,
+            "averageDailyVolume10Day": 12949357,
+            "exchange": "NYQ",
+            "shortName": "Alibaba Group Holding Limited",
+            "longName": "Alibaba Group Holding Limited",
+            "messageBoardId": "finmb_42083601",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "marketState": "REGULAR",
+            "displayName": "Alibaba",
+            "symbol": "BABA"
+          },
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Delayed Quote",
+            "triggerable": false,
+            "currency": "USD",
+            "tradeable": false,
+            "fiftyTwoWeekLowChange": 2.4650002,
+            "fiftyTwoWeekLowChangePercent": 0.7538227,
+            "fiftyTwoWeekRange": "3.27 - 10.95",
+            "fiftyTwoWeekHighChange": -5.2149997,
+            "fiftyTwoWeekHighChangePercent": -0.47625569,
+            "fiftyTwoWeekLow": 3.27,
+            "fiftyTwoWeekHigh": 10.95,
+            "dividendDate": 1216252800,
+            "epsTrailingTwelveMonths": -1.903,
+            "sharesOutstanding": 427432000,
+            "bookValue": 8.847,
+            "fiftyDayAverage": 5.971212,
+            "fiftyDayAverageChange": -0.23621178,
+            "fiftyDayAverageChangePercent": -0.039558433,
+            "twoHundredDayAverage": 4.960219,
+            "twoHundredDayAverageChange": 0.7747812,
+            "twoHundredDayAverageChangePercent": 0.156199,
+            "marketCap": 2389229568,
+            "priceToBook": 0.64824235,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "firstTradeDateMilliseconds": 1331731800000,
+            "priceHint": 2,
+            "regularMarketChange": -0.21499968,
+            "regularMarketChangePercent": -3.61344,
+            "regularMarketTime": 1613661689,
+            "regularMarketPrice": 5.735,
+            "regularMarketDayHigh": 5.735,
+            "regularMarketDayRange": "5.735 - 5.735",
+            "regularMarketDayLow": 5.735,
+            "regularMarketVolume": 210,
+            "regularMarketPreviousClose": 5.95,
+            "bid": 0,
+            "ask": 0,
+            "bidSize": 0,
+            "askSize": 0,
+            "fullExchangeName": "Other OTC",
+            "financialCurrency": "EUR",
+            "regularMarketOpen": 5.735,
+            "averageDailyVolume3Month": 2700,
+            "averageDailyVolume10Day": 1857,
+            "exchange": "PNK",
+            "shortName": "AIR FRANCE-KLM",
+            "longName": "Air France-KLM SA",
+            "messageBoardId": "finmb_4463198",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "marketState": "REGULAR",
+            "symbol": "AFRAF"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-BEKE-GOOG.json
+++ b/tests/http/quote-BEKE-GOOG.json
@@ -1,0 +1,205 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=BEKE%2CGOOG"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "80o2sihg2tgsn"
+      ],
+      "x-yahoo-request-id": [
+        "80o2sihg2tgsn"
+      ],
+      "x-request-id": [
+        "e4b214fc-530b-429b-82be-6116688d1352"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1250"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:23 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "firstTradeDateMilliseconds": 1597325400000,
+            "priceHint": 2,
+            "regularMarketChange": -2.6399994,
+            "regularMarketChangePercent": -3.9598012,
+            "regularMarketTime": 1613677445,
+            "regularMarketPrice": 64.03,
+            "regularMarketDayHigh": 65.84,
+            "regularMarketDayRange": "63.295 - 65.84",
+            "regularMarketDayLow": 63.295,
+            "regularMarketVolume": 3090043,
+            "regularMarketPreviousClose": 66.67,
+            "bid": 64.22,
+            "ask": 64.29,
+            "bidSize": 9,
+            "askSize": 18,
+            "fullExchangeName": "NYSE",
+            "financialCurrency": "CNY",
+            "regularMarketOpen": 65.29,
+            "averageDailyVolume3Month": 3739085,
+            "averageDailyVolume10Day": 5283557,
+            "fiftyTwoWeekLowChange": 32.239998,
+            "fiftyTwoWeekLowChangePercent": 1.0141553,
+            "fiftyTwoWeekRange": "31.79 - 79.4",
+            "fiftyTwoWeekHighChange": -15.370003,
+            "fiftyTwoWeekHighChangePercent": -0.19357686,
+            "fiftyTwoWeekLow": 31.79,
+            "fiftyTwoWeekHigh": 79.4,
+            "epsCurrentYear": 0.75,
+            "priceEpsCurrentYear": 85.37333,
+            "sharesOutstanding": 1143379968,
+            "fiftyDayAverage": 64.72818,
+            "fiftyDayAverageChange": -0.69818115,
+            "fiftyDayAverageChangePercent": -0.0107863555,
+            "twoHundredDayAverage": 61.72527,
+            "twoHundredDayAverageChange": 2.3047295,
+            "twoHundredDayAverageChangePercent": 0.037338506,
+            "marketCap": 75477286912,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "ipoExpectedDate": "2020-08-13",
+            "tradeable": false,
+            "exchange": "NYQ",
+            "shortName": "KE Holdings Inc",
+            "longName": "KE Holdings Inc.",
+            "messageBoardId": "finmb_665898843",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "marketState": "REGULAR",
+            "symbol": "BEKE"
+          },
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "firstTradeDateMilliseconds": 1092922200000,
+            "priceHint": 2,
+            "regularMarketChange": -3.340088,
+            "regularMarketChangePercent": -0.15693615,
+            "regularMarketTime": 1613677453,
+            "regularMarketPrice": 2124.97,
+            "regularMarketDayHigh": 2126.43,
+            "regularMarketDayRange": "2104.28 - 2126.43",
+            "regularMarketDayLow": 2104.28,
+            "regularMarketVolume": 698786,
+            "regularMarketPreviousClose": 2128.31,
+            "bid": 2117.62,
+            "ask": 2117.97,
+            "bidSize": 9,
+            "askSize": 12,
+            "fullExchangeName": "NasdaqGS",
+            "financialCurrency": "USD",
+            "regularMarketOpen": 2110.39,
+            "averageDailyVolume3Month": 1564532,
+            "averageDailyVolume10Day": 1038942,
+            "fiftyTwoWeekLowChange": 1111.434,
+            "fiftyTwoWeekLowChangePercent": 1.0965905,
+            "fiftyTwoWeekRange": "1013.536 - 2152.68",
+            "fiftyTwoWeekHighChange": -27.70996,
+            "fiftyTwoWeekHighChangePercent": -0.0128723085,
+            "fiftyTwoWeekLow": 1013.536,
+            "fiftyTwoWeekHigh": 2152.68,
+            "trailingPE": 36.254246,
+            "epsTrailingTwelveMonths": 58.613,
+            "epsForward": 81.21,
+            "epsCurrentYear": 69.79,
+            "priceEpsCurrentYear": 30.448057,
+            "sharesOutstanding": 329867008,
+            "bookValue": 329.586,
+            "fiftyDayAverage": 1897.9395,
+            "fiftyDayAverageChange": 227.03052,
+            "fiftyDayAverageChangePercent": 0.119619474,
+            "twoHundredDayAverage": 1689.6525,
+            "twoHundredDayAverageChange": 435.3175,
+            "twoHundredDayAverageChangePercent": 0.2576373,
+            "marketCap": 1429167669248,
+            "forwardPE": 26.166359,
+            "priceToBook": 6.4473915,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "exchange": "NMS",
+            "shortName": "Alphabet Inc.",
+            "longName": "Alphabet Inc.",
+            "messageBoardId": "finmb_29096",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "marketState": "REGULAR",
+            "displayName": "Alphabet",
+            "symbol": "GOOG"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-BFLY-SPOT.json
+++ b/tests/http/quote-BFLY-SPOT.json
@@ -1,0 +1,202 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=BFLY%2CSPOT"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "3g3mb0lg2tgsn"
+      ],
+      "x-yahoo-request-id": [
+        "3g3mb0lg2tgsn"
+      ],
+      "x-request-id": [
+        "a8cda02e-d5ca-4d7e-b852-0352ff80034a"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1217"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:23 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "regularMarketChange": 0.6800003,
+            "regularMarketChangePercent": 2.5855525,
+            "regularMarketTime": 1613677429,
+            "regularMarketPrice": 26.98,
+            "regularMarketDayHigh": 29.13,
+            "regularMarketDayRange": "25.11 - 29.13",
+            "regularMarketDayLow": 25.11,
+            "fiftyDayAverage": 24.4,
+            "fiftyDayAverageChange": 2.58,
+            "fiftyDayAverageChangePercent": 0.1057377,
+            "twoHundredDayAverage": 19.563334,
+            "twoHundredDayAverageChange": 7.416666,
+            "twoHundredDayAverageChangePercent": 0.37911054,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "newListingDate": "2021-02-16",
+            "tradeable": false,
+            "firstTradeDateMilliseconds": 1594647000000,
+            "priceHint": 2,
+            "marketState": "REGULAR",
+            "regularMarketVolume": 5624880,
+            "regularMarketPreviousClose": 26.3,
+            "bid": 27.14,
+            "ask": 27.18,
+            "bidSize": 22,
+            "askSize": 10,
+            "fullExchangeName": "NYSE",
+            "regularMarketOpen": 26,
+            "averageDailyVolume3Month": 4745100,
+            "averageDailyVolume10Day": 4745100,
+            "fiftyTwoWeekLowChange": 17.09,
+            "fiftyTwoWeekLowChangePercent": 1.728008,
+            "fiftyTwoWeekRange": "9.89 - 29.13",
+            "fiftyTwoWeekHighChange": -2.1499996,
+            "fiftyTwoWeekHighChangePercent": -0.07380706,
+            "fiftyTwoWeekLow": 9.89,
+            "fiftyTwoWeekHigh": 29.13,
+            "exchange": "NYQ",
+            "shortName": "Butterfly Network, Inc. Class A",
+            "longName": "Butterfly Network, Inc.",
+            "messageBoardId": "finmb_275830634",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "symbol": "BFLY"
+          },
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "regularMarketChange": 0.65078735,
+            "regularMarketChangePercent": 0.18322232,
+            "regularMarketTime": 1613677435,
+            "regularMarketPrice": 355.8408,
+            "regularMarketDayHigh": 355.96,
+            "regularMarketDayRange": "341.59 - 355.96",
+            "regularMarketDayLow": 341.59,
+            "epsTrailingTwelveMonths": -7.629,
+            "epsForward": -0.86,
+            "epsCurrentYear": -1.89,
+            "priceEpsCurrentYear": -188.27556,
+            "sharesOutstanding": 189586000,
+            "bookValue": 10.251,
+            "fiftyDayAverage": 331.26605,
+            "fiftyDayAverageChange": 24.574738,
+            "fiftyDayAverageChangePercent": 0.07418429,
+            "twoHundredDayAverage": 284.56094,
+            "twoHundredDayAverageChange": 71.27985,
+            "twoHundredDayAverageChangePercent": 0.2504906,
+            "marketCap": 67685539840,
+            "forwardPE": -413.76834,
+            "priceToBook": 34.712788,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "firstTradeDateMilliseconds": 1522762200000,
+            "priceHint": 2,
+            "marketState": "REGULAR",
+            "regularMarketVolume": 1017249,
+            "regularMarketPreviousClose": 355.19,
+            "bid": 354.03,
+            "ask": 354.49,
+            "bidSize": 8,
+            "askSize": 11,
+            "fullExchangeName": "NYSE",
+            "financialCurrency": "EUR",
+            "regularMarketOpen": 353.57,
+            "averageDailyVolume3Month": 1544000,
+            "averageDailyVolume10Day": 1414200,
+            "fiftyTwoWeekLowChange": 246.6608,
+            "fiftyTwoWeekLowChangePercent": 2.2592123,
+            "fiftyTwoWeekRange": "109.18 - 370.95",
+            "fiftyTwoWeekHighChange": -15.109222,
+            "fiftyTwoWeekHighChangePercent": -0.040731154,
+            "fiftyTwoWeekLow": 109.18,
+            "fiftyTwoWeekHigh": 370.95,
+            "earningsTimestamp": 1612332000,
+            "earningsTimestampStart": 1619526600,
+            "earningsTimestampEnd": 1620045000,
+            "exchange": "NYQ",
+            "shortName": "Spotify Technology S.A.",
+            "longName": "Spotify Technology S.A.",
+            "messageBoardId": "finmb_225595077",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "displayName": "Spotify ",
+            "symbol": "SPOT"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-GOOG-BEKE.json
+++ b/tests/http/quote-GOOG-BEKE.json
@@ -1,0 +1,205 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=GOOG%2CBEKE"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "a98l29hg2tgso"
+      ],
+      "x-yahoo-request-id": [
+        "a98l29hg2tgso"
+      ],
+      "x-request-id": [
+        "ac46932c-6f87-4acb-addf-4dc90bd4800b"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1249"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:24 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "gmtOffSetMilliseconds": -18000000,
+            "esgPopulated": false,
+            "exchange": "NMS",
+            "shortName": "Alphabet Inc.",
+            "longName": "Alphabet Inc.",
+            "messageBoardId": "finmb_29096",
+            "exchangeTimezoneName": "America/New_York",
+            "market": "us_market",
+            "exchangeTimezoneShortName": "EST",
+            "tradeable": false,
+            "trailingPE": 36.254246,
+            "epsTrailingTwelveMonths": 58.613,
+            "epsForward": 81.21,
+            "epsCurrentYear": 69.79,
+            "priceEpsCurrentYear": 30.448057,
+            "sharesOutstanding": 329867008,
+            "bookValue": 329.586,
+            "fiftyDayAverage": 1897.9395,
+            "fiftyDayAverageChange": 227.03052,
+            "fiftyDayAverageChangePercent": 0.119619474,
+            "twoHundredDayAverage": 1689.6525,
+            "twoHundredDayAverageChange": 435.3175,
+            "twoHundredDayAverageChangePercent": 0.2576373,
+            "marketCap": 1429167669248,
+            "forwardPE": 26.166359,
+            "priceToBook": 6.4473915,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "firstTradeDateMilliseconds": 1092922200000,
+            "priceHint": 2,
+            "marketState": "REGULAR",
+            "regularMarketChange": -3.340088,
+            "regularMarketChangePercent": -0.15693615,
+            "regularMarketTime": 1613677453,
+            "regularMarketPrice": 2124.97,
+            "regularMarketDayHigh": 2126.43,
+            "regularMarketDayRange": "2104.28 - 2126.43",
+            "regularMarketDayLow": 2104.28,
+            "regularMarketVolume": 698786,
+            "regularMarketPreviousClose": 2128.31,
+            "bid": 2117.62,
+            "ask": 2117.97,
+            "bidSize": 9,
+            "askSize": 12,
+            "fullExchangeName": "NasdaqGS",
+            "financialCurrency": "USD",
+            "regularMarketOpen": 2110.39,
+            "averageDailyVolume3Month": 1564532,
+            "averageDailyVolume10Day": 1038942,
+            "fiftyTwoWeekLowChange": 1111.434,
+            "fiftyTwoWeekLowChangePercent": 1.0965905,
+            "fiftyTwoWeekRange": "1013.536 - 2152.68",
+            "fiftyTwoWeekHighChange": -27.70996,
+            "fiftyTwoWeekHighChangePercent": -0.0128723085,
+            "fiftyTwoWeekLow": 1013.536,
+            "fiftyTwoWeekHigh": 2152.68,
+            "displayName": "Alphabet",
+            "symbol": "GOOG"
+          },
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "gmtOffSetMilliseconds": -18000000,
+            "esgPopulated": false,
+            "exchange": "NYQ",
+            "shortName": "KE Holdings Inc",
+            "longName": "KE Holdings Inc.",
+            "messageBoardId": "finmb_665898843",
+            "exchangeTimezoneName": "America/New_York",
+            "market": "us_market",
+            "exchangeTimezoneShortName": "EST",
+            "tradeable": false,
+            "epsCurrentYear": 0.75,
+            "priceEpsCurrentYear": 85.37333,
+            "sharesOutstanding": 1143379968,
+            "fiftyDayAverage": 64.72818,
+            "fiftyDayAverageChange": -0.69818115,
+            "fiftyDayAverageChangePercent": -0.0107863555,
+            "twoHundredDayAverage": 61.72527,
+            "twoHundredDayAverageChange": 2.3047295,
+            "twoHundredDayAverageChangePercent": 0.037338506,
+            "marketCap": 75477286912,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "firstTradeDateMilliseconds": 1597325400000,
+            "priceHint": 2,
+            "marketState": "REGULAR",
+            "ipoExpectedDate": "2020-08-13",
+            "regularMarketChange": -2.6399994,
+            "regularMarketChangePercent": -3.9598012,
+            "regularMarketTime": 1613677445,
+            "regularMarketPrice": 64.03,
+            "regularMarketDayHigh": 65.84,
+            "regularMarketDayRange": "63.295 - 65.84",
+            "regularMarketDayLow": 63.295,
+            "regularMarketVolume": 3090043,
+            "regularMarketPreviousClose": 66.67,
+            "bid": 64.22,
+            "ask": 64.29,
+            "bidSize": 9,
+            "askSize": 18,
+            "fullExchangeName": "NYSE",
+            "financialCurrency": "CNY",
+            "regularMarketOpen": 65.29,
+            "averageDailyVolume3Month": 3739085,
+            "averageDailyVolume10Day": 5283557,
+            "fiftyTwoWeekLowChange": 32.239998,
+            "fiftyTwoWeekLowChangePercent": 1.0141553,
+            "fiftyTwoWeekRange": "31.79 - 79.4",
+            "fiftyTwoWeekHighChange": -15.370003,
+            "fiftyTwoWeekHighChangePercent": -0.19357686,
+            "fiftyTwoWeekLow": 31.79,
+            "fiftyTwoWeekHigh": 79.4,
+            "symbol": "BEKE"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-OCDO.L-AMZN.json
+++ b/tests/http/quote-OCDO.L-AMZN.json
@@ -1,0 +1,211 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=OCDO.L%2CAMZN"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "83o6b5hg2tgso"
+      ],
+      "x-yahoo-request-id": [
+        "83o6b5hg2tgso"
+      ],
+      "x-request-id": [
+        "6c20a588-4bb0-4fb0-8acf-138d826fbaf1"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1319"
+      ],
+      "x-envoy-upstream-service-time": [
+        "6"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:24 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Delayed Quote",
+            "triggerable": false,
+            "currency": "GBp",
+            "tradeable": false,
+            "fiftyTwoWeekLowChange": 1573.988,
+            "fiftyTwoWeekLowChangePercent": 1.5834699,
+            "fiftyTwoWeekRange": "994.012 - 2914.0",
+            "fiftyTwoWeekHighChange": -346,
+            "fiftyTwoWeekHighChangePercent": -0.11873713,
+            "fiftyTwoWeekLow": 994.012,
+            "fiftyTwoWeekHigh": 2914,
+            "earningsTimestamp": 1612836000,
+            "earningsTimestampStart": 1612836000,
+            "earningsTimestampEnd": 1612836000,
+            "epsTrailingTwelveMonths": -17.5,
+            "sharesOutstanding": 748801984,
+            "bookValue": 2.394,
+            "fiftyDayAverage": 2614.5881,
+            "fiftyDayAverageChange": -46.588135,
+            "fiftyDayAverageChangePercent": -0.017818537,
+            "twoHundredDayAverage": 2443.1,
+            "twoHundredDayAverageChange": 124.8999,
+            "twoHundredDayAverageChangePercent": 0.05112353,
+            "marketCap": 19229235200,
+            "priceToBook": 1072.6816,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 20,
+            "firstTradeDateMilliseconds": 1279695600000,
+            "priceHint": 2,
+            "regularMarketChange": -25,
+            "regularMarketChangePercent": -0.9641342,
+            "regularMarketTime": 1613666318,
+            "regularMarketPrice": 2568,
+            "regularMarketDayHigh": 2598,
+            "regularMarketDayRange": "2528.0 - 2598.0",
+            "regularMarketDayLow": 2528,
+            "regularMarketVolume": 885289,
+            "regularMarketPreviousClose": 2593,
+            "bid": 2551,
+            "ask": 2553,
+            "bidSize": 0,
+            "askSize": 0,
+            "fullExchangeName": "LSE",
+            "financialCurrency": "GBP",
+            "regularMarketOpen": 2570,
+            "averageDailyVolume3Month": 1636988,
+            "averageDailyVolume10Day": 1293261,
+            "exchange": "LSE",
+            "shortName": "OCADO GROUP PLC ORD 2P",
+            "longName": "Ocado Group plc",
+            "messageBoardId": "finmb_109303666",
+            "exchangeTimezoneName": "Europe/London",
+            "exchangeTimezoneShortName": "GMT",
+            "gmtOffSetMilliseconds": 0,
+            "market": "gb_market",
+            "esgPopulated": false,
+            "marketState": "POSTPOST",
+            "symbol": "OCDO.L"
+          },
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "tradeable": false,
+            "fiftyTwoWeekLowChange": 1698.1199,
+            "fiftyTwoWeekLowChangePercent": 1.0443349,
+            "fiftyTwoWeekRange": "1626.03 - 3552.25",
+            "fiftyTwoWeekHighChange": -228.1001,
+            "fiftyTwoWeekHighChangePercent": -0.06421285,
+            "fiftyTwoWeekLow": 1626.03,
+            "fiftyTwoWeekHigh": 3552.25,
+            "earningsTimestamp": 1612281780,
+            "earningsTimestampStart": 1619640000,
+            "earningsTimestampEnd": 1620072000,
+            "trailingPE": 79.46808,
+            "epsTrailingTwelveMonths": 41.83,
+            "epsForward": 66.45,
+            "epsCurrentYear": 47.62,
+            "priceEpsCurrentYear": 69.805756,
+            "sharesOutstanding": 500889984,
+            "bookValue": 185.694,
+            "fiftyDayAverage": 3245.279,
+            "fiftyDayAverageChange": 78.87085,
+            "fiftyDayAverageChangePercent": 0.024303257,
+            "twoHundredDayAverage": 3207.455,
+            "twoHundredDayAverageChange": 116.694824,
+            "twoHundredDayAverageChangePercent": 0.036382373,
+            "marketCap": 1673925492736,
+            "forwardPE": 50.02483,
+            "priceToBook": 17.901224,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "firstTradeDateMilliseconds": 863703000000,
+            "priceHint": 2,
+            "regularMarketChange": 15.51001,
+            "regularMarketChangePercent": 0.46877298,
+            "regularMarketTime": 1613677436,
+            "regularMarketPrice": 3324.15,
+            "regularMarketDayHigh": 3338,
+            "regularMarketDayRange": "3273.94 - 3338.0",
+            "regularMarketDayLow": 3273.94,
+            "regularMarketVolume": 2228116,
+            "regularMarketPreviousClose": 3308.64,
+            "bid": 3325.74,
+            "ask": 3328.6,
+            "bidSize": 9,
+            "askSize": 9,
+            "fullExchangeName": "NasdaqGS",
+            "financialCurrency": "USD",
+            "regularMarketOpen": 3282.42,
+            "averageDailyVolume3Month": 3634800,
+            "averageDailyVolume10Day": 2731628,
+            "exchange": "NMS",
+            "shortName": "Amazon.com, Inc.",
+            "longName": "Amazon.com, Inc.",
+            "messageBoardId": "finmb_18749",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "marketState": "REGULAR",
+            "displayName": "Amazon.com",
+            "symbol": "AMZN"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-QQQ-ADH.json
+++ b/tests/http/quote-QQQ-ADH.json
@@ -1,0 +1,175 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=QQQ%2CADH"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "e53uafpg2tgsp"
+      ],
+      "x-yahoo-request-id": [
+        "e53uafpg2tgsp"
+      ],
+      "x-request-id": [
+        "d711751e-f4e7-480e-8f1f-8a060b143e3f"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1054"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:25 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "ETF",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "sharesOutstanding": 393100000,
+            "bookValue": 188.775,
+            "fiftyDayAverage": 322.49728,
+            "fiftyDayAverageChange": 9.4227295,
+            "fiftyDayAverageChangePercent": 0.029218012,
+            "twoHundredDayAverage": 295.23254,
+            "twoHundredDayAverageChange": 36.68747,
+            "twoHundredDayAverageChangePercent": 0.12426635,
+            "marketCap": 130477760512,
+            "priceToBook": 1.7582839,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "regularMarketChange": -2.0099792,
+            "regularMarketChangePercent": -0.6019163,
+            "regularMarketTime": 1613677462,
+            "regularMarketPrice": 331.92,
+            "regularMarketDayHigh": 333.8661,
+            "regularMarketDayRange": "328.36 - 333.8661",
+            "regularMarketDayLow": 328.36,
+            "regularMarketVolume": 23574225,
+            "regularMarketPreviousClose": 333.93,
+            "bid": 331.87,
+            "ask": 331.83,
+            "bidSize": 18,
+            "askSize": 11,
+            "fullExchangeName": "NasdaqGS",
+            "financialCurrency": "USD",
+            "regularMarketOpen": 330.23,
+            "averageDailyVolume3Month": 28331339,
+            "averageDailyVolume10Day": 23851857,
+            "fiftyTwoWeekLowChange": 166.99002,
+            "fiftyTwoWeekLowChangePercent": 1.0124903,
+            "fiftyTwoWeekRange": "164.93 - 338.19",
+            "fiftyTwoWeekHighChange": -6.269989,
+            "fiftyTwoWeekHighChangePercent": -0.018539842,
+            "fiftyTwoWeekLow": 164.93,
+            "fiftyTwoWeekHigh": 338.19,
+            "trailingAnnualDividendRate": 1.54,
+            "trailingPE": 85.21695,
+            "trailingAnnualDividendYield": 0.004611745,
+            "ytdReturn": 0.31,
+            "trailingThreeMonthReturns": 16.98,
+            "trailingThreeMonthNavReturns": 17.08,
+            "epsTrailingTwelveMonths": 3.895,
+            "firstTradeDateMilliseconds": 921076200000,
+            "priceHint": 2,
+            "exchange": "NMS",
+            "shortName": "Invesco QQQ Trust, Series 1",
+            "longName": "Invesco QQQ Trust",
+            "messageBoardId": "finmb_8108558",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "marketState": "REGULAR",
+            "symbol": "QQQ"
+          },
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "MUTUALFUND",
+            "quoteSourceName": "Delayed Quote",
+            "triggerable": false,
+            "fiftyDayAverage": 6.794706,
+            "twoHundredDayAverage": 6.402117,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "regularMarketTime": 1561759658,
+            "fullExchangeName": "YHD",
+            "averageDailyVolume3Month": 212721,
+            "averageDailyVolume10Day": 100595,
+            "fiftyTwoWeekRange": "5.6 - 9.24",
+            "fiftyTwoWeekLow": 5.6,
+            "fiftyTwoWeekHigh": 9.24,
+            "firstTradeDateMilliseconds": 1152538200000,
+            "priceHint": 2,
+            "exchange": "YHD",
+            "shortName": "54688",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "marketState": "REGULAR",
+            "symbol": "ADH"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-SIX-WSKT.JK.json
+++ b/tests/http/quote-SIX-WSKT.JK.json
@@ -1,0 +1,212 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=SIX%2CWSKT.JK"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "btuo89dg2tgsn"
+      ],
+      "x-yahoo-request-id": [
+        "btuo89dg2tgsn"
+      ],
+      "x-request-id": [
+        "a7e7ea14-f15c-48e1-a62a-1bad44775e14"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1379"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:23 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "4"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "marketCap": 3419903488,
+            "forwardPE": -36.922016,
+            "priceToBook": -3.1753983,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "firstTradeDateMilliseconds": 1273584600000,
+            "priceHint": 2,
+            "marketState": "REGULAR",
+            "exchange": "NYQ",
+            "shortName": "Six Flags Entertainment Corpora",
+            "longName": "Six Flags Entertainment Corporation",
+            "messageBoardId": "finmb_435998",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "regularMarketChange": -0.18500137,
+            "regularMarketChangePercent": -0.4575844,
+            "regularMarketTime": 1613677438,
+            "regularMarketPrice": 40.245,
+            "regularMarketDayHigh": 40.3,
+            "regularMarketDayRange": "38.96 - 40.3",
+            "regularMarketDayLow": 38.96,
+            "regularMarketVolume": 689923,
+            "regularMarketPreviousClose": 40.43,
+            "bid": 39.98,
+            "ask": 40.04,
+            "bidSize": 9,
+            "askSize": 8,
+            "fullExchangeName": "NYSE",
+            "financialCurrency": "USD",
+            "regularMarketOpen": 40.11,
+            "averageDailyVolume3Month": 1608519,
+            "averageDailyVolume10Day": 1130285,
+            "fiftyTwoWeekLowChange": 31.494999,
+            "fiftyTwoWeekLowChangePercent": 3.5994284,
+            "fiftyTwoWeekRange": "8.75 - 40.98",
+            "fiftyTwoWeekHighChange": -0.7350006,
+            "fiftyTwoWeekHighChangePercent": -0.017935593,
+            "fiftyTwoWeekLow": 8.75,
+            "fiftyTwoWeekHigh": 40.98,
+            "dividendDate": 1583884800,
+            "earningsTimestamp": 1614173400,
+            "earningsTimestampStart": 1614173400,
+            "earningsTimestampEnd": 1614173400,
+            "trailingAnnualDividendRate": 1.08,
+            "trailingAnnualDividendYield": 0.026712839,
+            "epsTrailingTwelveMonths": -4.118,
+            "epsForward": -1.09,
+            "epsCurrentYear": -4.85,
+            "priceEpsCurrentYear": -8.297938,
+            "sharesOutstanding": 84977104,
+            "bookValue": -12.674,
+            "fiftyDayAverage": 36.487274,
+            "fiftyDayAverageChange": 3.7577248,
+            "fiftyDayAverageChangePercent": 0.10298727,
+            "twoHundredDayAverage": 27.534307,
+            "twoHundredDayAverageChange": 12.710691,
+            "twoHundredDayAverageChangePercent": 0.46163106,
+            "displayName": "Six Flags",
+            "symbol": "SIX"
+          },
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Delayed Quote",
+            "triggerable": false,
+            "currency": "IDR",
+            "marketCap": 20225112145920,
+            "forwardPE": 6.3604546,
+            "priceToBook": 1.5155306,
+            "sourceInterval": 10,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "firstTradeDateMilliseconds": 1355882400000,
+            "priceHint": 2,
+            "marketState": "PREPRE",
+            "exchange": "JKT",
+            "shortName": "Waskita Karya (Persero) Tbk.",
+            "longName": "PT Waskita Karya (Persero) Tbk",
+            "messageBoardId": "finmb_32989878",
+            "exchangeTimezoneName": "Asia/Jakarta",
+            "exchangeTimezoneShortName": "WIB",
+            "gmtOffSetMilliseconds": 25200000,
+            "market": "id_market",
+            "esgPopulated": false,
+            "regularMarketChange": -25,
+            "regularMarketChangePercent": -1.6501651,
+            "regularMarketTime": 1613636074,
+            "regularMarketPrice": 1490,
+            "regularMarketDayHigh": 1545,
+            "regularMarketDayRange": "1470.0 - 1545.0",
+            "regularMarketDayLow": 1470,
+            "regularMarketVolume": 99867400,
+            "regularMarketPreviousClose": 1515,
+            "bid": 1490,
+            "ask": 1495,
+            "bidSize": 0,
+            "askSize": 0,
+            "fullExchangeName": "Jakarta",
+            "financialCurrency": "IDR",
+            "regularMarketOpen": 1520,
+            "averageDailyVolume3Month": 269827553,
+            "averageDailyVolume10Day": 198514460,
+            "fiftyTwoWeekLowChange": 1096,
+            "fiftyTwoWeekLowChangePercent": 2.781726,
+            "fiftyTwoWeekRange": "394.0 - 2080.0",
+            "fiftyTwoWeekHighChange": -590,
+            "fiftyTwoWeekHighChangePercent": -0.28365386,
+            "fiftyTwoWeekLow": 394,
+            "fiftyTwoWeekHigh": 2080,
+            "epsTrailingTwelveMonths": -209.899,
+            "epsForward": 234.26,
+            "sharesOutstanding": 13573900288,
+            "bookValue": 983.154,
+            "fiftyDayAverage": 1595.1562,
+            "fiftyDayAverageChange": -105.15625,
+            "fiftyDayAverageChangePercent": -0.06592222,
+            "twoHundredDayAverage": 980.8309,
+            "twoHundredDayAverageChange": 509.16913,
+            "twoHundredDayAverageChangePercent": 0.5191202,
+            "symbol": "WSKT.JK"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-SPOT-BFLY.json
+++ b/tests/http/quote-SPOT-BFLY.json
@@ -1,0 +1,202 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=SPOT%2CBFLY"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "8lkmhudg2tgso"
+      ],
+      "x-yahoo-request-id": [
+        "8lkmhudg2tgso"
+      ],
+      "x-request-id": [
+        "b03be58b-5363-43e7-8cd9-dae4f7d7e249"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1218"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:23 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "firstTradeDateMilliseconds": 1522762200000,
+            "priceHint": 2,
+            "regularMarketChange": 0.65078735,
+            "regularMarketChangePercent": 0.18322232,
+            "regularMarketTime": 1613677435,
+            "regularMarketPrice": 355.8408,
+            "regularMarketDayHigh": 355.96,
+            "regularMarketDayRange": "341.59 - 355.96",
+            "regularMarketDayLow": 341.59,
+            "regularMarketVolume": 1017249,
+            "regularMarketPreviousClose": 355.19,
+            "bid": 354.03,
+            "ask": 354.49,
+            "bidSize": 8,
+            "askSize": 11,
+            "fullExchangeName": "NYSE",
+            "financialCurrency": "EUR",
+            "regularMarketOpen": 353.57,
+            "averageDailyVolume3Month": 1544000,
+            "averageDailyVolume10Day": 1414200,
+            "fiftyTwoWeekLowChange": 246.6608,
+            "fiftyTwoWeekLowChangePercent": 2.2592123,
+            "fiftyTwoWeekRange": "109.18 - 370.95",
+            "fiftyTwoWeekHighChange": -15.109222,
+            "fiftyTwoWeekHighChangePercent": -0.040731154,
+            "fiftyTwoWeekLow": 109.18,
+            "fiftyTwoWeekHigh": 370.95,
+            "earningsTimestamp": 1612332000,
+            "earningsTimestampStart": 1619526600,
+            "earningsTimestampEnd": 1620045000,
+            "epsTrailingTwelveMonths": -7.629,
+            "epsForward": -0.86,
+            "epsCurrentYear": -1.89,
+            "priceEpsCurrentYear": -188.27556,
+            "sharesOutstanding": 189586000,
+            "bookValue": 10.251,
+            "fiftyDayAverage": 331.26605,
+            "fiftyDayAverageChange": 24.574738,
+            "fiftyDayAverageChangePercent": 0.07418429,
+            "twoHundredDayAverage": 284.56094,
+            "twoHundredDayAverageChange": 71.27985,
+            "twoHundredDayAverageChangePercent": 0.2504906,
+            "marketCap": 67685539840,
+            "forwardPE": -413.76834,
+            "priceToBook": 34.712788,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "marketState": "REGULAR",
+            "exchange": "NYQ",
+            "shortName": "Spotify Technology S.A.",
+            "longName": "Spotify Technology S.A.",
+            "messageBoardId": "finmb_225595077",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "displayName": "Spotify ",
+            "symbol": "SPOT"
+          },
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "firstTradeDateMilliseconds": 1594647000000,
+            "priceHint": 2,
+            "regularMarketChange": 0.6800003,
+            "regularMarketChangePercent": 2.5855525,
+            "regularMarketTime": 1613677429,
+            "regularMarketPrice": 26.98,
+            "regularMarketDayHigh": 29.13,
+            "regularMarketDayRange": "25.11 - 29.13",
+            "regularMarketDayLow": 25.11,
+            "regularMarketVolume": 5624880,
+            "regularMarketPreviousClose": 26.3,
+            "bid": 27.14,
+            "ask": 27.18,
+            "bidSize": 22,
+            "askSize": 10,
+            "fullExchangeName": "NYSE",
+            "regularMarketOpen": 26,
+            "averageDailyVolume3Month": 4745100,
+            "averageDailyVolume10Day": 4745100,
+            "fiftyTwoWeekLowChange": 17.09,
+            "fiftyTwoWeekLowChangePercent": 1.728008,
+            "fiftyTwoWeekRange": "9.89 - 29.13",
+            "fiftyTwoWeekHighChange": -2.1499996,
+            "fiftyTwoWeekHighChangePercent": -0.07380706,
+            "fiftyTwoWeekLow": 9.89,
+            "fiftyTwoWeekHigh": 29.13,
+            "fiftyDayAverage": 24.4,
+            "fiftyDayAverageChange": 2.58,
+            "fiftyDayAverageChangePercent": 0.1057377,
+            "twoHundredDayAverage": 19.563334,
+            "twoHundredDayAverageChange": 7.416666,
+            "twoHundredDayAverageChangePercent": 0.37911054,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "newListingDate": "2021-02-16",
+            "tradeable": false,
+            "marketState": "REGULAR",
+            "exchange": "NYQ",
+            "shortName": "Butterfly Network, Inc. Class A",
+            "longName": "Butterfly Network, Inc.",
+            "messageBoardId": "finmb_275830634",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "symbol": "BFLY"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-UNIR.MI-AZT.OL.json
+++ b/tests/http/quote-UNIR.MI-AZT.OL.json
@@ -1,0 +1,196 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=UNIR.MI%2CAZT.OL"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "bnr1dctg2tgso"
+      ],
+      "x-yahoo-request-id": [
+        "bnr1dctg2tgso"
+      ],
+      "x-request-id": [
+        "df93f1da-d5da-43af-abae-49e437568188"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1148"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:24 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "triggerable": false,
+            "gmtOffSetMilliseconds": 3600000,
+            "market": "it_market",
+            "esgPopulated": false,
+            "currency": "EUR",
+            "tradeable": false,
+            "sharesOutstanding": 20208400,
+            "bookValue": 6.862,
+            "fiftyDayAverage": 13.915882,
+            "fiftyDayAverageChange": 1.0441179,
+            "fiftyDayAverageChangePercent": 0.07503067,
+            "twoHundredDayAverage": 11.860647,
+            "twoHundredDayAverageChangePercent": 0.26131397,
+            "firstTradeDateMilliseconds": 1491289200000,
+            "regularMarketChange": -0.3000002,
+            "regularMarketChangePercent": -1.9659253,
+            "regularMarketTime": 1613666126,
+            "regularMarketPrice": 14.96,
+            "regularMarketDayHigh": 15.66,
+            "regularMarketDayRange": "14.94 - 15.66",
+            "regularMarketDayLow": 14.94,
+            "regularMarketVolume": 464206,
+            "regularMarketPreviousClose": 15.26,
+            "bid": 14.92,
+            "ask": 15.34,
+            "bidSize": 0,
+            "askSize": 0,
+            "fullExchangeName": "Milan",
+            "financialCurrency": "EUR",
+            "regularMarketOpen": 15.28,
+            "averageDailyVolume3Month": 303653,
+            "averageDailyVolume10Day": 280428,
+            "fiftyTwoWeekLowChange": 9.93,
+            "fiftyTwoWeekLowChangePercent": 1.9741551,
+            "fiftyTwoWeekRange": "5.03 - 15.96",
+            "fiftyTwoWeekHighChange": -1,
+            "fiftyTwoWeekHighChangePercent": -0.06265664,
+            "fiftyTwoWeekLow": 5.03,
+            "fiftyTwoWeekHigh": 15.96,
+            "earningsTimestamp": 1620298740,
+            "earningsTimestampStart": 1620298740,
+            "earningsTimestampEnd": 1620298740,
+            "trailingAnnualDividendRate": 1.07,
+            "trailingPE": 5.1926413,
+            "trailingAnnualDividendYield": 0.07011796,
+            "epsTrailingTwelveMonths": 2.881,
+            "twoHundredDayAverageChange": 3.0993528,
+            "marketCap": 302317664,
+            "priceToBook": 2.1801224,
+            "sourceInterval": 20,
+            "exchangeDataDelayedBy": 0,
+            "priceHint": 2,
+            "exchange": "MIL",
+            "shortName": "UNIEURO",
+            "longName": "Unieuro S.p.A.",
+            "messageBoardId": "finmb_931146",
+            "exchangeTimezoneName": "Europe/Rome",
+            "exchangeTimezoneShortName": "CET",
+            "marketState": "POSTPOST",
+            "symbol": "UNIR.MI"
+          },
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "triggerable": false,
+            "gmtOffSetMilliseconds": 3600000,
+            "market": "no_market",
+            "esgPopulated": false,
+            "currency": "NOK",
+            "tradeable": false,
+            "sharesOutstanding": 48334700,
+            "bookValue": 4.018,
+            "regularMarketChange": 0.19999695,
+            "regularMarketChangePercent": 0.27777356,
+            "regularMarketTime": 1613661913,
+            "regularMarketPrice": 72.2,
+            "regularMarketDayHigh": 73,
+            "regularMarketDayRange": "71.2 - 73.0",
+            "regularMarketDayLow": 71.2,
+            "regularMarketVolume": 587033,
+            "regularMarketPreviousClose": 72,
+            "bid": 71.8,
+            "ask": 74.8,
+            "fullExchangeName": "Oslo",
+            "financialCurrency": "NOK",
+            "regularMarketOpen": 72,
+            "fiftyTwoWeekLowChange": 1,
+            "fiftyTwoWeekLowChangePercent": 0.014044944,
+            "fiftyTwoWeekRange": "71.2 - 73.0",
+            "fiftyTwoWeekHighChange": -0.80000305,
+            "fiftyTwoWeekHighChangePercent": -0.010958946,
+            "fiftyTwoWeekLow": 71.2,
+            "fiftyTwoWeekHigh": 73,
+            "earningsTimestamp": 1611801000,
+            "earningsTimestampStart": 1611801000,
+            "earningsTimestampEnd": 1611801000,
+            "trailingPE": 41.97674,
+            "epsTrailingTwelveMonths": 1.72,
+            "marketCap": 3489765120,
+            "priceToBook": 17.969137,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "priceHint": 2,
+            "exchange": "OSL",
+            "shortName": "ARCTICZYMES TECH",
+            "longName": "ArcticZymes Technologies ASA",
+            "messageBoardId": "finmb_13529463",
+            "exchangeTimezoneName": "Europe/Oslo",
+            "exchangeTimezoneShortName": "CET",
+            "marketState": "POSTPOST",
+            "symbol": "AZT.OL"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-WSKT.JK-SIX.json
+++ b/tests/http/quote-WSKT.JK-SIX.json
@@ -1,0 +1,212 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=WSKT.JK%2CSIX"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "dqdeu9dg2tgsn"
+      ],
+      "x-yahoo-request-id": [
+        "dqdeu9dg2tgsn"
+      ],
+      "x-request-id": [
+        "4f8940d3-95f3-4845-821b-b0bbe6d84a8b"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1378"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:23 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Delayed Quote",
+            "triggerable": false,
+            "currency": "IDR",
+            "tradeable": false,
+            "firstTradeDateMilliseconds": 1355882400000,
+            "priceHint": 2,
+            "regularMarketChange": -25,
+            "regularMarketChangePercent": -1.6501651,
+            "regularMarketTime": 1613636074,
+            "regularMarketPrice": 1490,
+            "regularMarketDayHigh": 1545,
+            "regularMarketDayRange": "1470.0 - 1545.0",
+            "regularMarketDayLow": 1470,
+            "regularMarketVolume": 99867400,
+            "regularMarketPreviousClose": 1515,
+            "bid": 1490,
+            "ask": 1495,
+            "bidSize": 0,
+            "askSize": 0,
+            "fullExchangeName": "Jakarta",
+            "financialCurrency": "IDR",
+            "regularMarketOpen": 1520,
+            "averageDailyVolume3Month": 269827553,
+            "averageDailyVolume10Day": 198514460,
+            "fiftyTwoWeekLowChange": 1096,
+            "fiftyTwoWeekLowChangePercent": 2.781726,
+            "fiftyTwoWeekRange": "394.0 - 2080.0",
+            "fiftyTwoWeekHighChange": -590,
+            "fiftyTwoWeekHighChangePercent": -0.28365386,
+            "fiftyTwoWeekLow": 394,
+            "fiftyTwoWeekHigh": 2080,
+            "epsTrailingTwelveMonths": -209.899,
+            "epsForward": 234.26,
+            "sharesOutstanding": 13573900288,
+            "bookValue": 983.154,
+            "fiftyDayAverage": 1595.1562,
+            "fiftyDayAverageChange": -105.15625,
+            "fiftyDayAverageChangePercent": -0.06592222,
+            "twoHundredDayAverage": 980.8309,
+            "twoHundredDayAverageChange": 509.16913,
+            "twoHundredDayAverageChangePercent": 0.5191202,
+            "marketCap": 20225112145920,
+            "forwardPE": 6.3604546,
+            "priceToBook": 1.5155306,
+            "sourceInterval": 10,
+            "exchangeDataDelayedBy": 0,
+            "marketState": "PREPRE",
+            "exchange": "JKT",
+            "shortName": "Waskita Karya (Persero) Tbk.",
+            "longName": "PT Waskita Karya (Persero) Tbk",
+            "messageBoardId": "finmb_32989878",
+            "exchangeTimezoneName": "Asia/Jakarta",
+            "exchangeTimezoneShortName": "WIB",
+            "gmtOffSetMilliseconds": 25200000,
+            "market": "id_market",
+            "esgPopulated": false,
+            "symbol": "WSKT.JK"
+          },
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "tradeable": false,
+            "firstTradeDateMilliseconds": 1273584600000,
+            "priceHint": 2,
+            "regularMarketChange": -0.18500137,
+            "regularMarketChangePercent": -0.4575844,
+            "regularMarketTime": 1613677438,
+            "regularMarketPrice": 40.245,
+            "regularMarketDayHigh": 40.3,
+            "regularMarketDayRange": "38.96 - 40.3",
+            "regularMarketDayLow": 38.96,
+            "regularMarketVolume": 689923,
+            "regularMarketPreviousClose": 40.43,
+            "bid": 39.98,
+            "ask": 40.04,
+            "bidSize": 9,
+            "askSize": 8,
+            "fullExchangeName": "NYSE",
+            "financialCurrency": "USD",
+            "regularMarketOpen": 40.11,
+            "averageDailyVolume3Month": 1608519,
+            "averageDailyVolume10Day": 1130285,
+            "fiftyTwoWeekLowChange": 31.494999,
+            "fiftyTwoWeekLowChangePercent": 3.5994284,
+            "fiftyTwoWeekRange": "8.75 - 40.98",
+            "fiftyTwoWeekHighChange": -0.7350006,
+            "fiftyTwoWeekHighChangePercent": -0.017935593,
+            "fiftyTwoWeekLow": 8.75,
+            "fiftyTwoWeekHigh": 40.98,
+            "dividendDate": 1583884800,
+            "earningsTimestamp": 1614173400,
+            "earningsTimestampStart": 1614173400,
+            "earningsTimestampEnd": 1614173400,
+            "trailingAnnualDividendRate": 1.08,
+            "trailingAnnualDividendYield": 0.026712839,
+            "epsTrailingTwelveMonths": -4.118,
+            "epsForward": -1.09,
+            "epsCurrentYear": -4.85,
+            "priceEpsCurrentYear": -8.297938,
+            "sharesOutstanding": 84977104,
+            "bookValue": -12.674,
+            "fiftyDayAverage": 36.487274,
+            "fiftyDayAverageChange": 3.7577248,
+            "fiftyDayAverageChangePercent": 0.10298727,
+            "twoHundredDayAverage": 27.534307,
+            "twoHundredDayAverageChange": 12.710691,
+            "twoHundredDayAverageChangePercent": 0.46163106,
+            "marketCap": 3419903488,
+            "forwardPE": -36.922016,
+            "priceToBook": -3.1753983,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "marketState": "REGULAR",
+            "exchange": "NYQ",
+            "shortName": "Six Flags Entertainment Corpora",
+            "longName": "Six Flags Entertainment Corporation",
+            "messageBoardId": "finmb_435998",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "displayName": "Six Flags",
+            "symbol": "SIX"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-0P000071W8.TO-AAPL.json
+++ b/tests/http/recommendationsBySymbol-0P000071W8.TO-AAPL.json
@@ -1,0 +1,120 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/0P000071W8.TO,AAPL?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "85khtctg2tgsp"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "214"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:25 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "0P000071W8.TO",
+            "recommendedSymbols": [
+              {
+                "symbol": "0P000071WA.TO",
+                "score": 0.027855
+              },
+              {
+                "symbol": "0P000071AX.TO",
+                "score": 0.025188
+              },
+              {
+                "symbol": "0P000071B1.TO",
+                "score": 0.0178
+              },
+              {
+                "symbol": "0P000071W5.TO",
+                "score": 0.006958
+              },
+              {
+                "symbol": "0P000071WU.TO",
+                "score": 0.004539
+              }
+            ]
+          },
+          {
+            "symbol": "AAPL",
+            "recommendedSymbols": [
+              {
+                "symbol": "AMZN",
+                "score": 0.292695
+              },
+              {
+                "symbol": "FB",
+                "score": 0.273764
+              },
+              {
+                "symbol": "GOOG",
+                "score": 0.272766
+              },
+              {
+                "symbol": "TSLA",
+                "score": 0.272246
+              },
+              {
+                "symbol": "NFLX",
+                "score": 0.209203
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-AAPL-0P000071W8.TO.json
+++ b/tests/http/recommendationsBySymbol-AAPL-0P000071W8.TO.json
@@ -1,0 +1,120 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/AAPL,0P000071W8.TO?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "2e1kpcpg2tgsm"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "218"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:22 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "AAPL",
+            "recommendedSymbols": [
+              {
+                "symbol": "AMZN",
+                "score": 0.292695
+              },
+              {
+                "symbol": "FB",
+                "score": 0.273764
+              },
+              {
+                "symbol": "GOOG",
+                "score": 0.272766
+              },
+              {
+                "symbol": "TSLA",
+                "score": 0.272246
+              },
+              {
+                "symbol": "NFLX",
+                "score": 0.209203
+              }
+            ]
+          },
+          {
+            "symbol": "0P000071W8.TO",
+            "recommendedSymbols": [
+              {
+                "symbol": "0P000071WA.TO",
+                "score": 0.027855
+              },
+              {
+                "symbol": "0P000071AX.TO",
+                "score": 0.025188
+              },
+              {
+                "symbol": "0P000071B1.TO",
+                "score": 0.0178
+              },
+              {
+                "symbol": "0P000071W5.TO",
+                "score": 0.006958
+              },
+              {
+                "symbol": "0P000071WU.TO",
+                "score": 0.004539
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-AFRAF-QQQ.json
+++ b/tests/http/recommendationsBySymbol-AFRAF-QQQ.json
@@ -1,0 +1,120 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/AFRAF,QQQ?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "8uf26nhg2tgsm"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "214"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:22 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "AFRAF",
+            "recommendedSymbols": [
+              {
+                "symbol": "AFLYY",
+                "score": 0.013426
+              },
+              {
+                "symbol": "2106.TW",
+                "score": 0.011183
+              },
+              {
+                "symbol": "INV.L",
+                "score": 0.01097
+              },
+              {
+                "symbol": "0675.HK",
+                "score": 0.009798
+              },
+              {
+                "symbol": "EMBR",
+                "score": 0.009145
+              }
+            ]
+          },
+          {
+            "symbol": "QQQ",
+            "recommendedSymbols": [
+              {
+                "symbol": "SPY",
+                "score": 0.156256
+              },
+              {
+                "symbol": "MCD",
+                "score": 0.09092
+              },
+              {
+                "symbol": "DIA",
+                "score": 0.083234
+              },
+              {
+                "symbol": "T",
+                "score": 0.07687
+              },
+              {
+                "symbol": "GE",
+                "score": 0.06798
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-AMZN-BABA.json
+++ b/tests/http/recommendationsBySymbol-AMZN-BABA.json
@@ -1,0 +1,120 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/AMZN,BABA?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "2tu3495g2tgsm"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "208"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:22 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "AMZN",
+            "recommendedSymbols": [
+              {
+                "symbol": "FB",
+                "score": 0.293901
+              },
+              {
+                "symbol": "AAPL",
+                "score": 0.292695
+              },
+              {
+                "symbol": "GOOG",
+                "score": 0.286979
+              },
+              {
+                "symbol": "TSLA",
+                "score": 0.278374
+              },
+              {
+                "symbol": "NFLX",
+                "score": 0.275321
+              }
+            ]
+          },
+          {
+            "symbol": "BABA",
+            "recommendedSymbols": [
+              {
+                "symbol": "FB",
+                "score": 0.191634
+              },
+              {
+                "symbol": "NVDA",
+                "score": 0.161107
+              },
+              {
+                "symbol": "TSLA",
+                "score": 0.155281
+              },
+              {
+                "symbol": "NFLX",
+                "score": 0.151511
+              },
+              {
+                "symbol": "AMZN",
+                "score": 0.140821
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-AZT.OL-OCDO.L.json
+++ b/tests/http/recommendationsBySymbol-AZT.OL-OCDO.L.json
@@ -1,0 +1,120 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/AZT.OL,OCDO.L?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "dd0f4g1g2tgsm"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "223"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:22 GMT"
+      ],
+      "age": [
+        "3"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "AZT.OL",
+            "recommendedSymbols": [
+              {
+                "symbol": "BGBIO.OL",
+                "score": 0.008295
+              },
+              {
+                "symbol": "CARA.OL",
+                "score": 0.006061
+              },
+              {
+                "symbol": "PHO.OL",
+                "score": 0.005815
+              },
+              {
+                "symbol": "EMBRAC-B.ST",
+                "score": 0.005683
+              },
+              {
+                "symbol": "EVO.ST",
+                "score": 0.005557
+              }
+            ]
+          },
+          {
+            "symbol": "OCDO.L",
+            "recommendedSymbols": [
+              {
+                "symbol": "ASC.L",
+                "score": 0.059949
+              },
+              {
+                "symbol": "BOO.L",
+                "score": 0.058538
+              },
+              {
+                "symbol": "RMV.L",
+                "score": 0.055645
+              },
+              {
+                "symbol": "MRW.L",
+                "score": 0.051301
+              },
+              {
+                "symbol": "JD.L",
+                "score": 0.04895
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-BABA-AMZN.json
+++ b/tests/http/recommendationsBySymbol-BABA-AMZN.json
@@ -1,0 +1,120 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/BABA,AMZN?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "aou9u5pg2tgsp"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "202"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:25 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "BABA",
+            "recommendedSymbols": [
+              {
+                "symbol": "FB",
+                "score": 0.191634
+              },
+              {
+                "symbol": "NVDA",
+                "score": 0.161107
+              },
+              {
+                "symbol": "TSLA",
+                "score": 0.155281
+              },
+              {
+                "symbol": "NFLX",
+                "score": 0.151511
+              },
+              {
+                "symbol": "AMZN",
+                "score": 0.140821
+              }
+            ]
+          },
+          {
+            "symbol": "AMZN",
+            "recommendedSymbols": [
+              {
+                "symbol": "FB",
+                "score": 0.293901
+              },
+              {
+                "symbol": "AAPL",
+                "score": 0.292695
+              },
+              {
+                "symbol": "GOOG",
+                "score": 0.286979
+              },
+              {
+                "symbol": "TSLA",
+                "score": 0.278374
+              },
+              {
+                "symbol": "NFLX",
+                "score": 0.275321
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-BEKE-UNIR.MI.json
+++ b/tests/http/recommendationsBySymbol-BEKE-UNIR.MI.json
@@ -1,0 +1,120 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/BEKE,UNIR.MI?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "6p3scp1g2tgsn"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "212"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:23 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "BEKE",
+            "recommendedSymbols": [
+              {
+                "symbol": "DOYU",
+                "score": 0.058875
+              },
+              {
+                "symbol": "API",
+                "score": 0.058126
+              },
+              {
+                "symbol": "FUTU",
+                "score": 0.057645
+              },
+              {
+                "symbol": "YSG",
+                "score": 0.057196
+              },
+              {
+                "symbol": "DADA",
+                "score": 0.055713
+              }
+            ]
+          },
+          {
+            "symbol": "UNIR.MI",
+            "recommendedSymbols": [
+              {
+                "symbol": "BFF.MI",
+                "score": 0.037527
+              },
+              {
+                "symbol": "TGYM.MI",
+                "score": 0.03597
+              },
+              {
+                "symbol": "OVS.MI",
+                "score": 0.035226
+              },
+              {
+                "symbol": "AZM.MI",
+                "score": 0.030679
+              },
+              {
+                "symbol": "PST.MI",
+                "score": 0.030594
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-BFLY-GOOG.json
+++ b/tests/http/recommendationsBySymbol-BFLY-GOOG.json
@@ -1,0 +1,120 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/BFLY,GOOG?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "dobsdhtg2tgsn"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "215"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:23 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "BFLY",
+            "recommendedSymbols": [
+              {
+                "symbol": "LGVW",
+                "score": 0.036512
+              },
+              {
+                "symbol": "CMLF",
+                "score": 0.028625
+              },
+              {
+                "symbol": "ACIC",
+                "score": 0.027588
+              },
+              {
+                "symbol": "EXPC",
+                "score": 0.026606
+              },
+              {
+                "symbol": "SKLZ",
+                "score": 0.024837
+              }
+            ]
+          },
+          {
+            "symbol": "GOOG",
+            "recommendedSymbols": [
+              {
+                "symbol": "FB",
+                "score": 0.296066
+              },
+              {
+                "symbol": "AMZN",
+                "score": 0.286979
+              },
+              {
+                "symbol": "AAPL",
+                "score": 0.272766
+              },
+              {
+                "symbol": "NFLX",
+                "score": 0.250068
+              },
+              {
+                "symbol": "TSLA",
+                "score": 0.223886
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-GOOG-BFLY.json
+++ b/tests/http/recommendationsBySymbol-GOOG-BFLY.json
@@ -1,0 +1,120 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/GOOG,BFLY?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "4841oadg2tgso"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "217"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:24 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "GOOG",
+            "recommendedSymbols": [
+              {
+                "symbol": "FB",
+                "score": 0.296066
+              },
+              {
+                "symbol": "AMZN",
+                "score": 0.286979
+              },
+              {
+                "symbol": "AAPL",
+                "score": 0.272766
+              },
+              {
+                "symbol": "NFLX",
+                "score": 0.250068
+              },
+              {
+                "symbol": "TSLA",
+                "score": 0.223886
+              }
+            ]
+          },
+          {
+            "symbol": "BFLY",
+            "recommendedSymbols": [
+              {
+                "symbol": "LGVW",
+                "score": 0.036512
+              },
+              {
+                "symbol": "CMLF",
+                "score": 0.028625
+              },
+              {
+                "symbol": "ACIC",
+                "score": 0.027588
+              },
+              {
+                "symbol": "EXPC",
+                "score": 0.026606
+              },
+              {
+                "symbol": "SKLZ",
+                "score": 0.024837
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-OCDO.L-AZT.OL.json
+++ b/tests/http/recommendationsBySymbol-OCDO.L-AZT.OL.json
@@ -1,0 +1,120 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/OCDO.L,AZT.OL?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "19frb19g2tgso"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "223"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:24 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "OCDO.L",
+            "recommendedSymbols": [
+              {
+                "symbol": "ASC.L",
+                "score": 0.059949
+              },
+              {
+                "symbol": "BOO.L",
+                "score": 0.058538
+              },
+              {
+                "symbol": "RMV.L",
+                "score": 0.055645
+              },
+              {
+                "symbol": "MRW.L",
+                "score": 0.051301
+              },
+              {
+                "symbol": "JD.L",
+                "score": 0.04895
+              }
+            ]
+          },
+          {
+            "symbol": "AZT.OL",
+            "recommendedSymbols": [
+              {
+                "symbol": "BGBIO.OL",
+                "score": 0.008295
+              },
+              {
+                "symbol": "CARA.OL",
+                "score": 0.006061
+              },
+              {
+                "symbol": "PHO.OL",
+                "score": 0.005815
+              },
+              {
+                "symbol": "EMBRAC-B.ST",
+                "score": 0.005683
+              },
+              {
+                "symbol": "EVO.ST",
+                "score": 0.005557
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-QQQ-AFRAF.json
+++ b/tests/http/recommendationsBySymbol-QQQ-AFRAF.json
@@ -1,0 +1,120 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/QQQ,AFRAF?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "1jbvorhg2tgsp"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "217"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:25 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "QQQ",
+            "recommendedSymbols": [
+              {
+                "symbol": "SPY",
+                "score": 0.156256
+              },
+              {
+                "symbol": "MCD",
+                "score": 0.09092
+              },
+              {
+                "symbol": "DIA",
+                "score": 0.083234
+              },
+              {
+                "symbol": "T",
+                "score": 0.07687
+              },
+              {
+                "symbol": "GE",
+                "score": 0.06798
+              }
+            ]
+          },
+          {
+            "symbol": "AFRAF",
+            "recommendedSymbols": [
+              {
+                "symbol": "AFLYY",
+                "score": 0.013426
+              },
+              {
+                "symbol": "2106.TW",
+                "score": 0.011183
+              },
+              {
+                "symbol": "INV.L",
+                "score": 0.01097
+              },
+              {
+                "symbol": "0675.HK",
+                "score": 0.009798
+              },
+              {
+                "symbol": "EMBR",
+                "score": 0.009145
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-SIX-SIX.json
+++ b/tests/http/recommendationsBySymbol-SIX-SIX.json
@@ -1,0 +1,120 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/SIX,SIX?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "aq3giphg2tgsn"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "166"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:23 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "SIX",
+            "recommendedSymbols": [
+              {
+                "symbol": "FUN",
+                "score": 0.085996
+              },
+              {
+                "symbol": "SEAS",
+                "score": 0.071196
+              },
+              {
+                "symbol": "PLAY",
+                "score": 0.05392
+              },
+              {
+                "symbol": "CNK",
+                "score": 0.049486
+              },
+              {
+                "symbol": "NCLH",
+                "score": 0.039927
+              }
+            ]
+          },
+          {
+            "symbol": "SIX",
+            "recommendedSymbols": [
+              {
+                "symbol": "FUN",
+                "score": 0.085996
+              },
+              {
+                "symbol": "SEAS",
+                "score": 0.071196
+              },
+              {
+                "symbol": "PLAY",
+                "score": 0.05392
+              },
+              {
+                "symbol": "CNK",
+                "score": 0.049486
+              },
+              {
+                "symbol": "NCLH",
+                "score": 0.039927
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-SPOT-WSKT.JK.json
+++ b/tests/http/recommendationsBySymbol-SPOT-WSKT.JK.json
@@ -1,0 +1,120 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/SPOT,WSKT.JK?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "4kiudqhg2tgso"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "224"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:24 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "SPOT",
+            "recommendedSymbols": [
+              {
+                "symbol": "SHOP",
+                "score": 0.108548
+              },
+              {
+                "symbol": "ROKU",
+                "score": 0.105002
+              },
+              {
+                "symbol": "ZM",
+                "score": 0.097912
+              },
+              {
+                "symbol": "DOCU",
+                "score": 0.096422
+              },
+              {
+                "symbol": "DBX",
+                "score": 0.094762
+              }
+            ]
+          },
+          {
+            "symbol": "WSKT.JK",
+            "recommendedSymbols": [
+              {
+                "symbol": "WIKA.JK",
+                "score": 0.252411
+              },
+              {
+                "symbol": "PTPP.JK",
+                "score": 0.239344
+              },
+              {
+                "symbol": "ADHI.JK",
+                "score": 0.207734
+              },
+              {
+                "symbol": "JSMR.JK",
+                "score": 0.150421
+              },
+              {
+                "symbol": "BSDE.JK",
+                "score": 0.144335
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-UNIR.MI-BEKE.json
+++ b/tests/http/recommendationsBySymbol-UNIR.MI-BEKE.json
@@ -1,0 +1,120 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/UNIR.MI,BEKE?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "8ru248hg2tgso"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "209"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:24 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "UNIR.MI",
+            "recommendedSymbols": [
+              {
+                "symbol": "BFF.MI",
+                "score": 0.037527
+              },
+              {
+                "symbol": "TGYM.MI",
+                "score": 0.03597
+              },
+              {
+                "symbol": "OVS.MI",
+                "score": 0.035226
+              },
+              {
+                "symbol": "AZM.MI",
+                "score": 0.030679
+              },
+              {
+                "symbol": "PST.MI",
+                "score": 0.030594
+              }
+            ]
+          },
+          {
+            "symbol": "BEKE",
+            "recommendedSymbols": [
+              {
+                "symbol": "DOYU",
+                "score": 0.058875
+              },
+              {
+                "symbol": "API",
+                "score": 0.058126
+              },
+              {
+                "symbol": "FUTU",
+                "score": 0.057645
+              },
+              {
+                "symbol": "YSG",
+                "score": 0.057196
+              },
+              {
+                "symbol": "DADA",
+                "score": 0.055713
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-WSKT.JK-SPOT.json
+++ b/tests/http/recommendationsBySymbol-WSKT.JK-SPOT.json
@@ -1,0 +1,120 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/WSKT.JK,SPOT?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "0sfatspg2tgsn"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "219"
+      ],
+      "date": [
+        "Thu, 18 Feb 2021 19:44:23 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "WSKT.JK",
+            "recommendedSymbols": [
+              {
+                "symbol": "WIKA.JK",
+                "score": 0.252411
+              },
+              {
+                "symbol": "PTPP.JK",
+                "score": 0.239344
+              },
+              {
+                "symbol": "ADHI.JK",
+                "score": 0.207734
+              },
+              {
+                "symbol": "JSMR.JK",
+                "score": 0.150421
+              },
+              {
+                "symbol": "BSDE.JK",
+                "score": 0.144335
+              }
+            ]
+          },
+          {
+            "symbol": "SPOT",
+            "recommendedSymbols": [
+              {
+                "symbol": "SHOP",
+                "score": 0.108548
+              },
+              {
+                "symbol": "ROKU",
+                "score": 0.105002
+              },
+              {
+                "symbol": "ZM",
+                "score": 0.097912
+              },
+              {
+                "symbol": "DOCU",
+                "score": 0.096422
+              },
+              {
+                "symbol": "DBX",
+                "score": 0.094762
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/utils/zip.ts
+++ b/tests/utils/zip.ts
@@ -1,0 +1,7 @@
+export function zip<T>(...arrays: T[][]) {
+  return arrays[0].map(function (_, idx) {
+    return arrays.map(function (array) {
+      return array[idx];
+    });
+  });
+}


### PR DESCRIPTION
Ref #51, #63
This PR changes `it` to `it.each` in the `recommendationsBySymbol` and `quote` modules.

## Changes
- Use `it.each(testSymbols)` instead of `it()` alone.
- Add a test util `zip` for zipping 2 arrays together.

## Benefits
- Makes sure that the validation is working properly and isn't being too strict
- Makes sure that #57, #42, #46, etc. won't pop up