### PR TITLE
Add more symbols to symbols.ts and fix the validation for them

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1639,6 +1639,7 @@
     "Grade": {
       "enum": [
         "Accumulate",
+        "Add",
         "Buy",
         "",
         "Equal-Weight",
@@ -1664,6 +1665,7 @@
         "Sell",
         "Strong Buy",
         "Underperform",
+        "Underperformer",
         "Underweight"
       ],
       "type": "string"
@@ -1897,7 +1899,7 @@
           "yahooFinanceType": "number"
         },
         "interestExpense": {
-          "yahooFinanceType": "number"
+          "yahooFinanceType": "number|null"
         },
         "maxAge": {
           "yahooFinanceType": "number"
@@ -4212,7 +4214,10 @@
           "yahooFinanceType": "date"
         },
         "quoteType": {
-          "const": "CRYPTOCURRENCY",
+          "enum": [
+            "CRYPTOCURRENCY",
+            "FUTURE"
+          ],
           "type": "string"
         },
         "score": {
@@ -4225,7 +4230,10 @@
           "type": "string"
         },
         "typeDisp": {
-          "const": "Cryptocurrency",
+          "enum": [
+            "Cryptocurrency",
+            "Future"
+          ],
           "type": "string"
         }
       },
@@ -4261,7 +4269,10 @@
           "yahooFinanceType": "date"
         },
         "quoteType": {
-          "const": "CURRENCY",
+          "enum": [
+            "CURRENCY",
+            "FUTURE"
+          ],
           "type": "string"
         },
         "score": {
@@ -4274,7 +4285,10 @@
           "type": "string"
         },
         "typeDisp": {
-          "const": "Currency",
+          "enum": [
+            "Currency",
+            "Future"
+          ],
           "type": "string"
         }
       },
@@ -4310,7 +4324,10 @@
           "yahooFinanceType": "date"
         },
         "quoteType": {
-          "const": "ETF",
+          "enum": [
+            "ETF",
+            "FUTURE"
+          ],
           "type": "string"
         },
         "score": {
@@ -4323,7 +4340,10 @@
           "type": "string"
         },
         "typeDisp": {
-          "const": "ETF",
+          "enum": [
+            "ETF",
+            "Future"
+          ],
           "type": "string"
         }
       },
@@ -4359,7 +4379,10 @@
           "yahooFinanceType": "date"
         },
         "quoteType": {
-          "const": "EQUITY",
+          "enum": [
+            "EQUITY",
+            "FUTURE"
+          ],
           "type": "string"
         },
         "score": {
@@ -4372,7 +4395,10 @@
           "type": "string"
         },
         "typeDisp": {
-          "const": "Equity",
+          "enum": [
+            "Equity",
+            "Future"
+          ],
           "type": "string"
         }
       },
@@ -4408,7 +4434,10 @@
           "yahooFinanceType": "date"
         },
         "quoteType": {
-          "const": "MUTUALFUND",
+          "enum": [
+            "MUTUALFUND",
+            "FUTURE"
+          ],
           "type": "string"
         },
         "score": {
@@ -4421,7 +4450,10 @@
           "type": "string"
         },
         "typeDisp": {
-          "const": "Fund",
+          "enum": [
+            "Fund",
+            "Future"
+          ],
           "type": "string"
         }
       },
@@ -4457,7 +4489,10 @@
           "yahooFinanceType": "date"
         },
         "quoteType": {
-          "const": "INDEX",
+          "enum": [
+            "INDEX",
+            "FUTURE"
+          ],
           "type": "string"
         },
         "score": {
@@ -4470,7 +4505,10 @@
           "type": "string"
         },
         "typeDisp": {
-          "const": "Index",
+          "enum": [
+            "Index",
+            "Future"
+          ],
           "type": "string"
         }
       },
@@ -4506,7 +4544,10 @@
           "yahooFinanceType": "date"
         },
         "quoteType": {
-          "const": "OPTION",
+          "enum": [
+            "OPTION",
+            "FUTURE"
+          ],
           "type": "string"
         },
         "score": {
@@ -4519,7 +4560,10 @@
           "type": "string"
         },
         "typeDisp": {
-          "const": "Option",
+          "enum": [
+            "Option",
+            "Future"
+          ],
           "type": "string"
         }
       },
@@ -5207,7 +5251,8 @@
         "10-K",
         "10-Q",
         "8-K",
-        "8-K/A"
+        "8-K/A",
+        "10-K/A"
       ],
       "type": "string"
     },

--- a/schema.json
+++ b/schema.json
@@ -4214,10 +4214,7 @@
           "yahooFinanceType": "date"
         },
         "quoteType": {
-          "enum": [
-            "CRYPTOCURRENCY",
-            "FUTURE"
-          ],
+          "const": "CRYPTOCURRENCY",
           "type": "string"
         },
         "score": {
@@ -4230,10 +4227,7 @@
           "type": "string"
         },
         "typeDisp": {
-          "enum": [
-            "Cryptocurrency",
-            "Future"
-          ],
+          "const": "Cryptocurrency",
           "type": "string"
         }
       },
@@ -4269,10 +4263,7 @@
           "yahooFinanceType": "date"
         },
         "quoteType": {
-          "enum": [
-            "CURRENCY",
-            "FUTURE"
-          ],
+          "const": "CURRENCY",
           "type": "string"
         },
         "score": {
@@ -4285,10 +4276,7 @@
           "type": "string"
         },
         "typeDisp": {
-          "enum": [
-            "Currency",
-            "Future"
-          ],
+          "const": "Currency",
           "type": "string"
         }
       },
@@ -4324,10 +4312,7 @@
           "yahooFinanceType": "date"
         },
         "quoteType": {
-          "enum": [
-            "ETF",
-            "FUTURE"
-          ],
+          "const": "ETF",
           "type": "string"
         },
         "score": {
@@ -4340,10 +4325,7 @@
           "type": "string"
         },
         "typeDisp": {
-          "enum": [
-            "ETF",
-            "Future"
-          ],
+          "const": "ETF",
           "type": "string"
         }
       },
@@ -4379,10 +4361,7 @@
           "yahooFinanceType": "date"
         },
         "quoteType": {
-          "enum": [
-            "EQUITY",
-            "FUTURE"
-          ],
+          "const": "EQUITY",
           "type": "string"
         },
         "score": {
@@ -4395,10 +4374,7 @@
           "type": "string"
         },
         "typeDisp": {
-          "enum": [
-            "Equity",
-            "Future"
-          ],
+          "const": "Equity",
           "type": "string"
         }
       },
@@ -4434,10 +4410,7 @@
           "yahooFinanceType": "date"
         },
         "quoteType": {
-          "enum": [
-            "MUTUALFUND",
-            "FUTURE"
-          ],
+          "const": "MUTUALFUND",
           "type": "string"
         },
         "score": {
@@ -4450,10 +4423,56 @@
           "type": "string"
         },
         "typeDisp": {
-          "enum": [
-            "Fund",
-            "Future"
-          ],
+          "const": "Fund",
+          "type": "string"
+        }
+      },
+      "required": [
+        "exchange",
+        "index",
+        "isYahooFinance",
+        "quoteType",
+        "score",
+        "symbol",
+        "typeDisp"
+      ],
+      "type": "object"
+    },
+    "SearchQuoteYahooFuture": {
+      "additionalProperties": false,
+      "properties": {
+        "exchange": {
+          "type": "string"
+        },
+        "index": {
+          "const": "quotes",
+          "type": "string"
+        },
+        "isYahooFinance": {
+          "const": true,
+          "type": "boolean"
+        },
+        "longname": {
+          "type": "string"
+        },
+        "newListingDate": {
+          "yahooFinanceType": "date"
+        },
+        "quoteType": {
+          "const": "FUTURE",
+          "type": "string"
+        },
+        "score": {
+          "yahooFinanceType": "number"
+        },
+        "shortname": {
+          "type": "string"
+        },
+        "symbol": {
+          "type": "string"
+        },
+        "typeDisp": {
+          "const": "Future",
           "type": "string"
         }
       },
@@ -4489,10 +4508,7 @@
           "yahooFinanceType": "date"
         },
         "quoteType": {
-          "enum": [
-            "INDEX",
-            "FUTURE"
-          ],
+          "const": "INDEX",
           "type": "string"
         },
         "score": {
@@ -4505,10 +4521,7 @@
           "type": "string"
         },
         "typeDisp": {
-          "enum": [
-            "Index",
-            "Future"
-          ],
+          "const": "Index",
           "type": "string"
         }
       },
@@ -4544,10 +4557,7 @@
           "yahooFinanceType": "date"
         },
         "quoteType": {
-          "enum": [
-            "OPTION",
-            "FUTURE"
-          ],
+          "const": "OPTION",
           "type": "string"
         },
         "score": {
@@ -4560,10 +4570,7 @@
           "type": "string"
         },
         "typeDisp": {
-          "enum": [
-            "Option",
-            "Future"
-          ],
+          "const": "Option",
           "type": "string"
         }
       },
@@ -4628,6 +4635,9 @@
               },
               {
                 "$ref": "#/definitions/SearchQuoteNonYahoo"
+              },
+              {
+                "$ref": "#/definitions/SearchQuoteYahooFuture"
               }
             ]
           },

--- a/src/modules/quoteSummary-iface.ts
+++ b/src/modules/quoteSummary-iface.ts
@@ -517,7 +517,7 @@ export interface IncomeStatementHistoryElement {
   operatingIncome: number;
   totalOtherIncomeExpenseNet: number;
   ebit: number;
-  interestExpense: number;
+  interestExpense: number | null;
   incomeBeforeTax: number;
   incomeTaxExpense: number;
   minorityInterest: number | null;
@@ -727,6 +727,7 @@ export enum Type {
   The10Q = "10-Q",
   The8K = "8-K",
   The8KA = "8-K/A",
+  The10KA = "10-K/A",
 }
 
 export interface SummaryDetail {
@@ -881,6 +882,7 @@ export enum Action {
 
 export enum Grade {
   Accumulate = "Accumulate",
+  Add = "Add",
   Buy = "Buy",
   Empty = "",
   EqualWeight = "Equal-Weight",
@@ -906,5 +908,6 @@ export enum Grade {
   Sell = "Sell",
   StrongBuy = "Strong Buy",
   Underperform = "Underperform",
+  Underperformer = "Underperformer",
   Underweight = "Underweight",
 }

--- a/src/modules/search.ts
+++ b/src/modules/search.ts
@@ -16,32 +16,32 @@ export interface SearchQuoteYahoo {
   newListingDate?: Date; // "2021-02-16"
 }
 export interface SearchQuoteYahooEquity extends SearchQuoteYahoo {
-  quoteType: "EQUITY";
-  typeDisp: "Equity";
+  quoteType: "EQUITY" | "FUTURE";
+  typeDisp: "Equity" | "Future";
 }
 export interface SearchQuoteYahooOption extends SearchQuoteYahoo {
-  quoteType: "OPTION";
-  typeDisp: "Option";
+  quoteType: "OPTION" | "FUTURE";
+  typeDisp: "Option" | "Future";
 }
 export interface SearchQuoteYahooETF extends SearchQuoteYahoo {
-  quoteType: "ETF";
-  typeDisp: "ETF"; // "Option"
+  quoteType: "ETF" | "FUTURE";
+  typeDisp: "ETF" | "Future"; // "Option"
 }
 export interface SearchQuoteYahooFund extends SearchQuoteYahoo {
-  quoteType: "MUTUALFUND";
-  typeDisp: "Fund";
+  quoteType: "MUTUALFUND" | "FUTURE";
+  typeDisp: "Fund" | "Future";
 }
 export interface SearchQuoteYahooIndex extends SearchQuoteYahoo {
-  quoteType: "INDEX";
-  typeDisp: "Index";
+  quoteType: "INDEX" | "FUTURE";
+  typeDisp: "Index" | "Future";
 }
 export interface SearchQuoteYahooCurrency extends SearchQuoteYahoo {
-  quoteType: "CURRENCY";
-  typeDisp: "Currency";
+  quoteType: "CURRENCY" | "FUTURE";
+  typeDisp: "Currency" | "Future";
 }
 export interface SearchQuoteYahooCryptocurrency extends SearchQuoteYahoo {
-  quoteType: "CRYPTOCURRENCY";
-  typeDisp: "Cryptocurrency";
+  quoteType: "CRYPTOCURRENCY" | "FUTURE";
+  typeDisp: "Cryptocurrency" | "Future";
 }
 export interface SearchQuoteNonYahoo {
   index: string; // '78ddc07626ff4bbcae663e88514c23a0'

--- a/src/modules/search.ts
+++ b/src/modules/search.ts
@@ -16,33 +16,39 @@ export interface SearchQuoteYahoo {
   newListingDate?: Date; // "2021-02-16"
 }
 export interface SearchQuoteYahooEquity extends SearchQuoteYahoo {
-  quoteType: "EQUITY" | "FUTURE";
-  typeDisp: "Equity" | "Future";
+  quoteType: "EQUITY";
+  typeDisp: "Equity";
 }
 export interface SearchQuoteYahooOption extends SearchQuoteYahoo {
-  quoteType: "OPTION" | "FUTURE";
-  typeDisp: "Option" | "Future";
+  quoteType: "OPTION";
+  typeDisp: "Option";
 }
 export interface SearchQuoteYahooETF extends SearchQuoteYahoo {
-  quoteType: "ETF" | "FUTURE";
-  typeDisp: "ETF" | "Future"; // "Option"
+  quoteType: "ETF";
+  typeDisp: "ETF"; // "Option"
 }
 export interface SearchQuoteYahooFund extends SearchQuoteYahoo {
-  quoteType: "MUTUALFUND" | "FUTURE";
-  typeDisp: "Fund" | "Future";
+  quoteType: "MUTUALFUND";
+  typeDisp: "Fund";
 }
 export interface SearchQuoteYahooIndex extends SearchQuoteYahoo {
-  quoteType: "INDEX" | "FUTURE";
-  typeDisp: "Index" | "Future";
+  quoteType: "INDEX";
+  typeDisp: "Index";
 }
 export interface SearchQuoteYahooCurrency extends SearchQuoteYahoo {
-  quoteType: "CURRENCY" | "FUTURE";
-  typeDisp: "Currency" | "Future";
+  quoteType: "CURRENCY";
+  typeDisp: "Currency";
 }
 export interface SearchQuoteYahooCryptocurrency extends SearchQuoteYahoo {
-  quoteType: "CRYPTOCURRENCY" | "FUTURE";
-  typeDisp: "Cryptocurrency" | "Future";
+  quoteType: "CRYPTOCURRENCY";
+  typeDisp: "Cryptocurrency";
 }
+
+export interface SearchQuoteYahooFuture extends SearchQuoteYahoo {
+  quoteType: "FUTURE";
+  typeDisp: "Future";
+}
+
 export interface SearchQuoteNonYahoo {
   index: string; // '78ddc07626ff4bbcae663e88514c23a0'
   name: string; // 'AAPlasma'
@@ -71,6 +77,7 @@ export interface SearchResult {
     | SearchQuoteYahooCurrency
     | SearchQuoteYahooCryptocurrency
     | SearchQuoteNonYahoo
+    | SearchQuoteYahooFuture
   >;
   news: Array<SearchNews>;
   nav: Array<any>;

--- a/tests/http/autoc-ABBV.json
+++ b/tests/http/autoc-ABBV.json
@@ -1,0 +1,139 @@
+{
+  "request": {
+    "url": "https://autoc.finance.yahoo.com/autoc?region=1&lang=en&query=ABBV"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-content-type-options": [
+        "nosniff"
+      ],
+      "x-yahoo-request-id": [
+        "ftsb68dg2vse0"
+      ],
+      "cache-control": [
+        "public, max-age=300, stale-while-revalidate=30, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "content-length": [
+        "309"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:36 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=31536000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ]
+    },
+    "bodyJson": {
+      "ResultSet": {
+        "Query": "ABBV",
+        "Result": [
+          {
+            "symbol": "ABBV",
+            "name": "AbbVie Inc.",
+            "exch": "NYQ",
+            "type": "S",
+            "exchDisp": "NYSE",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "ABBV34.SA",
+            "name": "AbbVie Inc.",
+            "exch": "SAO",
+            "type": "S",
+            "exchDisp": "Sao Paolo",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "4AB.F",
+            "name": "AbbVie Inc.",
+            "exch": "FRA",
+            "type": "S",
+            "exchDisp": "Frankfurt",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "4AB.DE",
+            "name": "AbbVie Inc.",
+            "exch": "GER",
+            "type": "S",
+            "exchDisp": "XETRA",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "ABBV.VI",
+            "name": "AbbVie Inc.",
+            "exch": "VIE",
+            "type": "S",
+            "exchDisp": "Vienna",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "ABBV.MX",
+            "name": "AbbVie Inc.",
+            "exch": "MEX",
+            "type": "S",
+            "exchDisp": "Mexico",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "4AB.SG",
+            "name": "AbbVie Inc. Registered Shares D",
+            "exch": "STU",
+            "type": "S",
+            "exchDisp": "Stuttgart",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "4AB.DU",
+            "name": "ABBVIE INC.  DL-,01",
+            "exch": "DUS",
+            "type": "S",
+            "exchDisp": "Dusseldorf Stock Exchange",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "4AB.BE",
+            "name": "ABBVIE INC.  DL-,01",
+            "exch": "BER",
+            "type": "S",
+            "exchDisp": "Berlin",
+            "typeDisp": "Equity"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/http/autoc-BRKS.json
+++ b/tests/http/autoc-BRKS.json
@@ -1,0 +1,139 @@
+{
+  "request": {
+    "url": "https://autoc.finance.yahoo.com/autoc?region=1&lang=en&query=BRKS"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-content-type-options": [
+        "nosniff"
+      ],
+      "x-yahoo-request-id": [
+        "d70tcd1g2vse1"
+      ],
+      "cache-control": [
+        "public, max-age=300, stale-while-revalidate=30, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "content-length": [
+        "350"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:37 GMT"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=31536000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ]
+    },
+    "bodyJson": {
+      "ResultSet": {
+        "Query": "BRKS",
+        "Result": [
+          {
+            "symbol": "BRKS",
+            "name": "Brooks Automation, Inc.",
+            "exch": "NMS",
+            "type": "S",
+            "exchDisp": "NASDAQ",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "BRKSX",
+            "name": "MFS Blended Research Emerging Markets Equity Fund Class R2",
+            "exch": "NAS",
+            "type": "M",
+            "exchDisp": "NASDAQ",
+            "typeDisp": "Fund"
+          },
+          {
+            "symbol": "BRKSN.IS",
+            "name": "Berkosan Yalitim Ve Tecrit Maddeleri Üretim Ve Ticaret A.S.",
+            "exch": "IST",
+            "type": "S",
+            "exchDisp": "IST",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "BRKS210416C00095000",
+            "name": "BRKS Apr 2021 call 95.000",
+            "exch": "OPR",
+            "type": "O",
+            "exchDisp": "OPR",
+            "typeDisp": "Option"
+          },
+          {
+            "symbol": "BRKS210416C00092500",
+            "name": "BRKS Apr 2021 call 92.500",
+            "exch": "OPR",
+            "type": "O",
+            "exchDisp": "OPR",
+            "typeDisp": "Option"
+          },
+          {
+            "symbol": "BRKS210416C00090000",
+            "name": "BRKS Apr 2021 call 90.000",
+            "exch": "OPR",
+            "type": "O",
+            "exchDisp": "OPR",
+            "typeDisp": "Option"
+          },
+          {
+            "symbol": "BRKS210416C00087500",
+            "name": "BRKS Apr 2021 call 87.500",
+            "exch": "OPR",
+            "type": "O",
+            "exchDisp": "OPR",
+            "typeDisp": "Option"
+          },
+          {
+            "symbol": "BRKS210416C00085000",
+            "name": "BRKS Apr 2021 call 85.000",
+            "exch": "OPR",
+            "type": "O",
+            "exchDisp": "OPR",
+            "typeDisp": "Option"
+          },
+          {
+            "symbol": "BRKS210416C00082500",
+            "name": "BRKS Apr 2021 call 82.500",
+            "exch": "OPR",
+            "type": "O",
+            "exchDisp": "OPR",
+            "typeDisp": "Option"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/http/autoc-CRON.json
+++ b/tests/http/autoc-CRON.json
@@ -1,0 +1,139 @@
+{
+  "request": {
+    "url": "https://autoc.finance.yahoo.com/autoc?region=1&lang=en&query=CRON"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-content-type-options": [
+        "nosniff"
+      ],
+      "x-yahoo-request-id": [
+        "313uukdg2vse1"
+      ],
+      "cache-control": [
+        "public, max-age=300, stale-while-revalidate=30, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "content-length": [
+        "340"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:37 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=31536000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ]
+    },
+    "bodyJson": {
+      "ResultSet": {
+        "Query": "CRON",
+        "Result": [
+          {
+            "symbol": "CRON",
+            "name": "Cronos Group Inc.",
+            "exch": "NMS",
+            "type": "S",
+            "exchDisp": "NASDAQ",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "CRON.TO",
+            "name": "Cronos Group Inc.",
+            "exch": "YHD",
+            "type": "S",
+            "exchDisp": "Industry",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "7CI.F",
+            "name": "Cronos Group Inc.",
+            "exch": "FRA",
+            "type": "S",
+            "exchDisp": "Frankfurt",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "0P0000IV0O.F",
+            "name": "CRONISTA CARRERES DE INVERSIONES, SICAV S.A.",
+            "exch": "YHD",
+            "type": "M",
+            "exchDisp": "Industry",
+            "typeDisp": "Fund"
+          },
+          {
+            "symbol": "7CI.DU",
+            "name": "CRONOS GRP INC.",
+            "exch": "DUS",
+            "type": "S",
+            "exchDisp": "Dusseldorf Stock Exchange",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "7CI.SG",
+            "name": "Cronos Group Inc.",
+            "exch": "STU",
+            "type": "S",
+            "exchDisp": "Stuttgart",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "0P000085K2.F",
+            "name": "Solventis Cronos PP",
+            "exch": "FRA",
+            "type": "M",
+            "exchDisp": "Frankfurt",
+            "typeDisp": "Fund"
+          },
+          {
+            "symbol": "7CI.BE",
+            "name": "CRONOS GRP INC.",
+            "exch": "BER",
+            "type": "S",
+            "exchDisp": "Berlin",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "7CI.MU",
+            "name": "CRONOS GRP INC.",
+            "exch": "MUN",
+            "type": "S",
+            "exchDisp": "Munich",
+            "typeDisp": "Equity"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/http/autoc-EPAC.json
+++ b/tests/http/autoc-EPAC.json
@@ -1,0 +1,139 @@
+{
+  "request": {
+    "url": "https://autoc.finance.yahoo.com/autoc?region=1&lang=en&query=EPAC"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-content-type-options": [
+        "nosniff"
+      ],
+      "x-yahoo-request-id": [
+        "csauss5g2vse1"
+      ],
+      "cache-control": [
+        "public, max-age=300, stale-while-revalidate=30, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "content-length": [
+        "314"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:37 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=31536000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ]
+    },
+    "bodyJson": {
+      "ResultSet": {
+        "Query": "EPAC",
+        "Result": [
+          {
+            "symbol": "EPAC",
+            "name": "Enerpac Tool Group Corp.",
+            "exch": "NYQ",
+            "type": "S",
+            "exchDisp": "NYSE",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "^IDV-NV",
+            "name": "iShares Dow Jones EPAC Select D",
+            "exch": "ASE",
+            "type": "I",
+            "exchDisp": "NYSE MKT",
+            "typeDisp": "Index"
+          },
+          {
+            "symbol": "^IDV-EU",
+            "name": "iShares Dow Jones EPAC Select D",
+            "exch": "ASE",
+            "type": "I",
+            "exchDisp": "NYSE MKT",
+            "typeDisp": "Index"
+          },
+          {
+            "symbol": "^SPBEKLUP",
+            "name": "S&P EPAC Ex-Korea LargeMidCap (",
+            "exch": "SNP",
+            "type": "I",
+            "exchDisp": "SNP",
+            "typeDisp": "Index"
+          },
+          {
+            "symbol": "^SPBEKLUT",
+            "name": "S&P EPAC Ex-Korea LargeMidCap (",
+            "exch": "NYS",
+            "type": "I",
+            "exchDisp": "NYSE",
+            "typeDisp": "Index"
+          },
+          {
+            "symbol": "^SPEXLUH",
+            "name": "S&P EPAC Ex. Korea Low Volatili",
+            "exch": "NYS",
+            "type": "I",
+            "exchDisp": "NYSE",
+            "typeDisp": "Index"
+          },
+          {
+            "symbol": "^SPXKLHUP",
+            "name": "S&P EPAC Ex. Korea Low Volatili",
+            "exch": "NYS",
+            "type": "I",
+            "exchDisp": "NYSE",
+            "typeDisp": "Index"
+          },
+          {
+            "symbol": "^SPXKLHUT",
+            "name": "S&P EPAC Ex. Korea Low Volatili",
+            "exch": "NYS",
+            "type": "I",
+            "exchDisp": "NYSE",
+            "typeDisp": "Index"
+          },
+          {
+            "symbol": "^DJEPCSD",
+            "name": "Dow Jones EPAC Select Dividend ",
+            "exch": "DJI",
+            "type": "I",
+            "exchDisp": "Dow Jones",
+            "typeDisp": "Index"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/http/autoc-MDLY.json
+++ b/tests/http/autoc-MDLY.json
@@ -1,0 +1,75 @@
+{
+  "request": {
+    "url": "https://autoc.finance.yahoo.com/autoc?region=1&lang=en&query=MDLY"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-content-type-options": [
+        "nosniff"
+      ],
+      "x-yahoo-request-id": [
+        "06dlea5g2vse0"
+      ],
+      "cache-control": [
+        "public, max-age=300, stale-while-revalidate=30, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "content-length": [
+        "133"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:36 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=31536000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ]
+    },
+    "bodyJson": {
+      "ResultSet": {
+        "Query": "MDLY",
+        "Result": [
+          {
+            "symbol": "MDLY",
+            "name": "Medley Management Inc.",
+            "exch": "NYQ",
+            "type": "S",
+            "exchDisp": "NYSE",
+            "typeDisp": "Equity"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/http/autoc-SI.json
+++ b/tests/http/autoc-SI.json
@@ -1,0 +1,139 @@
+{
+  "request": {
+    "url": "https://autoc.finance.yahoo.com/autoc?region=1&lang=en&query=SI"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-content-type-options": [
+        "nosniff"
+      ],
+      "x-yahoo-request-id": [
+        "ad30repg2vse0"
+      ],
+      "cache-control": [
+        "public, max-age=300, stale-while-revalidate=30, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "content-length": [
+        "320"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:36 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=31536000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ]
+    },
+    "bodyJson": {
+      "ResultSet": {
+        "Query": "SI",
+        "Result": [
+          {
+            "symbol": "SI",
+            "name": "Silvergate Capital Corporation",
+            "exch": "NYQ",
+            "type": "S",
+            "exchDisp": "NYSE",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "SGFY",
+            "name": "Signify Health, Inc.",
+            "exch": "NYS",
+            "type": "S",
+            "exchDisp": "NYSE",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "SBTX",
+            "name": "Silverback Therapeutics, Inc.",
+            "exch": "NGM",
+            "type": "S",
+            "exchDisp": "NASDAQ",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "SLCRU",
+            "name": "Silver Crest Acquisition Corporation",
+            "exch": "NCM",
+            "type": "S",
+            "exchDisp": "NASDAQ",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "SGTX",
+            "name": "Sigilon Therapeutics, Inc.",
+            "exch": "NGM",
+            "type": "S",
+            "exchDisp": "NASDAQ",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "SPG",
+            "name": "Simon Property Group, Inc.",
+            "exch": "NYQ",
+            "type": "S",
+            "exchDisp": "NYSE",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "SIRI",
+            "name": "Sirius XM Holdings Inc.",
+            "exch": "NMS",
+            "type": "S",
+            "exchDisp": "NASDAQ",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "SIX",
+            "name": "Six Flags Entertainment Corporation",
+            "exch": "NYQ",
+            "type": "S",
+            "exchDisp": "NYSE",
+            "typeDisp": "Equity"
+          },
+          {
+            "symbol": "SIG",
+            "name": "Signet Jewelers Limited",
+            "exch": "NYQ",
+            "type": "S",
+            "exchDisp": "NYSE",
+            "typeDisp": "Equity"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/http/historical-ABBV-2020-01-01-to-2020-01-03.json
+++ b/tests/http/historical-ABBV-2020-01-01-to-2020-01-03.json
@@ -1,0 +1,73 @@
+{
+  "request": {
+    "url": "https://query1.finance.yahoo.com/v7/finance/download/ABBV?interval=1d&events=history&includeAdjustedClose=true&period1=1577836800&period2=1578009600"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-disposition": [
+        "attachment; filename=ABBV.csv"
+      ],
+      "content-type": [
+        "text/csv"
+      ],
+      "cache-control": [
+        "private, max-age=10, stale-while-revalidate=20"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "86rfdqdg2vsdu"
+      ],
+      "x-yahoo-request-id": [
+        "86rfdqdg2vsdu"
+      ],
+      "x-request-id": [
+        "24b2c143-55dd-4fd3-a501-42a12dd8b6ee"
+      ],
+      "content-length": [
+        "110"
+      ],
+      "x-envoy-upstream-service-time": [
+        "12"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:34 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-chart-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "body": "Date,Open,High,Low,Close,Adj Close,Volume\n2020-01-02,89.080002,89.570000,88.510002,89.550003,83.871666,5639200"
+  }
+}

--- a/tests/http/historical-BRKS-2020-01-01-to-2020-01-03.json
+++ b/tests/http/historical-BRKS-2020-01-01-to-2020-01-03.json
@@ -1,0 +1,73 @@
+{
+  "request": {
+    "url": "https://query1.finance.yahoo.com/v7/finance/download/BRKS?interval=1d&events=history&includeAdjustedClose=true&period1=1577836800&period2=1578009600"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-disposition": [
+        "attachment; filename=BRKS.csv"
+      ],
+      "content-type": [
+        "text/csv"
+      ],
+      "cache-control": [
+        "private, max-age=10, stale-while-revalidate=20"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "8888t9pg2vsdu"
+      ],
+      "x-yahoo-request-id": [
+        "8888t9pg2vsdu"
+      ],
+      "x-request-id": [
+        "5bab92ef-999a-4a36-bb06-e53f782718db"
+      ],
+      "content-length": [
+        "109"
+      ],
+      "x-envoy-upstream-service-time": [
+        "16"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:34 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-chart-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "body": "Date,Open,High,Low,Close,Adj Close,Volume\n2020-01-02,42.529999,42.910000,42.270000,42.900002,42.539421,318300"
+  }
+}

--- a/tests/http/historical-CRON-2020-01-01-to-2020-01-03.json
+++ b/tests/http/historical-CRON-2020-01-01-to-2020-01-03.json
@@ -1,0 +1,73 @@
+{
+  "request": {
+    "url": "https://query1.finance.yahoo.com/v7/finance/download/CRON?interval=1d&events=history&includeAdjustedClose=true&period1=1577836800&period2=1578009600"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-disposition": [
+        "attachment; filename=CRON.csv"
+      ],
+      "content-type": [
+        "text/csv"
+      ],
+      "cache-control": [
+        "private, max-age=10, stale-while-revalidate=20"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "f44vkitg2vsdu"
+      ],
+      "x-yahoo-request-id": [
+        "f44vkitg2vsdu"
+      ],
+      "x-request-id": [
+        "5b26556c-c2ad-4da6-84e9-be5ebf262706"
+      ],
+      "content-length": [
+        "106"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:34 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-chart-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "body": "Date,Open,High,Low,Close,Adj Close,Volume\n2020-01-02,7.920000,7.960000,7.230000,7.360000,7.360000,12655000"
+  }
+}

--- a/tests/http/historical-EPAC-2020-01-01-to-2020-01-03.json
+++ b/tests/http/historical-EPAC-2020-01-01-to-2020-01-03.json
@@ -1,0 +1,73 @@
+{
+  "request": {
+    "url": "https://query1.finance.yahoo.com/v7/finance/download/EPAC?interval=1d&events=history&includeAdjustedClose=true&period1=1577836800&period2=1578009600"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-disposition": [
+        "attachment; filename=EPAC.csv"
+      ],
+      "content-type": [
+        "text/csv"
+      ],
+      "cache-control": [
+        "private, max-age=10, stale-while-revalidate=20"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "95g46i5g2vsdu"
+      ],
+      "x-yahoo-request-id": [
+        "95g46i5g2vsdu"
+      ],
+      "x-request-id": [
+        "3768834f-d766-4abc-98cd-1bb48e9da2ee"
+      ],
+      "content-length": [
+        "109"
+      ],
+      "x-envoy-upstream-service-time": [
+        "23"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:34 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-chart-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "3"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "body": "Date,Open,High,Low,Close,Adj Close,Volume\n2020-01-02,26.190001,26.340000,25.750000,26.160000,26.104370,407900"
+  }
+}

--- a/tests/http/historical-MDLY-2020-01-01-to-2020-01-03.json
+++ b/tests/http/historical-MDLY-2020-01-01-to-2020-01-03.json
@@ -1,0 +1,73 @@
+{
+  "request": {
+    "url": "https://query1.finance.yahoo.com/v7/finance/download/MDLY?interval=1d&events=history&includeAdjustedClose=true&period1=1577836800&period2=1578009600"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-disposition": [
+        "attachment; filename=MDLY.csv"
+      ],
+      "content-type": [
+        "text/csv"
+      ],
+      "cache-control": [
+        "private, max-age=10, stale-while-revalidate=20"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "e4db9apg2vsdu"
+      ],
+      "x-yahoo-request-id": [
+        "e4db9apg2vsdu"
+      ],
+      "x-request-id": [
+        "0fa74e9a-5296-46b0-af94-8e963c064a0c"
+      ],
+      "content-length": [
+        "106"
+      ],
+      "x-envoy-upstream-service-time": [
+        "8"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:33 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-chart-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "body": "Date,Open,High,Low,Close,Adj Close,Volume\n2020-01-02,29.400000,29.799999,29.400000,29.700001,29.700001,510"
+  }
+}

--- a/tests/http/historical-SI-2020-01-01-to-2020-01-03.json
+++ b/tests/http/historical-SI-2020-01-01-to-2020-01-03.json
@@ -1,0 +1,73 @@
+{
+  "request": {
+    "url": "https://query1.finance.yahoo.com/v7/finance/download/SI?interval=1d&events=history&includeAdjustedClose=true&period1=1577836800&period2=1578009600"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-disposition": [
+        "attachment; filename=SI.csv"
+      ],
+      "content-type": [
+        "text/csv"
+      ],
+      "cache-control": [
+        "private, max-age=10, stale-while-revalidate=20"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "c4q80o1g2vsdt"
+      ],
+      "x-yahoo-request-id": [
+        "c4q80o1g2vsdt"
+      ],
+      "x-request-id": [
+        "2452324d-a242-4357-abb6-9eaf5243efa5"
+      ],
+      "content-length": [
+        "108"
+      ],
+      "x-envoy-upstream-service-time": [
+        "6"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:33 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-chart-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "body": "Date,Open,High,Low,Close,Adj Close,Volume\n2020-01-02,16.049999,16.049999,15.675000,15.930000,15.930000,60800"
+  }
+}

--- a/tests/http/quote-ABBV-10am.json
+++ b/tests/http/quote-ABBV-10am.json
@@ -1,0 +1,154 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=ABBV"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "1f4pcohg2vse0"
+      ],
+      "x-yahoo-request-id": [
+        "1f4pcohg2vse0"
+      ],
+      "x-request-id": [
+        "741d4f02-b37c-4513-874e-33fc736033ab"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "975"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:35 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "2"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "warning": [
+        "110 Response is stale"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "marketState": "REGULAR",
+            "exchange": "NYQ",
+            "shortName": "AbbVie Inc.",
+            "longName": "AbbVie Inc.",
+            "messageBoardId": "finmb_141885706",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "earningsTimestamp": 1612337885,
+            "earningsTimestampStart": 1619699400,
+            "earningsTimestampEnd": 1620045000,
+            "trailingAnnualDividendRate": 4.84,
+            "trailingPE": 38.8125,
+            "trailingAnnualDividendYield": 0.04563455,
+            "epsTrailingTwelveMonths": 2.72,
+            "epsForward": 13.75,
+            "epsCurrentYear": 12.43,
+            "priceEpsCurrentYear": 8.493161,
+            "sharesOutstanding": 1765469952,
+            "bookValue": 8.65,
+            "fiftyDayAverage": 107.234245,
+            "fiftyDayAverageChange": -1.6642456,
+            "fiftyDayAverageChangePercent": -0.015519721,
+            "twoHundredDayAverage": 97.44348,
+            "twoHundredDayAverageChange": 8.126518,
+            "twoHundredDayAverageChangePercent": 0.08339725,
+            "marketCap": 186380664832,
+            "forwardPE": 7.6778183,
+            "priceToBook": 12.204625,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "priceHint": 2,
+            "regularMarketChange": -0.48999786,
+            "regularMarketChangePercent": -0.46200064,
+            "regularMarketTime": 1613754810,
+            "regularMarketPrice": 105.57,
+            "regularMarketDayHigh": 106.35,
+            "regularMarketDayRange": "104.91 - 106.35",
+            "regularMarketDayLow": 104.91,
+            "regularMarketVolume": 2380410,
+            "regularMarketPreviousClose": 106.06,
+            "bid": 105.65,
+            "ask": 105.65,
+            "bidSize": 12,
+            "askSize": 8,
+            "fullExchangeName": "NYSE",
+            "financialCurrency": "USD",
+            "regularMarketOpen": 106.23,
+            "averageDailyVolume3Month": 7408847,
+            "averageDailyVolume10Day": 5676571,
+            "fiftyTwoWeekLowChange": 43.02,
+            "fiftyTwoWeekLowChangePercent": 0.6877698,
+            "fiftyTwoWeekRange": "62.55 - 113.41",
+            "fiftyTwoWeekHighChange": -7.840004,
+            "fiftyTwoWeekHighChangePercent": -0.06912974,
+            "fiftyTwoWeekLow": 62.55,
+            "fiftyTwoWeekHigh": 113.41,
+            "dividendDate": 1613433600,
+            "tradeable": false,
+            "firstTradeDateMilliseconds": 1357137000000,
+            "displayName": "AbbVie",
+            "symbol": "ABBV"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-ABBV.json
+++ b/tests/http/quote-ABBV.json
@@ -1,0 +1,151 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=ABBV"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "1f4pcohg2vse0"
+      ],
+      "x-yahoo-request-id": [
+        "1f4pcohg2vse0"
+      ],
+      "x-request-id": [
+        "741d4f02-b37c-4513-874e-33fc736033ab"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "975"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:35 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "marketState": "REGULAR",
+            "exchange": "NYQ",
+            "shortName": "AbbVie Inc.",
+            "longName": "AbbVie Inc.",
+            "messageBoardId": "finmb_141885706",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "earningsTimestamp": 1612337885,
+            "earningsTimestampStart": 1619699400,
+            "earningsTimestampEnd": 1620045000,
+            "trailingAnnualDividendRate": 4.84,
+            "trailingPE": 38.8125,
+            "trailingAnnualDividendYield": 0.04563455,
+            "epsTrailingTwelveMonths": 2.72,
+            "epsForward": 13.75,
+            "epsCurrentYear": 12.43,
+            "priceEpsCurrentYear": 8.493161,
+            "sharesOutstanding": 1765469952,
+            "bookValue": 8.65,
+            "fiftyDayAverage": 107.234245,
+            "fiftyDayAverageChange": -1.6642456,
+            "fiftyDayAverageChangePercent": -0.015519721,
+            "twoHundredDayAverage": 97.44348,
+            "twoHundredDayAverageChange": 8.126518,
+            "twoHundredDayAverageChangePercent": 0.08339725,
+            "marketCap": 186380664832,
+            "forwardPE": 7.6778183,
+            "priceToBook": 12.204625,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "priceHint": 2,
+            "regularMarketChange": -0.48999786,
+            "regularMarketChangePercent": -0.46200064,
+            "regularMarketTime": 1613754810,
+            "regularMarketPrice": 105.57,
+            "regularMarketDayHigh": 106.35,
+            "regularMarketDayRange": "104.91 - 106.35",
+            "regularMarketDayLow": 104.91,
+            "regularMarketVolume": 2380410,
+            "regularMarketPreviousClose": 106.06,
+            "bid": 105.65,
+            "ask": 105.65,
+            "bidSize": 12,
+            "askSize": 8,
+            "fullExchangeName": "NYSE",
+            "financialCurrency": "USD",
+            "regularMarketOpen": 106.23,
+            "averageDailyVolume3Month": 7408847,
+            "averageDailyVolume10Day": 5676571,
+            "fiftyTwoWeekLowChange": 43.02,
+            "fiftyTwoWeekLowChangePercent": 0.6877698,
+            "fiftyTwoWeekRange": "62.55 - 113.41",
+            "fiftyTwoWeekHighChange": -7.840004,
+            "fiftyTwoWeekHighChangePercent": -0.06912974,
+            "fiftyTwoWeekLow": 62.55,
+            "fiftyTwoWeekHigh": 113.41,
+            "dividendDate": 1613433600,
+            "tradeable": false,
+            "firstTradeDateMilliseconds": 1357137000000,
+            "displayName": "AbbVie",
+            "symbol": "ABBV"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-BRKS-10am.json
+++ b/tests/http/quote-BRKS-10am.json
@@ -1,0 +1,151 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=BRKS"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "9dvdt9hg2vse0"
+      ],
+      "x-yahoo-request-id": [
+        "9dvdt9hg2vse0"
+      ],
+      "x-request-id": [
+        "e3baece1-c6c5-4747-9e13-1bad717fab55"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "979"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:36 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "exchange": "NMS",
+            "shortName": "Brooks Automation, Inc.",
+            "longName": "Brooks Automation, Inc.",
+            "messageBoardId": "finmb_336648",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "priceEpsCurrentYear": 43.914574,
+            "sharesOutstanding": 74220096,
+            "bookValue": 17.118,
+            "fiftyDayAverage": 78.746666,
+            "fiftyDayAverageChange": 8.643333,
+            "fiftyDayAverageChangePercent": 0.10976126,
+            "twoHundredDayAverage": 62.45348,
+            "twoHundredDayAverageChange": 24.93652,
+            "twoHundredDayAverageChangePercent": 0.3992815,
+            "marketCap": 6486094336,
+            "forwardPE": 38.4978,
+            "priceToBook": 5.1051526,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "firstTradeDateMilliseconds": 791735400000,
+            "regularMarketChange": 4.4000015,
+            "priceHint": 2,
+            "regularMarketChangePercent": 5.3018456,
+            "regularMarketTime": 1613754775,
+            "regularMarketPrice": 87.39,
+            "regularMarketDayHigh": 87.9,
+            "regularMarketDayRange": "84.56 - 87.9",
+            "regularMarketDayLow": 84.56,
+            "regularMarketVolume": 146196,
+            "regularMarketPreviousClose": 82.99,
+            "bid": 87.55,
+            "ask": 87.74,
+            "bidSize": 13,
+            "askSize": 10,
+            "fullExchangeName": "NasdaqGS",
+            "financialCurrency": "USD",
+            "regularMarketOpen": 84.56,
+            "averageDailyVolume3Month": 865460,
+            "averageDailyVolume10Day": 520785,
+            "fiftyTwoWeekLowChange": 66.2,
+            "fiftyTwoWeekLowChangePercent": 3.124115,
+            "fiftyTwoWeekRange": "21.19 - 91.78",
+            "fiftyTwoWeekHighChange": -4.3899994,
+            "fiftyTwoWeekHighChangePercent": -0.047831766,
+            "fiftyTwoWeekLow": 21.19,
+            "fiftyTwoWeekHigh": 91.78,
+            "dividendDate": 1616716800,
+            "earningsTimestamp": 1612281904,
+            "earningsTimestampStart": 1619640000,
+            "earningsTimestampEnd": 1620072000,
+            "trailingAnnualDividendRate": 0.4,
+            "trailingPE": 83.546844,
+            "trailingAnnualDividendYield": 0.004819858,
+            "epsTrailingTwelveMonths": 1.046,
+            "epsForward": 2.27,
+            "epsCurrentYear": 1.99,
+            "marketState": "REGULAR",
+            "displayName": "Brooks Automation",
+            "symbol": "BRKS"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-BRKS.json
+++ b/tests/http/quote-BRKS.json
@@ -1,0 +1,151 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=BRKS"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "9dvdt9hg2vse0"
+      ],
+      "x-yahoo-request-id": [
+        "9dvdt9hg2vse0"
+      ],
+      "x-request-id": [
+        "e3baece1-c6c5-4747-9e13-1bad717fab55"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "979"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:36 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "exchange": "NMS",
+            "shortName": "Brooks Automation, Inc.",
+            "longName": "Brooks Automation, Inc.",
+            "messageBoardId": "finmb_336648",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "priceEpsCurrentYear": 43.914574,
+            "sharesOutstanding": 74220096,
+            "bookValue": 17.118,
+            "fiftyDayAverage": 78.746666,
+            "fiftyDayAverageChange": 8.643333,
+            "fiftyDayAverageChangePercent": 0.10976126,
+            "twoHundredDayAverage": 62.45348,
+            "twoHundredDayAverageChange": 24.93652,
+            "twoHundredDayAverageChangePercent": 0.3992815,
+            "marketCap": 6486094336,
+            "forwardPE": 38.4978,
+            "priceToBook": 5.1051526,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "firstTradeDateMilliseconds": 791735400000,
+            "regularMarketChange": 4.4000015,
+            "priceHint": 2,
+            "regularMarketChangePercent": 5.3018456,
+            "regularMarketTime": 1613754775,
+            "regularMarketPrice": 87.39,
+            "regularMarketDayHigh": 87.9,
+            "regularMarketDayRange": "84.56 - 87.9",
+            "regularMarketDayLow": 84.56,
+            "regularMarketVolume": 146196,
+            "regularMarketPreviousClose": 82.99,
+            "bid": 87.55,
+            "ask": 87.74,
+            "bidSize": 13,
+            "askSize": 10,
+            "fullExchangeName": "NasdaqGS",
+            "financialCurrency": "USD",
+            "regularMarketOpen": 84.56,
+            "averageDailyVolume3Month": 865460,
+            "averageDailyVolume10Day": 520785,
+            "fiftyTwoWeekLowChange": 66.2,
+            "fiftyTwoWeekLowChangePercent": 3.124115,
+            "fiftyTwoWeekRange": "21.19 - 91.78",
+            "fiftyTwoWeekHighChange": -4.3899994,
+            "fiftyTwoWeekHighChangePercent": -0.047831766,
+            "fiftyTwoWeekLow": 21.19,
+            "fiftyTwoWeekHigh": 91.78,
+            "dividendDate": 1616716800,
+            "earningsTimestamp": 1612281904,
+            "earningsTimestampStart": 1619640000,
+            "earningsTimestampEnd": 1620072000,
+            "trailingAnnualDividendRate": 0.4,
+            "trailingPE": 83.546844,
+            "trailingAnnualDividendYield": 0.004819858,
+            "epsTrailingTwelveMonths": 1.046,
+            "epsForward": 2.27,
+            "epsCurrentYear": 1.99,
+            "marketState": "REGULAR",
+            "displayName": "Brooks Automation",
+            "symbol": "BRKS"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-CRON-10am.json
+++ b/tests/http/quote-CRON-10am.json
@@ -1,0 +1,141 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=CRON"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "1c8b3ghg2vse0"
+      ],
+      "x-yahoo-request-id": [
+        "1c8b3ghg2vse0"
+      ],
+      "x-request-id": [
+        "b29deed4-f123-4177-9128-a81019c53c14"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "850"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:36 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "esgPopulated": false,
+            "regularMarketChange": 0.42999935,
+            "regularMarketChangePercent": 3.6689363,
+            "regularMarketTime": 1613754814,
+            "regularMarketPrice": 12.15,
+            "regularMarketDayHigh": 12.38,
+            "regularMarketDayRange": "11.77 - 12.38",
+            "regularMarketDayLow": 11.77,
+            "regularMarketVolume": 2577742,
+            "regularMarketPreviousClose": 11.72,
+            "bid": 12.17,
+            "ask": 12.18,
+            "bidSize": 11,
+            "askSize": 14,
+            "fullExchangeName": "NasdaqGS",
+            "financialCurrency": "USD",
+            "regularMarketOpen": 11.79,
+            "averageDailyVolume3Month": 6821504,
+            "averageDailyVolume10Day": 16615528,
+            "fiftyTwoWeekLowChange": 8.15,
+            "fiftyTwoWeekLowChangePercent": 2.0375,
+            "fiftyTwoWeekRange": "4.0 - 15.83",
+            "fiftyTwoWeekHighChange": -3.6800003,
+            "fiftyTwoWeekHighChangePercent": -0.23247002,
+            "fiftyTwoWeekLow": 4,
+            "fiftyTwoWeekHigh": 15.83,
+            "trailingPE": 42.33449,
+            "epsTrailingTwelveMonths": 0.287,
+            "twoHundredDayAverageChangePercent": 0.6397643,
+            "firstTradeDateMilliseconds": 1519741800000,
+            "priceHint": 2,
+            "sharesOutstanding": 356187008,
+            "bookValue": 4.967,
+            "fiftyDayAverage": 10.839394,
+            "fiftyDayAverageChange": 1.310606,
+            "fiftyDayAverageChangePercent": 0.120911375,
+            "twoHundredDayAverage": 7.409601,
+            "twoHundredDayAverageChange": 4.7403984,
+            "marketCap": 4316943360,
+            "priceToBook": 2.4461446,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "exchange": "NMS",
+            "shortName": "Cronos Group Inc. Common Share",
+            "longName": "Cronos Group Inc.",
+            "messageBoardId": "finmb_253038643",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "marketState": "REGULAR",
+            "displayName": "Cronos",
+            "symbol": "CRON"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-CRON.json
+++ b/tests/http/quote-CRON.json
@@ -1,0 +1,141 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=CRON"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "1c8b3ghg2vse0"
+      ],
+      "x-yahoo-request-id": [
+        "1c8b3ghg2vse0"
+      ],
+      "x-request-id": [
+        "b29deed4-f123-4177-9128-a81019c53c14"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "850"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:36 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "esgPopulated": false,
+            "regularMarketChange": 0.42999935,
+            "regularMarketChangePercent": 3.6689363,
+            "regularMarketTime": 1613754814,
+            "regularMarketPrice": 12.15,
+            "regularMarketDayHigh": 12.38,
+            "regularMarketDayRange": "11.77 - 12.38",
+            "regularMarketDayLow": 11.77,
+            "regularMarketVolume": 2577742,
+            "regularMarketPreviousClose": 11.72,
+            "bid": 12.17,
+            "ask": 12.18,
+            "bidSize": 11,
+            "askSize": 14,
+            "fullExchangeName": "NasdaqGS",
+            "financialCurrency": "USD",
+            "regularMarketOpen": 11.79,
+            "averageDailyVolume3Month": 6821504,
+            "averageDailyVolume10Day": 16615528,
+            "fiftyTwoWeekLowChange": 8.15,
+            "fiftyTwoWeekLowChangePercent": 2.0375,
+            "fiftyTwoWeekRange": "4.0 - 15.83",
+            "fiftyTwoWeekHighChange": -3.6800003,
+            "fiftyTwoWeekHighChangePercent": -0.23247002,
+            "fiftyTwoWeekLow": 4,
+            "fiftyTwoWeekHigh": 15.83,
+            "trailingPE": 42.33449,
+            "epsTrailingTwelveMonths": 0.287,
+            "twoHundredDayAverageChangePercent": 0.6397643,
+            "firstTradeDateMilliseconds": 1519741800000,
+            "priceHint": 2,
+            "sharesOutstanding": 356187008,
+            "bookValue": 4.967,
+            "fiftyDayAverage": 10.839394,
+            "fiftyDayAverageChange": 1.310606,
+            "fiftyDayAverageChangePercent": 0.120911375,
+            "twoHundredDayAverage": 7.409601,
+            "twoHundredDayAverageChange": 4.7403984,
+            "marketCap": 4316943360,
+            "priceToBook": 2.4461446,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "exchange": "NMS",
+            "shortName": "Cronos Group Inc. Common Share",
+            "longName": "Cronos Group Inc.",
+            "messageBoardId": "finmb_253038643",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "marketState": "REGULAR",
+            "displayName": "Cronos",
+            "symbol": "CRON"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-EPAC-10am.json
+++ b/tests/http/quote-EPAC-10am.json
@@ -1,0 +1,146 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=EPAC"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "6c1bbu9g2vse0"
+      ],
+      "x-yahoo-request-id": [
+        "6c1bbu9g2vse0"
+      ],
+      "x-request-id": [
+        "74440dd3-0797-4b85-be8b-d1af0f4c0700"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "868"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:36 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "2"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "warning": [
+        "110 Response is stale"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "fiftyTwoWeekLow": 13.28,
+            "fiftyTwoWeekHigh": 25.6,
+            "earningsTimestamp": 1608539404,
+            "earningsTimestampStart": 1615984200,
+            "earningsTimestampEnd": 1616416200,
+            "epsCurrentYear": 0.53,
+            "priceEpsCurrentYear": 43.962265,
+            "sharesOutstanding": 59871100,
+            "fiftyDayAverage": 22.127274,
+            "fiftyDayAverageChange": 1.1727257,
+            "fiftyDayAverageChangePercent": 0.052999105,
+            "twoHundredDayAverage": 21.097826,
+            "twoHundredDayAverageChange": 2.2021732,
+            "twoHundredDayAverageChangePercent": 0.104379155,
+            "marketCap": 1394996608,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "firstTradeDateMilliseconds": 964445400000,
+            "regularMarketChange": 0.6399994,
+            "regularMarketChangePercent": 2.8243575,
+            "regularMarketTime": 1613754689,
+            "regularMarketPrice": 23.3,
+            "regularMarketDayHigh": 23.3,
+            "regularMarketDayRange": "22.77 - 23.3",
+            "regularMarketDayLow": 22.77,
+            "regularMarketVolume": 62262,
+            "regularMarketPreviousClose": 22.66,
+            "bid": 23.21,
+            "ask": 23.24,
+            "bidSize": 8,
+            "askSize": 8,
+            "fullExchangeName": "NYSE",
+            "financialCurrency": "USD",
+            "regularMarketOpen": 22.79,
+            "averageDailyVolume3Month": 299491,
+            "averageDailyVolume10Day": 263085,
+            "fiftyTwoWeekLowChange": 10.0199995,
+            "fiftyTwoWeekLowChangePercent": 0.75451803,
+            "fiftyTwoWeekRange": "13.28 - 25.6",
+            "fiftyTwoWeekHighChange": -2.3000011,
+            "fiftyTwoWeekHighChangePercent": -0.089843795,
+            "dividendDate": 1603065600,
+            "priceHint": 2,
+            "tradeable": false,
+            "exchange": "NYQ",
+            "shortName": "Enerpac Tool Group Corp.",
+            "longName": "Enerpac Tool Group Corp.",
+            "messageBoardId": "finmb_251258",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "marketState": "REGULAR",
+            "displayName": "Actuant",
+            "symbol": "EPAC"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-EPAC.json
+++ b/tests/http/quote-EPAC.json
@@ -1,0 +1,143 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=EPAC"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "6c1bbu9g2vse0"
+      ],
+      "x-yahoo-request-id": [
+        "6c1bbu9g2vse0"
+      ],
+      "x-request-id": [
+        "74440dd3-0797-4b85-be8b-d1af0f4c0700"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "868"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:36 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "fiftyTwoWeekLow": 13.28,
+            "fiftyTwoWeekHigh": 25.6,
+            "earningsTimestamp": 1608539404,
+            "earningsTimestampStart": 1615984200,
+            "earningsTimestampEnd": 1616416200,
+            "epsCurrentYear": 0.53,
+            "priceEpsCurrentYear": 43.962265,
+            "sharesOutstanding": 59871100,
+            "fiftyDayAverage": 22.127274,
+            "fiftyDayAverageChange": 1.1727257,
+            "fiftyDayAverageChangePercent": 0.052999105,
+            "twoHundredDayAverage": 21.097826,
+            "twoHundredDayAverageChange": 2.2021732,
+            "twoHundredDayAverageChangePercent": 0.104379155,
+            "marketCap": 1394996608,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "firstTradeDateMilliseconds": 964445400000,
+            "regularMarketChange": 0.6399994,
+            "regularMarketChangePercent": 2.8243575,
+            "regularMarketTime": 1613754689,
+            "regularMarketPrice": 23.3,
+            "regularMarketDayHigh": 23.3,
+            "regularMarketDayRange": "22.77 - 23.3",
+            "regularMarketDayLow": 22.77,
+            "regularMarketVolume": 62262,
+            "regularMarketPreviousClose": 22.66,
+            "bid": 23.21,
+            "ask": 23.24,
+            "bidSize": 8,
+            "askSize": 8,
+            "fullExchangeName": "NYSE",
+            "financialCurrency": "USD",
+            "regularMarketOpen": 22.79,
+            "averageDailyVolume3Month": 299491,
+            "averageDailyVolume10Day": 263085,
+            "fiftyTwoWeekLowChange": 10.0199995,
+            "fiftyTwoWeekLowChangePercent": 0.75451803,
+            "fiftyTwoWeekRange": "13.28 - 25.6",
+            "fiftyTwoWeekHighChange": -2.3000011,
+            "fiftyTwoWeekHighChangePercent": -0.089843795,
+            "dividendDate": 1603065600,
+            "priceHint": 2,
+            "tradeable": false,
+            "exchange": "NYQ",
+            "shortName": "Enerpac Tool Group Corp.",
+            "longName": "Enerpac Tool Group Corp.",
+            "messageBoardId": "finmb_251258",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "marketState": "REGULAR",
+            "displayName": "Actuant",
+            "symbol": "EPAC"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-MDLY-10am.json
+++ b/tests/http/quote-MDLY-10am.json
@@ -1,0 +1,151 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=MDLY"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "a8o8uqdg2vse0"
+      ],
+      "x-yahoo-request-id": [
+        "a8o8uqdg2vse0"
+      ],
+      "x-request-id": [
+        "037c564b-504d-4492-b675-5d8b37f0a40e"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "933"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:35 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "2"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "warning": [
+        "110 Response is stale"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "epsTrailingTwelveMonths": -7.855,
+            "epsForward": 0.25,
+            "sharesOutstanding": 3045180,
+            "bookValue": -12.142,
+            "fiftyDayAverage": 9.882728,
+            "fiftyDayAverageChange": 0.5292721,
+            "fiftyDayAverageChangePercent": 0.053555265,
+            "twoHundredDayAverage": 7.6748624,
+            "twoHundredDayAverageChange": 2.7371373,
+            "twoHundredDayAverageChangePercent": 0.35663667,
+            "marketCap": 59543104,
+            "forwardPE": 41.648,
+            "priceToBook": -0.8575193,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "firstTradeDateMilliseconds": 1411565400000,
+            "priceHint": 2,
+            "regularMarketChange": 0.30200005,
+            "regularMarketChangePercent": 2.987142,
+            "regularMarketTime": 1613753447,
+            "regularMarketPrice": 10.412,
+            "regularMarketDayHigh": 10.42,
+            "regularMarketDayRange": "10.14 - 10.42",
+            "regularMarketDayLow": 10.14,
+            "regularMarketVolume": 19267,
+            "regularMarketPreviousClose": 10.11,
+            "bid": 10.3,
+            "ask": 10.41,
+            "bidSize": 14,
+            "askSize": 12,
+            "fullExchangeName": "NYSE",
+            "financialCurrency": "USD",
+            "regularMarketOpen": 10.22,
+            "averageDailyVolume3Month": 205062,
+            "averageDailyVolume10Day": 167414,
+            "fiftyTwoWeekLowChange": 7.6119995,
+            "fiftyTwoWeekLowChangePercent": 2.7185712,
+            "fiftyTwoWeekRange": "2.8 - 29.0",
+            "fiftyTwoWeekHighChange": -18.588001,
+            "fiftyTwoWeekHighChangePercent": -0.6409656,
+            "fiftyTwoWeekLow": 2.8,
+            "fiftyTwoWeekHigh": 29,
+            "dividendDate": 1556841600,
+            "earningsTimestamp": 1605533400,
+            "earningsTimestampStart": 1605533400,
+            "earningsTimestampEnd": 1605533400,
+            "trailingAnnualDividendRate": 0.03,
+            "trailingAnnualDividendYield": 0.002967359,
+            "exchange": "NYQ",
+            "shortName": "Medley Management Inc.",
+            "longName": "Medley Management Inc.",
+            "messageBoardId": "finmb_269214791",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "marketState": "REGULAR",
+            "displayName": "Medley Management",
+            "symbol": "MDLY"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-MDLY.json
+++ b/tests/http/quote-MDLY.json
@@ -1,0 +1,148 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=MDLY"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "a8o8uqdg2vse0"
+      ],
+      "x-yahoo-request-id": [
+        "a8o8uqdg2vse0"
+      ],
+      "x-request-id": [
+        "037c564b-504d-4492-b675-5d8b37f0a40e"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "933"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:35 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "epsTrailingTwelveMonths": -7.855,
+            "epsForward": 0.25,
+            "sharesOutstanding": 3045180,
+            "bookValue": -12.142,
+            "fiftyDayAverage": 9.882728,
+            "fiftyDayAverageChange": 0.5292721,
+            "fiftyDayAverageChangePercent": 0.053555265,
+            "twoHundredDayAverage": 7.6748624,
+            "twoHundredDayAverageChange": 2.7371373,
+            "twoHundredDayAverageChangePercent": 0.35663667,
+            "marketCap": 59543104,
+            "forwardPE": 41.648,
+            "priceToBook": -0.8575193,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "firstTradeDateMilliseconds": 1411565400000,
+            "priceHint": 2,
+            "regularMarketChange": 0.30200005,
+            "regularMarketChangePercent": 2.987142,
+            "regularMarketTime": 1613753447,
+            "regularMarketPrice": 10.412,
+            "regularMarketDayHigh": 10.42,
+            "regularMarketDayRange": "10.14 - 10.42",
+            "regularMarketDayLow": 10.14,
+            "regularMarketVolume": 19267,
+            "regularMarketPreviousClose": 10.11,
+            "bid": 10.3,
+            "ask": 10.41,
+            "bidSize": 14,
+            "askSize": 12,
+            "fullExchangeName": "NYSE",
+            "financialCurrency": "USD",
+            "regularMarketOpen": 10.22,
+            "averageDailyVolume3Month": 205062,
+            "averageDailyVolume10Day": 167414,
+            "fiftyTwoWeekLowChange": 7.6119995,
+            "fiftyTwoWeekLowChangePercent": 2.7185712,
+            "fiftyTwoWeekRange": "2.8 - 29.0",
+            "fiftyTwoWeekHighChange": -18.588001,
+            "fiftyTwoWeekHighChangePercent": -0.6409656,
+            "fiftyTwoWeekLow": 2.8,
+            "fiftyTwoWeekHigh": 29,
+            "dividendDate": 1556841600,
+            "earningsTimestamp": 1605533400,
+            "earningsTimestampStart": 1605533400,
+            "earningsTimestampEnd": 1605533400,
+            "trailingAnnualDividendRate": 0.03,
+            "trailingAnnualDividendYield": 0.002967359,
+            "exchange": "NYQ",
+            "shortName": "Medley Management Inc.",
+            "longName": "Medley Management Inc.",
+            "messageBoardId": "finmb_269214791",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "marketState": "REGULAR",
+            "displayName": "Medley Management",
+            "symbol": "MDLY"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-SI-10am.json
+++ b/tests/http/quote-SI-10am.json
@@ -1,0 +1,151 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=SI"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "1163dtlg2vsdv"
+      ],
+      "x-yahoo-request-id": [
+        "1163dtlg2vsdv"
+      ],
+      "x-request-id": [
+        "0fb902db-fefe-4f4f-b8a4-7dcb15ce1215"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "932"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:35 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "2"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "warning": [
+        "110 Response is stale"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "firstTradeDateMilliseconds": 1573137000000,
+            "priceHint": 2,
+            "regularMarketChange": 18.14,
+            "regularMarketChangePercent": 11.798374,
+            "regularMarketTime": 1613754783,
+            "regularMarketPrice": 171.89,
+            "regularMarketDayHigh": 174.5,
+            "regularMarketDayRange": "154.0101 - 174.5",
+            "regularMarketDayLow": 154.0101,
+            "regularMarketVolume": 570805,
+            "regularMarketPreviousClose": 153.75,
+            "bid": 171.5,
+            "ask": 172.21,
+            "bidSize": 31,
+            "askSize": 14,
+            "fullExchangeName": "NYSE",
+            "financialCurrency": "USD",
+            "regularMarketOpen": 157.91,
+            "averageDailyVolume3Month": 1145291,
+            "averageDailyVolume10Day": 1460285,
+            "fiftyTwoWeekLowChange": 164.29,
+            "fiftyTwoWeekLowChangePercent": 21.617105,
+            "fiftyTwoWeekRange": "7.6 - 187.864",
+            "fiftyTwoWeekHighChange": -15.973999,
+            "fiftyTwoWeekHighChangePercent": -0.085029595,
+            "fiftyTwoWeekLow": 7.6,
+            "fiftyTwoWeekHigh": 187.864,
+            "exchange": "NYQ",
+            "shortName": "Silvergate Capital Corporation",
+            "longName": "Silvergate Capital Corporation",
+            "messageBoardId": "finmb_53838840",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "earningsTimestamp": 1611216000,
+            "earningsTimestampStart": 1611216000,
+            "earningsTimestampEnd": 1611216000,
+            "trailingPE": 126.3897,
+            "epsTrailingTwelveMonths": 1.36,
+            "epsForward": 2.51,
+            "epsCurrentYear": 1.91,
+            "priceEpsCurrentYear": 89.99477,
+            "sharesOutstanding": 22754500,
+            "bookValue": 15.701,
+            "fiftyDayAverage": 99.940605,
+            "fiftyDayAverageChange": 71.949394,
+            "fiftyDayAverageChangePercent": 0.7199215,
+            "twoHundredDayAverage": 43.128407,
+            "twoHundredDayAverageChange": 128.7616,
+            "twoHundredDayAverageChangePercent": 2.9855404,
+            "marketCap": 3922306304,
+            "forwardPE": 68.48207,
+            "priceToBook": 10.94771,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "marketState": "REGULAR",
+            "displayName": "Silvergate Capital",
+            "symbol": "SI"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quote-SI.json
+++ b/tests/http/quote-SI.json
@@ -1,0 +1,148 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v7/finance/quote?symbols=SI"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "1163dtlg2vsdv"
+      ],
+      "x-yahoo-request-id": [
+        "1163dtlg2vsdv"
+      ],
+      "x-request-id": [
+        "0fb902db-fefe-4f4f-b8a4-7dcb15ce1215"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "932"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:35 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-quote-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteResponse": {
+        "result": [
+          {
+            "language": "en-US",
+            "region": "US",
+            "quoteType": "EQUITY",
+            "quoteSourceName": "Nasdaq Real Time Price",
+            "triggerable": true,
+            "currency": "USD",
+            "firstTradeDateMilliseconds": 1573137000000,
+            "priceHint": 2,
+            "regularMarketChange": 18.14,
+            "regularMarketChangePercent": 11.798374,
+            "regularMarketTime": 1613754783,
+            "regularMarketPrice": 171.89,
+            "regularMarketDayHigh": 174.5,
+            "regularMarketDayRange": "154.0101 - 174.5",
+            "regularMarketDayLow": 154.0101,
+            "regularMarketVolume": 570805,
+            "regularMarketPreviousClose": 153.75,
+            "bid": 171.5,
+            "ask": 172.21,
+            "bidSize": 31,
+            "askSize": 14,
+            "fullExchangeName": "NYSE",
+            "financialCurrency": "USD",
+            "regularMarketOpen": 157.91,
+            "averageDailyVolume3Month": 1145291,
+            "averageDailyVolume10Day": 1460285,
+            "fiftyTwoWeekLowChange": 164.29,
+            "fiftyTwoWeekLowChangePercent": 21.617105,
+            "fiftyTwoWeekRange": "7.6 - 187.864",
+            "fiftyTwoWeekHighChange": -15.973999,
+            "fiftyTwoWeekHighChangePercent": -0.085029595,
+            "fiftyTwoWeekLow": 7.6,
+            "fiftyTwoWeekHigh": 187.864,
+            "exchange": "NYQ",
+            "shortName": "Silvergate Capital Corporation",
+            "longName": "Silvergate Capital Corporation",
+            "messageBoardId": "finmb_53838840",
+            "exchangeTimezoneName": "America/New_York",
+            "exchangeTimezoneShortName": "EST",
+            "gmtOffSetMilliseconds": -18000000,
+            "market": "us_market",
+            "esgPopulated": false,
+            "earningsTimestamp": 1611216000,
+            "earningsTimestampStart": 1611216000,
+            "earningsTimestampEnd": 1611216000,
+            "trailingPE": 126.3897,
+            "epsTrailingTwelveMonths": 1.36,
+            "epsForward": 2.51,
+            "epsCurrentYear": 1.91,
+            "priceEpsCurrentYear": 89.99477,
+            "sharesOutstanding": 22754500,
+            "bookValue": 15.701,
+            "fiftyDayAverage": 99.940605,
+            "fiftyDayAverageChange": 71.949394,
+            "fiftyDayAverageChangePercent": 0.7199215,
+            "twoHundredDayAverage": 43.128407,
+            "twoHundredDayAverageChange": 128.7616,
+            "twoHundredDayAverageChangePercent": 2.9855404,
+            "marketCap": 3922306304,
+            "forwardPE": 68.48207,
+            "priceToBook": 10.94771,
+            "sourceInterval": 15,
+            "exchangeDataDelayedBy": 0,
+            "tradeable": false,
+            "marketState": "REGULAR",
+            "displayName": "Silvergate Capital",
+            "symbol": "SI"
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-all-ABBV.json
+++ b/tests/http/quoteSummary-all-ABBV.json
@@ -1,0 +1,8785 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=assetProfile%2CbalanceSheetHistory%2CbalanceSheetHistoryQuarterly%2CcalendarEvents%2CcashflowStatementHistory%2CcashflowStatementHistoryQuarterly%2CdefaultKeyStatistics%2Cearnings%2CearningsHistory%2CearningsTrend%2CfinancialData%2CfundOwnership%2CfundPerformance%2CfundProfile%2CincomeStatementHistory%2CincomeStatementHistoryQuarterly%2CindexTrend%2CindustryTrend%2CinsiderHolders%2CinsiderTransactions%2CinstitutionOwnership%2CmajorDirectHolders%2CmajorHoldersBreakdown%2CnetSharePurchaseActivity%2Cprice%2CquoteType%2CrecommendationTrend%2CsecFilings%2CsectorTrend%2CsummaryDetail%2CsummaryProfile%2CtopHoldings%2CupgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "53vksvpg2vsf2"
+      ],
+      "x-yahoo-request-id": [
+        "53vksvpg2vsf2"
+      ],
+      "x-request-id": [
+        "1981d270-e34d-4d61-9459-30b115446a05"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "11"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:10 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "1 North Waukegan Road",
+              "city": "North Chicago",
+              "state": "IL",
+              "zip": "60064",
+              "country": "United States",
+              "phone": "847 932 7900",
+              "website": "http://www.abbvie.com",
+              "industry": "Drug Manufacturers—General",
+              "sector": "Healthcare",
+              "longBusinessSummary": "AbbVie Inc. discovers, develops, manufactures, and sells pharmaceuticals in the United States, Japan, Germany, Canada, France, Spain, Italy, the Netherlands, the United Kingdom, Brazil, and internationally. The company offers HUMIRA, a therapy administered as an injection for autoimmune and intestinal BehÃ§et's diseases; SKYRIZI to treat moderate to severe plaque psoriasis in adults; RINVOQ, a JAK inhibitor for the treatment of moderate to severe active rheumatoid arthritis in adult patients; IMBRUVICA to treat adult patients with chronic lymphocytic leukemia (CLL), small lymphocytic lymphoma (SLL), mantle cell lymphoma, waldenstrÃ¶m's macroglobulinemia, marginal zone lymphoma, and chronic graft versus host disease; VENCLEXTA, a BCL-2 inhibitor used to treat adults with CLL or SLL; VIEKIRA PAK, an interferon-free therapy to treat adults with genotype 1 chronic hepatitis C virus (HCV); TECHNIVIE to treat adults with genotype 4 HCV infection; and MAVYRET to treat patients with chronic HCV genotype 1-6 infection. It also provides SYNAGIS that protects at-risk infants from severe respiratory disease; KALETRA, a prescription anti-HIV-1 medicine; CREON, a pancreatic enzyme therapy for exocrine pancreatic insufficiency; Synthroid used in the treatment of hypothyroidism; AndroGel for males diagnosed with symptomatic low testosterone; and Lupron, a product for the palliative treatment of advanced prostate cancer, endometriosis and central precocious puberty, and patients with anemia caused by uterine fibroids. In addition, the company offers ORILISSA, a nonpeptide small molecule gonadotropin-releasing hormone antagonist; Duopa and Duodopa, a levodopa-carbidopa intestinal gel to treat Parkinson's disease; and Sevoflurane, an anesthesia product. It has collaborations with Calico Life Sciences LLC; Alector, Inc.; Janssen Biotech, Inc.; Frontier Medicines, Corp.; Jacobio Pharmaceuticals; I-Mab; and Genmab A/S. The company was incorporated in 2012 and is based in North Chicago, Illinois.",
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Richard A. Gonzalez",
+                  "age": 66,
+                  "title": "Chairman & CEO",
+                  "yearBorn": 1954,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 7110537,
+                    "fmt": "7.11M",
+                    "longFmt": "7,110,537"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 16561981,
+                    "fmt": "16.56M",
+                    "longFmt": "16,561,981"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Michael E. Severino",
+                  "age": 54,
+                  "title": "Vice Chairman & Pres",
+                  "yearBorn": 1966,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 3975467,
+                    "fmt": "3.98M",
+                    "longFmt": "3,975,467"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 10544840,
+                    "fmt": "10.54M",
+                    "longFmt": "10,544,840"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Robert A. Michael",
+                  "age": 50,
+                  "title": "Exec. VP & CFO",
+                  "yearBorn": 1970,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 2762336,
+                    "fmt": "2.76M",
+                    "longFmt": "2,762,336"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 548437,
+                    "fmt": "548.44k",
+                    "longFmt": "548,437"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Laura J. Schumacher",
+                  "age": 57,
+                  "title": "Vice Chairman of External Affairs, Chief Legal Officer & Corp. Sec.",
+                  "yearBorn": 1963,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 4303763,
+                    "fmt": "4.3M",
+                    "longFmt": "4,303,763"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 7517504,
+                    "fmt": "7.52M",
+                    "longFmt": "7,517,504"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Carlos  Alban",
+                  "age": 57,
+                  "title": "Vice Chairman & Chief Commercial Officer",
+                  "yearBorn": 1963,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 4076821,
+                    "fmt": "4.08M",
+                    "longFmt": "4,076,821"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 16574024,
+                    "fmt": "16.57M",
+                    "longFmt": "16,574,024"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Azita  Saleki-Gerhardt",
+                  "age": 57,
+                  "title": "Exec. VP of Operations",
+                  "yearBorn": 1963,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Thomas J. Hudson",
+                  "age": 58,
+                  "title": "Sr. VP of R&D and Chief Scientific Officer",
+                  "yearBorn": 1962,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Elizabeth  Shea",
+                  "title": "VP of Investor Relations",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Timothy J. Richmond",
+                  "age": 54,
+                  "title": "Exec. VP & Chief HR Officer",
+                  "yearBorn": 1966,
+                  "fiscalYear": 2013,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Scott C. Brun M.D.",
+                  "title": "VP of Scientific Affairs & Head of AbbVie Ventures",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "auditRisk": 2,
+              "boardRisk": 7,
+              "compensationRisk": 3,
+              "shareHolderRightsRisk": 9,
+              "overallRisk": 8,
+              "governanceEpochDate": 1606867200,
+              "compensationAsOfEpochDate": 1577750400,
+              "maxAge": 86400
+            },
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 4,
+                  "buy": 6,
+                  "hold": 10,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 6,
+                  "buy": 11,
+                  "hold": 5,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 6,
+                  "buy": 11,
+                  "hold": 5,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 1,
+                  "buy": 3,
+                  "hold": 10,
+                  "sell": 1,
+                  "strongSell": 1
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 4616000000,
+                    "fmt": "4.62B",
+                    "longFmt": "4,616,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 7882000000,
+                    "fmt": "7.88B",
+                    "longFmt": "7,882,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 2017000000,
+                    "fmt": "2.02B",
+                    "longFmt": "2,017,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 4754000000,
+                    "fmt": "4.75B",
+                    "longFmt": "4,754,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -74000000,
+                    "fmt": "-74M",
+                    "longFmt": "-74,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -1121000000,
+                    "fmt": "-1.12B",
+                    "longFmt": "-1,121,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -231000000,
+                    "fmt": "-231M",
+                    "longFmt": "-231,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 97000000,
+                    "fmt": "97M",
+                    "longFmt": "97,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 13324000000,
+                    "fmt": "13.32B",
+                    "longFmt": "13,324,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -552000000,
+                    "fmt": "-552M",
+                    "longFmt": "-552,000,000"
+                  },
+                  "investments": {
+                    "raw": 2116000000,
+                    "fmt": "2.12B",
+                    "longFmt": "2,116,000,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 167000000,
+                    "fmt": "167M",
+                    "longFmt": "167,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 596000000,
+                    "fmt": "596M",
+                    "longFmt": "596,000,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -6366000000,
+                    "fmt": "-6.37B",
+                    "longFmt": "-6,366,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 26247000000,
+                    "fmt": "26.25B",
+                    "longFmt": "26,247,000,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -552000000,
+                    "fmt": "-552M",
+                    "longFmt": "-552,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 18708000000,
+                    "fmt": "18.71B",
+                    "longFmt": "18,708,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 7000000,
+                    "fmt": "7M",
+                    "longFmt": "7,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 32635000000,
+                    "fmt": "32.63B",
+                    "longFmt": "32,635,000,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -629000000,
+                    "fmt": "-629M",
+                    "longFmt": "-629,000,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 8000000,
+                    "fmt": "8M",
+                    "longFmt": "8,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 5687000000,
+                    "fmt": "5.69B",
+                    "longFmt": "5,687,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 1765000000,
+                    "fmt": "1.76B",
+                    "longFmt": "1,765,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 7101000000,
+                    "fmt": "7.1B",
+                    "longFmt": "7,101,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -591000000,
+                    "fmt": "-591M",
+                    "longFmt": "-591,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 190000000,
+                    "fmt": "190M",
+                    "longFmt": "190,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -226000000,
+                    "fmt": "-226M",
+                    "longFmt": "-226,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -499000000,
+                    "fmt": "-499M",
+                    "longFmt": "-499,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 13427000000,
+                    "fmt": "13.43B",
+                    "longFmt": "13,427,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -638000000,
+                    "fmt": "-638M",
+                    "longFmt": "-638,000,000"
+                  },
+                  "investments": {
+                    "raw": 368000000,
+                    "fmt": "368M",
+                    "longFmt": "368,000,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 167000000,
+                    "fmt": "167M",
+                    "longFmt": "167,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -1006000000,
+                    "fmt": "-1.01B",
+                    "longFmt": "-1,006,000,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -5580000000,
+                    "fmt": "-5.58B",
+                    "longFmt": "-5,580,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 3229000000,
+                    "fmt": "3.23B",
+                    "longFmt": "3,229,000,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -104000000,
+                    "fmt": "-104M",
+                    "longFmt": "-104,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -14396000000,
+                    "fmt": "-14.4B",
+                    "longFmt": "-14,396,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -39000000,
+                    "fmt": "-39M",
+                    "longFmt": "-39,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": -2014000000,
+                    "fmt": "-2.01B",
+                    "longFmt": "-2,014,000,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -12014000000,
+                    "fmt": "-12.01B",
+                    "longFmt": "-12,014,000,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 73000000,
+                    "fmt": "73M",
+                    "longFmt": "73,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 5309000000,
+                    "fmt": "5.31B",
+                    "longFmt": "5,309,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 1501000000,
+                    "fmt": "1.5B",
+                    "longFmt": "1,501,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 3141000000,
+                    "fmt": "3.14B",
+                    "longFmt": "3,141,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -391000000,
+                    "fmt": "-391M",
+                    "longFmt": "-391,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 425000000,
+                    "fmt": "425M",
+                    "longFmt": "425,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 93000000,
+                    "fmt": "93M",
+                    "longFmt": "93,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -118000000,
+                    "fmt": "-118M",
+                    "longFmt": "-118,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 9960000000,
+                    "fmt": "9.96B",
+                    "longFmt": "9,960,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -529000000,
+                    "fmt": "-529M",
+                    "longFmt": "-529,000,000"
+                  },
+                  "investments": {
+                    "raw": 563000000,
+                    "fmt": "563M",
+                    "longFmt": "563,000,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 167000000,
+                    "fmt": "167M",
+                    "longFmt": "167,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -274000000,
+                    "fmt": "-274M",
+                    "longFmt": "-274,000,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -4107000000,
+                    "fmt": "-4.11B",
+                    "longFmt": "-4,107,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -2000000,
+                    "fmt": "-2M",
+                    "longFmt": "-2,000,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -247000000,
+                    "fmt": "-247M",
+                    "longFmt": "-247,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -5512000000,
+                    "fmt": "-5.51B",
+                    "longFmt": "-5,512,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 29000000,
+                    "fmt": "29M",
+                    "longFmt": "29,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 4203000000,
+                    "fmt": "4.2B",
+                    "longFmt": "4,203,000,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -1410000000,
+                    "fmt": "-1.41B",
+                    "longFmt": "-1,410,000,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 254000000,
+                    "fmt": "254M",
+                    "longFmt": "254,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 8.58013,
+              "pegRatio": 0.771291,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.286
+                },
+                {
+                  "period": "+1q",
+                  "growth": 1.032
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.175
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.15100001
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0827489
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            },
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": 266400169984,
+              "forwardPE": 7.6778183,
+              "profitMargins": 0.10078,
+              "floatShares": 1737614744,
+              "sharesOutstanding": 1765469952,
+              "sharesShort": 14874548,
+              "sharesShortPriorMonth": 13334764,
+              "sharesShortPreviousMonthDate": 1609372800,
+              "dateShortInterest": 1611878400,
+              "sharesPercentSharesOut": 0.0084,
+              "heldPercentInsiders": 0.001,
+              "heldPercentInstitutions": 0.70001,
+              "shortRatio": 1.99,
+              "shortPercentOfFloat": 0.0084,
+              "beta": 0.80683,
+              "category": null,
+              "bookValue": 8.65,
+              "priceToBook": 12.204625,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1609372800,
+              "nextFiscalYearEnd": 1672444800,
+              "mostRecentQuarter": 1609372800,
+              "earningsQuarterlyGrowth": -0.987,
+              "netIncomeToCommon": 4616000000,
+              "trailingEps": 2.72,
+              "forwardEps": 13.75,
+              "pegRatio": 1.9,
+              "lastSplitFactor": null,
+              "enterpriseToRevenue": 5.816,
+              "enterpriseToEbitda": 12.375,
+              "52WeekChange": 0.116891265,
+              "SandP52WeekChange": 0.17263722,
+              "lastDividendValue": 1.3,
+              "lastDividendDate": 1610582400
+            },
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "quoteType": {
+              "exchange": "NYQ",
+              "quoteType": "EQUITY",
+              "symbol": "ABBV",
+              "underlyingSymbol": "ABBV",
+              "shortName": "AbbVie Inc.",
+              "longName": "AbbVie Inc.",
+              "firstTradeDateEpochUtc": 1357137000,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "73238d42-cdcc-3f92-8141-dd675addae10",
+              "messageBoardId": "finmb_141885706",
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            },
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 45804000000,
+                    "fmt": "45.8B",
+                    "longFmt": "45,804,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 14095000000,
+                    "fmt": "14.1B",
+                    "longFmt": "14,095,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 31709000000,
+                    "fmt": "31.71B",
+                    "longFmt": "31,709,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 6173000000,
+                    "fmt": "6.17B",
+                    "longFmt": "6,173,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 9883000000,
+                    "fmt": "9.88B",
+                    "longFmt": "9,883,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 30151000000,
+                    "fmt": "30.15B",
+                    "longFmt": "30,151,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 15653000000,
+                    "fmt": "15.65B",
+                    "longFmt": "15,653,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -12255000000,
+                    "fmt": "-12.26B",
+                    "longFmt": "-12,255,000,000"
+                  },
+                  "ebit": {
+                    "raw": 15653000000,
+                    "fmt": "15.65B",
+                    "longFmt": "15,653,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -2006000000,
+                    "fmt": "-2.01B",
+                    "longFmt": "-2,006,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 3398000000,
+                    "fmt": "3.4B",
+                    "longFmt": "3,398,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -1224000000,
+                    "fmt": "-1.22B",
+                    "longFmt": "-1,224,000,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 4622000000,
+                    "fmt": "4.62B",
+                    "longFmt": "4,622,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 4616000000,
+                    "fmt": "4.62B",
+                    "longFmt": "4,616,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 4616000000,
+                    "fmt": "4.62B",
+                    "longFmt": "4,616,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 33266000000,
+                    "fmt": "33.27B",
+                    "longFmt": "33,266,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 7439000000,
+                    "fmt": "7.44B",
+                    "longFmt": "7,439,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 25827000000,
+                    "fmt": "25.83B",
+                    "longFmt": "25,827,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 5377000000,
+                    "fmt": "5.38B",
+                    "longFmt": "5,377,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 6763000000,
+                    "fmt": "6.76B",
+                    "longFmt": "6,763,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": -10000000,
+                    "fmt": "-10M",
+                    "longFmt": "-10,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 19569000000,
+                    "fmt": "19.57B",
+                    "longFmt": "19,569,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 13697000000,
+                    "fmt": "13.7B",
+                    "longFmt": "13,697,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -5271000000,
+                    "fmt": "-5.27B",
+                    "longFmt": "-5,271,000,000"
+                  },
+                  "ebit": {
+                    "raw": 13697000000,
+                    "fmt": "13.7B",
+                    "longFmt": "13,697,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -1421000000,
+                    "fmt": "-1.42B",
+                    "longFmt": "-1,421,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 8426000000,
+                    "fmt": "8.43B",
+                    "longFmt": "8,426,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 544000000,
+                    "fmt": "544M",
+                    "longFmt": "544,000,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 7882000000,
+                    "fmt": "7.88B",
+                    "longFmt": "7,882,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 7882000000,
+                    "fmt": "7.88B",
+                    "longFmt": "7,882,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 7842000000,
+                    "fmt": "7.84B",
+                    "longFmt": "7,842,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 32753000000,
+                    "fmt": "32.75B",
+                    "longFmt": "32,753,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 7718000000,
+                    "fmt": "7.72B",
+                    "longFmt": "7,718,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 25035000000,
+                    "fmt": "25.04B",
+                    "longFmt": "25,035,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 5259000000,
+                    "fmt": "5.26B",
+                    "longFmt": "5,259,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 7003000000,
+                    "fmt": "7B",
+                    "longFmt": "7,003,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 500000000,
+                    "fmt": "500M",
+                    "longFmt": "500,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 20480000000,
+                    "fmt": "20.48B",
+                    "longFmt": "20,480,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 12273000000,
+                    "fmt": "12.27B",
+                    "longFmt": "12,273,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -7076000000,
+                    "fmt": "-7.08B",
+                    "longFmt": "-7,076,000,000"
+                  },
+                  "ebit": {
+                    "raw": 12273000000,
+                    "fmt": "12.27B",
+                    "longFmt": "12,273,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -1348000000,
+                    "fmt": "-1.35B",
+                    "longFmt": "-1,348,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 5197000000,
+                    "fmt": "5.2B",
+                    "longFmt": "5,197,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -490000000,
+                    "fmt": "-490M",
+                    "longFmt": "-490,000,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 5687000000,
+                    "fmt": "5.69B",
+                    "longFmt": "5,687,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 5687000000,
+                    "fmt": "5.69B",
+                    "longFmt": "5,687,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 5657000000,
+                    "fmt": "5.66B",
+                    "longFmt": "5,657,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 28216000000,
+                    "fmt": "28.22B",
+                    "longFmt": "28,216,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 6688000000,
+                    "fmt": "6.69B",
+                    "longFmt": "6,688,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 21528000000,
+                    "fmt": "21.53B",
+                    "longFmt": "21,528,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 5007000000,
+                    "fmt": "5.01B",
+                    "longFmt": "5,007,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 6248000000,
+                    "fmt": "6.25B",
+                    "longFmt": "6,248,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 500000000,
+                    "fmt": "500M",
+                    "longFmt": "500,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 17943000000,
+                    "fmt": "17.94B",
+                    "longFmt": "17,943,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 10273000000,
+                    "fmt": "10.27B",
+                    "longFmt": "10,273,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -2546000000,
+                    "fmt": "-2.55B",
+                    "longFmt": "-2,546,000,000"
+                  },
+                  "ebit": {
+                    "raw": 10273000000,
+                    "fmt": "10.27B",
+                    "longFmt": "10,273,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -1150000000,
+                    "fmt": "-1.15B",
+                    "longFmt": "-1,150,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 7727000000,
+                    "fmt": "7.73B",
+                    "longFmt": "7,727,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 2418000000,
+                    "fmt": "2.42B",
+                    "longFmt": "2,418,000,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 5309000000,
+                    "fmt": "5.31B",
+                    "longFmt": "5,309,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 5309000000,
+                    "fmt": "5.31B",
+                    "longFmt": "5,309,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 5283000000,
+                    "fmt": "5.28B",
+                    "longFmt": "5,283,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            },
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 106.06,
+              "open": 106.23,
+              "dayLow": 104.91,
+              "dayHigh": 106.35,
+              "regularMarketPreviousClose": 106.06,
+              "regularMarketOpen": 106.23,
+              "regularMarketDayLow": 104.91,
+              "regularMarketDayHigh": 106.35,
+              "dividendRate": 5.2,
+              "dividendYield": 0.049000002,
+              "exDividendDate": 1610582400,
+              "payoutRatio": 1.8053,
+              "fiveYearAvgDividendYield": 4.14,
+              "beta": 0.80683,
+              "trailingPE": 38.8125,
+              "forwardPE": 7.6778183,
+              "volume": 2383767,
+              "regularMarketVolume": 2383767,
+              "averageVolume": 7408847,
+              "averageVolume10days": 5676571,
+              "averageDailyVolume10Day": 5676571,
+              "bid": 105.64,
+              "ask": 105.65,
+              "bidSize": 1200,
+              "askSize": 800,
+              "marketCap": 186380664832,
+              "fiftyTwoWeekLow": 62.55,
+              "fiftyTwoWeekHigh": 113.41,
+              "priceToSalesTrailing12Months": 4.0690913,
+              "fiftyDayAverage": 107.234245,
+              "twoHundredDayAverage": 97.44348,
+              "trailingAnnualDividendRate": 4.84,
+              "trailingAnnualDividendYield": 0.04563455,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            },
+            "insiderHolders": {
+              "holders": [
+                {
+                  "maxAge": 1,
+                  "name": "ALBAN CARLOS",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  },
+                  "positionDirect": {
+                    "raw": 155341,
+                    "fmt": "155.34k",
+                    "longFmt": "155,341"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "GONZALEZ RICHARD A",
+                  "relation": "Chief Executive Officer",
+                  "url": "",
+                  "transactionDescription": "Stock Gift",
+                  "latestTransDate": {
+                    "raw": 1608681600,
+                    "fmt": "2020-12-23"
+                  },
+                  "positionDirect": {
+                    "raw": 315815,
+                    "fmt": "315.81k",
+                    "longFmt": "315,815"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1608681600,
+                    "fmt": "2020-12-23"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "GOSEBRUCH HENRY O",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1605830400,
+                    "fmt": "2020-11-20"
+                  },
+                  "positionDirect": {
+                    "raw": 71370,
+                    "fmt": "71.37k",
+                    "longFmt": "71,370"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605830400,
+                    "fmt": "2020-11-20"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "RAPP EDWARD J",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Gift",
+                  "latestTransDate": {
+                    "raw": 1599091200,
+                    "fmt": "2020-09-03"
+                  },
+                  "positionDirect": {
+                    "raw": 35870,
+                    "fmt": "35.87k",
+                    "longFmt": "35,870"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1599091200,
+                    "fmt": "2020-09-03"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "RICHMOND TIMOTHY J",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1606435200,
+                    "fmt": "2020-11-27"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1606435200,
+                    "fmt": "2020-11-27"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "SALEKI-GERHARDT AZITA PH.D.",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1604966400,
+                    "fmt": "2020-11-10"
+                  },
+                  "positionDirect": {
+                    "raw": 102507,
+                    "fmt": "102.51k",
+                    "longFmt": "102,507"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1604966400,
+                    "fmt": "2020-11-10"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "SCHUMACHER LAURA J",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Stock Gift",
+                  "latestTransDate": {
+                    "raw": 1608681600,
+                    "fmt": "2020-12-23"
+                  },
+                  "positionDirect": {
+                    "raw": 177541,
+                    "fmt": "177.54k",
+                    "longFmt": "177,541"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1608681600,
+                    "fmt": "2020-12-23"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "SEVERINO MICHAEL E. M.D.",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1604448000,
+                    "fmt": "2020-11-04"
+                  },
+                  "positionDirect": {
+                    "raw": 67281,
+                    "fmt": "67.28k",
+                    "longFmt": "67,281"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1604448000,
+                    "fmt": "2020-11-04"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "STEWART JEFFREY RYAN",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1609200000,
+                    "fmt": "2020-12-29"
+                  },
+                  "positionDirect": {
+                    "raw": 52307,
+                    "fmt": "52.31k",
+                    "longFmt": "52,307"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1609200000,
+                    "fmt": "2020-12-29"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "STROM CARRIE C",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1589155200,
+                    "fmt": "2020-05-11"
+                  },
+                  "positionDirect": {
+                    "raw": 63538,
+                    "fmt": "63.54k",
+                    "longFmt": "63,538"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1589155200,
+                    "fmt": "2020-05-11"
+                  }
+                }
+              ],
+              "maxAge": 1
+            },
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": [
+                  1619654400,
+                  1620000000
+                ],
+                "earningsAverage": 2.79,
+                "earningsLow": 2.14,
+                "earningsHigh": 3.01,
+                "revenueAverage": 12819100000,
+                "revenueLow": 12663000000,
+                "revenueHigh": 13478000000
+              },
+              "exDividendDate": 1610582400,
+              "dividendDate": 1613433600
+            },
+            "upgradeDowngradeHistory": {
+              "history": [
+                {
+                  "epochGradeDate": 1612444417,
+                  "firm": "SVB Leerink",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1611838763,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1608118351,
+                  "firm": "SVB Leerink",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606744188,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1605696352,
+                  "firm": "BMO Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1605009332,
+                  "firm": "Bernstein",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1604322306,
+                  "firm": "SVB Leerink",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1603457553,
+                  "firm": "Truist Securities",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1602865351,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1601370668,
+                  "firm": "Berenberg",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1599052634,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1597922970,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1596462541,
+                  "firm": "Mizuho",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1596452036,
+                  "firm": "RBC Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1592907855,
+                  "firm": "Atlantic Equities",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1591104723,
+                  "firm": "Argus Research",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1589293439,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1589193617,
+                  "firm": "SVB Leerink",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588588230,
+                  "firm": "SVB Leerink",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1587380464,
+                  "firm": "RBC Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Sector Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1586785464,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1584957458,
+                  "firm": "Societe Generale",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1582808111,
+                  "firm": "Barclays",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1582029876,
+                  "firm": "Cowen & Co.",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1581337503,
+                  "firm": "Mizuho",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580983772,
+                  "firm": "Mizuho",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1577366857,
+                  "firm": "Cowen & Co.",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1574259354,
+                  "firm": "Citi",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1574165810,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1569493972,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1568285548,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1567592868,
+                  "firm": "Piper Jaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1566298075,
+                  "firm": "Piper Jaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1561548212,
+                  "firm": "SVB Leerink",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1559043603,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1556533190,
+                  "firm": "BMO Capital",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "Underperformer",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1546519892,
+                  "firm": "Bank of America",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1545830036,
+                  "firm": "Standpoint Research",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1541516185,
+                  "firm": "Argus",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1541430524,
+                  "firm": "BMO Capital",
+                  "toGrade": "Underperform",
+                  "fromGrade": "Underperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1538668151,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1534954342,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1532959651,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1531397700,
+                  "firm": "Berenberg",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1528718826,
+                  "firm": "Argus",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1527856691,
+                  "firm": "PiperJaffray",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1527677434,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Underperform",
+                  "fromGrade": "Neutral",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1527078696,
+                  "firm": "BMO Capital",
+                  "toGrade": "Underperform",
+                  "fromGrade": "Underperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1525094105,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "Equal-Weight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1524833438,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Neutral",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1522950220,
+                  "firm": "Barclays",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "Equal-Weight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1521805591,
+                  "firm": "BMO Capital",
+                  "toGrade": "Underperform",
+                  "fromGrade": "Underperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1517583371,
+                  "firm": "Argus",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1517321253,
+                  "firm": "BMO Capital",
+                  "toGrade": "Underperform",
+                  "fromGrade": "Market Perform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1517322426,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "Equal-Weight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1517234094,
+                  "firm": "Leerink Swann",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1510843001,
+                  "firm": "BMO Capital",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1509379355,
+                  "firm": "Leerink Swann",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1507913213,
+                  "firm": "Barclays",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1507894758,
+                  "firm": "UBS",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1507723223,
+                  "firm": "Cowen & Co.",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1507220245,
+                  "firm": "Leerink Swann",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1506945690,
+                  "firm": "Leerink Swann",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1506944848,
+                  "firm": "Leerink Swann",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1506337137,
+                  "firm": "UBS",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1505493521,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1502968716,
+                  "firm": "Evercore ISI Group",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1500309421,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1500307959,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1489152246,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1480344081,
+                  "firm": "Citigroup",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1477906447,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1476786217,
+                  "firm": "Leerink Swann",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1473310283,
+                  "firm": "JP Morgan",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1472796914,
+                  "firm": "Raymond James",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1465539883,
+                  "firm": "BMO Capital",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1465359521,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1465198474,
+                  "firm": "Cowen & Co.",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1459943194,
+                  "firm": "Societe Generale",
+                  "toGrade": "Sell",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1458013425,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1457329015,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1456201417,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1454653994,
+                  "firm": "William Blair",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1452779838,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1450428830,
+                  "firm": "Atlantic Equities",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1448945874,
+                  "firm": "Barclays",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1446452173,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Equal-Weight",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1443416557,
+                  "firm": "Citigroup",
+                  "toGrade": "",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1438150675,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1437549227,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1434472615,
+                  "firm": "PiperJaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1433748419,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1429866000,
+                  "firm": "BMO Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1428905117,
+                  "firm": "BMO Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1423462299,
+                  "firm": "Citigroup",
+                  "toGrade": "Sell",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1422954000,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1421398800,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1421312400,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1420761600,
+                  "firm": "Bank of America",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1418300965,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1417683600,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1415945061,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1415091600,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1415005200,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1413528428,
+                  "firm": "ISI Group",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1412230174,
+                  "firm": "Guggenheim",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1407360502,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1406537390,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1405691807,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1405381691,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1404281721,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Equal-weight",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1403296430,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1399445710,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Equal-weight",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1398322200,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1397510413,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1392964858,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1390804859,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1388472817,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1387435425,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Equal-weight",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1382709675,
+                  "firm": "BMO Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1381248000,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1525527134,
+                  "firm": "Argus",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1370591309,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1369729504,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1368607661,
+                  "firm": "Cowen & Co.",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1367224672,
+                  "firm": "BMO Capital",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1366611299,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Equal-Weight",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1365584976,
+                  "firm": "UBS",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1365579900,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1365494839,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1365147616,
+                  "firm": "BMO Capital",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1364806405,
+                  "firm": "BMO Capital",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1362989132,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                }
+              ],
+              "maxAge": 86400
+            },
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": 0.00226292,
+              "preMarketChange": 0.240005,
+              "preMarketTime": 1613744999,
+              "preMarketPrice": 106.3,
+              "preMarketSource": "FREE_REALTIME",
+              "regularMarketChangePercent": -0.0046200063,
+              "regularMarketChange": -0.48999786,
+              "regularMarketTime": 1613754838,
+              "priceHint": 2,
+              "regularMarketPrice": 105.57,
+              "regularMarketDayHigh": 106.35,
+              "regularMarketDayLow": 104.91,
+              "regularMarketVolume": 2383767,
+              "averageDailyVolume10Day": 5676571,
+              "averageDailyVolume3Month": 7408847,
+              "regularMarketPreviousClose": 106.06,
+              "regularMarketSource": "FREE_REALTIME",
+              "regularMarketOpen": 106.23,
+              "exchange": "NYQ",
+              "exchangeName": "NYSE",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "EQUITY",
+              "symbol": "ABBV",
+              "underlyingSymbol": null,
+              "shortName": "AbbVie Inc.",
+              "longName": "AbbVie Inc.",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 186380664832
+            },
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 15270000000,
+                    "fmt": "15.27B",
+                    "longFmt": "15,270,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -102174000000,
+                    "fmt": "-102.17B",
+                    "longFmt": "-102,174,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 39924000000,
+                    "fmt": "39.92B",
+                    "longFmt": "39,924,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 5428000000,
+                    "fmt": "5.43B",
+                    "longFmt": "5,428,000,000"
+                  },
+                  "inventory": {
+                    "raw": 1813000000,
+                    "fmt": "1.81B",
+                    "longFmt": "1,813,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 22000000,
+                    "fmt": "22M",
+                    "longFmt": "22,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 49519000000,
+                    "fmt": "49.52B",
+                    "longFmt": "49,519,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 124000000,
+                    "fmt": "124M",
+                    "longFmt": "124,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 3306000000,
+                    "fmt": "3.31B",
+                    "longFmt": "3,306,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 15604000000,
+                    "fmt": "15.6B",
+                    "longFmt": "15,604,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 18649000000,
+                    "fmt": "18.65B",
+                    "longFmt": "18,649,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 1913000000,
+                    "fmt": "1.91B",
+                    "longFmt": "1,913,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 89115000000,
+                    "fmt": "89.11B",
+                    "longFmt": "89,115,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1452000000,
+                    "fmt": "1.45B",
+                    "longFmt": "1,452,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 3746000000,
+                    "fmt": "3.75B",
+                    "longFmt": "3,746,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 4633000000,
+                    "fmt": "4.63B",
+                    "longFmt": "4,633,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 62955000000,
+                    "fmt": "62.95B",
+                    "longFmt": "62,955,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 18476000000,
+                    "fmt": "18.48B",
+                    "longFmt": "18,476,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 15585000000,
+                    "fmt": "15.59B",
+                    "longFmt": "15,585,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 97287000000,
+                    "fmt": "97.29B",
+                    "longFmt": "97,287,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 18000000,
+                    "fmt": "18M",
+                    "longFmt": "18,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 4717000000,
+                    "fmt": "4.72B",
+                    "longFmt": "4,717,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -28100000000,
+                    "fmt": "-28.1B",
+                    "longFmt": "-28,100,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 15193000000,
+                    "fmt": "15.19B",
+                    "longFmt": "15,193,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -3596000000,
+                    "fmt": "-3.6B",
+                    "longFmt": "-3,596,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -8172000000,
+                    "fmt": "-8.17B",
+                    "longFmt": "-8,172,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -42425000000,
+                    "fmt": "-42.42B",
+                    "longFmt": "-42,425,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "cash": {
+                    "raw": 7289000000,
+                    "fmt": "7.29B",
+                    "longFmt": "7,289,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 772000000,
+                    "fmt": "772M",
+                    "longFmt": "772,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 5384000000,
+                    "fmt": "5.38B",
+                    "longFmt": "5,384,000,000"
+                  },
+                  "inventory": {
+                    "raw": 1605000000,
+                    "fmt": "1.6B",
+                    "longFmt": "1,605,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 132000000,
+                    "fmt": "132M",
+                    "longFmt": "132,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 16945000000,
+                    "fmt": "16.95B",
+                    "longFmt": "16,945,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 1420000000,
+                    "fmt": "1.42B",
+                    "longFmt": "1,420,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 2883000000,
+                    "fmt": "2.88B",
+                    "longFmt": "2,883,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 15663000000,
+                    "fmt": "15.66B",
+                    "longFmt": "15,663,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 21233000000,
+                    "fmt": "21.23B",
+                    "longFmt": "21,233,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 1208000000,
+                    "fmt": "1.21B",
+                    "longFmt": "1,208,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 59352000000,
+                    "fmt": "59.35B",
+                    "longFmt": "59,352,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1546000000,
+                    "fmt": "1.55B",
+                    "longFmt": "1,546,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 1609000000,
+                    "fmt": "1.61B",
+                    "longFmt": "1,609,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 5355000000,
+                    "fmt": "5.36B",
+                    "longFmt": "5,355,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 35002000000,
+                    "fmt": "35B",
+                    "longFmt": "35,002,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 15557000000,
+                    "fmt": "15.56B",
+                    "longFmt": "15,557,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 17239000000,
+                    "fmt": "17.24B",
+                    "longFmt": "17,239,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 67798000000,
+                    "fmt": "67.8B",
+                    "longFmt": "67,798,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 18000000,
+                    "fmt": "18M",
+                    "longFmt": "18,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 3368000000,
+                    "fmt": "3.37B",
+                    "longFmt": "3,368,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -26588000000,
+                    "fmt": "-26.59B",
+                    "longFmt": "-26,588,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 14756000000,
+                    "fmt": "14.76B",
+                    "longFmt": "14,756,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -2480000000,
+                    "fmt": "-2.48B",
+                    "longFmt": "-2,480,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -8446000000,
+                    "fmt": "-8.45B",
+                    "longFmt": "-8,446,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -45342000000,
+                    "fmt": "-45.34B",
+                    "longFmt": "-45,342,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "cash": {
+                    "raw": 9303000000,
+                    "fmt": "9.3B",
+                    "longFmt": "9,303,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 486000000,
+                    "fmt": "486M",
+                    "longFmt": "486,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 7188000000,
+                    "fmt": "7.19B",
+                    "longFmt": "7,188,000,000"
+                  },
+                  "inventory": {
+                    "raw": 1605000000,
+                    "fmt": "1.6B",
+                    "longFmt": "1,605,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 23000000,
+                    "fmt": "23M",
+                    "longFmt": "23,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 21223000000,
+                    "fmt": "21.22B",
+                    "longFmt": "21,223,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2090000000,
+                    "fmt": "2.09B",
+                    "longFmt": "2,090,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 2803000000,
+                    "fmt": "2.8B",
+                    "longFmt": "2,803,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 15785000000,
+                    "fmt": "15.79B",
+                    "longFmt": "15,785,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 27559000000,
+                    "fmt": "27.56B",
+                    "longFmt": "27,559,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 1326000000,
+                    "fmt": "1.33B",
+                    "longFmt": "1,326,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 70786000000,
+                    "fmt": "70.79B",
+                    "longFmt": "70,786,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1474000000,
+                    "fmt": "1.47B",
+                    "longFmt": "1,474,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 6015000000,
+                    "fmt": "6.01B",
+                    "longFmt": "6,015,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 4406000000,
+                    "fmt": "4.41B",
+                    "longFmt": "4,406,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 30953000000,
+                    "fmt": "30.95B",
+                    "longFmt": "30,953,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 18095000000,
+                    "fmt": "18.09B",
+                    "longFmt": "18,095,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 16641000000,
+                    "fmt": "16.64B",
+                    "longFmt": "16,641,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 65689000000,
+                    "fmt": "65.69B",
+                    "longFmt": "65,689,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 18000000,
+                    "fmt": "18M",
+                    "longFmt": "18,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 5459000000,
+                    "fmt": "5.46B",
+                    "longFmt": "5,459,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -14650000000,
+                    "fmt": "-14.65B",
+                    "longFmt": "-14,650,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 14270000000,
+                    "fmt": "14.27B",
+                    "longFmt": "14,270,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -2727000000,
+                    "fmt": "-2.73B",
+                    "longFmt": "-2,727,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 5097000000,
+                    "fmt": "5.1B",
+                    "longFmt": "5,097,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -38247000000,
+                    "fmt": "-38.25B",
+                    "longFmt": "-38,247,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": "2021-03-31",
+                  "growth": {
+                    "raw": 0.153,
+                    "fmt": "15.30%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 2.79,
+                      "fmt": "2.79"
+                    },
+                    "low": {
+                      "raw": 2.14,
+                      "fmt": "2.14"
+                    },
+                    "high": {
+                      "raw": 3.01,
+                      "fmt": "3.01"
+                    },
+                    "yearAgoEps": {
+                      "raw": 2.42,
+                      "fmt": "2.42"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 13,
+                      "fmt": "13",
+                      "longFmt": "13"
+                    },
+                    "growth": {
+                      "raw": 0.153,
+                      "fmt": "15.30%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 12819100000,
+                      "fmt": "12.82B",
+                      "longFmt": "12,819,100,000"
+                    },
+                    "low": {
+                      "raw": 12663000000,
+                      "fmt": "12.66B",
+                      "longFmt": "12,663,000,000"
+                    },
+                    "high": {
+                      "raw": 13478000000,
+                      "fmt": "13.48B",
+                      "longFmt": "13,478,000,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 12,
+                      "fmt": "12",
+                      "longFmt": "12"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 8619000000,
+                      "fmt": "8.62B",
+                      "longFmt": "8,619,000,000"
+                    },
+                    "growth": {
+                      "raw": 0.48700002,
+                      "fmt": "48.70%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 2.79,
+                      "fmt": "2.79"
+                    },
+                    "7daysAgo": {
+                      "raw": 2.79,
+                      "fmt": "2.79"
+                    },
+                    "30daysAgo": {
+                      "raw": 2.85,
+                      "fmt": "2.85"
+                    },
+                    "60daysAgo": {
+                      "raw": 2.86,
+                      "fmt": "2.86"
+                    },
+                    "90daysAgo": {
+                      "raw": 2.81,
+                      "fmt": "2.81"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 3,
+                      "fmt": "3",
+                      "longFmt": "3"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": "2021-06-30",
+                  "growth": {
+                    "raw": 0.269,
+                    "fmt": "26.90%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 2.97,
+                      "fmt": "2.97"
+                    },
+                    "low": {
+                      "raw": 1.93,
+                      "fmt": "1.93"
+                    },
+                    "high": {
+                      "raw": 3.13,
+                      "fmt": "3.13"
+                    },
+                    "yearAgoEps": {
+                      "raw": 2.34,
+                      "fmt": "2.34"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 13,
+                      "fmt": "13",
+                      "longFmt": "13"
+                    },
+                    "growth": {
+                      "raw": 0.269,
+                      "fmt": "26.90%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 13554000000,
+                      "fmt": "13.55B",
+                      "longFmt": "13,554,000,000"
+                    },
+                    "low": {
+                      "raw": 13083000000,
+                      "fmt": "13.08B",
+                      "longFmt": "13,083,000,000"
+                    },
+                    "high": {
+                      "raw": 13757000000,
+                      "fmt": "13.76B",
+                      "longFmt": "13,757,000,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 12,
+                      "fmt": "12",
+                      "longFmt": "12"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 10082100000,
+                      "fmt": "10.08B",
+                      "longFmt": "10,082,100,000"
+                    },
+                    "growth": {
+                      "raw": 0.344,
+                      "fmt": "34.40%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 2.97,
+                      "fmt": "2.97"
+                    },
+                    "7daysAgo": {
+                      "raw": 2.97,
+                      "fmt": "2.97"
+                    },
+                    "30daysAgo": {
+                      "raw": 2.96,
+                      "fmt": "2.96"
+                    },
+                    "60daysAgo": {
+                      "raw": 2.94,
+                      "fmt": "2.94"
+                    },
+                    "90daysAgo": {
+                      "raw": 2.91,
+                      "fmt": "2.91"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": "2021-12-31",
+                  "growth": {
+                    "raw": 0.177,
+                    "fmt": "17.70%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 12.43,
+                      "fmt": "12.43"
+                    },
+                    "low": {
+                      "raw": 11.94,
+                      "fmt": "11.94"
+                    },
+                    "high": {
+                      "raw": 12.75,
+                      "fmt": "12.75"
+                    },
+                    "yearAgoEps": {
+                      "raw": 10.56,
+                      "fmt": "10.56"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 16,
+                      "fmt": "16",
+                      "longFmt": "16"
+                    },
+                    "growth": {
+                      "raw": 0.177,
+                      "fmt": "17.70%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 55351600000,
+                      "fmt": "55.35B",
+                      "longFmt": "55,351,600,000"
+                    },
+                    "low": {
+                      "raw": 53395000000,
+                      "fmt": "53.4B",
+                      "longFmt": "53,395,000,000"
+                    },
+                    "high": {
+                      "raw": 56349000000,
+                      "fmt": "56.35B",
+                      "longFmt": "56,349,000,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 15,
+                      "fmt": "15",
+                      "longFmt": "15"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 45784000000,
+                      "fmt": "45.78B",
+                      "longFmt": "45,784,000,000"
+                    },
+                    "growth": {
+                      "raw": 0.20899999,
+                      "fmt": "20.90%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 12.43,
+                      "fmt": "12.43"
+                    },
+                    "7daysAgo": {
+                      "raw": 12.43,
+                      "fmt": "12.43"
+                    },
+                    "30daysAgo": {
+                      "raw": 12.19,
+                      "fmt": "12.19"
+                    },
+                    "60daysAgo": {
+                      "raw": 12.19,
+                      "fmt": "12.19"
+                    },
+                    "90daysAgo": {
+                      "raw": 12.19,
+                      "fmt": "12.19"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 12,
+                      "fmt": "12",
+                      "longFmt": "12"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": "2022-12-31",
+                  "growth": {
+                    "raw": 0.106000006,
+                    "fmt": "10.60%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 13.75,
+                      "fmt": "13.75"
+                    },
+                    "low": {
+                      "raw": 12.63,
+                      "fmt": "12.63"
+                    },
+                    "high": {
+                      "raw": 14.5,
+                      "fmt": "14.5"
+                    },
+                    "yearAgoEps": {
+                      "raw": 12.43,
+                      "fmt": "12.43"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 15,
+                      "fmt": "15",
+                      "longFmt": "15"
+                    },
+                    "growth": {
+                      "raw": 0.106000006,
+                      "fmt": "10.60%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 58865800000,
+                      "fmt": "58.87B",
+                      "longFmt": "58,865,800,000"
+                    },
+                    "low": {
+                      "raw": 55134000000,
+                      "fmt": "55.13B",
+                      "longFmt": "55,134,000,000"
+                    },
+                    "high": {
+                      "raw": 60787000000,
+                      "fmt": "60.79B",
+                      "longFmt": "60,787,000,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 14,
+                      "fmt": "14",
+                      "longFmt": "14"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 55351600000,
+                      "fmt": "55.35B",
+                      "longFmt": "55,351,600,000"
+                    },
+                    "growth": {
+                      "raw": 0.063,
+                      "fmt": "6.30%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 13.75,
+                      "fmt": "13.75"
+                    },
+                    "7daysAgo": {
+                      "raw": 13.75,
+                      "fmt": "13.75"
+                    },
+                    "30daysAgo": {
+                      "raw": 13.68,
+                      "fmt": "13.68"
+                    },
+                    "60daysAgo": {
+                      "raw": 13.7,
+                      "fmt": "13.7"
+                    },
+                    "90daysAgo": {
+                      "raw": 13.58,
+                      "fmt": "13.58"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 6,
+                      "fmt": "6",
+                      "longFmt": "6"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": 0.0477,
+                    "fmt": "4.77%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": 0.21909,
+                    "fmt": "21.91%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            },
+            "secFilings": {
+              "filings": [
+                {
+                  "date": "2021-02-03",
+                  "epochDate": 1612356124,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001551152-21-000003&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-01-12",
+                  "epochDate": 1610487133,
+                  "type": "8-K",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-21-003462&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-01-06",
+                  "epochDate": 1609970467,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-21-001570&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-11-18",
+                  "epochDate": 1605737834,
+                  "type": "8-K",
+                  "title": "Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-126925&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-11-12",
+                  "epochDate": 1605193572,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-124093&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-11-04",
+                  "epochDate": 1604501677,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001551152-20-000032&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-30",
+                  "epochDate": 1604062390,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001551152-20-000029&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-19",
+                  "epochDate": 1603116885,
+                  "type": "8-K",
+                  "title": "Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-115857&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-02",
+                  "epochDate": 1601672779,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-111687&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-08-04",
+                  "epochDate": 1596553047,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001551152-20-000023&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-07-31",
+                  "epochDate": 1596203025,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001551152-20-000019&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-14",
+                  "epochDate": 1589490080,
+                  "type": "8-K/A",
+                  "title": "ABBVIE INC. FILES (8-K/A) Disclosing Completion of Acquisition or Disposition of Assets, Financial Statements and Exhibi",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-061687&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-14",
+                  "epochDate": 1589487483,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Creation of a Direct Financial Obligation",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-061621&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-12",
+                  "epochDate": 1589317905,
+                  "type": "8-K",
+                  "title": "Disclosing Submission of Matters to a Vote of Security Holders",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-060256&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-08",
+                  "epochDate": 1588969976,
+                  "type": "8-K",
+                  "title": "Disclosing Completion of Acquisition or Disposition of Assets, Creation of a Direct Financial Ob",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-058837&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-08",
+                  "epochDate": 1588932759,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001551152-20-000015&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-06",
+                  "epochDate": 1588759551,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-057093&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-01",
+                  "epochDate": 1588333539,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001551152-20-000010&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-27",
+                  "epochDate": 1587989675,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-051316&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-20",
+                  "epochDate": 1587384867,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-048487&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-06",
+                  "epochDate": 1586174946,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-043408&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-03-23",
+                  "epochDate": 1584965668,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-037093&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-03-09",
+                  "epochDate": 1583761537,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-030507&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-02-24",
+                  "epochDate": 1582553626,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-024097&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-02-21",
+                  "epochDate": 1582300388,
+                  "type": "10-K",
+                  "title": "Annual Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001551152-20-000007&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-02-14",
+                  "epochDate": 1581721519,
+                  "type": "8-K",
+                  "title": "Disclosing Termination of a Material Definitive Agreement",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-022002&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-02-07",
+                  "epochDate": 1581079738,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001551152-20-000004&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-01-27",
+                  "epochDate": 1580131627,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-006940&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-12-20",
+                  "epochDate": 1576850543,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-19-074689&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-26",
+                  "epochDate": 1574776012,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Creation of a Direct Financial Obligation",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-19-067264&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-18",
+                  "epochDate": 1574083314,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-19-064905&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-13",
+                  "epochDate": 1573681496,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-19-063366&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-08",
+                  "epochDate": 1573211272,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-19-061290&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-07",
+                  "epochDate": 1573136325,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-19-060862&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-06",
+                  "epochDate": 1573072291,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure, Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-19-060477&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-06",
+                  "epochDate": 1573053495,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001551152-19-000030&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-01",
+                  "epochDate": 1572609095,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001551152-19-000026&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-10-25",
+                  "epochDate": 1572006398,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-19-056315&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-10-22",
+                  "epochDate": 1571776970,
+                  "type": "8-K",
+                  "title": "Disclosing Amendments to Articles of Inc. or Bylaws; Change in Fiscal Year, Financial Statements",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-19-055567&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-09-26",
+                  "epochDate": 1569528434,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Creation of a Direct Financial Obligation",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001410578-19-001438&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-09-23",
+                  "epochDate": 1569270339,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001410578-19-001379&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-09-16",
+                  "epochDate": 1568635072,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001410578-19-001244&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-08-30",
+                  "epochDate": 1567196448,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Creation of a Direct Financial Obligation",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001410578-19-000980&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-08-05",
+                  "epochDate": 1565022903,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001551152-19-000023&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-07-26",
+                  "epochDate": 1564141489,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001551152-19-000021&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-07-16",
+                  "epochDate": 1563309841,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Creation of a Direct Financial Obligation",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-19-040574&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-06-25",
+                  "epochDate": 1561498049,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Creation of a Direct Financial Obligation",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-19-037446&nav=1&src=Yahoo",
+                  "maxAge": 1
+                }
+              ],
+              "maxAge": 86400
+            },
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Group, Inc. (The)",
+                  "pctHeld": {
+                    "raw": 0.08180001,
+                    "fmt": "8.18%"
+                  },
+                  "position": {
+                    "raw": 144334850,
+                    "fmt": "144.33M",
+                    "longFmt": "144,334,850"
+                  },
+                  "value": {
+                    "raw": 12642289511,
+                    "fmt": "12.64B",
+                    "longFmt": "12,642,289,511"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Blackrock Inc.",
+                  "pctHeld": {
+                    "raw": 0.0705,
+                    "fmt": "7.05%"
+                  },
+                  "position": {
+                    "raw": 124423484,
+                    "fmt": "124.42M",
+                    "longFmt": "124,423,484"
+                  },
+                  "value": {
+                    "raw": 13331976310,
+                    "fmt": "13.33B",
+                    "longFmt": "13,331,976,310"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "State Street Corporation",
+                  "pctHeld": {
+                    "raw": 0.044299997,
+                    "fmt": "4.43%"
+                  },
+                  "position": {
+                    "raw": 78208461,
+                    "fmt": "78.21M",
+                    "longFmt": "78,208,461"
+                  },
+                  "value": {
+                    "raw": 6850279098,
+                    "fmt": "6.85B",
+                    "longFmt": "6,850,279,098"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Capital Research Global Investors",
+                  "pctHeld": {
+                    "raw": 0.0231,
+                    "fmt": "2.31%"
+                  },
+                  "position": {
+                    "raw": 40804113,
+                    "fmt": "40.8M",
+                    "longFmt": "40,804,113"
+                  },
+                  "value": {
+                    "raw": 3574032257,
+                    "fmt": "3.57B",
+                    "longFmt": "3,574,032,257"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Price (T.Rowe) Associates Inc",
+                  "pctHeld": {
+                    "raw": 0.0185,
+                    "fmt": "1.85%"
+                  },
+                  "position": {
+                    "raw": 32739879,
+                    "fmt": "32.74M",
+                    "longFmt": "32,739,879"
+                  },
+                  "value": {
+                    "raw": 2867686001,
+                    "fmt": "2.87B",
+                    "longFmt": "2,867,686,001"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "JP Morgan Chase & Company",
+                  "pctHeld": {
+                    "raw": 0.0165,
+                    "fmt": "1.65%"
+                  },
+                  "position": {
+                    "raw": 29190573,
+                    "fmt": "29.19M",
+                    "longFmt": "29,190,573"
+                  },
+                  "value": {
+                    "raw": 2556802289,
+                    "fmt": "2.56B",
+                    "longFmt": "2,556,802,289"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "FMR, LLC",
+                  "pctHeld": {
+                    "raw": 0.0165,
+                    "fmt": "1.65%"
+                  },
+                  "position": {
+                    "raw": 29054142,
+                    "fmt": "29.05M",
+                    "longFmt": "29,054,142"
+                  },
+                  "value": {
+                    "raw": 3113151315,
+                    "fmt": "3.11B",
+                    "longFmt": "3,113,151,315"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Geode Capital Management, LLC",
+                  "pctHeld": {
+                    "raw": 0.0148,
+                    "fmt": "1.48%"
+                  },
+                  "position": {
+                    "raw": 26135072,
+                    "fmt": "26.14M",
+                    "longFmt": "26,135,072"
+                  },
+                  "value": {
+                    "raw": 2289170956,
+                    "fmt": "2.29B",
+                    "longFmt": "2,289,170,956"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Northern Trust Corporation",
+                  "pctHeld": {
+                    "raw": 0.0138,
+                    "fmt": "1.38%"
+                  },
+                  "position": {
+                    "raw": 24363192,
+                    "fmt": "24.36M",
+                    "longFmt": "24,363,192"
+                  },
+                  "value": {
+                    "raw": 2133971987,
+                    "fmt": "2.13B",
+                    "longFmt": "2,133,971,987"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Berkshire Hathaway, Inc",
+                  "pctHeld": {
+                    "raw": 0.012,
+                    "fmt": "1.20%"
+                  },
+                  "position": {
+                    "raw": 21264316,
+                    "fmt": "21.26M",
+                    "longFmt": "21,264,316"
+                  },
+                  "value": {
+                    "raw": 1862541438,
+                    "fmt": "1.86B",
+                    "longFmt": "1,862,541,438"
+                  }
+                }
+              ]
+            },
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.001,
+              "institutionsPercentHeld": 0.70001,
+              "institutionsFloatPercentHeld": 0.7007,
+              "institutionsCount": 2979
+            },
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 15270000000,
+                    "fmt": "15.27B",
+                    "longFmt": "15,270,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -102174000000,
+                    "fmt": "-102.17B",
+                    "longFmt": "-102,174,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 7890000000,
+                    "fmt": "7.89B",
+                    "longFmt": "7,890,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 60000000,
+                    "fmt": "60M",
+                    "longFmt": "60,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 8416000000,
+                    "fmt": "8.42B",
+                    "longFmt": "8,416,000,000"
+                  },
+                  "inventory": {
+                    "raw": 3474000000,
+                    "fmt": "3.47B",
+                    "longFmt": "3,474,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 49000000,
+                    "fmt": "49M",
+                    "longFmt": "49,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 23009000000,
+                    "fmt": "23.01B",
+                    "longFmt": "23,009,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 403000000,
+                    "fmt": "403M",
+                    "longFmt": "403,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 4986000000,
+                    "fmt": "4.99B",
+                    "longFmt": "4,986,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 42801000000,
+                    "fmt": "42.8B",
+                    "longFmt": "42,801,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 74643000000,
+                    "fmt": "74.64B",
+                    "longFmt": "74,643,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 3779000000,
+                    "fmt": "3.78B",
+                    "longFmt": "3,779,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 149621000000,
+                    "fmt": "149.62B",
+                    "longFmt": "149,621,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 18859000000,
+                    "fmt": "18.86B",
+                    "longFmt": "18,859,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 4730000000,
+                    "fmt": "4.73B",
+                    "longFmt": "4,730,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 538000000,
+                    "fmt": "538M",
+                    "longFmt": "538,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 82315000000,
+                    "fmt": "82.31B",
+                    "longFmt": "82,315,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 27836000000,
+                    "fmt": "27.84B",
+                    "longFmt": "27,836,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 19000000,
+                    "fmt": "19M",
+                    "longFmt": "19,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 24181000000,
+                    "fmt": "24.18B",
+                    "longFmt": "24,181,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 134332000000,
+                    "fmt": "134.33B",
+                    "longFmt": "134,332,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 18000000,
+                    "fmt": "18M",
+                    "longFmt": "18,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 3335000000,
+                    "fmt": "3.33B",
+                    "longFmt": "3,335,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -5231000000,
+                    "fmt": "-5.23B",
+                    "longFmt": "-5,231,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 17148000000,
+                    "fmt": "17.15B",
+                    "longFmt": "17,148,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -3259000000,
+                    "fmt": "-3.26B",
+                    "longFmt": "-3,259,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 15270000000,
+                    "fmt": "15.27B",
+                    "longFmt": "15,270,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -102174000000,
+                    "fmt": "-102.17B",
+                    "longFmt": "-102,174,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "cash": {
+                    "raw": 6017000000,
+                    "fmt": "6.02B",
+                    "longFmt": "6,017,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 23000000,
+                    "fmt": "23M",
+                    "longFmt": "23,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 8354000000,
+                    "fmt": "8.35B",
+                    "longFmt": "8,354,000,000"
+                  },
+                  "inventory": {
+                    "raw": 4059000000,
+                    "fmt": "4.06B",
+                    "longFmt": "4,059,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 51000000,
+                    "fmt": "51M",
+                    "longFmt": "51,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 21256000000,
+                    "fmt": "21.26B",
+                    "longFmt": "21,256,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 381000000,
+                    "fmt": "381M",
+                    "longFmt": "381,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 4908000000,
+                    "fmt": "4.91B",
+                    "longFmt": "4,908,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 42669000000,
+                    "fmt": "42.67B",
+                    "longFmt": "42,669,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 76463000000,
+                    "fmt": "76.46B",
+                    "longFmt": "76,463,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 3853000000,
+                    "fmt": "3.85B",
+                    "longFmt": "3,853,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 149530000000,
+                    "fmt": "149.53B",
+                    "longFmt": "149,530,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 18754000000,
+                    "fmt": "18.75B",
+                    "longFmt": "18,754,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 5316000000,
+                    "fmt": "5.32B",
+                    "longFmt": "5,316,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 512000000,
+                    "fmt": "512M",
+                    "longFmt": "512,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 82099000000,
+                    "fmt": "82.1B",
+                    "longFmt": "82,099,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 28053000000,
+                    "fmt": "28.05B",
+                    "longFmt": "28,053,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 24000000,
+                    "fmt": "24M",
+                    "longFmt": "24,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 24646000000,
+                    "fmt": "24.65B",
+                    "longFmt": "24,646,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 134798000000,
+                    "fmt": "134.8B",
+                    "longFmt": "134,798,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 18000000,
+                    "fmt": "18M",
+                    "longFmt": "18,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 3130000000,
+                    "fmt": "3.13B",
+                    "longFmt": "3,130,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -5393000000,
+                    "fmt": "-5.39B",
+                    "longFmt": "-5,393,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 16953000000,
+                    "fmt": "16.95B",
+                    "longFmt": "16,953,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -3435000000,
+                    "fmt": "-3.44B",
+                    "longFmt": "-3,435,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 14708000000,
+                    "fmt": "14.71B",
+                    "longFmt": "14,708,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -104424000000,
+                    "fmt": "-104.42B",
+                    "longFmt": "-104,424,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "cash": {
+                    "raw": 41142000000,
+                    "fmt": "41.14B",
+                    "longFmt": "41,142,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 6362000000,
+                    "fmt": "6.36B",
+                    "longFmt": "6,362,000,000"
+                  },
+                  "inventory": {
+                    "raw": 1844000000,
+                    "fmt": "1.84B",
+                    "longFmt": "1,844,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 100000000,
+                    "fmt": "100M",
+                    "longFmt": "100,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 51758000000,
+                    "fmt": "51.76B",
+                    "longFmt": "51,758,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 211000000,
+                    "fmt": "211M",
+                    "longFmt": "211,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 2961000000,
+                    "fmt": "2.96B",
+                    "longFmt": "2,961,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 15561000000,
+                    "fmt": "15.56B",
+                    "longFmt": "15,561,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 18203000000,
+                    "fmt": "18.2B",
+                    "longFmt": "18,203,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 2505000000,
+                    "fmt": "2.5B",
+                    "longFmt": "2,505,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 91199000000,
+                    "fmt": "91.2B",
+                    "longFmt": "91,199,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 12251000000,
+                    "fmt": "12.25B",
+                    "longFmt": "12,251,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 3756000000,
+                    "fmt": "3.76B",
+                    "longFmt": "3,756,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 458000000,
+                    "fmt": "458M",
+                    "longFmt": "458,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 63328000000,
+                    "fmt": "63.33B",
+                    "longFmt": "63,328,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 18815000000,
+                    "fmt": "18.82B",
+                    "longFmt": "18,815,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 16471000000,
+                    "fmt": "16.47B",
+                    "longFmt": "16,471,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 98614000000,
+                    "fmt": "98.61B",
+                    "longFmt": "98,614,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 18000000,
+                    "fmt": "18M",
+                    "longFmt": "18,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 5973000000,
+                    "fmt": "5.97B",
+                    "longFmt": "5,973,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -28807000000,
+                    "fmt": "-28.81B",
+                    "longFmt": "-28,807,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 15401000000,
+                    "fmt": "15.4B",
+                    "longFmt": "15,401,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -3697000000,
+                    "fmt": "-3.7B",
+                    "longFmt": "-3,697,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -7415000000,
+                    "fmt": "-7.42B",
+                    "longFmt": "-7,415,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -41179000000,
+                    "fmt": "-41.18B",
+                    "longFmt": "-41,179,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 2.42,
+                    "fmt": "2.42"
+                  },
+                  "epsEstimate": {
+                    "raw": 2.25,
+                    "fmt": "2.25"
+                  },
+                  "epsDifference": {
+                    "raw": 0.17,
+                    "fmt": "0.17"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.076,
+                    "fmt": "7.60%"
+                  },
+                  "quarter": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 2.34,
+                    "fmt": "2.34"
+                  },
+                  "epsEstimate": {
+                    "raw": 2.19,
+                    "fmt": "2.19"
+                  },
+                  "epsDifference": {
+                    "raw": 0.15,
+                    "fmt": "0.15"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.068,
+                    "fmt": "6.80%"
+                  },
+                  "quarter": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 2.83,
+                    "fmt": "2.83"
+                  },
+                  "epsEstimate": {
+                    "raw": 2.76,
+                    "fmt": "2.76"
+                  },
+                  "epsDifference": {
+                    "raw": 0.07,
+                    "fmt": "0.07"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.025,
+                    "fmt": "2.50%"
+                  },
+                  "quarter": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 2.92,
+                    "fmt": "2.92"
+                  },
+                  "epsEstimate": {
+                    "raw": 2.85,
+                    "fmt": "2.85"
+                  },
+                  "epsDifference": {
+                    "raw": 0.07,
+                    "fmt": "0.07"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.025,
+                    "fmt": "2.50%"
+                  },
+                  "quarter": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            },
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            },
+            "summaryProfile": {
+              "address1": "1 North Waukegan Road",
+              "city": "North Chicago",
+              "state": "IL",
+              "zip": "60064",
+              "country": "United States",
+              "phone": "847 932 7900",
+              "website": "http://www.abbvie.com",
+              "industry": "Drug Manufacturers—General",
+              "sector": "Healthcare",
+              "longBusinessSummary": "AbbVie Inc. discovers, develops, manufactures, and sells pharmaceuticals in the United States, Japan, Germany, Canada, France, Spain, Italy, the Netherlands, the United Kingdom, Brazil, and internationally. The company offers HUMIRA, a therapy administered as an injection for autoimmune and intestinal BehÃ§et's diseases; SKYRIZI to treat moderate to severe plaque psoriasis in adults; RINVOQ, a JAK inhibitor for the treatment of moderate to severe active rheumatoid arthritis in adult patients; IMBRUVICA to treat adult patients with chronic lymphocytic leukemia (CLL), small lymphocytic lymphoma (SLL), mantle cell lymphoma, waldenstrÃ¶m's macroglobulinemia, marginal zone lymphoma, and chronic graft versus host disease; VENCLEXTA, a BCL-2 inhibitor used to treat adults with CLL or SLL; VIEKIRA PAK, an interferon-free therapy to treat adults with genotype 1 chronic hepatitis C virus (HCV); TECHNIVIE to treat adults with genotype 4 HCV infection; and MAVYRET to treat patients with chronic HCV genotype 1-6 infection. It also provides SYNAGIS that protects at-risk infants from severe respiratory disease; KALETRA, a prescription anti-HIV-1 medicine; CREON, a pancreatic enzyme therapy for exocrine pancreatic insufficiency; Synthroid used in the treatment of hypothyroidism; AndroGel for males diagnosed with symptomatic low testosterone; and Lupron, a product for the palliative treatment of advanced prostate cancer, endometriosis and central precocious puberty, and patients with anemia caused by uterine fibroids. In addition, the company offers ORILISSA, a nonpeptide small molecule gonadotropin-releasing hormone antagonist; Duopa and Duodopa, a levodopa-carbidopa intestinal gel to treat Parkinson's disease; and Sevoflurane, an anesthesia product. It has collaborations with Calico Life Sciences LLC; Alector, Inc.; Janssen Biotech, Inc.; Frontier Medicines, Corp.; Jacobio Pharmaceuticals; I-Mab; and Genmab A/S. The company was incorporated in 2012 and is based in North Chicago, Illinois.",
+              "companyOfficers": [],
+              "maxAge": 86400
+            },
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 9,
+              "buyInfoShares": 460769,
+              "buyPercentInsiderShares": 0.244,
+              "sellInfoCount": 9,
+              "sellInfoShares": 582419,
+              "sellPercentInsiderShares": 0.309,
+              "netInfoCount": 18,
+              "netInfoShares": -121650,
+              "netPercentInsiderShares": -0.064,
+              "totalInsiderShares": 1765474
+            },
+            "insiderTransactions": {
+              "transactions": [
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 25290,
+                    "fmt": "25.29k",
+                    "longFmt": "25,290"
+                  },
+                  "value": {
+                    "raw": 2655450,
+                    "fmt": "2.66M",
+                    "longFmt": "2,655,450"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 105.00 per share.",
+                  "filerName": "STEWART JEFFREY RYAN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1609200000,
+                    "fmt": "2020-12-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 25290,
+                    "fmt": "25.29k",
+                    "longFmt": "25,290"
+                  },
+                  "value": {
+                    "raw": 1300412,
+                    "fmt": "1.3M",
+                    "longFmt": "1,300,412"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 51.42 per share.",
+                  "filerName": "STEWART JEFFREY RYAN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1609200000,
+                    "fmt": "2020-12-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 29017,
+                    "fmt": "29.02k",
+                    "longFmt": "29,017"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1608681600,
+                    "fmt": "2020-12-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 28950,
+                    "fmt": "28.95k",
+                    "longFmt": "28,950"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1608681600,
+                    "fmt": "2020-12-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3225,
+                    "fmt": "3.23k",
+                    "longFmt": "3,225"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1607299200,
+                    "fmt": "2020-12-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 51990,
+                    "fmt": "51.99k",
+                    "longFmt": "51,990"
+                  },
+                  "value": {
+                    "raw": 5458950,
+                    "fmt": "5.46M",
+                    "longFmt": "5,458,950"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 105.00 per share.",
+                  "filerName": "RICHMOND TIMOTHY J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606435200,
+                    "fmt": "2020-11-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 51990,
+                    "fmt": "51.99k",
+                    "longFmt": "51,990"
+                  },
+                  "value": {
+                    "raw": 2673326,
+                    "fmt": "2.67M",
+                    "longFmt": "2,673,326"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 51.42 per share.",
+                  "filerName": "RICHMOND TIMOTHY J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606435200,
+                    "fmt": "2020-11-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 40000,
+                    "fmt": "40k",
+                    "longFmt": "40,000"
+                  },
+                  "value": {
+                    "raw": 3975046,
+                    "fmt": "3.98M",
+                    "longFmt": "3,975,046"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 98.83 - 99.49 per share.",
+                  "filerName": "GOSEBRUCH HENRY O",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605830400,
+                    "fmt": "2020-11-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 115830,
+                    "fmt": "115.83k",
+                    "longFmt": "115,830"
+                  },
+                  "value": {
+                    "raw": 11583000,
+                    "fmt": "11.58M",
+                    "longFmt": "11,583,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 100.00 per share.",
+                  "filerName": "ALBAN CARLOS",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 115830,
+                    "fmt": "115.83k",
+                    "longFmt": "115,830"
+                  },
+                  "value": {
+                    "raw": 4155980,
+                    "fmt": "4.16M",
+                    "longFmt": "4,155,980"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 35.88 per share.",
+                  "filerName": "ALBAN CARLOS",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 231604,
+                    "fmt": "231.6k",
+                    "longFmt": "231,604"
+                  },
+                  "value": {
+                    "raw": 22437253,
+                    "fmt": "22.44M",
+                    "longFmt": "22,437,253"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 95.74 - 97.49 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605139200,
+                    "fmt": "2020-11-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 194154,
+                    "fmt": "194.15k",
+                    "longFmt": "194,154"
+                  },
+                  "value": {
+                    "raw": 11089858,
+                    "fmt": "11.09M",
+                    "longFmt": "11,089,858"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 54.86 - 58.88 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605139200,
+                    "fmt": "2020-11-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 17426,
+                    "fmt": "17.43k",
+                    "longFmt": "17,426"
+                  },
+                  "value": {
+                    "raw": 1707748,
+                    "fmt": "1.71M",
+                    "longFmt": "1,707,748"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 98.00 per share.",
+                  "filerName": "SALEKI-GERHARDT AZITA PH.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604966400,
+                    "fmt": "2020-11-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4800,
+                    "fmt": "4.8k",
+                    "longFmt": "4,800"
+                  },
+                  "value": {
+                    "raw": 449328,
+                    "fmt": "449.33k",
+                    "longFmt": "449,328"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 93.61 per share.",
+                  "filerName": "SALEKI-GERHARDT AZITA PH.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604448000,
+                    "fmt": "2020-11-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4800,
+                    "fmt": "4.8k",
+                    "longFmt": "4,800"
+                  },
+                  "value": {
+                    "raw": 449328,
+                    "fmt": "449.33k",
+                    "longFmt": "449,328"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 93.61 per share.",
+                  "filerName": "SALEKI-GERHARDT AZITA PH.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604448000,
+                    "fmt": "2020-11-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4800,
+                    "fmt": "4.8k",
+                    "longFmt": "4,800"
+                  },
+                  "value": {
+                    "raw": 116199,
+                    "fmt": "116.2k",
+                    "longFmt": "116,199"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 24.21 per share.",
+                  "filerName": "SALEKI-GERHARDT AZITA PH.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604448000,
+                    "fmt": "2020-11-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 90679,
+                    "fmt": "90.68k",
+                    "longFmt": "90,679"
+                  },
+                  "value": {
+                    "raw": 8488461,
+                    "fmt": "8.49M",
+                    "longFmt": "8,488,461"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 93.61 per share.",
+                  "filerName": "SEVERINO MICHAEL E. M.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604448000,
+                    "fmt": "2020-11-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7513,
+                    "fmt": "7.51k",
+                    "longFmt": "7,513"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "RAPP EDWARD J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1599091200,
+                    "fmt": "2020-09-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 53325,
+                    "fmt": "53.33k",
+                    "longFmt": "53,325"
+                  },
+                  "value": {
+                    "raw": 5332555,
+                    "fmt": "5.33M",
+                    "longFmt": "5,332,555"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 100.00 per share.",
+                  "filerName": "ALBAN CARLOS",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1594080000,
+                    "fmt": "2020-07-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 23024,
+                    "fmt": "23.02k",
+                    "longFmt": "23,024"
+                  },
+                  "value": {
+                    "raw": 2072211,
+                    "fmt": "2.07M",
+                    "longFmt": "2,072,211"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 90.00 per share.",
+                  "filerName": "STEWART JEFFREY RYAN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589241600,
+                    "fmt": "2020-05-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 63538,
+                    "fmt": "63.54k",
+                    "longFmt": "63,538"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "STROM CARRIE C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589155200,
+                    "fmt": "2020-05-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4916,
+                    "fmt": "4.92k",
+                    "longFmt": "4,916"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "FREYMAN THOMAS C",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588896000,
+                    "fmt": "2020-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4916,
+                    "fmt": "4.92k",
+                    "longFmt": "4,916"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "FREYMAN THOMAS C",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588896000,
+                    "fmt": "2020-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2333,
+                    "fmt": "2.33k",
+                    "longFmt": "2,333"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "LIDDY EDWARD M",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588896000,
+                    "fmt": "2020-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2333,
+                    "fmt": "2.33k",
+                    "longFmt": "2,333"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "AUSTIN ROXANNE SCHUH",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588896000,
+                    "fmt": "2020-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2333,
+                    "fmt": "2.33k",
+                    "longFmt": "2,333"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "TILTON GLENN FLETCHER",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588896000,
+                    "fmt": "2020-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2333,
+                    "fmt": "2.33k",
+                    "longFmt": "2,333"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WADDELL FREDERICK H",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588896000,
+                    "fmt": "2020-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2333,
+                    "fmt": "2.33k",
+                    "longFmt": "2,333"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RAPP EDWARD J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588896000,
+                    "fmt": "2020-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2333,
+                    "fmt": "2.33k",
+                    "longFmt": "2,333"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALPERN ROBERT J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588896000,
+                    "fmt": "2020-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2333,
+                    "fmt": "2.33k",
+                    "longFmt": "2,333"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "HART BRETT J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588896000,
+                    "fmt": "2020-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2333,
+                    "fmt": "2.33k",
+                    "longFmt": "2,333"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BURNSIDE WILLIAM H L",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588896000,
+                    "fmt": "2020-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2333,
+                    "fmt": "2.33k",
+                    "longFmt": "2,333"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MEYER MELODY B",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588896000,
+                    "fmt": "2020-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2333,
+                    "fmt": "2.33k",
+                    "longFmt": "2,333"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROBERTS REBECCA B",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588896000,
+                    "fmt": "2020-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 60,
+                    "fmt": "60",
+                    "longFmt": "60"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DURKIN BRIAN L.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588896000,
+                    "fmt": "2020-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 19445,
+                    "fmt": "19.45k",
+                    "longFmt": "19,445"
+                  },
+                  "value": {
+                    "raw": 1652825,
+                    "fmt": "1.65M",
+                    "longFmt": "1,652,825"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 85.00 per share.",
+                  "filerName": "RICHMOND TIMOTHY J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588636800,
+                    "fmt": "2020-05-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 21800,
+                    "fmt": "21.8k",
+                    "longFmt": "21,800"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588032000,
+                    "fmt": "2020-04-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 18500,
+                    "fmt": "18.5k",
+                    "longFmt": "18,500"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GOSEBRUCH HENRY O",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1586131200,
+                    "fmt": "2020-04-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 410,
+                    "fmt": "410",
+                    "longFmt": "410"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1585785600,
+                    "fmt": "2020-04-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 56950,
+                    "fmt": "56.95k",
+                    "longFmt": "56,950"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1585094400,
+                    "fmt": "2020-03-25"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3675,
+                    "fmt": "3.67k",
+                    "longFmt": "3,675"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582243200,
+                    "fmt": "2020-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 200262,
+                    "fmt": "200.26k",
+                    "longFmt": "200,262"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582156800,
+                    "fmt": "2020-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 76166,
+                    "fmt": "76.17k",
+                    "longFmt": "76,166"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582156800,
+                    "fmt": "2020-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 72439,
+                    "fmt": "72.44k",
+                    "longFmt": "72,439"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALBAN CARLOS",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582156800,
+                    "fmt": "2020-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 34907,
+                    "fmt": "34.91k",
+                    "longFmt": "34,907"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RICHMOND TIMOTHY J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582156800,
+                    "fmt": "2020-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 36897,
+                    "fmt": "36.9k",
+                    "longFmt": "36,897"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SALEKI-GERHARDT AZITA PH.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582156800,
+                    "fmt": "2020-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 75595,
+                    "fmt": "75.59k",
+                    "longFmt": "75,595"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SEVERINO MICHAEL E. M.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582156800,
+                    "fmt": "2020-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 58781,
+                    "fmt": "58.78k",
+                    "longFmt": "58,781"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "GOSEBRUCH HENRY O",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582156800,
+                    "fmt": "2020-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 16795,
+                    "fmt": "16.8k",
+                    "longFmt": "16,795"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MICHAEL ROBERT A.",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582156800,
+                    "fmt": "2020-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6527,
+                    "fmt": "6.53k",
+                    "longFmt": "6,527"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DURKIN BRIAN L.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582156800,
+                    "fmt": "2020-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 21896,
+                    "fmt": "21.9k",
+                    "longFmt": "21,896"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "STEWART JEFFREY RYAN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582156800,
+                    "fmt": "2020-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5316,
+                    "fmt": "5.32k",
+                    "longFmt": "5,316"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DONOGHOE NICHOLAS",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582156800,
+                    "fmt": "2020-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12372,
+                    "fmt": "12.37k",
+                    "longFmt": "12,372"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "HUDSON THOMAS J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582156800,
+                    "fmt": "2020-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4000,
+                    "fmt": "4k",
+                    "longFmt": "4,000"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1575417600,
+                    "fmt": "2019-12-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 358,
+                    "fmt": "358",
+                    "longFmt": "358"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1572825600,
+                    "fmt": "2019-11-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15515,
+                    "fmt": "15.52k",
+                    "longFmt": "15,515"
+                  },
+                  "value": {
+                    "raw": 1163873,
+                    "fmt": "1.16M",
+                    "longFmt": "1,163,873"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 75.02 per share.",
+                  "filerName": "RICHMOND TIMOTHY J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1569542400,
+                    "fmt": "2019-09-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15010,
+                    "fmt": "15.01k",
+                    "longFmt": "15,010"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1568073600,
+                    "fmt": "2019-09-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3050,
+                    "fmt": "3.05k",
+                    "longFmt": "3,050"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1566950400,
+                    "fmt": "2019-08-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 30000,
+                    "fmt": "30k",
+                    "longFmt": "30,000"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GOSEBRUCH HENRY O",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1565740800,
+                    "fmt": "2019-08-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 21708,
+                    "fmt": "21.71k",
+                    "longFmt": "21,708"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1564704000,
+                    "fmt": "2019-08-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2419,
+                    "fmt": "2.42k",
+                    "longFmt": "2,419"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "LIDDY EDWARD M",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556841600,
+                    "fmt": "2019-05-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2419,
+                    "fmt": "2.42k",
+                    "longFmt": "2,419"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "AUSTIN ROXANNE SCHUH",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556841600,
+                    "fmt": "2019-05-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2419,
+                    "fmt": "2.42k",
+                    "longFmt": "2,419"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "TILTON GLENN FLETCHER",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556841600,
+                    "fmt": "2019-05-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2419,
+                    "fmt": "2.42k",
+                    "longFmt": "2,419"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WADDELL FREDERICK H",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556841600,
+                    "fmt": "2019-05-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2419,
+                    "fmt": "2.42k",
+                    "longFmt": "2,419"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RAPP EDWARD J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556841600,
+                    "fmt": "2019-05-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2419,
+                    "fmt": "2.42k",
+                    "longFmt": "2,419"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALPERN ROBERT J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556841600,
+                    "fmt": "2019-05-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2419,
+                    "fmt": "2.42k",
+                    "longFmt": "2,419"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "HART BRETT J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556841600,
+                    "fmt": "2019-05-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2419,
+                    "fmt": "2.42k",
+                    "longFmt": "2,419"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BURNSIDE WILLIAM H L",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556841600,
+                    "fmt": "2019-05-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2419,
+                    "fmt": "2.42k",
+                    "longFmt": "2,419"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MEYER MELODY B",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556841600,
+                    "fmt": "2019-05-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2419,
+                    "fmt": "2.42k",
+                    "longFmt": "2,419"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROBERTS REBECCA B",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556841600,
+                    "fmt": "2019-05-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 475,
+                    "fmt": "475",
+                    "longFmt": "475"
+                  },
+                  "value": {
+                    "raw": 37853,
+                    "fmt": "37.85k",
+                    "longFmt": "37,853"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 79.69 per share.",
+                  "filerName": "DURKIN BRIAN L.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1553472000,
+                    "fmt": "2019-03-25"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 25000,
+                    "fmt": "25k",
+                    "longFmt": "25,000"
+                  },
+                  "value": {
+                    "raw": 2000000,
+                    "fmt": "2M",
+                    "longFmt": "2,000,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 80.00 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1552521600,
+                    "fmt": "2019-03-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15797,
+                    "fmt": "15.8k",
+                    "longFmt": "15,797"
+                  },
+                  "value": {
+                    "raw": 1248480,
+                    "fmt": "1.25M",
+                    "longFmt": "1,248,480"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 79.03 per share.",
+                  "filerName": "SALEKI-GERHARDT AZITA PH.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1551744000,
+                    "fmt": "2019-03-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 164609,
+                    "fmt": "164.61k",
+                    "longFmt": "164,609"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550707200,
+                    "fmt": "2019-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 54791,
+                    "fmt": "54.79k",
+                    "longFmt": "54,791"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550707200,
+                    "fmt": "2019-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 54450,
+                    "fmt": "54.45k",
+                    "longFmt": "54,450"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALBAN CARLOS",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550707200,
+                    "fmt": "2019-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 61565,
+                    "fmt": "61.56k",
+                    "longFmt": "61,565"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CHASE WILLIAM J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550707200,
+                    "fmt": "2019-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 27860,
+                    "fmt": "27.86k",
+                    "longFmt": "27,860"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RICHMOND TIMOTHY J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550707200,
+                    "fmt": "2019-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 28366,
+                    "fmt": "28.37k",
+                    "longFmt": "28,366"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SALEKI-GERHARDT AZITA PH.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550707200,
+                    "fmt": "2019-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 60286,
+                    "fmt": "60.29k",
+                    "longFmt": "60,286"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SEVERINO MICHAEL E. M.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550707200,
+                    "fmt": "2019-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 51815,
+                    "fmt": "51.81k",
+                    "longFmt": "51,815"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "GOSEBRUCH HENRY O",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550707200,
+                    "fmt": "2019-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7243,
+                    "fmt": "7.24k",
+                    "longFmt": "7,243"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MICHAEL ROBERT A.",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550707200,
+                    "fmt": "2019-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3737,
+                    "fmt": "3.74k",
+                    "longFmt": "3,737"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DURKIN BRIAN L.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550707200,
+                    "fmt": "2019-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15586,
+                    "fmt": "15.59k",
+                    "longFmt": "15,586"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "STEWART JEFFREY RYAN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550707200,
+                    "fmt": "2019-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2964,
+                    "fmt": "2.96k",
+                    "longFmt": "2,964"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1546992000,
+                    "fmt": "2019-01-09"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5565,
+                    "fmt": "5.57k",
+                    "longFmt": "5,565"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DONOGHOE NICHOLAS",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1546387200,
+                    "fmt": "2019-01-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 25000,
+                    "fmt": "25k",
+                    "longFmt": "25,000"
+                  },
+                  "value": {
+                    "raw": 2250000,
+                    "fmt": "2.25M",
+                    "longFmt": "2,250,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 90.00 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1545955200,
+                    "fmt": "2018-12-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1614,
+                    "fmt": "1.61k",
+                    "longFmt": "1,614"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1545609600,
+                    "fmt": "2018-12-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 112530,
+                    "fmt": "112.53k",
+                    "longFmt": "112,530"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1544659200,
+                    "fmt": "2018-12-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 60000,
+                    "fmt": "60k",
+                    "longFmt": "60,000"
+                  },
+                  "value": {
+                    "raw": 5400000,
+                    "fmt": "5.4M",
+                    "longFmt": "5,400,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 90.00 per share.",
+                  "filerName": "CHASE WILLIAM J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1544572800,
+                    "fmt": "2018-12-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 16850,
+                    "fmt": "16.85k",
+                    "longFmt": "16,850"
+                  },
+                  "value": {
+                    "raw": 1495438,
+                    "fmt": "1.5M",
+                    "longFmt": "1,495,438"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 88.75 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1544486400,
+                    "fmt": "2018-12-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 11595,
+                    "fmt": "11.6k",
+                    "longFmt": "11,595"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "STEWART JEFFREY RYAN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1544400000,
+                    "fmt": "2018-12-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 94140,
+                    "fmt": "94.14k",
+                    "longFmt": "94,140"
+                  },
+                  "value": {
+                    "raw": 8809552,
+                    "fmt": "8.81M",
+                    "longFmt": "8,809,552"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 91.77 - 94.34 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543881600,
+                    "fmt": "2018-12-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 94140,
+                    "fmt": "94.14k",
+                    "longFmt": "94,140"
+                  },
+                  "value": {
+                    "raw": 4840679,
+                    "fmt": "4.84M",
+                    "longFmt": "4,840,679"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 51.42 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543881600,
+                    "fmt": "2018-12-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4237,
+                    "fmt": "4.24k",
+                    "longFmt": "4,237"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543449600,
+                    "fmt": "2018-11-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 42450,
+                    "fmt": "42.45k",
+                    "longFmt": "42,450"
+                  },
+                  "value": {
+                    "raw": 3824940,
+                    "fmt": "3.82M",
+                    "longFmt": "3,824,940"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 90.10 per share.",
+                  "filerName": "GOSEBRUCH HENRY O",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543449600,
+                    "fmt": "2018-11-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 59,
+                    "fmt": "59",
+                    "longFmt": "59"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543276800,
+                    "fmt": "2018-11-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 50000,
+                    "fmt": "50k",
+                    "longFmt": "50,000"
+                  },
+                  "value": {
+                    "raw": 4876060,
+                    "fmt": "4.88M",
+                    "longFmt": "4,876,060"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 96.97 - 97.91 per share.",
+                  "filerName": "SEVERINO MICHAEL E. M.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1534464000,
+                    "fmt": "2018-08-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 17588,
+                    "fmt": "17.59k",
+                    "longFmt": "17,588"
+                  },
+                  "value": {
+                    "raw": 1749485,
+                    "fmt": "1.75M",
+                    "longFmt": "1,749,485"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 99.47 per share.",
+                  "filerName": "RICHMOND TIMOTHY J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1529020800,
+                    "fmt": "2018-06-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1899,
+                    "fmt": "1.9k",
+                    "longFmt": "1,899"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "LIDDY EDWARD M",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525392000,
+                    "fmt": "2018-05-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1899,
+                    "fmt": "1.9k",
+                    "longFmt": "1,899"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "AUSTIN ROXANNE SCHUH",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525392000,
+                    "fmt": "2018-05-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1899,
+                    "fmt": "1.9k",
+                    "longFmt": "1,899"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "TILTON GLENN FLETCHER",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525392000,
+                    "fmt": "2018-05-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1899,
+                    "fmt": "1.9k",
+                    "longFmt": "1,899"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WADDELL FREDERICK H",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525392000,
+                    "fmt": "2018-05-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1899,
+                    "fmt": "1.9k",
+                    "longFmt": "1,899"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RAPP EDWARD J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525392000,
+                    "fmt": "2018-05-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1899,
+                    "fmt": "1.9k",
+                    "longFmt": "1,899"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALPERN ROBERT J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525392000,
+                    "fmt": "2018-05-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1899,
+                    "fmt": "1.9k",
+                    "longFmt": "1,899"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "HART BRETT J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525392000,
+                    "fmt": "2018-05-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1899,
+                    "fmt": "1.9k",
+                    "longFmt": "1,899"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BURNSIDE WILLIAM H L",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525392000,
+                    "fmt": "2018-05-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1899,
+                    "fmt": "1.9k",
+                    "longFmt": "1,899"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MEYER MELODY B",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525392000,
+                    "fmt": "2018-05-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1899,
+                    "fmt": "1.9k",
+                    "longFmt": "1,899"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROBERTS REBECCA B",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525392000,
+                    "fmt": "2018-05-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5722,
+                    "fmt": "5.72k",
+                    "longFmt": "5,722"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1521158400,
+                    "fmt": "2018-03-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 25000,
+                    "fmt": "25k",
+                    "longFmt": "25,000"
+                  },
+                  "value": {
+                    "raw": 2946148,
+                    "fmt": "2.95M",
+                    "longFmt": "2,946,148"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 117.85 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519862400,
+                    "fmt": "2018-03-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 83574,
+                    "fmt": "83.57k",
+                    "longFmt": "83,574"
+                  },
+                  "value": {
+                    "raw": 9568737,
+                    "fmt": "9.57M",
+                    "longFmt": "9,568,737"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 113.75 - 117.85 per share.",
+                  "filerName": "ALBAN CARLOS",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519862400,
+                    "fmt": "2018-03-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 48100,
+                    "fmt": "48.1k",
+                    "longFmt": "48,100"
+                  },
+                  "value": {
+                    "raw": 1405795,
+                    "fmt": "1.41M",
+                    "longFmt": "1,405,795"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 29.23 per share.",
+                  "filerName": "ALBAN CARLOS",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519862400,
+                    "fmt": "2018-03-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 70928,
+                    "fmt": "70.93k",
+                    "longFmt": "70,928"
+                  },
+                  "value": {
+                    "raw": 8311640,
+                    "fmt": "8.31M",
+                    "longFmt": "8,311,640"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 114.50 - 119.44 per share.",
+                  "filerName": "CHASE WILLIAM J",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519862400,
+                    "fmt": "2018-03-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 32400,
+                    "fmt": "32.4k",
+                    "longFmt": "32,400"
+                  },
+                  "value": {
+                    "raw": 839339,
+                    "fmt": "839.34k",
+                    "longFmt": "839,339"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 24.21 - 28.31 per share.",
+                  "filerName": "CHASE WILLIAM J",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519862400,
+                    "fmt": "2018-03-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8280,
+                    "fmt": "8.28k",
+                    "longFmt": "8,280"
+                  },
+                  "value": {
+                    "raw": 976084,
+                    "fmt": "976.08k",
+                    "longFmt": "976,084"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 117.88 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519776000,
+                    "fmt": "2018-02-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 18129,
+                    "fmt": "18.13k",
+                    "longFmt": "18,129"
+                  },
+                  "value": {
+                    "raw": 2151452,
+                    "fmt": "2.15M",
+                    "longFmt": "2,151,452"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 118.67 per share.",
+                  "filerName": "RICHMOND TIMOTHY J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519776000,
+                    "fmt": "2018-02-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1337,
+                    "fmt": "1.34k",
+                    "longFmt": "1,337"
+                  },
+                  "value": {
+                    "raw": 157458,
+                    "fmt": "157.46k",
+                    "longFmt": "157,458"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 117.77 per share.",
+                  "filerName": "SALEKI-GERHARDT AZITA PH.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519776000,
+                    "fmt": "2018-02-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2643,
+                    "fmt": "2.64k",
+                    "longFmt": "2,643"
+                  },
+                  "value": {
+                    "raw": 311684,
+                    "fmt": "311.68k",
+                    "longFmt": "311,684"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 117.93 per share.",
+                  "filerName": "SEVERINO MICHAEL E. M.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519776000,
+                    "fmt": "2018-02-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4294,
+                    "fmt": "4.29k",
+                    "longFmt": "4,294"
+                  },
+                  "value": {
+                    "raw": 512853,
+                    "fmt": "512.85k",
+                    "longFmt": "512,853"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 119.43 per share.",
+                  "filerName": "MICHAEL ROBERT A.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519776000,
+                    "fmt": "2018-02-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 992,
+                    "fmt": "992",
+                    "longFmt": "992"
+                  },
+                  "value": {
+                    "raw": 119351,
+                    "fmt": "119.35k",
+                    "longFmt": "119,351"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 120.29 - 120.33 per share.",
+                  "filerName": "MICHAEL ROBERT A.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519084800,
+                    "fmt": "2018-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 126946,
+                    "fmt": "126.95k",
+                    "longFmt": "126,946"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518652800,
+                    "fmt": "2018-02-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 45420,
+                    "fmt": "45.42k",
+                    "longFmt": "45,420"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518652800,
+                    "fmt": "2018-02-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 44257,
+                    "fmt": "44.26k",
+                    "longFmt": "44,257"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALBAN CARLOS",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518652800,
+                    "fmt": "2018-02-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 48255,
+                    "fmt": "48.26k",
+                    "longFmt": "48,255"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CHASE WILLIAM J",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518652800,
+                    "fmt": "2018-02-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 21822,
+                    "fmt": "21.82k",
+                    "longFmt": "21,822"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RICHMOND TIMOTHY J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518652800,
+                    "fmt": "2018-02-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 22533,
+                    "fmt": "22.53k",
+                    "longFmt": "22,533"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SALEKI-GERHARDT AZITA PH.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518652800,
+                    "fmt": "2018-02-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 47685,
+                    "fmt": "47.69k",
+                    "longFmt": "47,685"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SEVERINO MICHAEL E. M.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518652800,
+                    "fmt": "2018-02-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 39316,
+                    "fmt": "39.32k",
+                    "longFmt": "39,316"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "GOSEBRUCH HENRY O",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518652800,
+                    "fmt": "2018-02-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5380,
+                    "fmt": "5.38k",
+                    "longFmt": "5,380"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MICHAEL ROBERT A.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518652800,
+                    "fmt": "2018-02-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 87040,
+                    "fmt": "87.04k",
+                    "longFmt": "87,040"
+                  },
+                  "value": {
+                    "raw": 8569053,
+                    "fmt": "8.57M",
+                    "longFmt": "8,569,053"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 98.45 per share.",
+                  "filerName": "RICHMOND TIMOTHY J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1513555200,
+                    "fmt": "2017-12-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 87040,
+                    "fmt": "87.04k",
+                    "longFmt": "87,040"
+                  },
+                  "value": {
+                    "raw": 3122995,
+                    "fmt": "3.12M",
+                    "longFmt": "3,122,995"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 35.88 per share.",
+                  "filerName": "RICHMOND TIMOTHY J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1513555200,
+                    "fmt": "2017-12-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 145510,
+                    "fmt": "145.51k",
+                    "longFmt": "145,510"
+                  },
+                  "value": {
+                    "raw": 14071982,
+                    "fmt": "14.07M",
+                    "longFmt": "14,071,982"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 96.71 - 96.86 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1513296000,
+                    "fmt": "2017-12-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 145510,
+                    "fmt": "145.51k",
+                    "longFmt": "145,510"
+                  },
+                  "value": {
+                    "raw": 5220899,
+                    "fmt": "5.22M",
+                    "longFmt": "5,220,899"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 35.88 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1513296000,
+                    "fmt": "2017-12-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 218193,
+                    "fmt": "218.19k",
+                    "longFmt": "218,193"
+                  },
+                  "value": {
+                    "raw": 20511800,
+                    "fmt": "20.51M",
+                    "longFmt": "20,511,800"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 94.01 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1511222400,
+                    "fmt": "2017-11-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 218193,
+                    "fmt": "218.19k",
+                    "longFmt": "218,193"
+                  },
+                  "value": {
+                    "raw": 12847204,
+                    "fmt": "12.85M",
+                    "longFmt": "12,847,204"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 58.88 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1511222400,
+                    "fmt": "2017-11-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 25633,
+                    "fmt": "25.63k",
+                    "longFmt": "25,633"
+                  },
+                  "value": {
+                    "raw": 2427212,
+                    "fmt": "2.43M",
+                    "longFmt": "2,427,212"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 94.69 per share.",
+                  "filerName": "SEVERINO MICHAEL E. M.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1510272000,
+                    "fmt": "2017-11-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 18300,
+                    "fmt": "18.3k",
+                    "longFmt": "18,300"
+                  },
+                  "value": {
+                    "raw": 1657037,
+                    "fmt": "1.66M",
+                    "longFmt": "1,657,037"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 89.38 - 92.02 per share.",
+                  "filerName": "GOSEBRUCH HENRY O",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1509321600,
+                    "fmt": "2017-10-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6699,
+                    "fmt": "6.7k",
+                    "longFmt": "6,699"
+                  },
+                  "value": {
+                    "raw": 589512,
+                    "fmt": "589.51k",
+                    "longFmt": "589,512"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 88.00 per share.",
+                  "filerName": "MICHAEL ROBERT A.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1506556800,
+                    "fmt": "2017-09-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2093,
+                    "fmt": "2.09k",
+                    "longFmt": "2,093"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1505088000,
+                    "fmt": "2017-09-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8300,
+                    "fmt": "8.3k",
+                    "longFmt": "8,300"
+                  },
+                  "value": {
+                    "raw": 705655,
+                    "fmt": "705.65k",
+                    "longFmt": "705,655"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 84.99 - 85.06 per share.",
+                  "filerName": "SALEKI-GERHARDT AZITA PH.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1505088000,
+                    "fmt": "2017-09-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4800,
+                    "fmt": "4.8k",
+                    "longFmt": "4,800"
+                  },
+                  "value": {
+                    "raw": 116199,
+                    "fmt": "116.2k",
+                    "longFmt": "116,199"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 24.21 per share.",
+                  "filerName": "SALEKI-GERHARDT AZITA PH.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1505088000,
+                    "fmt": "2017-09-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 193131,
+                    "fmt": "193.13k",
+                    "longFmt": "193,131"
+                  },
+                  "value": {
+                    "raw": 13713186,
+                    "fmt": "13.71M",
+                    "longFmt": "13,713,186"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 71.00 - 71.06 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1502064000,
+                    "fmt": "2017-08-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 193131,
+                    "fmt": "193.13k",
+                    "longFmt": "193,131"
+                  },
+                  "value": {
+                    "raw": 9930796,
+                    "fmt": "9.93M",
+                    "longFmt": "9,930,796"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 51.42 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1502064000,
+                    "fmt": "2017-08-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 87899,
+                    "fmt": "87.9k",
+                    "longFmt": "87,899"
+                  },
+                  "value": {
+                    "raw": 6242297,
+                    "fmt": "6.24M",
+                    "longFmt": "6,242,297"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 71.00 - 71.13 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1501804800,
+                    "fmt": "2017-08-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 87899,
+                    "fmt": "87.9k",
+                    "longFmt": "87,899"
+                  },
+                  "value": {
+                    "raw": 4519767,
+                    "fmt": "4.52M",
+                    "longFmt": "4,519,767"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 51.42 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1501804800,
+                    "fmt": "2017-08-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 18000,
+                    "fmt": "18k",
+                    "longFmt": "18,000"
+                  },
+                  "value": {
+                    "raw": 1261638,
+                    "fmt": "1.26M",
+                    "longFmt": "1,261,638"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 70.00 - 70.34 per share.",
+                  "filerName": "GOSEBRUCH HENRY O",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1501459200,
+                    "fmt": "2017-07-31"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 300,
+                    "fmt": "300",
+                    "longFmt": "300"
+                  },
+                  "value": {
+                    "raw": 21127,
+                    "fmt": "21.13k",
+                    "longFmt": "21,127"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 70.37 - 70.45 per share.",
+                  "filerName": "GOSEBRUCH HENRY O",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1501459200,
+                    "fmt": "2017-07-31"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2235,
+                    "fmt": "2.23k",
+                    "longFmt": "2,235"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1498521600,
+                    "fmt": "2017-06-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 79800,
+                    "fmt": "79.8k",
+                    "longFmt": "79,800"
+                  },
+                  "value": {
+                    "raw": 5586000,
+                    "fmt": "5.59M",
+                    "longFmt": "5,586,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 70.00 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1497398400,
+                    "fmt": "2017-06-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 79800,
+                    "fmt": "79.8k",
+                    "longFmt": "79,800"
+                  },
+                  "value": {
+                    "raw": 2332275,
+                    "fmt": "2.33M",
+                    "longFmt": "2,332,275"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 29.23 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1497398400,
+                    "fmt": "2017-06-14"
+                  },
+                  "ownership": "D"
+                }
+              ],
+              "maxAge": 1
+            },
+            "sectorTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 13858000000,
+                    "fmt": "13.86B",
+                    "longFmt": "13,858,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 4412000000,
+                    "fmt": "4.41B",
+                    "longFmt": "4,412,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 9446000000,
+                    "fmt": "9.45B",
+                    "longFmt": "9,446,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 1821000000,
+                    "fmt": "1.82B",
+                    "longFmt": "1,821,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 3105000000,
+                    "fmt": "3.1B",
+                    "longFmt": "3,105,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 9338000000,
+                    "fmt": "9.34B",
+                    "longFmt": "9,338,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 4520000000,
+                    "fmt": "4.52B",
+                    "longFmt": "4,520,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -6027000000,
+                    "fmt": "-6.03B",
+                    "longFmt": "-6,027,000,000"
+                  },
+                  "ebit": {
+                    "raw": 4520000000,
+                    "fmt": "4.52B",
+                    "longFmt": "4,520,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -618000000,
+                    "fmt": "-618M",
+                    "longFmt": "-618,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -1507000000,
+                    "fmt": "-1.51B",
+                    "longFmt": "-1,507,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -1545000000,
+                    "fmt": "-1.54B",
+                    "longFmt": "-1,545,000,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 38000000,
+                    "fmt": "38M",
+                    "longFmt": "38,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 36000000,
+                    "fmt": "36M",
+                    "longFmt": "36,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 36000000,
+                    "fmt": "36M",
+                    "longFmt": "36,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 12902000000,
+                    "fmt": "12.9B",
+                    "longFmt": "12,902,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 5028000000,
+                    "fmt": "5.03B",
+                    "longFmt": "5,028,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 7874000000,
+                    "fmt": "7.87B",
+                    "longFmt": "7,874,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 1575000000,
+                    "fmt": "1.57B",
+                    "longFmt": "1,575,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 2752000000,
+                    "fmt": "2.75B",
+                    "longFmt": "2,752,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 9355000000,
+                    "fmt": "9.36B",
+                    "longFmt": "9,355,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 3547000000,
+                    "fmt": "3.55B",
+                    "longFmt": "3,547,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -1047000000,
+                    "fmt": "-1.05B",
+                    "longFmt": "-1,047,000,000"
+                  },
+                  "ebit": {
+                    "raw": 3547000000,
+                    "fmt": "3.55B",
+                    "longFmt": "3,547,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -630000000,
+                    "fmt": "-630M",
+                    "longFmt": "-630,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 2500000000,
+                    "fmt": "2.5B",
+                    "longFmt": "2,500,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 187000000,
+                    "fmt": "187M",
+                    "longFmt": "187,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 19000000,
+                    "fmt": "19M",
+                    "longFmt": "19,000,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 2313000000,
+                    "fmt": "2.31B",
+                    "longFmt": "2,313,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 2308000000,
+                    "fmt": "2.31B",
+                    "longFmt": "2,308,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 2291000000,
+                    "fmt": "2.29B",
+                    "longFmt": "2,291,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 10425000000,
+                    "fmt": "10.43B",
+                    "longFmt": "10,425,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 3246000000,
+                    "fmt": "3.25B",
+                    "longFmt": "3,246,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 7179000000,
+                    "fmt": "7.18B",
+                    "longFmt": "7,179,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 1406000000,
+                    "fmt": "1.41B",
+                    "longFmt": "1,406,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 2367000000,
+                    "fmt": "2.37B",
+                    "longFmt": "2,367,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 7019000000,
+                    "fmt": "7.02B",
+                    "longFmt": "7,019,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 3406000000,
+                    "fmt": "3.41B",
+                    "longFmt": "3,406,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -4099000000,
+                    "fmt": "-4.1B",
+                    "longFmt": "-4,099,000,000"
+                  },
+                  "ebit": {
+                    "raw": 3406000000,
+                    "fmt": "3.41B",
+                    "longFmt": "3,406,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -632000000,
+                    "fmt": "-632M",
+                    "longFmt": "-632,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -693000000,
+                    "fmt": "-693M",
+                    "longFmt": "-693,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 46000000,
+                    "fmt": "46M",
+                    "longFmt": "46,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 24000000,
+                    "fmt": "24M",
+                    "longFmt": "24,000,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -739000000,
+                    "fmt": "-739M",
+                    "longFmt": "-739,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -738000000,
+                    "fmt": "-738M",
+                    "longFmt": "-738,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -756000000,
+                    "fmt": "-756M",
+                    "longFmt": "-756,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 8619000000,
+                    "fmt": "8.62B",
+                    "longFmt": "8,619,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 2373000000,
+                    "fmt": "2.37B",
+                    "longFmt": "2,373,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 6246000000,
+                    "fmt": "6.25B",
+                    "longFmt": "6,246,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 1379000000,
+                    "fmt": "1.38B",
+                    "longFmt": "1,379,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 1649000000,
+                    "fmt": "1.65B",
+                    "longFmt": "1,649,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 5401000000,
+                    "fmt": "5.4B",
+                    "longFmt": "5,401,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 3218000000,
+                    "fmt": "3.22B",
+                    "longFmt": "3,218,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -120000000,
+                    "fmt": "-120M",
+                    "longFmt": "-120,000,000"
+                  },
+                  "ebit": {
+                    "raw": 3218000000,
+                    "fmt": "3.22B",
+                    "longFmt": "3,218,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -563000000,
+                    "fmt": "-563M",
+                    "longFmt": "-563,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 3098000000,
+                    "fmt": "3.1B",
+                    "longFmt": "3,098,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 88000000,
+                    "fmt": "88M",
+                    "longFmt": "88,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 24000000,
+                    "fmt": "24M",
+                    "longFmt": "24,000,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 3010000000,
+                    "fmt": "3.01B",
+                    "longFmt": "3,010,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 3010000000,
+                    "fmt": "3.01B",
+                    "longFmt": "3,010,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 3000000000,
+                    "fmt": "3B",
+                    "longFmt": "3,000,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 36000000,
+                    "fmt": "36M",
+                    "longFmt": "36,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 2308000000,
+                    "fmt": "2.31B",
+                    "longFmt": "2,308,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 2292000000,
+                    "fmt": "2.29B",
+                    "longFmt": "2,292,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 265000000,
+                    "fmt": "265M",
+                    "longFmt": "265,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -31000000,
+                    "fmt": "-31M",
+                    "longFmt": "-31,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 1437000000,
+                    "fmt": "1.44B",
+                    "longFmt": "1,437,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 111000000,
+                    "fmt": "111M",
+                    "longFmt": "111,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -50000000,
+                    "fmt": "-50M",
+                    "longFmt": "-50,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 5830000000,
+                    "fmt": "5.83B",
+                    "longFmt": "5,830,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -217000000,
+                    "fmt": "-217M",
+                    "longFmt": "-217,000,000"
+                  },
+                  "investments": {
+                    "raw": 20000000,
+                    "fmt": "20M",
+                    "longFmt": "20,000,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -72000000,
+                    "fmt": "-72M",
+                    "longFmt": "-72,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -1149000000,
+                    "fmt": "-1.15B",
+                    "longFmt": "-1,149,000,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -2100000000,
+                    "fmt": "-2.1B",
+                    "longFmt": "-2,100,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -651000000,
+                    "fmt": "-651M",
+                    "longFmt": "-651,000,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -75000000,
+                    "fmt": "-75M",
+                    "longFmt": "-75,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -2814000000,
+                    "fmt": "-2.81B",
+                    "longFmt": "-2,814,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 6000000,
+                    "fmt": "6M",
+                    "longFmt": "6,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 1873000000,
+                    "fmt": "1.87B",
+                    "longFmt": "1,873,000,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -20000000,
+                    "fmt": "-20M",
+                    "longFmt": "-20,000,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 32000000,
+                    "fmt": "32M",
+                    "longFmt": "32,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "netIncome": {
+                    "raw": -738000000,
+                    "fmt": "-738M",
+                    "longFmt": "-738,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 1555000000,
+                    "fmt": "1.55B",
+                    "longFmt": "1,555,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 2123000000,
+                    "fmt": "2.12B",
+                    "longFmt": "2,123,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 482000000,
+                    "fmt": "482M",
+                    "longFmt": "482,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -599000000,
+                    "fmt": "-599M",
+                    "longFmt": "-599,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -197000000,
+                    "fmt": "-197M",
+                    "longFmt": "-197,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 259000000,
+                    "fmt": "259M",
+                    "longFmt": "259,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 3089000000,
+                    "fmt": "3.09B",
+                    "longFmt": "3,089,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -177000000,
+                    "fmt": "-177M",
+                    "longFmt": "-177,000,000"
+                  },
+                  "investments": {
+                    "raw": 1384000000,
+                    "fmt": "1.38B",
+                    "longFmt": "1,384,000,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 1459000000,
+                    "fmt": "1.46B",
+                    "longFmt": "1,459,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -35652000000,
+                    "fmt": "-35.65B",
+                    "longFmt": "-35,652,000,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -1752000000,
+                    "fmt": "-1.75B",
+                    "longFmt": "-1,752,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -763000000,
+                    "fmt": "-763M",
+                    "longFmt": "-763,000,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -101000000,
+                    "fmt": "-101M",
+                    "longFmt": "-101,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -2570000000,
+                    "fmt": "-2.57B",
+                    "longFmt": "-2,570,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 8000000,
+                    "fmt": "8M",
+                    "longFmt": "8,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": -35125000000,
+                    "fmt": "-35.12B",
+                    "longFmt": "-35,125,000,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -19000000,
+                    "fmt": "-19M",
+                    "longFmt": "-19,000,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 65000000,
+                    "fmt": "65M",
+                    "longFmt": "65,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "netIncome": {
+                    "raw": 3010000000,
+                    "fmt": "3.01B",
+                    "longFmt": "3,010,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 559000000,
+                    "fmt": "559M",
+                    "longFmt": "559,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 332000000,
+                    "fmt": "332M",
+                    "longFmt": "332,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -1025000000,
+                    "fmt": "-1.02B",
+                    "longFmt": "-1,025,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 1065000000,
+                    "fmt": "1.06B",
+                    "longFmt": "1,065,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -107000000,
+                    "fmt": "-107M",
+                    "longFmt": "-107,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -19000000,
+                    "fmt": "-19M",
+                    "longFmt": "-19,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 3815000000,
+                    "fmt": "3.81B",
+                    "longFmt": "3,815,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -125000000,
+                    "fmt": "-125M",
+                    "longFmt": "-125,000,000"
+                  },
+                  "investments": {
+                    "raw": 13000000,
+                    "fmt": "13M",
+                    "longFmt": "13,000,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -5000000,
+                    "fmt": "-5M",
+                    "longFmt": "-5,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -129000000,
+                    "fmt": "-129M",
+                    "longFmt": "-129,000,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -1763000000,
+                    "fmt": "-1.76B",
+                    "longFmt": "-1,763,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -763000000,
+                    "fmt": "-763M",
+                    "longFmt": "-763,000,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -28000000,
+                    "fmt": "-28M",
+                    "longFmt": "-28,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -2422000000,
+                    "fmt": "-2.42B",
+                    "longFmt": "-2,422,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -46000000,
+                    "fmt": "-46M",
+                    "longFmt": "-46,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 1218000000,
+                    "fmt": "1.22B",
+                    "longFmt": "1,218,000,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -643000000,
+                    "fmt": "-643M",
+                    "longFmt": "-643,000,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 12000000,
+                    "fmt": "12M",
+                    "longFmt": "12,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [
+                  {
+                    "date": "1Q2020",
+                    "actual": 2.42,
+                    "estimate": 2.25
+                  },
+                  {
+                    "date": "2Q2020",
+                    "actual": 2.34,
+                    "estimate": 2.19
+                  },
+                  {
+                    "date": "3Q2020",
+                    "actual": 2.83,
+                    "estimate": 2.76
+                  },
+                  {
+                    "date": "4Q2020",
+                    "actual": 2.92,
+                    "estimate": 2.85
+                  }
+                ],
+                "currentQuarterEstimate": 2.79,
+                "currentQuarterEstimateDate": "1Q",
+                "currentQuarterEstimateYear": 2021,
+                "earningsDate": [
+                  1619654400,
+                  1620000000
+                ]
+              },
+              "financialsChart": {
+                "yearly": [
+                  {
+                    "date": 2017,
+                    "revenue": 28216000000,
+                    "earnings": 5309000000
+                  },
+                  {
+                    "date": 2018,
+                    "revenue": 32753000000,
+                    "earnings": 5687000000
+                  },
+                  {
+                    "date": 2019,
+                    "revenue": 33266000000,
+                    "earnings": 7882000000
+                  },
+                  {
+                    "date": 2020,
+                    "revenue": 45804000000,
+                    "earnings": 4616000000
+                  }
+                ],
+                "quarterly": [
+                  {
+                    "date": "1Q2020",
+                    "revenue": 8619000000,
+                    "earnings": 3010000000
+                  },
+                  {
+                    "date": "2Q2020",
+                    "revenue": 10425000000,
+                    "earnings": -738000000
+                  },
+                  {
+                    "date": "3Q2020",
+                    "revenue": 12902000000,
+                    "earnings": 2308000000
+                  },
+                  {
+                    "date": "4Q2020",
+                    "revenue": 13858000000,
+                    "earnings": 36000000
+                  }
+                ]
+              },
+              "financialCurrency": "USD"
+            },
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 105.57,
+              "targetHighPrice": 140,
+              "targetLowPrice": 97,
+              "targetMeanPrice": 120.48,
+              "targetMedianPrice": 120,
+              "recommendationMean": 2,
+              "recommendationKey": "buy",
+              "numberOfAnalystOpinions": 21,
+              "totalCash": 7964000256,
+              "totalCashPerShare": 4.511,
+              "ebitda": 21527664640,
+              "totalDebt": 87098998784,
+              "totalRevenue": 45803999232,
+              "debtToEquity": 569.684,
+              "revenuePerShare": 27.378,
+              "returnOnEquity": 1.2988601,
+              "grossProfits": 31709000000,
+              "earningsGrowth": -0.995,
+              "revenueGrowth": 0.592,
+              "grossMargins": 0.69228,
+              "ebitdaMargins": 0.46999002,
+              "operatingMargins": 0.34174,
+              "profitMargins": 0.10078,
+              "financialCurrency": "USD"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-all-BRKS.json
+++ b/tests/http/quoteSummary-all-BRKS.json
@@ -1,0 +1,8465 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=assetProfile%2CbalanceSheetHistory%2CbalanceSheetHistoryQuarterly%2CcalendarEvents%2CcashflowStatementHistory%2CcashflowStatementHistoryQuarterly%2CdefaultKeyStatistics%2Cearnings%2CearningsHistory%2CearningsTrend%2CfinancialData%2CfundOwnership%2CfundPerformance%2CfundProfile%2CincomeStatementHistory%2CincomeStatementHistoryQuarterly%2CindexTrend%2CindustryTrend%2CinsiderHolders%2CinsiderTransactions%2CinstitutionOwnership%2CmajorDirectHolders%2CmajorHoldersBreakdown%2CnetSharePurchaseActivity%2Cprice%2CquoteType%2CrecommendationTrend%2CsecFilings%2CsectorTrend%2CsummaryDetail%2CsummaryProfile%2CtopHoldings%2CupgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "a3ut63lg2vsf2"
+      ],
+      "x-yahoo-request-id": [
+        "a3ut63lg2vsf2"
+      ],
+      "x-request-id": [
+        "ba3ede4f-d2fc-4477-8be6-aead681daf99"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "10"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:10 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "15 Elizabeth Drive",
+              "city": "Chelmsford",
+              "state": "MA",
+              "zip": "01824",
+              "country": "United States",
+              "phone": "978 262 2400",
+              "fax": "978 262 2500",
+              "website": "http://www.brooks.com",
+              "industry": "Semiconductor Equipment & Materials",
+              "sector": "Technology",
+              "longBusinessSummary": "Brooks Automation, Inc. provides manufacturing automation solutions for the semiconductor industry, and life science sample-based services and solutions for the life sciences market worldwide. The company operates in three segments: Brooks Semiconductor Solutions Group, Brooks Life Sciences Services, and Brooks Life Sciences Products. The Brooks Semiconductor Solutions Group segment offers wafer automation and contamination controls solutions and services. Its products include atmospheric and vacuum robots, robotic modules, and tool automation systems that offer precision handling and clean wafer environments; and automated cleaning and inspection systems for wafer carriers, reticle pod cleaners, and stockers. It also offers repair and refurbishment, diagnostics, and installation services, as well as spare parts and productivity enhancement upgrade services. The Brooks Life Sciences Services segment provides gene sequencing and gene synthesis services, including next generation sequencing, sanger sequencing, gene synthesis, bioinformatics, and good laboratory practices regulatory services; on-site and off-site sample storage, cold chain logistics, sample transport and collection relocation, bio-processing solutions, disaster recovery, and business continuity, as well as project management and consulting services; and sample intelligence software solutions and integration of customer technology. The Brooks Life Sciences Products segment offers automated cold storage systems; consumables, such as various formats of racks, tubes, caps, plates, and foils used for the storage and handling of samples in cold storage environments; and instruments used for labeling, bar coding, capping, de-capping, auditing, sealing, peeling, and piercing tubes and plates. The company serves semiconductor capital equipment and life sciences sample management markets in approximately 50 countries. Brooks Automation, Inc. was founded in 1978 and is headquartered in Chelmsford, Massachusetts.",
+              "fullTimeEmployees": 3200,
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Stephen S. Schwartz",
+                  "age": 61,
+                  "title": "CEO, Pres & Director",
+                  "yearBorn": 1959,
+                  "fiscalYear": 2020,
+                  "totalPay": {
+                    "raw": 1417517,
+                    "fmt": "1.42M",
+                    "longFmt": "1,417,517"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Lindon G. Robertson",
+                  "age": 58,
+                  "title": "Exec. VP & CFO",
+                  "yearBorn": 1962,
+                  "fiscalYear": 2020,
+                  "totalPay": {
+                    "raw": 1004200,
+                    "fmt": "1M",
+                    "longFmt": "1,004,200"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Jason W. Joseph",
+                  "age": 49,
+                  "title": "Sr. VP, Gen. Counsel & Sec.",
+                  "yearBorn": 1971,
+                  "fiscalYear": 2020,
+                  "totalPay": {
+                    "raw": 586543,
+                    "fmt": "586.54k",
+                    "longFmt": "586,543"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Guojuan  Liao Ph.D.",
+                  "age": 55,
+                  "title": "Pres of Life Sciences Services",
+                  "yearBorn": 1965,
+                  "fiscalYear": 2020,
+                  "totalPay": {
+                    "raw": 713921,
+                    "fmt": "713.92k",
+                    "longFmt": "713,921"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. David E. Jarzynka",
+                  "age": 52,
+                  "title": "Pres of Semiconductor Solutions Group",
+                  "yearBorn": 1968,
+                  "fiscalYear": 2020,
+                  "totalPay": {
+                    "raw": 770351,
+                    "fmt": "770.35k",
+                    "longFmt": "770,351"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. David F. Pietrantoni",
+                  "age": 47,
+                  "title": "VP of Fin., Corp. Controller & Principal Accounting Officer",
+                  "yearBorn": 1973,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Mark  Namaroff",
+                  "age": 57,
+                  "title": "Director of Investor Relations",
+                  "yearBorn": 1963,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. John E. O'Brien",
+                  "age": 50,
+                  "title": "VP of Corp. Devel.",
+                  "yearBorn": 1970,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. William T. Montone",
+                  "age": 68,
+                  "title": "Sr. VP of HR",
+                  "yearBorn": 1952,
+                  "fiscalYear": 2014,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. J. Robert Woodward",
+                  "title": "Sr. VP of Quality & Engineering",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "auditRisk": 5,
+              "boardRisk": 1,
+              "compensationRisk": 3,
+              "shareHolderRightsRisk": 6,
+              "overallRisk": 3,
+              "governanceEpochDate": 1606867200,
+              "compensationAsOfEpochDate": 1609372800,
+              "maxAge": 86400
+            },
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 3,
+                  "buy": 1,
+                  "hold": 2,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 2,
+                  "buy": 3,
+                  "hold": 2,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 2,
+                  "buy": 3,
+                  "hold": 2,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 1,
+                  "buy": 1,
+                  "hold": 4,
+                  "sell": 0,
+                  "strongSell": 0
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 64853000,
+                    "fmt": "64.85M",
+                    "longFmt": "64,853,000"
+                  },
+                  "depreciation": {
+                    "raw": 65496000,
+                    "fmt": "65.5M",
+                    "longFmt": "65,496,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -79812000,
+                    "fmt": "-79.81M",
+                    "longFmt": "-79,812,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -18755000,
+                    "fmt": "-18.75M",
+                    "longFmt": "-18,755,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 653000,
+                    "fmt": "653k",
+                    "longFmt": "653,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -13144000,
+                    "fmt": "-13.14M",
+                    "longFmt": "-13,144,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 18575000,
+                    "fmt": "18.57M",
+                    "longFmt": "18,575,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 37866000,
+                    "fmt": "37.87M",
+                    "longFmt": "37,866,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -39924000,
+                    "fmt": "-39.92M",
+                    "longFmt": "-39,924,000"
+                  },
+                  "investments": {
+                    "raw": 33926000,
+                    "fmt": "33.93M",
+                    "longFmt": "33,926,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -1000000,
+                    "fmt": "-1M",
+                    "longFmt": "-1,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -22742000,
+                    "fmt": "-22.74M",
+                    "longFmt": "-22,742,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -29513000,
+                    "fmt": "-29.51M",
+                    "longFmt": "-29,513,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -2105000,
+                    "fmt": "-2.1M",
+                    "longFmt": "-2,105,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -27023000,
+                    "fmt": "-27.02M",
+                    "longFmt": "-27,023,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 9254000,
+                    "fmt": "9.25M",
+                    "longFmt": "9,254,000"
+                  },
+                  "changeInCash": {
+                    "raw": -2645000,
+                    "fmt": "-2.65M",
+                    "longFmt": "-2,645,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 4595000,
+                    "fmt": "4.59M",
+                    "longFmt": "4,595,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1569801600,
+                    "fmt": "2019-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 437416000,
+                    "fmt": "437.42M",
+                    "longFmt": "437,416,000"
+                  },
+                  "depreciation": {
+                    "raw": 54450000,
+                    "fmt": "54.45M",
+                    "longFmt": "54,450,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -407241000,
+                    "fmt": "-407.24M",
+                    "longFmt": "-407,241,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -11445000,
+                    "fmt": "-11.45M",
+                    "longFmt": "-11,445,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 8908000,
+                    "fmt": "8.91M",
+                    "longFmt": "8,908,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -2933000,
+                    "fmt": "-2.93M",
+                    "longFmt": "-2,933,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 11743000,
+                    "fmt": "11.74M",
+                    "longFmt": "11,743,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 90898000,
+                    "fmt": "90.9M",
+                    "longFmt": "90,898,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -23861000,
+                    "fmt": "-23.86M",
+                    "longFmt": "-23,861,000"
+                  },
+                  "investments": {
+                    "raw": 16235000,
+                    "fmt": "16.23M",
+                    "longFmt": "16,235,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -1000000,
+                    "fmt": "-1M",
+                    "longFmt": "-1,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 211312000,
+                    "fmt": "211.31M",
+                    "longFmt": "211,312,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -28895000,
+                    "fmt": "-28.89M",
+                    "longFmt": "-28,895,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -165001000,
+                    "fmt": "-165M",
+                    "longFmt": "-165,001,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -687000,
+                    "fmt": "-687k",
+                    "longFmt": "-687,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -191161000,
+                    "fmt": "-191.16M",
+                    "longFmt": "-191,161,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -3586000,
+                    "fmt": "-3.59M",
+                    "longFmt": "-3,586,000"
+                  },
+                  "changeInCash": {
+                    "raw": 107463000,
+                    "fmt": "107.46M",
+                    "longFmt": "107,463,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 3422000,
+                    "fmt": "3.42M",
+                    "longFmt": "3,422,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1538265600,
+                    "fmt": "2018-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 116575000,
+                    "fmt": "116.58M",
+                    "longFmt": "116,575,000"
+                  },
+                  "depreciation": {
+                    "raw": 36686000,
+                    "fmt": "36.69M",
+                    "longFmt": "36,686,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -32702000,
+                    "fmt": "-32.7M",
+                    "longFmt": "-32,702,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -28463000,
+                    "fmt": "-28.46M",
+                    "longFmt": "-28,463,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 8248000,
+                    "fmt": "8.25M",
+                    "longFmt": "8,248,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -24365000,
+                    "fmt": "-24.36M",
+                    "longFmt": "-24,365,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -2015000,
+                    "fmt": "-2.02M",
+                    "longFmt": "-2,015,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 73964000,
+                    "fmt": "73.96M",
+                    "longFmt": "73,964,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -12787000,
+                    "fmt": "-12.79M",
+                    "longFmt": "-12,787,000"
+                  },
+                  "investments": {
+                    "raw": -50126000,
+                    "fmt": "-50.13M",
+                    "longFmt": "-50,126,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -1000000,
+                    "fmt": "-1M",
+                    "longFmt": "-1,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -148468000,
+                    "fmt": "-148.47M",
+                    "longFmt": "-148,468,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -28285000,
+                    "fmt": "-28.29M",
+                    "longFmt": "-28,285,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 196054000,
+                    "fmt": "196.05M",
+                    "longFmt": "196,054,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -318000,
+                    "fmt": "-318k",
+                    "longFmt": "-318,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 170277000,
+                    "fmt": "170.28M",
+                    "longFmt": "170,277,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 313000,
+                    "fmt": "313k",
+                    "longFmt": "313,000"
+                  },
+                  "changeInCash": {
+                    "raw": 96086000,
+                    "fmt": "96.09M",
+                    "longFmt": "96,086,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 2826000,
+                    "fmt": "2.83M",
+                    "longFmt": "2,826,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1506729600,
+                    "fmt": "2017-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 62612000,
+                    "fmt": "62.61M",
+                    "longFmt": "62,612,000"
+                  },
+                  "depreciation": {
+                    "raw": 27230000,
+                    "fmt": "27.23M",
+                    "longFmt": "27,230,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 7073000,
+                    "fmt": "7.07M",
+                    "longFmt": "7,073,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -11178000,
+                    "fmt": "-11.18M",
+                    "longFmt": "-11,178,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 15895000,
+                    "fmt": "15.89M",
+                    "longFmt": "15,895,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -12792000,
+                    "fmt": "-12.79M",
+                    "longFmt": "-12,792,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 7384000,
+                    "fmt": "7.38M",
+                    "longFmt": "7,384,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 96224000,
+                    "fmt": "96.22M",
+                    "longFmt": "96,224,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -12677000,
+                    "fmt": "-12.68M",
+                    "longFmt": "-12,677,000"
+                  },
+                  "investments": {
+                    "raw": 3420000,
+                    "fmt": "3.42M",
+                    "longFmt": "3,420,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -1000000,
+                    "fmt": "-1M",
+                    "longFmt": "-1,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -54188000,
+                    "fmt": "-54.19M",
+                    "longFmt": "-54,188,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -27932000,
+                    "fmt": "-27.93M",
+                    "longFmt": "-27,932,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 196054000,
+                    "fmt": "196.05M",
+                    "longFmt": "196,054,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -28000,
+                    "fmt": "-28k",
+                    "longFmt": "-28,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -25920000,
+                    "fmt": "-25.92M",
+                    "longFmt": "-25,920,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 420000,
+                    "fmt": "420k",
+                    "longFmt": "420,000"
+                  },
+                  "changeInCash": {
+                    "raw": 16536000,
+                    "fmt": "16.54M",
+                    "longFmt": "16,536,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 2040000,
+                    "fmt": "2.04M",
+                    "longFmt": "2,040,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 8.58013,
+              "pegRatio": 0.771291,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.286
+                },
+                {
+                  "period": "+1q",
+                  "growth": 1.032
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.175
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.15100001
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0827489
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            },
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": 5856073216,
+              "forwardPE": 38.493393,
+              "profitMargins": 0.08312,
+              "floatShares": 71729128,
+              "sharesOutstanding": 74220096,
+              "sharesShort": 2188456,
+              "sharesShortPriorMonth": 2341236,
+              "sharesShortPreviousMonthDate": 1609372800,
+              "dateShortInterest": 1611878400,
+              "sharesPercentSharesOut": 0.0295,
+              "heldPercentInsiders": 0.01582,
+              "heldPercentInstitutions": 1.00236,
+              "shortRatio": 1.55,
+              "shortPercentOfFloat": 0.0399,
+              "beta": 1.930096,
+              "category": null,
+              "bookValue": 17.118,
+              "priceToBook": 5.104568,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1601424000,
+              "nextFiscalYearEnd": 1664496000,
+              "mostRecentQuarter": 1609372800,
+              "earningsQuarterlyGrowth": 0.993,
+              "netIncomeToCommon": 78868000,
+              "trailingEps": 1.046,
+              "forwardEps": 2.27,
+              "pegRatio": 2.92,
+              "lastSplitFactor": null,
+              "enterpriseToRevenue": 6.255,
+              "enterpriseToEbitda": 34.865,
+              "52WeekChange": 1.1730819,
+              "SandP52WeekChange": 0.17263722,
+              "lastDividendValue": 0.1,
+              "lastDividendDate": 1606953600
+            },
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "quoteType": {
+              "exchange": "NMS",
+              "quoteType": "EQUITY",
+              "symbol": "BRKS",
+              "underlyingSymbol": "BRKS",
+              "shortName": "Brooks Automation, Inc.",
+              "longName": "Brooks Automation, Inc.",
+              "firstTradeDateEpochUtc": 791735400,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "35dd4682-0b8a-3535-ae1c-cde5d5fbf2a6",
+              "messageBoardId": "finmb_336648",
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            },
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 897273000,
+                    "fmt": "897.27M",
+                    "longFmt": "897,273,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 516948000,
+                    "fmt": "516.95M",
+                    "longFmt": "516,948,000"
+                  },
+                  "grossProfit": {
+                    "raw": 380325000,
+                    "fmt": "380.32M",
+                    "longFmt": "380,325,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 59063000,
+                    "fmt": "59.06M",
+                    "longFmt": "59,063,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 240637000,
+                    "fmt": "240.64M",
+                    "longFmt": "240,637,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 816648000,
+                    "fmt": "816.65M",
+                    "longFmt": "816,648,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 80625000,
+                    "fmt": "80.62M",
+                    "longFmt": "80,625,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -5653000,
+                    "fmt": "-5.65M",
+                    "longFmt": "-5,653,000"
+                  },
+                  "ebit": {
+                    "raw": 80625000,
+                    "fmt": "80.62M",
+                    "longFmt": "80,625,000"
+                  },
+                  "interestExpense": {
+                    "raw": -2944000,
+                    "fmt": "-2.94M",
+                    "longFmt": "-2,944,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 74972000,
+                    "fmt": "74.97M",
+                    "longFmt": "74,972,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 9937000,
+                    "fmt": "9.94M",
+                    "longFmt": "9,937,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 65035000,
+                    "fmt": "65.03M",
+                    "longFmt": "65,035,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -182000,
+                    "fmt": "-182k",
+                    "longFmt": "-182,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 64853000,
+                    "fmt": "64.85M",
+                    "longFmt": "64,853,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 64853000,
+                    "fmt": "64.85M",
+                    "longFmt": "64,853,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1569801600,
+                    "fmt": "2019-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 780848000,
+                    "fmt": "780.85M",
+                    "longFmt": "780,848,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 464119000,
+                    "fmt": "464.12M",
+                    "longFmt": "464,119,000"
+                  },
+                  "grossProfit": {
+                    "raw": 316729000,
+                    "fmt": "316.73M",
+                    "longFmt": "316,729,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 56368000,
+                    "fmt": "56.37M",
+                    "longFmt": "56,368,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 205260000,
+                    "fmt": "205.26M",
+                    "longFmt": "205,260,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 725747000,
+                    "fmt": "725.75M",
+                    "longFmt": "725,747,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 55101000,
+                    "fmt": "55.1M",
+                    "longFmt": "55,101,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -45658000,
+                    "fmt": "-45.66M",
+                    "longFmt": "-45,658,000"
+                  },
+                  "ebit": {
+                    "raw": 55101000,
+                    "fmt": "55.1M",
+                    "longFmt": "55,101,000"
+                  },
+                  "interestExpense": {
+                    "raw": -22250000,
+                    "fmt": "-22.25M",
+                    "longFmt": "-22,250,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 9443000,
+                    "fmt": "9.44M",
+                    "longFmt": "9,443,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -111000,
+                    "fmt": "-111k",
+                    "longFmt": "-111,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 9554000,
+                    "fmt": "9.55M",
+                    "longFmt": "9,554,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": 427862000,
+                    "fmt": "427.86M",
+                    "longFmt": "427,862,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 437416000,
+                    "fmt": "437.42M",
+                    "longFmt": "437,416,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 437416000,
+                    "fmt": "437.42M",
+                    "longFmt": "437,416,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1538265600,
+                    "fmt": "2018-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 631560000,
+                    "fmt": "631.56M",
+                    "longFmt": "631,560,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 385479000,
+                    "fmt": "385.48M",
+                    "longFmt": "385,479,000"
+                  },
+                  "grossProfit": {
+                    "raw": 246081000,
+                    "fmt": "246.08M",
+                    "longFmt": "246,081,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 46936000,
+                    "fmt": "46.94M",
+                    "longFmt": "46,936,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 163222000,
+                    "fmt": "163.22M",
+                    "longFmt": "163,222,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 595637000,
+                    "fmt": "595.64M",
+                    "longFmt": "595,637,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 35923000,
+                    "fmt": "35.92M",
+                    "longFmt": "35,923,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -15457000,
+                    "fmt": "-15.46M",
+                    "longFmt": "-15,457,000"
+                  },
+                  "ebit": {
+                    "raw": 35923000,
+                    "fmt": "35.92M",
+                    "longFmt": "35,923,000"
+                  },
+                  "interestExpense": {
+                    "raw": -9520000,
+                    "fmt": "-9.52M",
+                    "longFmt": "-9,520,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 20466000,
+                    "fmt": "20.47M",
+                    "longFmt": "20,466,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -47251000,
+                    "fmt": "-47.25M",
+                    "longFmt": "-47,251,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 67717000,
+                    "fmt": "67.72M",
+                    "longFmt": "67,717,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": 48747000,
+                    "fmt": "48.75M",
+                    "longFmt": "48,747,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 116575000,
+                    "fmt": "116.58M",
+                    "longFmt": "116,575,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 116575000,
+                    "fmt": "116.58M",
+                    "longFmt": "116,575,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1506729600,
+                    "fmt": "2017-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 527499000,
+                    "fmt": "527.5M",
+                    "longFmt": "527,499,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 328089000,
+                    "fmt": "328.09M",
+                    "longFmt": "328,089,000"
+                  },
+                  "grossProfit": {
+                    "raw": 199410000,
+                    "fmt": "199.41M",
+                    "longFmt": "199,410,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 39875000,
+                    "fmt": "39.88M",
+                    "longFmt": "39,875,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 140849000,
+                    "fmt": "140.85M",
+                    "longFmt": "140,849,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 508813000,
+                    "fmt": "508.81M",
+                    "longFmt": "508,813,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 18686000,
+                    "fmt": "18.69M",
+                    "longFmt": "18,686,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -4619000,
+                    "fmt": "-4.62M",
+                    "longFmt": "-4,619,000"
+                  },
+                  "ebit": {
+                    "raw": 18686000,
+                    "fmt": "18.69M",
+                    "longFmt": "18,686,000"
+                  },
+                  "interestExpense": {
+                    "raw": -408000,
+                    "fmt": "-408k",
+                    "longFmt": "-408,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 14067000,
+                    "fmt": "14.07M",
+                    "longFmt": "14,067,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 3380000,
+                    "fmt": "3.38M",
+                    "longFmt": "3,380,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 10687000,
+                    "fmt": "10.69M",
+                    "longFmt": "10,687,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": 51925000,
+                    "fmt": "51.92M",
+                    "longFmt": "51,925,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 62612000,
+                    "fmt": "62.61M",
+                    "longFmt": "62,612,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 62612000,
+                    "fmt": "62.61M",
+                    "longFmt": "62,612,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            },
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 82.99,
+              "open": 84.56,
+              "dayLow": 84.56,
+              "dayHigh": 87.9,
+              "regularMarketPreviousClose": 82.99,
+              "regularMarketOpen": 84.56,
+              "regularMarketDayLow": 84.56,
+              "regularMarketDayHigh": 87.9,
+              "dividendRate": 0.4,
+              "dividendYield": 0.0047999998,
+              "exDividendDate": 1614816000,
+              "payoutRatio": 0.3774,
+              "fiveYearAvgDividendYield": 1.62,
+              "beta": 1.930096,
+              "trailingPE": 83.537285,
+              "forwardPE": 38.493393,
+              "volume": 146528,
+              "regularMarketVolume": 146528,
+              "averageVolume": 865460,
+              "averageVolume10days": 520785,
+              "averageDailyVolume10Day": 520785,
+              "bid": 87.55,
+              "ask": 87.74,
+              "bidSize": 1300,
+              "askSize": 1000,
+              "marketCap": 6485351936,
+              "fiftyTwoWeekLow": 21.19,
+              "fiftyTwoWeekHigh": 91.78,
+              "priceToSalesTrailing12Months": 6.9267526,
+              "fiftyDayAverage": 78.746666,
+              "twoHundredDayAverage": 62.45348,
+              "trailingAnnualDividendRate": 0.4,
+              "trailingAnnualDividendYield": 0.004819858,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            },
+            "insiderHolders": {
+              "holders": [
+                {
+                  "maxAge": 1,
+                  "name": "DAVIS ROBYN C",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "positionDirect": {
+                    "raw": 21596,
+                    "fmt": "21.6k",
+                    "longFmt": "21,596"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "GRAY DAVID C",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "positionDirect": {
+                    "raw": 77265,
+                    "fmt": "77.27k",
+                    "longFmt": "77,265"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "JOSEPH JASON W",
+                  "relation": "General Counsel",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "positionDirect": {
+                    "raw": 85855,
+                    "fmt": "85.86k",
+                    "longFmt": "85,855"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "MARTIN JOSEPH R",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "positionDirect": {
+                    "raw": 85881,
+                    "fmt": "85.88k",
+                    "longFmt": "85,881"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "MCLAUGHLIN ERICA",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "positionDirect": {
+                    "raw": 4827,
+                    "fmt": "4.83k",
+                    "longFmt": "4,827"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "PALEPU KRISHNA G",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "positionDirect": {
+                    "raw": 99867,
+                    "fmt": "99.87k",
+                    "longFmt": "99,867"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "ROSENBLATT MICHAEL",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "positionDirect": {
+                    "raw": 9642,
+                    "fmt": "9.64k",
+                    "longFmt": "9,642"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "SCHWARTZ STEPHEN S",
+                  "relation": "Chief Executive Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "positionDirect": {
+                    "raw": 377711,
+                    "fmt": "377.71k",
+                    "longFmt": "377,711"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "WRIGHTON MARK S",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "positionDirect": {
+                    "raw": 109896,
+                    "fmt": "109.9k",
+                    "longFmt": "109,896"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "ZANE ELLEN M",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "positionDirect": {
+                    "raw": 54374,
+                    "fmt": "54.37k",
+                    "longFmt": "54,374"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  }
+                }
+              ],
+              "maxAge": 1
+            },
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": [
+                  1619568000,
+                  1620000000
+                ],
+                "earningsAverage": 0.5,
+                "earningsLow": 0.47,
+                "earningsHigh": 0.52,
+                "revenueAverage": 272280000,
+                "revenueLow": 267000000,
+                "revenueHigh": 275000000
+              },
+              "exDividendDate": 1614816000,
+              "dividendDate": 1616716800
+            },
+            "upgradeDowngradeHistory": {
+              "history": [
+                {
+                  "epochGradeDate": 1612951408,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612364233,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612348099,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1605110698,
+                  "firm": "Stephens & Co.",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Equal-Weight",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1605102162,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1605095791,
+                  "firm": "Needham",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1605085293,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1604999142,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1600684623,
+                  "firm": "Stifel",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1596533779,
+                  "firm": "Needham",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1592822498,
+                  "firm": "Stifel",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1588349666,
+                  "firm": "Citigroup",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588345551,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1586777922,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1586430717,
+                  "firm": "Needham",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1584700492,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1581343474,
+                  "firm": "Citigroup",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1573147433,
+                  "firm": "B. Riley",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1573144723,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1569240895,
+                  "firm": "Citigroup",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1564762274,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1556632844,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1542810590,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1542723863,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Neutral",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1537874344,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1536065070,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1531489051,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1525528839,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1525266233,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Neutral",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1525262323,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1513876510,
+                  "firm": "Stephens & Co.",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1510344803,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1510144846,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1505741265,
+                  "firm": "Needham",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1502102249,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1483961183,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Underperform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1483460244,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1476267631,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1473807740,
+                  "firm": "Janney Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1473662772,
+                  "firm": "Citigroup",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1457420331,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Underperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1525528836,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1439550000,
+                  "firm": "Citigroup",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1435560550,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1415869200,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1415091600,
+                  "firm": "Citigroup",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1412670600,
+                  "firm": "Furey Research",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1404109560,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1403853516,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1525528836,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1398209548,
+                  "firm": "Citigroup",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1384762831,
+                  "firm": "Citigroup",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1377675441,
+                  "firm": "Northland Securities",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1357215341,
+                  "firm": "Barclays",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "Underweight",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1349180160,
+                  "firm": "Barclays",
+                  "toGrade": "Underweight",
+                  "fromGrade": "Equal-Weight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1349165700,
+                  "firm": "Barclays",
+                  "toGrade": "Underweight",
+                  "fromGrade": "Equal-Weight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1344607620,
+                  "firm": "Barclays",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "",
+                  "action": "main"
+                }
+              ],
+              "maxAge": 86400
+            },
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": 0.020725401,
+              "preMarketChange": 1.72,
+              "preMarketTime": 1613744999,
+              "preMarketPrice": 84.71,
+              "preMarketSource": "FREE_REALTIME",
+              "regularMarketChangePercent": 0.052897934,
+              "regularMarketChange": 4.3899994,
+              "regularMarketTime": 1613754822,
+              "priceHint": 2,
+              "regularMarketPrice": 87.38,
+              "regularMarketDayHigh": 87.9,
+              "regularMarketDayLow": 84.56,
+              "regularMarketVolume": 146528,
+              "averageDailyVolume10Day": 520785,
+              "averageDailyVolume3Month": 865460,
+              "regularMarketPreviousClose": 82.99,
+              "regularMarketSource": "FREE_REALTIME",
+              "regularMarketOpen": 84.56,
+              "exchange": "NMS",
+              "exchangeName": "NasdaqGS",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "EQUITY",
+              "symbol": "BRKS",
+              "underlyingSymbol": null,
+              "shortName": "Brooks Automation, Inc.",
+              "longName": "Brooks Automation, Inc.",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 6485351936
+            },
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 295649000,
+                    "fmt": "295.65M",
+                    "longFmt": "295,649,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 67000,
+                    "fmt": "67k",
+                    "longFmt": "67,000"
+                  },
+                  "netReceivables": {
+                    "raw": 205091000,
+                    "fmt": "205.09M",
+                    "longFmt": "205,091,000"
+                  },
+                  "inventory": {
+                    "raw": 114834000,
+                    "fmt": "114.83M",
+                    "longFmt": "114,834,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 3937000,
+                    "fmt": "3.94M",
+                    "longFmt": "3,937,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 649453000,
+                    "fmt": "649.45M",
+                    "longFmt": "649,453,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 3101000,
+                    "fmt": "3.1M",
+                    "longFmt": "3,101,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 156736000,
+                    "fmt": "156.74M",
+                    "longFmt": "156,736,000"
+                  },
+                  "goodWill": {
+                    "raw": 501536000,
+                    "fmt": "501.54M",
+                    "longFmt": "501,536,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 218325000,
+                    "fmt": "218.32M",
+                    "longFmt": "218,325,000"
+                  },
+                  "otherAssets": {
+                    "raw": 29974000,
+                    "fmt": "29.97M",
+                    "longFmt": "29,974,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 4979000,
+                    "fmt": "4.98M",
+                    "longFmt": "4,979,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1559125000,
+                    "fmt": "1.56B",
+                    "longFmt": "1,559,125,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 61758000,
+                    "fmt": "61.76M",
+                    "longFmt": "61,758,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 827000,
+                    "fmt": "827k",
+                    "longFmt": "827,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 50071000,
+                    "fmt": "50.07M",
+                    "longFmt": "50,071,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 49588000,
+                    "fmt": "49.59M",
+                    "longFmt": "49,588,000"
+                  },
+                  "otherLiab": {
+                    "raw": 52602000,
+                    "fmt": "52.6M",
+                    "longFmt": "52,602,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 400000,
+                    "fmt": "400k",
+                    "longFmt": "400,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 211118000,
+                    "fmt": "211.12M",
+                    "longFmt": "211,118,000"
+                  },
+                  "totalLiab": {
+                    "raw": 345511000,
+                    "fmt": "345.51M",
+                    "longFmt": "345,511,000"
+                  },
+                  "commonStock": {
+                    "raw": 873000,
+                    "fmt": "873k",
+                    "longFmt": "873,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -551072000,
+                    "fmt": "-551.07M",
+                    "longFmt": "-551,072,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -179037000,
+                    "fmt": "-179.04M",
+                    "longFmt": "-179,037,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1942850000,
+                    "fmt": "1.94B",
+                    "longFmt": "1,942,850,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 21919000,
+                    "fmt": "21.92M",
+                    "longFmt": "21,919,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1213614000,
+                    "fmt": "1.21B",
+                    "longFmt": "1,213,614,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 493753000,
+                    "fmt": "493.75M",
+                    "longFmt": "493,753,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1569801600,
+                    "fmt": "2019-09-30"
+                  },
+                  "cash": {
+                    "raw": 301642000,
+                    "fmt": "301.64M",
+                    "longFmt": "301,642,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 34124000,
+                    "fmt": "34.12M",
+                    "longFmt": "34,124,000"
+                  },
+                  "netReceivables": {
+                    "raw": 179602000,
+                    "fmt": "179.6M",
+                    "longFmt": "179,602,000"
+                  },
+                  "inventory": {
+                    "raw": 99445000,
+                    "fmt": "99.44M",
+                    "longFmt": "99,445,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 3546000,
+                    "fmt": "3.55M",
+                    "longFmt": "3,546,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 647145000,
+                    "fmt": "647.14M",
+                    "longFmt": "647,145,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2845000,
+                    "fmt": "2.85M",
+                    "longFmt": "2,845,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 100669000,
+                    "fmt": "100.67M",
+                    "longFmt": "100,669,000"
+                  },
+                  "goodWill": {
+                    "raw": 488602000,
+                    "fmt": "488.6M",
+                    "longFmt": "488,602,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 251168000,
+                    "fmt": "251.17M",
+                    "longFmt": "251,168,000"
+                  },
+                  "otherAssets": {
+                    "raw": 25570000,
+                    "fmt": "25.57M",
+                    "longFmt": "25,570,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 5064000,
+                    "fmt": "5.06M",
+                    "longFmt": "5,064,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1515999000,
+                    "fmt": "1.52B",
+                    "longFmt": "1,515,999,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 58919000,
+                    "fmt": "58.92M",
+                    "longFmt": "58,919,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 829000,
+                    "fmt": "829k",
+                    "longFmt": "829,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 137253000,
+                    "fmt": "137.25M",
+                    "longFmt": "137,253,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 50315000,
+                    "fmt": "50.31M",
+                    "longFmt": "50,315,000"
+                  },
+                  "otherLiab": {
+                    "raw": 53076000,
+                    "fmt": "53.08M",
+                    "longFmt": "53,076,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 800000,
+                    "fmt": "800k",
+                    "longFmt": "800,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 272270000,
+                    "fmt": "272.27M",
+                    "longFmt": "272,270,000"
+                  },
+                  "totalLiab": {
+                    "raw": 377045000,
+                    "fmt": "377.05M",
+                    "longFmt": "377,045,000"
+                  },
+                  "commonStock": {
+                    "raw": 857000,
+                    "fmt": "857k",
+                    "longFmt": "857,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -586412000,
+                    "fmt": "-586.41M",
+                    "longFmt": "-586,412,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -197445000,
+                    "fmt": "-197.44M",
+                    "longFmt": "-197,445,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1921954000,
+                    "fmt": "1.92B",
+                    "longFmt": "1,921,954,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 3511000,
+                    "fmt": "3.51M",
+                    "longFmt": "3,511,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1138954000,
+                    "fmt": "1.14B",
+                    "longFmt": "1,138,954,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 399184000,
+                    "fmt": "399.18M",
+                    "longFmt": "399,184,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1538265600,
+                    "fmt": "2018-09-30"
+                  },
+                  "cash": {
+                    "raw": 197708000,
+                    "fmt": "197.71M",
+                    "longFmt": "197,708,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 46281000,
+                    "fmt": "46.28M",
+                    "longFmt": "46,281,000"
+                  },
+                  "netReceivables": {
+                    "raw": 137992000,
+                    "fmt": "137.99M",
+                    "longFmt": "137,992,000"
+                  },
+                  "inventory": {
+                    "raw": 96986000,
+                    "fmt": "96.99M",
+                    "longFmt": "96,986,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 66318000,
+                    "fmt": "66.32M",
+                    "longFmt": "66,318,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 564056000,
+                    "fmt": "564.06M",
+                    "longFmt": "564,056,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 7237000,
+                    "fmt": "7.24M",
+                    "longFmt": "7,237,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 59988000,
+                    "fmt": "59.99M",
+                    "longFmt": "59,988,000"
+                  },
+                  "goodWill": {
+                    "raw": 255876000,
+                    "fmt": "255.88M",
+                    "longFmt": "255,876,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 99956000,
+                    "fmt": "99.96M",
+                    "longFmt": "99,956,000"
+                  },
+                  "otherAssets": {
+                    "raw": 108144000,
+                    "fmt": "108.14M",
+                    "longFmt": "108,144,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 43798000,
+                    "fmt": "43.8M",
+                    "longFmt": "43,798,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1095257000,
+                    "fmt": "1.1B",
+                    "longFmt": "1,095,257,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 44724000,
+                    "fmt": "44.72M",
+                    "longFmt": "44,724,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2000000,
+                    "fmt": "2M",
+                    "longFmt": "2,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 58343000,
+                    "fmt": "58.34M",
+                    "longFmt": "58,343,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 194071000,
+                    "fmt": "194.07M",
+                    "longFmt": "194,071,000"
+                  },
+                  "otherLiab": {
+                    "raw": 18737000,
+                    "fmt": "18.74M",
+                    "longFmt": "18,737,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 1500000,
+                    "fmt": "1.5M",
+                    "longFmt": "1,500,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 164617000,
+                    "fmt": "164.62M",
+                    "longFmt": "164,617,000"
+                  },
+                  "totalLiab": {
+                    "raw": 377425000,
+                    "fmt": "377.43M",
+                    "longFmt": "377,425,000"
+                  },
+                  "commonStock": {
+                    "raw": 841000,
+                    "fmt": "841k",
+                    "longFmt": "841,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -994074000,
+                    "fmt": "-994.07M",
+                    "longFmt": "-994,074,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -187369000,
+                    "fmt": "-187.37M",
+                    "longFmt": "-187,369,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1898434000,
+                    "fmt": "1.9B",
+                    "longFmt": "1,898,434,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 13587000,
+                    "fmt": "13.59M",
+                    "longFmt": "13,587,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 717832000,
+                    "fmt": "717.83M",
+                    "longFmt": "717,832,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 362000000,
+                    "fmt": "362M",
+                    "longFmt": "362,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1506729600,
+                    "fmt": "2017-09-30"
+                  },
+                  "cash": {
+                    "raw": 101622000,
+                    "fmt": "101.62M",
+                    "longFmt": "101,622,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 28000,
+                    "fmt": "28k",
+                    "longFmt": "28,000"
+                  },
+                  "netReceivables": {
+                    "raw": 93465000,
+                    "fmt": "93.47M",
+                    "longFmt": "93,465,000"
+                  },
+                  "inventory": {
+                    "raw": 73397000,
+                    "fmt": "73.4M",
+                    "longFmt": "73,397,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 60675000,
+                    "fmt": "60.67M",
+                    "longFmt": "60,675,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 351777000,
+                    "fmt": "351.78M",
+                    "longFmt": "351,777,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2642000,
+                    "fmt": "2.64M",
+                    "longFmt": "2,642,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 56981000,
+                    "fmt": "56.98M",
+                    "longFmt": "56,981,000"
+                  },
+                  "goodWill": {
+                    "raw": 207154000,
+                    "fmt": "207.15M",
+                    "longFmt": "207,154,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 83504000,
+                    "fmt": "83.5M",
+                    "longFmt": "83,504,000"
+                  },
+                  "otherAssets": {
+                    "raw": 64570000,
+                    "fmt": "64.57M",
+                    "longFmt": "64,570,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 1692000,
+                    "fmt": "1.69M",
+                    "longFmt": "1,692,000"
+                  },
+                  "totalAssets": {
+                    "raw": 766628000,
+                    "fmt": "766.63M",
+                    "longFmt": "766,628,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 49100000,
+                    "fmt": "49.1M",
+                    "longFmt": "49,100,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 49139000,
+                    "fmt": "49.14M",
+                    "longFmt": "49,139,000"
+                  },
+                  "otherLiab": {
+                    "raw": 12206000,
+                    "fmt": "12.21M",
+                    "longFmt": "12,206,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 500000,
+                    "fmt": "500k",
+                    "longFmt": "500,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 146778000,
+                    "fmt": "146.78M",
+                    "longFmt": "146,778,000"
+                  },
+                  "totalLiab": {
+                    "raw": 158984000,
+                    "fmt": "158.98M",
+                    "longFmt": "158,984,000"
+                  },
+                  "commonStock": {
+                    "raw": 833000,
+                    "fmt": "833k",
+                    "longFmt": "833,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -1082364000,
+                    "fmt": "-1.08B",
+                    "longFmt": "-1,082,364,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -185743000,
+                    "fmt": "-185.74M",
+                    "longFmt": "-185,743,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1874918000,
+                    "fmt": "1.87B",
+                    "longFmt": "1,874,918,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 15213000,
+                    "fmt": "15.21M",
+                    "longFmt": "15,213,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 607644000,
+                    "fmt": "607.64M",
+                    "longFmt": "607,644,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 316986000,
+                    "fmt": "316.99M",
+                    "longFmt": "316,986,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": "2021-03-31",
+                  "growth": {
+                    "raw": 1,
+                    "fmt": "100.00%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.5,
+                      "fmt": "0.5"
+                    },
+                    "low": {
+                      "raw": 0.47,
+                      "fmt": "0.47"
+                    },
+                    "high": {
+                      "raw": 0.52,
+                      "fmt": "0.52"
+                    },
+                    "yearAgoEps": {
+                      "raw": 0.25,
+                      "fmt": "0.25"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "growth": {
+                      "raw": 1,
+                      "fmt": "100.00%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 272280000,
+                      "fmt": "272.28M",
+                      "longFmt": "272,280,000"
+                    },
+                    "low": {
+                      "raw": 267000000,
+                      "fmt": "267M",
+                      "longFmt": "267,000,000"
+                    },
+                    "high": {
+                      "raw": 275000000,
+                      "fmt": "275M",
+                      "longFmt": "275,000,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.5,
+                      "fmt": "0.5"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.5,
+                      "fmt": "0.5"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.41,
+                      "fmt": "0.41"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.41,
+                      "fmt": "0.41"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.41,
+                      "fmt": "0.41"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": "2021-06-30",
+                  "growth": {
+                    "raw": 0.625,
+                    "fmt": "62.50%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.52,
+                      "fmt": "0.52"
+                    },
+                    "low": {
+                      "raw": 0.49,
+                      "fmt": "0.49"
+                    },
+                    "high": {
+                      "raw": 0.54,
+                      "fmt": "0.54"
+                    },
+                    "yearAgoEps": {
+                      "raw": 0.32,
+                      "fmt": "0.32"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "growth": {
+                      "raw": 0.625,
+                      "fmt": "62.50%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 273800000,
+                      "fmt": "273.8M",
+                      "longFmt": "273,800,000"
+                    },
+                    "low": {
+                      "raw": 271500000,
+                      "fmt": "271.5M",
+                      "longFmt": "271,500,000"
+                    },
+                    "high": {
+                      "raw": 277000000,
+                      "fmt": "277M",
+                      "longFmt": "277,000,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.52,
+                      "fmt": "0.52"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.52,
+                      "fmt": "0.52"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.43,
+                      "fmt": "0.43"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.43,
+                      "fmt": "0.43"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.43,
+                      "fmt": "0.43"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": "2021-09-30",
+                  "growth": {
+                    "raw": 0.579,
+                    "fmt": "57.90%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 1.99,
+                      "fmt": "1.99"
+                    },
+                    "low": {
+                      "raw": 1.94,
+                      "fmt": "1.94"
+                    },
+                    "high": {
+                      "raw": 2.06,
+                      "fmt": "2.06"
+                    },
+                    "yearAgoEps": {
+                      "raw": 1.26,
+                      "fmt": "1.26"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "growth": {
+                      "raw": 0.579,
+                      "fmt": "57.90%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 1065180000,
+                      "fmt": "1.07B",
+                      "longFmt": "1,065,180,000"
+                    },
+                    "low": {
+                      "raw": 1059000000,
+                      "fmt": "1.06B",
+                      "longFmt": "1,059,000,000"
+                    },
+                    "high": {
+                      "raw": 1073600000,
+                      "fmt": "1.07B",
+                      "longFmt": "1,073,600,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 897273000,
+                      "fmt": "897.27M",
+                      "longFmt": "897,273,000"
+                    },
+                    "growth": {
+                      "raw": 0.187,
+                      "fmt": "18.70%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 1.99,
+                      "fmt": "1.99"
+                    },
+                    "7daysAgo": {
+                      "raw": 1.99,
+                      "fmt": "1.99"
+                    },
+                    "30daysAgo": {
+                      "raw": 1.73,
+                      "fmt": "1.73"
+                    },
+                    "60daysAgo": {
+                      "raw": 1.72,
+                      "fmt": "1.72"
+                    },
+                    "90daysAgo": {
+                      "raw": 1.72,
+                      "fmt": "1.72"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 6,
+                      "fmt": "6",
+                      "longFmt": "6"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": "2022-09-30",
+                  "growth": {
+                    "raw": 0.141,
+                    "fmt": "14.10%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 2.27,
+                      "fmt": "2.27"
+                    },
+                    "low": {
+                      "raw": 2.12,
+                      "fmt": "2.12"
+                    },
+                    "high": {
+                      "raw": 2.4,
+                      "fmt": "2.4"
+                    },
+                    "yearAgoEps": {
+                      "raw": 1.99,
+                      "fmt": "1.99"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 4,
+                      "fmt": "4",
+                      "longFmt": "4"
+                    },
+                    "growth": {
+                      "raw": 0.141,
+                      "fmt": "14.10%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 1161180000,
+                      "fmt": "1.16B",
+                      "longFmt": "1,161,180,000"
+                    },
+                    "low": {
+                      "raw": 1151900000,
+                      "fmt": "1.15B",
+                      "longFmt": "1,151,900,000"
+                    },
+                    "high": {
+                      "raw": 1172800000,
+                      "fmt": "1.17B",
+                      "longFmt": "1,172,800,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 4,
+                      "fmt": "4",
+                      "longFmt": "4"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 1065180000,
+                      "fmt": "1.07B",
+                      "longFmt": "1,065,180,000"
+                    },
+                    "growth": {
+                      "raw": 0.09,
+                      "fmt": "9.00%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 2.27,
+                      "fmt": "2.27"
+                    },
+                    "7daysAgo": {
+                      "raw": 2.27,
+                      "fmt": "2.27"
+                    },
+                    "30daysAgo": {
+                      "raw": 2.13,
+                      "fmt": "2.13"
+                    },
+                    "60daysAgo": {
+                      "raw": 2.11,
+                      "fmt": "2.11"
+                    },
+                    "90daysAgo": {
+                      "raw": 2.11,
+                      "fmt": "2.11"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 4,
+                      "fmt": "4",
+                      "longFmt": "4"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": 0.12,
+                    "fmt": "12.00%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": 0.39747003,
+                    "fmt": "39.75%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            },
+            "secFilings": {
+              "filings": [
+                {
+                  "date": "2021-02-03",
+                  "epochDate": 1612390320,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001558370-21-000702&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-02-02",
+                  "epochDate": 1612300597,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-21-000008&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-02-01",
+                  "epochDate": 1612214814,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-21-000005&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-01-28",
+                  "epochDate": 1611870228,
+                  "type": "8-K",
+                  "title": "Submission of Matters to a Vote of Security Holders",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-21-000002&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-12-10",
+                  "epochDate": 1607634609,
+                  "type": "8-K",
+                  "title": "Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-20-000034&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-11-18",
+                  "epochDate": 1605733974,
+                  "type": "10-K",
+                  "title": "Annual Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001558370-20-013971&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-11-10",
+                  "epochDate": 1605042486,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-20-000028&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-07-31",
+                  "epochDate": 1596233317,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001558370-20-008910&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-07-31",
+                  "epochDate": 1596193625,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-20-000025&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-01",
+                  "epochDate": 1588365708,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001558370-20-004927&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-30",
+                  "epochDate": 1588277507,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and E",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-20-000014&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-13",
+                  "epochDate": 1586810221,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and E",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-20-000011&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-07",
+                  "epochDate": 1586291288,
+                  "type": "8-K",
+                  "title": "Disclosing Change in Directors or Principal Officers, Financial Statements and Exhib",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-20-000008&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-02-06",
+                  "epochDate": 1581024552,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001558370-20-000586&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-02-06",
+                  "epochDate": 1581023295,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and E",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-20-000005&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-12-17",
+                  "epochDate": 1576587551,
+                  "type": "10-K",
+                  "title": "Annual Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001558370-19-011541&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-06",
+                  "epochDate": 1573074797,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and E",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-19-000035&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-08-02",
+                  "epochDate": 1564779064,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001558370-19-006962&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-08-01",
+                  "epochDate": 1564690437,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and E",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-19-000028&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-07-05",
+                  "epochDate": 1562326896,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Completion of Acquisition or ",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-19-000025&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-06-18",
+                  "epochDate": 1560889297,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-19-000023&nav=1&src=Yahoo",
+                  "maxAge": 1
+                }
+              ],
+              "maxAge": 86400
+            },
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Blackrock Inc.",
+                  "pctHeld": {
+                    "raw": 0.1552,
+                    "fmt": "15.52%"
+                  },
+                  "position": {
+                    "raw": 11519488,
+                    "fmt": "11.52M",
+                    "longFmt": "11,519,488"
+                  },
+                  "value": {
+                    "raw": 781597260,
+                    "fmt": "781.6M",
+                    "longFmt": "781,597,260"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Group, Inc. (The)",
+                  "pctHeld": {
+                    "raw": 0.106000006,
+                    "fmt": "10.60%"
+                  },
+                  "position": {
+                    "raw": 7864600,
+                    "fmt": "7.86M",
+                    "longFmt": "7,864,600"
+                  },
+                  "value": {
+                    "raw": 363816396,
+                    "fmt": "363.82M",
+                    "longFmt": "363,816,396"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Kayne Anderson Rudnick Investment Management LLC",
+                  "pctHeld": {
+                    "raw": 0.056500003,
+                    "fmt": "5.65%"
+                  },
+                  "position": {
+                    "raw": 4196259,
+                    "fmt": "4.2M",
+                    "longFmt": "4,196,259"
+                  },
+                  "value": {
+                    "raw": 194118941,
+                    "fmt": "194.12M",
+                    "longFmt": "194,118,941"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "William Blair Investment Management, LLC",
+                  "pctHeld": {
+                    "raw": 0.0517,
+                    "fmt": "5.17%"
+                  },
+                  "position": {
+                    "raw": 3839521,
+                    "fmt": "3.84M",
+                    "longFmt": "3,839,521"
+                  },
+                  "value": {
+                    "raw": 260511499,
+                    "fmt": "260.51M",
+                    "longFmt": "260,511,499"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Silvercrest Asset Management Group LLC",
+                  "pctHeld": {
+                    "raw": 0.0317,
+                    "fmt": "3.17%"
+                  },
+                  "position": {
+                    "raw": 2351652,
+                    "fmt": "2.35M",
+                    "longFmt": "2,351,652"
+                  },
+                  "value": {
+                    "raw": 108787421,
+                    "fmt": "108.79M",
+                    "longFmt": "108,787,421"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "State Street Corporation",
+                  "pctHeld": {
+                    "raw": 0.0296,
+                    "fmt": "2.96%"
+                  },
+                  "position": {
+                    "raw": 2194903,
+                    "fmt": "2.19M",
+                    "longFmt": "2,194,903"
+                  },
+                  "value": {
+                    "raw": 101536212,
+                    "fmt": "101.54M",
+                    "longFmt": "101,536,212"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Dimensional Fund Advisors LP",
+                  "pctHeld": {
+                    "raw": 0.0286,
+                    "fmt": "2.86%"
+                  },
+                  "position": {
+                    "raw": 2125368,
+                    "fmt": "2.13M",
+                    "longFmt": "2,125,368"
+                  },
+                  "value": {
+                    "raw": 98319523,
+                    "fmt": "98.32M",
+                    "longFmt": "98,319,523"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Wells Fargo & Company",
+                  "pctHeld": {
+                    "raw": 0.0248,
+                    "fmt": "2.48%"
+                  },
+                  "position": {
+                    "raw": 1840894,
+                    "fmt": "1.84M",
+                    "longFmt": "1,840,894"
+                  },
+                  "value": {
+                    "raw": 124904657,
+                    "fmt": "124.9M",
+                    "longFmt": "124,904,657"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Mirae Asset Global Investments Co., Ltd.",
+                  "pctHeld": {
+                    "raw": 0.0229,
+                    "fmt": "2.29%"
+                  },
+                  "position": {
+                    "raw": 1696024,
+                    "fmt": "1.7M",
+                    "longFmt": "1,696,024"
+                  },
+                  "value": {
+                    "raw": 115075228,
+                    "fmt": "115.08M",
+                    "longFmt": "115,075,228"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Macquarie Group Limited",
+                  "pctHeld": {
+                    "raw": 0.0208,
+                    "fmt": "2.08%"
+                  },
+                  "position": {
+                    "raw": 1543755,
+                    "fmt": "1.54M",
+                    "longFmt": "1,543,755"
+                  },
+                  "value": {
+                    "raw": 71414106,
+                    "fmt": "71.41M",
+                    "longFmt": "71,414,106"
+                  }
+                }
+              ]
+            },
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.01582,
+              "institutionsPercentHeld": 1.00236,
+              "institutionsFloatPercentHeld": 1.01848,
+              "institutionsCount": 385
+            },
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "cash": {
+                    "raw": 308517000,
+                    "fmt": "308.52M",
+                    "longFmt": "308,517,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 55000,
+                    "fmt": "55k",
+                    "longFmt": "55,000"
+                  },
+                  "netReceivables": {
+                    "raw": 209579000,
+                    "fmt": "209.58M",
+                    "longFmt": "209,579,000"
+                  },
+                  "inventory": {
+                    "raw": 123917000,
+                    "fmt": "123.92M",
+                    "longFmt": "123,917,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 3571000,
+                    "fmt": "3.57M",
+                    "longFmt": "3,571,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 675156000,
+                    "fmt": "675.16M",
+                    "longFmt": "675,156,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 3410000,
+                    "fmt": "3.41M",
+                    "longFmt": "3,410,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 164276000,
+                    "fmt": "164.28M",
+                    "longFmt": "164,276,000"
+                  },
+                  "goodWill": {
+                    "raw": 512989000,
+                    "fmt": "512.99M",
+                    "longFmt": "512,989,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 224666000,
+                    "fmt": "224.67M",
+                    "longFmt": "224,666,000"
+                  },
+                  "otherAssets": {
+                    "raw": 34235000,
+                    "fmt": "34.23M",
+                    "longFmt": "34,235,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 4765000,
+                    "fmt": "4.76M",
+                    "longFmt": "4,765,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1614732000,
+                    "fmt": "1.61B",
+                    "longFmt": "1,614,732,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 67811000,
+                    "fmt": "67.81M",
+                    "longFmt": "67,811,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 414000,
+                    "fmt": "414k",
+                    "longFmt": "414,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 59967000,
+                    "fmt": "59.97M",
+                    "longFmt": "59,967,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 49629000,
+                    "fmt": "49.63M",
+                    "longFmt": "49,629,000"
+                  },
+                  "otherLiab": {
+                    "raw": 52848000,
+                    "fmt": "52.85M",
+                    "longFmt": "52,848,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 400000,
+                    "fmt": "400k",
+                    "longFmt": "400,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 225770000,
+                    "fmt": "225.77M",
+                    "longFmt": "225,770,000"
+                  },
+                  "totalLiab": {
+                    "raw": 362578000,
+                    "fmt": "362.58M",
+                    "longFmt": "362,578,000"
+                  },
+                  "commonStock": {
+                    "raw": 877000,
+                    "fmt": "877k",
+                    "longFmt": "877,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -532468000,
+                    "fmt": "-532.47M",
+                    "longFmt": "-532,468,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -165811000,
+                    "fmt": "-165.81M",
+                    "longFmt": "-165,811,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1949556000,
+                    "fmt": "1.95B",
+                    "longFmt": "1,949,556,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 35145000,
+                    "fmt": "35.15M",
+                    "longFmt": "35,145,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1252154000,
+                    "fmt": "1.25B",
+                    "longFmt": "1,252,154,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 514499000,
+                    "fmt": "514.5M",
+                    "longFmt": "514,499,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 295649000,
+                    "fmt": "295.65M",
+                    "longFmt": "295,649,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 67000,
+                    "fmt": "67k",
+                    "longFmt": "67,000"
+                  },
+                  "netReceivables": {
+                    "raw": 205091000,
+                    "fmt": "205.09M",
+                    "longFmt": "205,091,000"
+                  },
+                  "inventory": {
+                    "raw": 114834000,
+                    "fmt": "114.83M",
+                    "longFmt": "114,834,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 3937000,
+                    "fmt": "3.94M",
+                    "longFmt": "3,937,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 649453000,
+                    "fmt": "649.45M",
+                    "longFmt": "649,453,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 3101000,
+                    "fmt": "3.1M",
+                    "longFmt": "3,101,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 156736000,
+                    "fmt": "156.74M",
+                    "longFmt": "156,736,000"
+                  },
+                  "goodWill": {
+                    "raw": 501536000,
+                    "fmt": "501.54M",
+                    "longFmt": "501,536,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 218325000,
+                    "fmt": "218.32M",
+                    "longFmt": "218,325,000"
+                  },
+                  "otherAssets": {
+                    "raw": 29974000,
+                    "fmt": "29.97M",
+                    "longFmt": "29,974,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 4979000,
+                    "fmt": "4.98M",
+                    "longFmt": "4,979,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1559125000,
+                    "fmt": "1.56B",
+                    "longFmt": "1,559,125,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 61758000,
+                    "fmt": "61.76M",
+                    "longFmt": "61,758,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 827000,
+                    "fmt": "827k",
+                    "longFmt": "827,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 50071000,
+                    "fmt": "50.07M",
+                    "longFmt": "50,071,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 49588000,
+                    "fmt": "49.59M",
+                    "longFmt": "49,588,000"
+                  },
+                  "otherLiab": {
+                    "raw": 52602000,
+                    "fmt": "52.6M",
+                    "longFmt": "52,602,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 400000,
+                    "fmt": "400k",
+                    "longFmt": "400,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 211118000,
+                    "fmt": "211.12M",
+                    "longFmt": "211,118,000"
+                  },
+                  "totalLiab": {
+                    "raw": 345511000,
+                    "fmt": "345.51M",
+                    "longFmt": "345,511,000"
+                  },
+                  "commonStock": {
+                    "raw": 873000,
+                    "fmt": "873k",
+                    "longFmt": "873,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -551072000,
+                    "fmt": "-551.07M",
+                    "longFmt": "-551,072,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -179037000,
+                    "fmt": "-179.04M",
+                    "longFmt": "-179,037,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1942850000,
+                    "fmt": "1.94B",
+                    "longFmt": "1,942,850,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 21919000,
+                    "fmt": "21.92M",
+                    "longFmt": "21,919,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1213614000,
+                    "fmt": "1.21B",
+                    "longFmt": "1,213,614,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 493753000,
+                    "fmt": "493.75M",
+                    "longFmt": "493,753,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "cash": {
+                    "raw": 256633000,
+                    "fmt": "256.63M",
+                    "longFmt": "256,633,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 136000,
+                    "fmt": "136k",
+                    "longFmt": "136,000"
+                  },
+                  "netReceivables": {
+                    "raw": 198667000,
+                    "fmt": "198.67M",
+                    "longFmt": "198,667,000"
+                  },
+                  "inventory": {
+                    "raw": 117686000,
+                    "fmt": "117.69M",
+                    "longFmt": "117,686,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 3567000,
+                    "fmt": "3.57M",
+                    "longFmt": "3,567,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 602011000,
+                    "fmt": "602.01M",
+                    "longFmt": "602,011,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2939000,
+                    "fmt": "2.94M",
+                    "longFmt": "2,939,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 147640000,
+                    "fmt": "147.64M",
+                    "longFmt": "147,640,000"
+                  },
+                  "goodWill": {
+                    "raw": 500062000,
+                    "fmt": "500.06M",
+                    "longFmt": "500,062,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 226623000,
+                    "fmt": "226.62M",
+                    "longFmt": "226,623,000"
+                  },
+                  "otherAssets": {
+                    "raw": 24642000,
+                    "fmt": "24.64M",
+                    "longFmt": "24,642,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 3489000,
+                    "fmt": "3.49M",
+                    "longFmt": "3,489,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1503917000,
+                    "fmt": "1.5B",
+                    "longFmt": "1,503,917,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 70344000,
+                    "fmt": "70.34M",
+                    "longFmt": "70,344,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 828000,
+                    "fmt": "828k",
+                    "longFmt": "828,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 56696000,
+                    "fmt": "56.7M",
+                    "longFmt": "56,696,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 49563000,
+                    "fmt": "49.56M",
+                    "longFmt": "49,563,000"
+                  },
+                  "otherLiab": {
+                    "raw": 43817000,
+                    "fmt": "43.82M",
+                    "longFmt": "43,817,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 800000,
+                    "fmt": "800k",
+                    "longFmt": "800,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 205805000,
+                    "fmt": "205.81M",
+                    "longFmt": "205,805,000"
+                  },
+                  "totalLiab": {
+                    "raw": 329064000,
+                    "fmt": "329.06M",
+                    "longFmt": "329,064,000"
+                  },
+                  "commonStock": {
+                    "raw": 872000,
+                    "fmt": "872k",
+                    "longFmt": "872,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -572659000,
+                    "fmt": "-572.66M",
+                    "longFmt": "-572,659,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -189979000,
+                    "fmt": "-189.98M",
+                    "longFmt": "-189,979,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1936619000,
+                    "fmt": "1.94B",
+                    "longFmt": "1,936,619,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 10977000,
+                    "fmt": "10.98M",
+                    "longFmt": "10,977,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1174853000,
+                    "fmt": "1.17B",
+                    "longFmt": "1,174,853,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 448168000,
+                    "fmt": "448.17M",
+                    "longFmt": "448,168,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "cash": {
+                    "raw": 242274000,
+                    "fmt": "242.27M",
+                    "longFmt": "242,274,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 162000,
+                    "fmt": "162k",
+                    "longFmt": "162,000"
+                  },
+                  "netReceivables": {
+                    "raw": 179014000,
+                    "fmt": "179.01M",
+                    "longFmt": "179,014,000"
+                  },
+                  "inventory": {
+                    "raw": 107699000,
+                    "fmt": "107.7M",
+                    "longFmt": "107,699,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 3529000,
+                    "fmt": "3.53M",
+                    "longFmt": "3,529,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 572528000,
+                    "fmt": "572.53M",
+                    "longFmt": "572,528,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2555000,
+                    "fmt": "2.56M",
+                    "longFmt": "2,555,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 108744000,
+                    "fmt": "108.74M",
+                    "longFmt": "108,744,000"
+                  },
+                  "goodWill": {
+                    "raw": 498502000,
+                    "fmt": "498.5M",
+                    "longFmt": "498,502,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 236095000,
+                    "fmt": "236.09M",
+                    "longFmt": "236,095,000"
+                  },
+                  "otherAssets": {
+                    "raw": 60907000,
+                    "fmt": "60.91M",
+                    "longFmt": "60,907,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 5080000,
+                    "fmt": "5.08M",
+                    "longFmt": "5,080,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1479331000,
+                    "fmt": "1.48B",
+                    "longFmt": "1,479,331,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 63958000,
+                    "fmt": "63.96M",
+                    "longFmt": "63,958,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 828000,
+                    "fmt": "828k",
+                    "longFmt": "828,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 47069000,
+                    "fmt": "47.07M",
+                    "longFmt": "47,069,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 49951000,
+                    "fmt": "49.95M",
+                    "longFmt": "49,951,000"
+                  },
+                  "otherLiab": {
+                    "raw": 43979000,
+                    "fmt": "43.98M",
+                    "longFmt": "43,979,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 900000,
+                    "fmt": "900k",
+                    "longFmt": "900,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 197035000,
+                    "fmt": "197.03M",
+                    "longFmt": "197,035,000"
+                  },
+                  "totalLiab": {
+                    "raw": 318198000,
+                    "fmt": "318.2M",
+                    "longFmt": "318,198,000"
+                  },
+                  "commonStock": {
+                    "raw": 872000,
+                    "fmt": "872k",
+                    "longFmt": "872,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -578975000,
+                    "fmt": "-578.98M",
+                    "longFmt": "-578,975,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -193657000,
+                    "fmt": "-193.66M",
+                    "longFmt": "-193,657,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1932893000,
+                    "fmt": "1.93B",
+                    "longFmt": "1,932,893,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 7299000,
+                    "fmt": "7.3M",
+                    "longFmt": "7,299,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1161133000,
+                    "fmt": "1.16B",
+                    "longFmt": "1,161,133,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 426536000,
+                    "fmt": "426.54M",
+                    "longFmt": "426,536,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.25,
+                    "fmt": "0.25"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.24,
+                    "fmt": "0.24"
+                  },
+                  "epsDifference": {
+                    "raw": 0.01,
+                    "fmt": "0.01"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.042,
+                    "fmt": "4.20%"
+                  },
+                  "quarter": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.32,
+                    "fmt": "0.32"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.2,
+                    "fmt": "0.2"
+                  },
+                  "epsDifference": {
+                    "raw": 0.12,
+                    "fmt": "0.12"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.6,
+                    "fmt": "60.00%"
+                  },
+                  "quarter": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.47,
+                    "fmt": "0.47"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.36,
+                    "fmt": "0.36"
+                  },
+                  "epsDifference": {
+                    "raw": 0.11,
+                    "fmt": "0.11"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.306,
+                    "fmt": "30.60%"
+                  },
+                  "quarter": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.47,
+                    "fmt": "0.47"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.42,
+                    "fmt": "0.42"
+                  },
+                  "epsDifference": {
+                    "raw": 0.05,
+                    "fmt": "0.05"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.118999995,
+                    "fmt": "11.90%"
+                  },
+                  "quarter": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            },
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            },
+            "summaryProfile": {
+              "address1": "15 Elizabeth Drive",
+              "city": "Chelmsford",
+              "state": "MA",
+              "zip": "01824",
+              "country": "United States",
+              "phone": "978 262 2400",
+              "fax": "978 262 2500",
+              "website": "http://www.brooks.com",
+              "industry": "Semiconductor Equipment & Materials",
+              "sector": "Technology",
+              "longBusinessSummary": "Brooks Automation, Inc. provides manufacturing automation solutions for the semiconductor industry, and life science sample-based services and solutions for the life sciences market worldwide. The company operates in three segments: Brooks Semiconductor Solutions Group, Brooks Life Sciences Services, and Brooks Life Sciences Products. The Brooks Semiconductor Solutions Group segment offers wafer automation and contamination controls solutions and services. Its products include atmospheric and vacuum robots, robotic modules, and tool automation systems that offer precision handling and clean wafer environments; and automated cleaning and inspection systems for wafer carriers, reticle pod cleaners, and stockers. It also offers repair and refurbishment, diagnostics, and installation services, as well as spare parts and productivity enhancement upgrade services. The Brooks Life Sciences Services segment provides gene sequencing and gene synthesis services, including next generation sequencing, sanger sequencing, gene synthesis, bioinformatics, and good laboratory practices regulatory services; on-site and off-site sample storage, cold chain logistics, sample transport and collection relocation, bio-processing solutions, disaster recovery, and business continuity, as well as project management and consulting services; and sample intelligence software solutions and integration of customer technology. The Brooks Life Sciences Products segment offers automated cold storage systems; consumables, such as various formats of racks, tubes, caps, plates, and foils used for the storage and handling of samples in cold storage environments; and instruments used for labeling, bar coding, capping, de-capping, auditing, sealing, peeling, and piercing tubes and plates. The company serves semiconductor capital equipment and life sciences sample management markets in approximately 50 countries. Brooks Automation, Inc. was founded in 1978 and is headquartered in Chelmsford, Massachusetts.",
+              "fullTimeEmployees": 3200,
+              "companyOfficers": [],
+              "maxAge": 86400
+            },
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 17,
+              "buyInfoShares": 181423,
+              "buyPercentInsiderShares": 0.14,
+              "sellInfoCount": 12,
+              "sellInfoShares": 319555,
+              "sellPercentInsiderShares": 0.24700001,
+              "netInfoCount": 29,
+              "netInfoShares": -138132,
+              "netPercentInsiderShares": -0.107,
+              "totalInsiderShares": 1157346
+            },
+            "insiderTransactions": {
+              "transactions": [
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1760,
+                    "fmt": "1.76k",
+                    "longFmt": "1,760"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROSENBLATT MICHAEL",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1760,
+                    "fmt": "1.76k",
+                    "longFmt": "1,760"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WRIGHTON MARK S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2262,
+                    "fmt": "2.26k",
+                    "longFmt": "2,262"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MARTIN JOSEPH R",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1760,
+                    "fmt": "1.76k",
+                    "longFmt": "1,760"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ZANE ELLEN M",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1760,
+                    "fmt": "1.76k",
+                    "longFmt": "1,760"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PALEPU KRISHNA G",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1760,
+                    "fmt": "1.76k",
+                    "longFmt": "1,760"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DAVIS ROBYN C",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1760,
+                    "fmt": "1.76k",
+                    "longFmt": "1,760"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MCLAUGHLIN ERICA",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1450,
+                    "fmt": "1.45k",
+                    "longFmt": "1,450"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "WRIGHTON MARK S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5925,
+                    "fmt": "5.92k",
+                    "longFmt": "5,925"
+                  },
+                  "value": {
+                    "raw": 412498,
+                    "fmt": "412.5k",
+                    "longFmt": "412,498"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 69.62 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 27822,
+                    "fmt": "27.82k",
+                    "longFmt": "27,822"
+                  },
+                  "value": {
+                    "raw": 1936968,
+                    "fmt": "1.94M",
+                    "longFmt": "1,936,968"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 69.62 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8777,
+                    "fmt": "8.78k",
+                    "longFmt": "8,777"
+                  },
+                  "value": {
+                    "raw": 606676,
+                    "fmt": "606.68k",
+                    "longFmt": "606,676"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 68.19 - 69.62 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 13983,
+                    "fmt": "13.98k",
+                    "longFmt": "13,983"
+                  },
+                  "value": {
+                    "raw": 973496,
+                    "fmt": "973.5k",
+                    "longFmt": "973,496"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 69.62 per share.",
+                  "filerName": "ROBERTSON LINDON GENE",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5496,
+                    "fmt": "5.5k",
+                    "longFmt": "5,496"
+                  },
+                  "value": {
+                    "raw": 382632,
+                    "fmt": "382.63k",
+                    "longFmt": "382,632"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 69.62 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3457,
+                    "fmt": "3.46k",
+                    "longFmt": "3,457"
+                  },
+                  "value": {
+                    "raw": 240676,
+                    "fmt": "240.68k",
+                    "longFmt": "240,676"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 69.62 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 53050,
+                    "fmt": "53.05k",
+                    "longFmt": "53,050"
+                  },
+                  "value": {
+                    "raw": 3664672,
+                    "fmt": "3.66M",
+                    "longFmt": "3,664,672"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 69.03 - 69.62 per share.",
+                  "filerName": "JARZYNKA DAVID E",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1354,
+                    "fmt": "1.35k",
+                    "longFmt": "1,354"
+                  },
+                  "value": {
+                    "raw": 94265,
+                    "fmt": "94.27k",
+                    "longFmt": "94,265"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 69.62 per share.",
+                  "filerName": "LIAO GUOJUAN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6490,
+                    "fmt": "6.49k",
+                    "longFmt": "6,490"
+                  },
+                  "value": {
+                    "raw": 451834,
+                    "fmt": "451.83k",
+                    "longFmt": "451,834"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 69.62 per share.",
+                  "filerName": "VACHA ROBIN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 14319,
+                    "fmt": "14.32k",
+                    "longFmt": "14,319"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 59490,
+                    "fmt": "59.49k",
+                    "longFmt": "59,490"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 13863,
+                    "fmt": "13.86k",
+                    "longFmt": "13,863"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 27427,
+                    "fmt": "27.43k",
+                    "longFmt": "27,427"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROBERTSON LINDON GENE",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8980,
+                    "fmt": "8.98k",
+                    "longFmt": "8,980"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7582,
+                    "fmt": "7.58k",
+                    "longFmt": "7,582"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 17704,
+                    "fmt": "17.7k",
+                    "longFmt": "17,704"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JARZYNKA DAVID E",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3102,
+                    "fmt": "3.1k",
+                    "longFmt": "3,102"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "LIAO GUOJUAN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 14684,
+                    "fmt": "14.68k",
+                    "longFmt": "14,684"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "VACHA ROBIN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 69291,
+                    "fmt": "69.29k",
+                    "longFmt": "69,291"
+                  },
+                  "value": {
+                    "raw": 3122833,
+                    "fmt": "3.12M",
+                    "longFmt": "3,122,833"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 45.00 - 45.51 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1600300800,
+                    "fmt": "2020-09-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 33910,
+                    "fmt": "33.91k",
+                    "longFmt": "33,910"
+                  },
+                  "value": {
+                    "raw": 1526536,
+                    "fmt": "1.53M",
+                    "longFmt": "1,526,536"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 45.00 - 45.15 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1599696000,
+                    "fmt": "2020-09-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 90000,
+                    "fmt": "90k",
+                    "longFmt": "90,000"
+                  },
+                  "value": {
+                    "raw": 4234800,
+                    "fmt": "4.23M",
+                    "longFmt": "4,234,800"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 45.30 - 48.87 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1599523200,
+                    "fmt": "2020-09-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 39238,
+                    "fmt": "39.24k",
+                    "longFmt": "39,238"
+                  },
+                  "value": {
+                    "raw": 2170048,
+                    "fmt": "2.17M",
+                    "longFmt": "2,170,048"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 55.26 - 55.34 per share.",
+                  "filerName": "ROBERTSON LINDON GENE",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597622400,
+                    "fmt": "2020-08-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4343,
+                    "fmt": "4.34k",
+                    "longFmt": "4,343"
+                  },
+                  "value": {
+                    "raw": 236911,
+                    "fmt": "236.91k",
+                    "longFmt": "236,911"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 54.55 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596412800,
+                    "fmt": "2020-08-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4877,
+                    "fmt": "4.88k",
+                    "longFmt": "4,877"
+                  },
+                  "value": {
+                    "raw": 243850,
+                    "fmt": "243.85k",
+                    "longFmt": "243,850"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 50.00 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596153600,
+                    "fmt": "2020-07-31"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12000,
+                    "fmt": "12k",
+                    "longFmt": "12,000"
+                  },
+                  "value": {
+                    "raw": 585000,
+                    "fmt": "585k",
+                    "longFmt": "585,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 47.50 - 50.00 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596153600,
+                    "fmt": "2020-07-31"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6000,
+                    "fmt": "6k",
+                    "longFmt": "6,000"
+                  },
+                  "value": {
+                    "raw": 270000,
+                    "fmt": "270k",
+                    "longFmt": "270,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 45.00 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1593993600,
+                    "fmt": "2020-07-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 20000,
+                    "fmt": "20k",
+                    "longFmt": "20,000"
+                  },
+                  "value": {
+                    "raw": 900000,
+                    "fmt": "900k",
+                    "longFmt": "900,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 45.00 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1593993600,
+                    "fmt": "2020-07-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4000,
+                    "fmt": "4k",
+                    "longFmt": "4,000"
+                  },
+                  "value": {
+                    "raw": 180000,
+                    "fmt": "180k",
+                    "longFmt": "180,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 45.00 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1593993600,
+                    "fmt": "2020-07-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1612,
+                    "fmt": "1.61k",
+                    "longFmt": "1,612"
+                  },
+                  "value": {
+                    "raw": 72540,
+                    "fmt": "72.54k",
+                    "longFmt": "72,540"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 45.00 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1593993600,
+                    "fmt": "2020-07-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4000,
+                    "fmt": "4k",
+                    "longFmt": "4,000"
+                  },
+                  "value": {
+                    "raw": 176000,
+                    "fmt": "176k",
+                    "longFmt": "176,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 44.00 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3196,
+                    "fmt": "3.2k",
+                    "longFmt": "3,196"
+                  },
+                  "value": {
+                    "raw": 139505,
+                    "fmt": "139.5k",
+                    "longFmt": "139,505"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 43.65 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1591574400,
+                    "fmt": "2020-06-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12132,
+                    "fmt": "12.13k",
+                    "longFmt": "12,132"
+                  },
+                  "value": {
+                    "raw": 537448,
+                    "fmt": "537.45k",
+                    "longFmt": "537,448"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 44.30 per share.",
+                  "filerName": "ROBERTSON LINDON GENE",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1591315200,
+                    "fmt": "2020-06-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5000,
+                    "fmt": "5k",
+                    "longFmt": "5,000"
+                  },
+                  "value": {
+                    "raw": 212800,
+                    "fmt": "212.8k",
+                    "longFmt": "212,800"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 42.56 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1591142400,
+                    "fmt": "2020-06-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5000,
+                    "fmt": "5k",
+                    "longFmt": "5,000"
+                  },
+                  "value": {
+                    "raw": 202700,
+                    "fmt": "202.7k",
+                    "longFmt": "202,700"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 40.54 per share.",
+                  "filerName": "MARTIN JOSEPH R",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589932800,
+                    "fmt": "2020-05-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12000,
+                    "fmt": "12k",
+                    "longFmt": "12,000"
+                  },
+                  "value": {
+                    "raw": 468060,
+                    "fmt": "468.06k",
+                    "longFmt": "468,060"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 37.50 - 40.51 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588118400,
+                    "fmt": "2020-04-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4000,
+                    "fmt": "4k",
+                    "longFmt": "4,000"
+                  },
+                  "value": {
+                    "raw": 170000,
+                    "fmt": "170k",
+                    "longFmt": "170,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 42.50 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588118400,
+                    "fmt": "2020-04-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3067,
+                    "fmt": "3.07k",
+                    "longFmt": "3,067"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MCLAUGHLIN ERICA",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1586304000,
+                    "fmt": "2020-04-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6000,
+                    "fmt": "6k",
+                    "longFmt": "6,000"
+                  },
+                  "value": {
+                    "raw": 248040,
+                    "fmt": "248.04k",
+                    "longFmt": "248,040"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 41.34 per share.",
+                  "filerName": "MARTIN JOSEPH R",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582070400,
+                    "fmt": "2020-02-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 83088,
+                    "fmt": "83.09k",
+                    "longFmt": "83,088"
+                  },
+                  "value": {
+                    "raw": 3442321,
+                    "fmt": "3.44M",
+                    "longFmt": "3,442,321"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 41.29 - 41.49 per share.",
+                  "filerName": "ROBERTSON LINDON GENE",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582070400,
+                    "fmt": "2020-02-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 500,
+                    "fmt": "500",
+                    "longFmt": "500"
+                  },
+                  "value": {
+                    "raw": 21500,
+                    "fmt": "21.5k",
+                    "longFmt": "21,500"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 43.00 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581465600,
+                    "fmt": "2020-02-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2831,
+                    "fmt": "2.83k",
+                    "longFmt": "2,831"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROSENBLATT MICHAEL",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581379200,
+                    "fmt": "2020-02-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2831,
+                    "fmt": "2.83k",
+                    "longFmt": "2,831"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WRIGHTON MARK S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581379200,
+                    "fmt": "2020-02-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2831,
+                    "fmt": "2.83k",
+                    "longFmt": "2,831"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALLEN A CLINTON",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581379200,
+                    "fmt": "2020-02-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3774,
+                    "fmt": "3.77k",
+                    "longFmt": "3,774"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MARTIN JOSEPH R",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581379200,
+                    "fmt": "2020-02-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2831,
+                    "fmt": "2.83k",
+                    "longFmt": "2,831"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ZANE ELLEN M",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581379200,
+                    "fmt": "2020-02-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2831,
+                    "fmt": "2.83k",
+                    "longFmt": "2,831"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PALEPU KRISHNA G",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581379200,
+                    "fmt": "2020-02-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6000,
+                    "fmt": "6k",
+                    "longFmt": "6,000"
+                  },
+                  "value": {
+                    "raw": 255780,
+                    "fmt": "255.78k",
+                    "longFmt": "255,780"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 42.63 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1577923200,
+                    "fmt": "2020-01-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 22500,
+                    "fmt": "22.5k",
+                    "longFmt": "22,500"
+                  },
+                  "value": {
+                    "raw": 955600,
+                    "fmt": "955.6k",
+                    "longFmt": "955,600"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 42.32 - 43.00 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1576540800,
+                    "fmt": "2019-12-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 26950,
+                    "fmt": "26.95k",
+                    "longFmt": "26,950"
+                  },
+                  "value": {
+                    "raw": 1213901,
+                    "fmt": "1.21M",
+                    "longFmt": "1,213,901"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 43.22 - 45.25 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1574294400,
+                    "fmt": "2019-11-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 112320,
+                    "fmt": "112.32k",
+                    "longFmt": "112,320"
+                  },
+                  "value": {
+                    "raw": 5074504,
+                    "fmt": "5.07M",
+                    "longFmt": "5,074,504"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 43.22 - 45.25 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1574294400,
+                    "fmt": "2019-11-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 26143,
+                    "fmt": "26.14k",
+                    "longFmt": "26,143"
+                  },
+                  "value": {
+                    "raw": 1181294,
+                    "fmt": "1.18M",
+                    "longFmt": "1,181,294"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 43.22 - 45.25 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1574294400,
+                    "fmt": "2019-11-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 50505,
+                    "fmt": "50.51k",
+                    "longFmt": "50,505"
+                  },
+                  "value": {
+                    "raw": 2279448,
+                    "fmt": "2.28M",
+                    "longFmt": "2,279,448"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 43.22 - 45.25 per share.",
+                  "filerName": "ROBERTSON LINDON GENE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1574294400,
+                    "fmt": "2019-11-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 36353,
+                    "fmt": "36.35k",
+                    "longFmt": "36,353"
+                  },
+                  "value": {
+                    "raw": 1621308,
+                    "fmt": "1.62M",
+                    "longFmt": "1,621,308"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 43.22 - 45.25 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1574294400,
+                    "fmt": "2019-11-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15948,
+                    "fmt": "15.95k",
+                    "longFmt": "15,948"
+                  },
+                  "value": {
+                    "raw": 716858,
+                    "fmt": "716.86k",
+                    "longFmt": "716,858"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 43.22 - 45.25 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1574294400,
+                    "fmt": "2019-11-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 34002,
+                    "fmt": "34k",
+                    "longFmt": "34,002"
+                  },
+                  "value": {
+                    "raw": 1536037,
+                    "fmt": "1.54M",
+                    "longFmt": "1,536,037"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 43.22 - 45.25 per share.",
+                  "filerName": "JARZYNKA DAVID E",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1574294400,
+                    "fmt": "2019-11-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 966,
+                    "fmt": "966",
+                    "longFmt": "966"
+                  },
+                  "value": {
+                    "raw": 41751,
+                    "fmt": "41.75k",
+                    "longFmt": "41,751"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 43.22 per share.",
+                  "filerName": "LIAO GUOJUAN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1574294400,
+                    "fmt": "2019-11-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 50767,
+                    "fmt": "50.77k",
+                    "longFmt": "50,767"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 215672,
+                    "fmt": "215.67k",
+                    "longFmt": "215,672"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 50767,
+                    "fmt": "50.77k",
+                    "longFmt": "50,767"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 94572,
+                    "fmt": "94.57k",
+                    "longFmt": "94,572"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROBERTSON LINDON GENE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 50767,
+                    "fmt": "50.77k",
+                    "longFmt": "50,767"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 27557,
+                    "fmt": "27.56k",
+                    "longFmt": "27,557"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 65272,
+                    "fmt": "65.27k",
+                    "longFmt": "65,272"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JARZYNKA DAVID E",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6000,
+                    "fmt": "6k",
+                    "longFmt": "6,000"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573516800,
+                    "fmt": "2019-11-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3989,
+                    "fmt": "3.99k",
+                    "longFmt": "3,989"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573430400,
+                    "fmt": "2019-11-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 13295,
+                    "fmt": "13.29k",
+                    "longFmt": "13,295"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573430400,
+                    "fmt": "2019-11-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2792,
+                    "fmt": "2.79k",
+                    "longFmt": "2,792"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573430400,
+                    "fmt": "2019-11-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5584,
+                    "fmt": "5.58k",
+                    "longFmt": "5,584"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROBERTSON LINDON GENE",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573430400,
+                    "fmt": "2019-11-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10637,
+                    "fmt": "10.64k",
+                    "longFmt": "10,637"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573430400,
+                    "fmt": "2019-11-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1728,
+                    "fmt": "1.73k",
+                    "longFmt": "1,728"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573430400,
+                    "fmt": "2019-11-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4520,
+                    "fmt": "4.52k",
+                    "longFmt": "4,520"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JARZYNKA DAVID E",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573430400,
+                    "fmt": "2019-11-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4254,
+                    "fmt": "4.25k",
+                    "longFmt": "4,254"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "LIAO GUOJUAN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573430400,
+                    "fmt": "2019-11-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7500,
+                    "fmt": "7.5k",
+                    "longFmt": "7,500"
+                  },
+                  "value": {
+                    "raw": 350700,
+                    "fmt": "350.7k",
+                    "longFmt": "350,700"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 46.76 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573171200,
+                    "fmt": "2019-11-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 49417,
+                    "fmt": "49.42k",
+                    "longFmt": "49,417"
+                  },
+                  "value": {
+                    "raw": 2299708,
+                    "fmt": "2.3M",
+                    "longFmt": "2,299,708"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 46.14 - 46.75 per share.",
+                  "filerName": "JARZYNKA DAVID E",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573171200,
+                    "fmt": "2019-11-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4334,
+                    "fmt": "4.33k",
+                    "longFmt": "4,334"
+                  },
+                  "value": {
+                    "raw": 203698,
+                    "fmt": "203.7k",
+                    "longFmt": "203,698"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 47.00 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573084800,
+                    "fmt": "2019-11-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3333,
+                    "fmt": "3.33k",
+                    "longFmt": "3,333"
+                  },
+                  "value": {
+                    "raw": 146652,
+                    "fmt": "146.65k",
+                    "longFmt": "146,652"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 44.00 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1572220800,
+                    "fmt": "2019-10-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5478,
+                    "fmt": "5.48k",
+                    "longFmt": "5,478"
+                  },
+                  "value": {
+                    "raw": 232815,
+                    "fmt": "232.81k",
+                    "longFmt": "232,815"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 42.50 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1571875200,
+                    "fmt": "2019-10-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3333,
+                    "fmt": "3.33k",
+                    "longFmt": "3,333"
+                  },
+                  "value": {
+                    "raw": 136653,
+                    "fmt": "136.65k",
+                    "longFmt": "136,653"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 41.00 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1563840000,
+                    "fmt": "2019-07-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3000,
+                    "fmt": "3k",
+                    "longFmt": "3,000"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "WOOLLACOTT ALFREDIII",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1557360000,
+                    "fmt": "2019-05-09"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4355,
+                    "fmt": "4.36k",
+                    "longFmt": "4,355"
+                  },
+                  "value": {
+                    "raw": 169540,
+                    "fmt": "169.54k",
+                    "longFmt": "169,540"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 38.93 per share.",
+                  "filerName": "WOOLLACOTT ALFREDIII",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1557273600,
+                    "fmt": "2019-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3000,
+                    "fmt": "3k",
+                    "longFmt": "3,000"
+                  },
+                  "value": {
+                    "raw": 118500,
+                    "fmt": "118.5k",
+                    "longFmt": "118,500"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 39.50 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1557100800,
+                    "fmt": "2019-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2577,
+                    "fmt": "2.58k",
+                    "longFmt": "2,577"
+                  },
+                  "value": {
+                    "raw": 100374,
+                    "fmt": "100.37k",
+                    "longFmt": "100,374"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 38.95 per share.",
+                  "filerName": "JARZYNKA DAVID E",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1557100800,
+                    "fmt": "2019-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1692,
+                    "fmt": "1.69k",
+                    "longFmt": "1,692"
+                  },
+                  "value": {
+                    "raw": 64398,
+                    "fmt": "64.4k",
+                    "longFmt": "64,398"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 38.06 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556755200,
+                    "fmt": "2019-05-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4539,
+                    "fmt": "4.54k",
+                    "longFmt": "4,539"
+                  },
+                  "value": {
+                    "raw": 156788,
+                    "fmt": "156.79k",
+                    "longFmt": "156,788"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 34.10 - 35.00 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556582400,
+                    "fmt": "2019-04-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8000,
+                    "fmt": "8k",
+                    "longFmt": "8,000"
+                  },
+                  "value": {
+                    "raw": 284040,
+                    "fmt": "284.04k",
+                    "longFmt": "284,040"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 34.01 - 37.00 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556582400,
+                    "fmt": "2019-04-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6000,
+                    "fmt": "6k",
+                    "longFmt": "6,000"
+                  },
+                  "value": {
+                    "raw": 178860,
+                    "fmt": "178.86k",
+                    "longFmt": "178,860"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 29.81 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1554076800,
+                    "fmt": "2019-04-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3000,
+                    "fmt": "3k",
+                    "longFmt": "3,000"
+                  },
+                  "value": {
+                    "raw": 100500,
+                    "fmt": "100.5k",
+                    "longFmt": "100,500"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 33.50 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550534400,
+                    "fmt": "2019-02-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10204,
+                    "fmt": "10.2k",
+                    "longFmt": "10,204"
+                  },
+                  "value": {
+                    "raw": 331732,
+                    "fmt": "331.73k",
+                    "longFmt": "331,732"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 32.51 per share.",
+                  "filerName": "TENNEY MAURICE H III",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550188800,
+                    "fmt": "2019-02-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4033,
+                    "fmt": "4.03k",
+                    "longFmt": "4,033"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROSENBLATT MICHAEL",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1549584000,
+                    "fmt": "2019-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4033,
+                    "fmt": "4.03k",
+                    "longFmt": "4,033"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WRIGHTON MARK S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1549584000,
+                    "fmt": "2019-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4033,
+                    "fmt": "4.03k",
+                    "longFmt": "4,033"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALLEN A CLINTON",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1549584000,
+                    "fmt": "2019-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4033,
+                    "fmt": "4.03k",
+                    "longFmt": "4,033"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WOOLLACOTT ALFREDIII",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1549584000,
+                    "fmt": "2019-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5377,
+                    "fmt": "5.38k",
+                    "longFmt": "5,377"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MARTIN JOSEPH R",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1549584000,
+                    "fmt": "2019-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4033,
+                    "fmt": "4.03k",
+                    "longFmt": "4,033"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ZANE ELLEN M",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1549584000,
+                    "fmt": "2019-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4033,
+                    "fmt": "4.03k",
+                    "longFmt": "4,033"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PALEPU KRISHNA G",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1549584000,
+                    "fmt": "2019-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7500,
+                    "fmt": "7.5k",
+                    "longFmt": "7,500"
+                  },
+                  "value": {
+                    "raw": 243750,
+                    "fmt": "243.75k",
+                    "longFmt": "243,750"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 32.50 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1549411200,
+                    "fmt": "2019-02-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8164,
+                    "fmt": "8.16k",
+                    "longFmt": "8,164"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "DAVIS ROBYN C",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548979200,
+                    "fmt": "2019-02-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3000,
+                    "fmt": "3k",
+                    "longFmt": "3,000"
+                  },
+                  "value": {
+                    "raw": 91500,
+                    "fmt": "91.5k",
+                    "longFmt": "91,500"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 30.50 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548374400,
+                    "fmt": "2019-01-25"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 300,
+                    "fmt": "300",
+                    "longFmt": "300"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "ALLEN A CLINTON",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543449600,
+                    "fmt": "2018-11-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5356,
+                    "fmt": "5.36k",
+                    "longFmt": "5,356"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543449600,
+                    "fmt": "2018-11-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 24347,
+                    "fmt": "24.35k",
+                    "longFmt": "24,347"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543449600,
+                    "fmt": "2018-11-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5113,
+                    "fmt": "5.11k",
+                    "longFmt": "5,113"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543449600,
+                    "fmt": "2018-11-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 18018,
+                    "fmt": "18.02k",
+                    "longFmt": "18,018"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROBERTSON LINDON GENE",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543449600,
+                    "fmt": "2018-11-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7791,
+                    "fmt": "7.79k",
+                    "longFmt": "7,791"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "TENNEY MAURICE H III",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543449600,
+                    "fmt": "2018-11-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15583,
+                    "fmt": "15.58k",
+                    "longFmt": "15,583"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543449600,
+                    "fmt": "2018-11-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2921,
+                    "fmt": "2.92k",
+                    "longFmt": "2,921"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543449600,
+                    "fmt": "2018-11-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7791,
+                    "fmt": "7.79k",
+                    "longFmt": "7,791"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JARZYNKA DAVID E",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543449600,
+                    "fmt": "2018-11-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7791,
+                    "fmt": "7.79k",
+                    "longFmt": "7,791"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "LIAO GUOJUAN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543449600,
+                    "fmt": "2018-11-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3896,
+                    "fmt": "3.9k",
+                    "longFmt": "3,896"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1542931200,
+                    "fmt": "2018-11-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3896,
+                    "fmt": "3.9k",
+                    "longFmt": "3,896"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1542931200,
+                    "fmt": "2018-11-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3896,
+                    "fmt": "3.9k",
+                    "longFmt": "3,896"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1542931200,
+                    "fmt": "2018-11-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2636,
+                    "fmt": "2.64k",
+                    "longFmt": "2,636"
+                  },
+                  "value": {
+                    "raw": 74618,
+                    "fmt": "74.62k",
+                    "longFmt": "74,618"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 27.51 - 28.59 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1542585600,
+                    "fmt": "2018-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1946,
+                    "fmt": "1.95k",
+                    "longFmt": "1,946"
+                  },
+                  "value": {
+                    "raw": 55636,
+                    "fmt": "55.64k",
+                    "longFmt": "55,636"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 28.59 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1542326400,
+                    "fmt": "2018-11-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8127,
+                    "fmt": "8.13k",
+                    "longFmt": "8,127"
+                  },
+                  "value": {
+                    "raw": 232351,
+                    "fmt": "232.35k",
+                    "longFmt": "232,351"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 28.59 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1542326400,
+                    "fmt": "2018-11-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3675,
+                    "fmt": "3.67k",
+                    "longFmt": "3,675"
+                  },
+                  "value": {
+                    "raw": 105068,
+                    "fmt": "105.07k",
+                    "longFmt": "105,068"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 28.59 per share.",
+                  "filerName": "ROBERTSON LINDON GENE",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1542326400,
+                    "fmt": "2018-11-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3461,
+                    "fmt": "3.46k",
+                    "longFmt": "3,461"
+                  },
+                  "value": {
+                    "raw": 98950,
+                    "fmt": "98.95k",
+                    "longFmt": "98,950"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 28.59 per share.",
+                  "filerName": "TENNEY MAURICE H III",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1542326400,
+                    "fmt": "2018-11-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1337,
+                    "fmt": "1.34k",
+                    "longFmt": "1,337"
+                  },
+                  "value": {
+                    "raw": 38225,
+                    "fmt": "38.23k",
+                    "longFmt": "38,225"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 28.59 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1542326400,
+                    "fmt": "2018-11-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1048,
+                    "fmt": "1.05k",
+                    "longFmt": "1,048"
+                  },
+                  "value": {
+                    "raw": 29962,
+                    "fmt": "29.96k",
+                    "longFmt": "29,962"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 28.59 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1542326400,
+                    "fmt": "2018-11-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5058,
+                    "fmt": "5.06k",
+                    "longFmt": "5,058"
+                  },
+                  "value": {
+                    "raw": 143986,
+                    "fmt": "143.99k",
+                    "longFmt": "143,986"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 28.35 - 28.59 per share.",
+                  "filerName": "JARZYNKA DAVID E",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1542326400,
+                    "fmt": "2018-11-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 34153,
+                    "fmt": "34.15k",
+                    "longFmt": "34,153"
+                  },
+                  "value": {
+                    "raw": 1037023,
+                    "fmt": "1.04M",
+                    "longFmt": "1,037,023"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 29.04 - 30.93 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1542067200,
+                    "fmt": "2018-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 20704,
+                    "fmt": "20.7k",
+                    "longFmt": "20,704"
+                  },
+                  "value": {
+                    "raw": 640375,
+                    "fmt": "640.38k",
+                    "longFmt": "640,375"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 30.93 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541980800,
+                    "fmt": "2018-11-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 94826,
+                    "fmt": "94.83k",
+                    "longFmt": "94,826"
+                  },
+                  "value": {
+                    "raw": 2932968,
+                    "fmt": "2.93M",
+                    "longFmt": "2,932,968"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 30.93 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541980800,
+                    "fmt": "2018-11-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 40040,
+                    "fmt": "40.04k",
+                    "longFmt": "40,040"
+                  },
+                  "value": {
+                    "raw": 1238437,
+                    "fmt": "1.24M",
+                    "longFmt": "1,238,437"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 30.93 per share.",
+                  "filerName": "ROBERTSON LINDON GENE",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541980800,
+                    "fmt": "2018-11-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 46487,
+                    "fmt": "46.49k",
+                    "longFmt": "46,487"
+                  },
+                  "value": {
+                    "raw": 1437843,
+                    "fmt": "1.44M",
+                    "longFmt": "1,437,843"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 30.93 per share.",
+                  "filerName": "TENNEY MAURICE H III",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541980800,
+                    "fmt": "2018-11-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 20704,
+                    "fmt": "20.7k",
+                    "longFmt": "20,704"
+                  },
+                  "value": {
+                    "raw": 640375,
+                    "fmt": "640.38k",
+                    "longFmt": "640,375"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 30.93 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541980800,
+                    "fmt": "2018-11-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9899,
+                    "fmt": "9.9k",
+                    "longFmt": "9,899"
+                  },
+                  "value": {
+                    "raw": 306176,
+                    "fmt": "306.18k",
+                    "longFmt": "306,176"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 30.93 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541980800,
+                    "fmt": "2018-11-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 27896,
+                    "fmt": "27.9k",
+                    "longFmt": "27,896"
+                  },
+                  "value": {
+                    "raw": 862823,
+                    "fmt": "862.82k",
+                    "longFmt": "862,823"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 30.93 per share.",
+                  "filerName": "JARZYNKA DAVID E",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541980800,
+                    "fmt": "2018-11-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 83582,
+                    "fmt": "83.58k",
+                    "longFmt": "83,582"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541462400,
+                    "fmt": "2018-11-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 24265,
+                    "fmt": "24.27k",
+                    "longFmt": "24,265"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541462400,
+                    "fmt": "2018-11-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1933,
+                    "fmt": "1.93k",
+                    "longFmt": "1,933"
+                  },
+                  "value": {
+                    "raw": 61415,
+                    "fmt": "61.41k",
+                    "longFmt": "61,415"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 31.76 - 31.79 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541462400,
+                    "fmt": "2018-11-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 37747,
+                    "fmt": "37.75k",
+                    "longFmt": "37,747"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROBERTSON LINDON GENE",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541462400,
+                    "fmt": "2018-11-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 43140,
+                    "fmt": "43.14k",
+                    "longFmt": "43,140"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "TENNEY MAURICE H III",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541462400,
+                    "fmt": "2018-11-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 21570,
+                    "fmt": "21.57k",
+                    "longFmt": "21,570"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541462400,
+                    "fmt": "2018-11-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12132,
+                    "fmt": "12.13k",
+                    "longFmt": "12,132"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541462400,
+                    "fmt": "2018-11-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 24265,
+                    "fmt": "24.27k",
+                    "longFmt": "24,265"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JARZYNKA DAVID E",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541462400,
+                    "fmt": "2018-11-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1026,
+                    "fmt": "1.03k",
+                    "longFmt": "1,026"
+                  },
+                  "value": {
+                    "raw": 32586,
+                    "fmt": "32.59k",
+                    "longFmt": "32,586"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 31.76 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541376000,
+                    "fmt": "2018-11-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3976,
+                    "fmt": "3.98k",
+                    "longFmt": "3,976"
+                  },
+                  "value": {
+                    "raw": 126278,
+                    "fmt": "126.28k",
+                    "longFmt": "126,278"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 31.76 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541376000,
+                    "fmt": "2018-11-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1796,
+                    "fmt": "1.8k",
+                    "longFmt": "1,796"
+                  },
+                  "value": {
+                    "raw": 57041,
+                    "fmt": "57.04k",
+                    "longFmt": "57,041"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 31.76 per share.",
+                  "filerName": "ROBERTSON LINDON GENE",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541376000,
+                    "fmt": "2018-11-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2052,
+                    "fmt": "2.05k",
+                    "longFmt": "2,052"
+                  },
+                  "value": {
+                    "raw": 65172,
+                    "fmt": "65.17k",
+                    "longFmt": "65,172"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 31.76 per share.",
+                  "filerName": "TENNEY MAURICE H III",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541376000,
+                    "fmt": "2018-11-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1026,
+                    "fmt": "1.03k",
+                    "longFmt": "1,026"
+                  },
+                  "value": {
+                    "raw": 32586,
+                    "fmt": "32.59k",
+                    "longFmt": "32,586"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 31.76 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541376000,
+                    "fmt": "2018-11-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 577,
+                    "fmt": "577",
+                    "longFmt": "577"
+                  },
+                  "value": {
+                    "raw": 18326,
+                    "fmt": "18.33k",
+                    "longFmt": "18,326"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 31.76 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541376000,
+                    "fmt": "2018-11-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1661,
+                    "fmt": "1.66k",
+                    "longFmt": "1,661"
+                  },
+                  "value": {
+                    "raw": 52753,
+                    "fmt": "52.75k",
+                    "longFmt": "52,753"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 31.76 per share.",
+                  "filerName": "JARZYNKA DAVID E",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541376000,
+                    "fmt": "2018-11-05"
+                  },
+                  "ownership": "D"
+                }
+              ],
+              "maxAge": 1
+            },
+            "sectorTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 249503000,
+                    "fmt": "249.5M",
+                    "longFmt": "249,503,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 136375000,
+                    "fmt": "136.38M",
+                    "longFmt": "136,375,000"
+                  },
+                  "grossProfit": {
+                    "raw": 113128000,
+                    "fmt": "113.13M",
+                    "longFmt": "113,128,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 16083000,
+                    "fmt": "16.08M",
+                    "longFmt": "16,083,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 63030000,
+                    "fmt": "63.03M",
+                    "longFmt": "63,030,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 215488000,
+                    "fmt": "215.49M",
+                    "longFmt": "215,488,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 34015000,
+                    "fmt": "34.02M",
+                    "longFmt": "34,015,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -2238000,
+                    "fmt": "-2.24M",
+                    "longFmt": "-2,238,000"
+                  },
+                  "ebit": {
+                    "raw": 34015000,
+                    "fmt": "34.02M",
+                    "longFmt": "34,015,000"
+                  },
+                  "interestExpense": {
+                    "raw": -556000,
+                    "fmt": "-556k",
+                    "longFmt": "-556,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 31777000,
+                    "fmt": "31.78M",
+                    "longFmt": "31,777,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 4770000,
+                    "fmt": "4.77M",
+                    "longFmt": "4,770,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 27007000,
+                    "fmt": "27.01M",
+                    "longFmt": "27,007,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -979000,
+                    "fmt": "-979k",
+                    "longFmt": "-979,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 26028000,
+                    "fmt": "26.03M",
+                    "longFmt": "26,028,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 26028000,
+                    "fmt": "26.03M",
+                    "longFmt": "26,028,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 246196000,
+                    "fmt": "246.2M",
+                    "longFmt": "246,196,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 134226000,
+                    "fmt": "134.23M",
+                    "longFmt": "134,226,000"
+                  },
+                  "grossProfit": {
+                    "raw": 111970000,
+                    "fmt": "111.97M",
+                    "longFmt": "111,970,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 15336000,
+                    "fmt": "15.34M",
+                    "longFmt": "15,336,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 62471000,
+                    "fmt": "62.47M",
+                    "longFmt": "62,471,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 212033000,
+                    "fmt": "212.03M",
+                    "longFmt": "212,033,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 34163000,
+                    "fmt": "34.16M",
+                    "longFmt": "34,163,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -810000,
+                    "fmt": "-810k",
+                    "longFmt": "-810,000"
+                  },
+                  "ebit": {
+                    "raw": 34163000,
+                    "fmt": "34.16M",
+                    "longFmt": "34,163,000"
+                  },
+                  "interestExpense": {
+                    "raw": -695000,
+                    "fmt": "-695k",
+                    "longFmt": "-695,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 33353000,
+                    "fmt": "33.35M",
+                    "longFmt": "33,353,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 4380000,
+                    "fmt": "4.38M",
+                    "longFmt": "4,380,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 28973000,
+                    "fmt": "28.97M",
+                    "longFmt": "28,973,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -979000,
+                    "fmt": "-979k",
+                    "longFmt": "-979,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 28973000,
+                    "fmt": "28.97M",
+                    "longFmt": "28,973,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 28973000,
+                    "fmt": "28.97M",
+                    "longFmt": "28,973,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 220350000,
+                    "fmt": "220.35M",
+                    "longFmt": "220,350,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 127262000,
+                    "fmt": "127.26M",
+                    "longFmt": "127,262,000"
+                  },
+                  "grossProfit": {
+                    "raw": 93088000,
+                    "fmt": "93.09M",
+                    "longFmt": "93,088,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 14004000,
+                    "fmt": "14M",
+                    "longFmt": "14,004,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 59714000,
+                    "fmt": "59.71M",
+                    "longFmt": "59,714,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 200980000,
+                    "fmt": "200.98M",
+                    "longFmt": "200,980,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 19370000,
+                    "fmt": "19.37M",
+                    "longFmt": "19,370,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -554000,
+                    "fmt": "-554k",
+                    "longFmt": "-554,000"
+                  },
+                  "ebit": {
+                    "raw": 19370000,
+                    "fmt": "19.37M",
+                    "longFmt": "19,370,000"
+                  },
+                  "interestExpense": {
+                    "raw": -810000,
+                    "fmt": "-810k",
+                    "longFmt": "-810,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 18816000,
+                    "fmt": "18.82M",
+                    "longFmt": "18,816,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 5120000,
+                    "fmt": "5.12M",
+                    "longFmt": "5,120,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 13696000,
+                    "fmt": "13.7M",
+                    "longFmt": "13,696,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -979000,
+                    "fmt": "-979k",
+                    "longFmt": "-979,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 13696000,
+                    "fmt": "13.7M",
+                    "longFmt": "13,696,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 13696000,
+                    "fmt": "13.7M",
+                    "longFmt": "13,696,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 220227000,
+                    "fmt": "220.23M",
+                    "longFmt": "220,227,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 129946000,
+                    "fmt": "129.95M",
+                    "longFmt": "129,946,000"
+                  },
+                  "grossProfit": {
+                    "raw": 90281000,
+                    "fmt": "90.28M",
+                    "longFmt": "90,281,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 15322000,
+                    "fmt": "15.32M",
+                    "longFmt": "15,322,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 59609000,
+                    "fmt": "59.61M",
+                    "longFmt": "59,609,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 204877000,
+                    "fmt": "204.88M",
+                    "longFmt": "204,877,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 15350000,
+                    "fmt": "15.35M",
+                    "longFmt": "15,350,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -2758000,
+                    "fmt": "-2.76M",
+                    "longFmt": "-2,758,000"
+                  },
+                  "ebit": {
+                    "raw": 15350000,
+                    "fmt": "15.35M",
+                    "longFmt": "15,350,000"
+                  },
+                  "interestExpense": {
+                    "raw": -718000,
+                    "fmt": "-718k",
+                    "longFmt": "-718,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 12592000,
+                    "fmt": "12.59M",
+                    "longFmt": "12,592,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 3400000,
+                    "fmt": "3.4M",
+                    "longFmt": "3,400,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 9192000,
+                    "fmt": "9.19M",
+                    "longFmt": "9,192,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -65000,
+                    "fmt": "-65k",
+                    "longFmt": "-65,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 9127000,
+                    "fmt": "9.13M",
+                    "longFmt": "9,127,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 9127000,
+                    "fmt": "9.13M",
+                    "longFmt": "9,127,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 26028000,
+                    "fmt": "26.03M",
+                    "longFmt": "26,028,000"
+                  },
+                  "depreciation": {
+                    "raw": 15746000,
+                    "fmt": "15.75M",
+                    "longFmt": "15,746,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 2755000,
+                    "fmt": "2.75M",
+                    "longFmt": "2,755,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -4504000,
+                    "fmt": "-4.5M",
+                    "longFmt": "-4,504,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 8913000,
+                    "fmt": "8.91M",
+                    "longFmt": "8,913,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -6307000,
+                    "fmt": "-6.31M",
+                    "longFmt": "-6,307,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 1099000,
+                    "fmt": "1.1M",
+                    "longFmt": "1,099,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 43730000,
+                    "fmt": "43.73M",
+                    "longFmt": "43,730,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -15227000,
+                    "fmt": "-15.23M",
+                    "longFmt": "-15,227,000"
+                  },
+                  "investments": {
+                    "raw": -4000,
+                    "fmt": "-4k",
+                    "longFmt": "-4,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -30292000,
+                    "fmt": "-30.29M",
+                    "longFmt": "-30,292,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -7424000,
+                    "fmt": "-7.42M",
+                    "longFmt": "-7,424,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -733000,
+                    "fmt": "-733k",
+                    "longFmt": "-733,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -8157000,
+                    "fmt": "-8.16M",
+                    "longFmt": "-8,157,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 11250000,
+                    "fmt": "11.25M",
+                    "longFmt": "11,250,000"
+                  },
+                  "changeInCash": {
+                    "raw": 16531000,
+                    "fmt": "16.53M",
+                    "longFmt": "16,531,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 28973000,
+                    "fmt": "28.97M",
+                    "longFmt": "28,973,000"
+                  },
+                  "depreciation": {
+                    "raw": 15736000,
+                    "fmt": "15.74M",
+                    "longFmt": "15,736,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 7699000,
+                    "fmt": "7.7M",
+                    "longFmt": "7,699,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -3036000,
+                    "fmt": "-3.04M",
+                    "longFmt": "-3,036,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -10593000,
+                    "fmt": "-10.59M",
+                    "longFmt": "-10,593,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 4551000,
+                    "fmt": "4.55M",
+                    "longFmt": "4,551,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 8469000,
+                    "fmt": "8.47M",
+                    "longFmt": "8,469,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 51799000,
+                    "fmt": "51.8M",
+                    "longFmt": "51,799,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -10239000,
+                    "fmt": "-10.24M",
+                    "longFmt": "-10,239,000"
+                  },
+                  "investments": {
+                    "raw": -949000,
+                    "fmt": "-949k",
+                    "longFmt": "-949,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 1000000,
+                    "fmt": "1M",
+                    "longFmt": "1,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -10189000,
+                    "fmt": "-10.19M",
+                    "longFmt": "-10,189,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -7386000,
+                    "fmt": "-7.39M",
+                    "longFmt": "-7,386,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -320000,
+                    "fmt": "-320k",
+                    "longFmt": "-320,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -5443000,
+                    "fmt": "-5.44M",
+                    "longFmt": "-5,443,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 6159000,
+                    "fmt": "6.16M",
+                    "longFmt": "6,159,000"
+                  },
+                  "changeInCash": {
+                    "raw": 42326000,
+                    "fmt": "42.33M",
+                    "longFmt": "42,326,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 2263000,
+                    "fmt": "2.26M",
+                    "longFmt": "2,263,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "netIncome": {
+                    "raw": 13696000,
+                    "fmt": "13.7M",
+                    "longFmt": "13,696,000"
+                  },
+                  "depreciation": {
+                    "raw": 16681000,
+                    "fmt": "16.68M",
+                    "longFmt": "16,681,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 4304000,
+                    "fmt": "4.3M",
+                    "longFmt": "4,304,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -3049000,
+                    "fmt": "-3.05M",
+                    "longFmt": "-3,049,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 6917000,
+                    "fmt": "6.92M",
+                    "longFmt": "6,917,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -8601000,
+                    "fmt": "-8.6M",
+                    "longFmt": "-8,601,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -3824000,
+                    "fmt": "-3.82M",
+                    "longFmt": "-3,824,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 26124000,
+                    "fmt": "26.12M",
+                    "longFmt": "26,124,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -8515000,
+                    "fmt": "-8.52M",
+                    "longFmt": "-8,515,000"
+                  },
+                  "investments": {
+                    "raw": -949000,
+                    "fmt": "-949k",
+                    "longFmt": "-949,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 1000000,
+                    "fmt": "1M",
+                    "longFmt": "1,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -8515000,
+                    "fmt": "-8.52M",
+                    "longFmt": "-8,515,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -7380000,
+                    "fmt": "-7.38M",
+                    "longFmt": "-7,380,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -732000,
+                    "fmt": "-732k",
+                    "longFmt": "-732,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -8110000,
+                    "fmt": "-8.11M",
+                    "longFmt": "-8,110,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 4898000,
+                    "fmt": "4.9M",
+                    "longFmt": "4,898,000"
+                  },
+                  "changeInCash": {
+                    "raw": 14397000,
+                    "fmt": "14.4M",
+                    "longFmt": "14,397,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 2000,
+                    "fmt": "2k",
+                    "longFmt": "2,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "netIncome": {
+                    "raw": 9127000,
+                    "fmt": "9.13M",
+                    "longFmt": "9,127,000"
+                  },
+                  "depreciation": {
+                    "raw": 16602000,
+                    "fmt": "16.6M",
+                    "longFmt": "16,602,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -88554000,
+                    "fmt": "-88.55M",
+                    "longFmt": "-88,554,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -14173000,
+                    "fmt": "-14.17M",
+                    "longFmt": "-14,173,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -206000,
+                    "fmt": "-206k",
+                    "longFmt": "-206,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -4759000,
+                    "fmt": "-4.76M",
+                    "longFmt": "-4,759,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 16163000,
+                    "fmt": "16.16M",
+                    "longFmt": "16,163,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -65800000,
+                    "fmt": "-65.8M",
+                    "longFmt": "-65,800,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -11556000,
+                    "fmt": "-11.56M",
+                    "longFmt": "-11,556,000"
+                  },
+                  "investments": {
+                    "raw": 10033000,
+                    "fmt": "10.03M",
+                    "longFmt": "10,033,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -1000000,
+                    "fmt": "-1M",
+                    "longFmt": "-1,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -17266000,
+                    "fmt": "-17.27M",
+                    "longFmt": "-17,266,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -7378000,
+                    "fmt": "-7.38M",
+                    "longFmt": "-7,378,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -320000,
+                    "fmt": "-320k",
+                    "longFmt": "-320,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -5368000,
+                    "fmt": "-5.37M",
+                    "longFmt": "-5,368,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -4611000,
+                    "fmt": "-4.61M",
+                    "longFmt": "-4,611,000"
+                  },
+                  "changeInCash": {
+                    "raw": -93045000,
+                    "fmt": "-93.05M",
+                    "longFmt": "-93,045,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 2330000,
+                    "fmt": "2.33M",
+                    "longFmt": "2,330,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [
+                  {
+                    "date": "1Q2020",
+                    "actual": 0.25,
+                    "estimate": 0.24
+                  },
+                  {
+                    "date": "2Q2020",
+                    "actual": 0.32,
+                    "estimate": 0.2
+                  },
+                  {
+                    "date": "3Q2020",
+                    "actual": 0.47,
+                    "estimate": 0.36
+                  },
+                  {
+                    "date": "4Q2020",
+                    "actual": 0.47,
+                    "estimate": 0.42
+                  }
+                ],
+                "currentQuarterEstimate": 0.5,
+                "currentQuarterEstimateDate": "1Q",
+                "currentQuarterEstimateYear": 2021,
+                "earningsDate": [
+                  1619568000,
+                  1620000000
+                ]
+              },
+              "financialsChart": {
+                "yearly": [
+                  {
+                    "date": 2017,
+                    "revenue": 527499000,
+                    "earnings": 62612000
+                  },
+                  {
+                    "date": 2018,
+                    "revenue": 631560000,
+                    "earnings": 116575000
+                  },
+                  {
+                    "date": 2019,
+                    "revenue": 780848000,
+                    "earnings": 437416000
+                  },
+                  {
+                    "date": 2020,
+                    "revenue": 897273000,
+                    "earnings": 64853000
+                  }
+                ],
+                "quarterly": [
+                  {
+                    "date": "1Q2020",
+                    "revenue": 220227000,
+                    "earnings": 9127000
+                  },
+                  {
+                    "date": "2Q2020",
+                    "revenue": 220350000,
+                    "earnings": 13696000
+                  },
+                  {
+                    "date": "3Q2020",
+                    "revenue": 246196000,
+                    "earnings": 28973000
+                  },
+                  {
+                    "date": "4Q2020",
+                    "revenue": 249503000,
+                    "earnings": 26028000
+                  }
+                ]
+              },
+              "financialCurrency": "USD"
+            },
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 87.38,
+              "targetHighPrice": 111,
+              "targetLowPrice": 70,
+              "targetMeanPrice": 95.17,
+              "targetMedianPrice": 97.5,
+              "recommendationMean": 2,
+              "recommendationKey": "buy",
+              "numberOfAnalystOpinions": 6,
+              "totalCash": 308572000,
+              "totalCashPerShare": 4.218,
+              "ebitda": 167963008,
+              "totalDebt": 93333000,
+              "quickRatio": 2.295,
+              "currentRatio": 2.99,
+              "totalRevenue": 936275968,
+              "debtToEquity": 7.454,
+              "revenuePerShare": 12.683,
+              "returnOnAssets": 0.04064,
+              "returnOnEquity": 0.06543,
+              "grossProfits": 380325000,
+              "freeCashflow": -7406125,
+              "operatingCashflow": 55853000,
+              "earningsGrowth": 0.944,
+              "revenueGrowth": 0.185,
+              "grossMargins": 0.43627,
+              "ebitdaMargins": 0.17939,
+              "operatingMargins": 0.11022,
+              "profitMargins": 0.08312,
+              "financialCurrency": "USD"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-all-CRON.json
+++ b/tests/http/quoteSummary-all-CRON.json
@@ -1,0 +1,3958 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=assetProfile%2CbalanceSheetHistory%2CbalanceSheetHistoryQuarterly%2CcalendarEvents%2CcashflowStatementHistory%2CcashflowStatementHistoryQuarterly%2CdefaultKeyStatistics%2Cearnings%2CearningsHistory%2CearningsTrend%2CfinancialData%2CfundOwnership%2CfundPerformance%2CfundProfile%2CincomeStatementHistory%2CincomeStatementHistoryQuarterly%2CindexTrend%2CindustryTrend%2CinsiderHolders%2CinsiderTransactions%2CinstitutionOwnership%2CmajorDirectHolders%2CmajorHoldersBreakdown%2CnetSharePurchaseActivity%2Cprice%2CquoteType%2CrecommendationTrend%2CsecFilings%2CsectorTrend%2CsummaryDetail%2CsummaryProfile%2CtopHoldings%2CupgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "agco59hg2vsf2"
+      ],
+      "x-yahoo-request-id": [
+        "agco59hg2vsf2"
+      ],
+      "x-request-id": [
+        "391395c9-e882-4d59-9b3a-6bfe9659f7f3"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "15"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:10 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "2"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "720 King Street West",
+              "address2": "Suite 320",
+              "city": "Toronto",
+              "state": "ON",
+              "zip": "M5V 2T3",
+              "country": "Canada",
+              "phone": "416-504-0004",
+              "website": "http://www.thecronosgroup.com",
+              "industry": "Drug Manufacturers—Specialty & Generic",
+              "sector": "Healthcare",
+              "longBusinessSummary": "Cronos Group Inc. operates as a cannabinoid company in the United States and internationally. It manufactures, markets, and distributes hemp-derived supplements and cosmetic products through ecommerce, retail, and hospitality partner channels. The company is also involved in the cultivation, manufacture, and marketing of cannabis and cannabis-derived products for the medical and adult-use markets. Its brand portfolio includes PEACE NATURALS, a global wellness platform; adult-use brands comprise COVE and Spinach; and hemp-derived CBD brands consists of Lord Jones and PEACE+. Cronos Group Inc. is based in Toronto, Canada.",
+              "fullTimeEmployees": 631,
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Michael Ryan Gorenstein",
+                  "age": 33,
+                  "title": "Exec. Chairman",
+                  "yearBorn": 1987,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 333571,
+                    "fmt": "333.57k",
+                    "longFmt": "333,571"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 15739047,
+                    "fmt": "15.74M",
+                    "longFmt": "15,739,047"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Jerry Filomena Barbato",
+                  "age": 44,
+                  "title": "Chief Financial Officer",
+                  "yearBorn": 1976,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 299626,
+                    "fmt": "299.63k",
+                    "longFmt": "299,626"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Xiuming  Shum",
+                  "age": 34,
+                  "title": "Exec. VP of Legal and Regulatory Affairs & Corp. Sec.",
+                  "yearBorn": 1986,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 190178,
+                    "fmt": "190.18k",
+                    "longFmt": "190,178"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 1076139,
+                    "fmt": "1.08M",
+                    "longFmt": "1,076,139"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Kurt Thomas Schmidt B.Sc., M.B.A.",
+                  "age": 63,
+                  "title": "Pres & CEO",
+                  "yearBorn": 1957,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Shayne J. Laidlaw",
+                  "title": "Director of Investor Relations & Strategy",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Shannon  Buggy",
+                  "title": "Sr. VP & Global Head of People",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Anna  Shlimak",
+                  "age": 34,
+                  "title": "Sr. VP of Corp. Affairs",
+                  "yearBorn": 1986,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Todd K. Abraham",
+                  "age": 65,
+                  "title": "Chief Innovation Officer",
+                  "yearBorn": 1955,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Puneet  Mathur",
+                  "title": "VP & Controller",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Summer  Frein",
+                  "age": 36,
+                  "title": "Gen. Mang. of USA",
+                  "yearBorn": 1984,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "auditRisk": 10,
+              "boardRisk": 5,
+              "compensationRisk": 5,
+              "shareHolderRightsRisk": 5,
+              "overallRisk": 7,
+              "governanceEpochDate": 1606867200,
+              "compensationAsOfEpochDate": 1577750400,
+              "maxAge": 86400
+            },
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 1166506000,
+                    "fmt": "1.17B",
+                    "longFmt": "1,166,506,000"
+                  },
+                  "depreciation": {
+                    "raw": 3913000,
+                    "fmt": "3.91M",
+                    "longFmt": "3,913,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -1246218000,
+                    "fmt": "-1.25B",
+                    "longFmt": "-1,246,218,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -702000,
+                    "fmt": "-702k",
+                    "longFmt": "-702,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 13317000,
+                    "fmt": "13.32M",
+                    "longFmt": "13,317,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -51888000,
+                    "fmt": "-51.89M",
+                    "longFmt": "-51,888,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -14935000,
+                    "fmt": "-14.94M",
+                    "longFmt": "-14,935,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -130007000,
+                    "fmt": "-130.01M",
+                    "longFmt": "-130,007,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -38664000,
+                    "fmt": "-38.66M",
+                    "longFmt": "-38,664,000"
+                  },
+                  "investments": {
+                    "raw": -297102000,
+                    "fmt": "-297.1M",
+                    "longFmt": "-297,102,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -89000,
+                    "fmt": "-89k",
+                    "longFmt": "-89,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -603539000,
+                    "fmt": "-603.54M",
+                    "longFmt": "-603,539,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -16484000,
+                    "fmt": "-16.48M",
+                    "longFmt": "-16,484,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -3722000,
+                    "fmt": "-3.72M",
+                    "longFmt": "-3,722,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 1856941000,
+                    "fmt": "1.86B",
+                    "longFmt": "1,856,941,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 52371000,
+                    "fmt": "52.37M",
+                    "longFmt": "52,371,000"
+                  },
+                  "changeInCash": {
+                    "raw": 1175766000,
+                    "fmt": "1.18B",
+                    "longFmt": "1,175,766,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -915000,
+                    "fmt": "-915k",
+                    "longFmt": "-915,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 1878062000,
+                    "fmt": "1.88B",
+                    "longFmt": "1,878,062,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -21636000,
+                    "fmt": "-21.64M",
+                    "longFmt": "-21,636,000"
+                  },
+                  "depreciation": {
+                    "raw": 1848000,
+                    "fmt": "1.85M",
+                    "longFmt": "1,848,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 8609000,
+                    "fmt": "8.61M",
+                    "longFmt": "8,609,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -2569000,
+                    "fmt": "-2.57M",
+                    "longFmt": "-2,569,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 12705000,
+                    "fmt": "12.71M",
+                    "longFmt": "12,705,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -4092000,
+                    "fmt": "-4.09M",
+                    "longFmt": "-4,092,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -2382000,
+                    "fmt": "-2.38M",
+                    "longFmt": "-2,382,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -7517000,
+                    "fmt": "-7.52M",
+                    "longFmt": "-7,517,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -88308000,
+                    "fmt": "-88.31M",
+                    "longFmt": "-88,308,000"
+                  },
+                  "investments": {
+                    "raw": -5179000,
+                    "fmt": "-5.18M",
+                    "longFmt": "-5,179,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -143000,
+                    "fmt": "-143k",
+                    "longFmt": "-143,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -93908000,
+                    "fmt": "-93.91M",
+                    "longFmt": "-93,908,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 11583000,
+                    "fmt": "11.58M",
+                    "longFmt": "11,583,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -7577000,
+                    "fmt": "-7.58M",
+                    "longFmt": "-7,577,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 122112000,
+                    "fmt": "122.11M",
+                    "longFmt": "122,112,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -4085000,
+                    "fmt": "-4.08M",
+                    "longFmt": "-4,085,000"
+                  },
+                  "changeInCash": {
+                    "raw": 16602000,
+                    "fmt": "16.6M",
+                    "longFmt": "16,602,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -16000,
+                    "fmt": "-16k",
+                    "longFmt": "-16,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 118122000,
+                    "fmt": "118.12M",
+                    "longFmt": "118,122,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -1483000,
+                    "fmt": "-1.48M",
+                    "longFmt": "-1,483,000"
+                  },
+                  "depreciation": {
+                    "raw": 768000,
+                    "fmt": "768k",
+                    "longFmt": "768,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -2804000,
+                    "fmt": "-2.8M",
+                    "longFmt": "-2,804,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -3198000,
+                    "fmt": "-3.2M",
+                    "longFmt": "-3,198,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 5164000,
+                    "fmt": "5.16M",
+                    "longFmt": "5,164,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -2504000,
+                    "fmt": "-2.5M",
+                    "longFmt": "-2,504,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -221000,
+                    "fmt": "-221k",
+                    "longFmt": "-221,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -4278000,
+                    "fmt": "-4.28M",
+                    "longFmt": "-4,278,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -32926000,
+                    "fmt": "-32.93M",
+                    "longFmt": "-32,926,000"
+                  },
+                  "investments": {
+                    "raw": 5026000,
+                    "fmt": "5.03M",
+                    "longFmt": "5,026,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -143000,
+                    "fmt": "-143k",
+                    "longFmt": "-143,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -29897000,
+                    "fmt": "-29.9M",
+                    "longFmt": "-29,897,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 1938000,
+                    "fmt": "1.94M",
+                    "longFmt": "1,938,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -3103000,
+                    "fmt": "-3.1M",
+                    "longFmt": "-3,103,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 39074000,
+                    "fmt": "39.07M",
+                    "longFmt": "39,074,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -152000,
+                    "fmt": "-152k",
+                    "longFmt": "-152,000"
+                  },
+                  "changeInCash": {
+                    "raw": 4747000,
+                    "fmt": "4.75M",
+                    "longFmt": "4,747,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -16000,
+                    "fmt": "-16k",
+                    "longFmt": "-16,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 40239000,
+                    "fmt": "40.24M",
+                    "longFmt": "40,239,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -1190000,
+                    "fmt": "-1.19M",
+                    "longFmt": "-1,190,000"
+                  },
+                  "depreciation": {
+                    "raw": 382000,
+                    "fmt": "382k",
+                    "longFmt": "382,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -839000,
+                    "fmt": "-839k",
+                    "longFmt": "-839,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -57000,
+                    "fmt": "-57k",
+                    "longFmt": "-57,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -2746000,
+                    "fmt": "-2.75M",
+                    "longFmt": "-2,746,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -1643000,
+                    "fmt": "-1.64M",
+                    "longFmt": "-1,643,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -383000,
+                    "fmt": "-383k",
+                    "longFmt": "-383,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -6476000,
+                    "fmt": "-6.48M",
+                    "longFmt": "-6,476,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -900000,
+                    "fmt": "-900k",
+                    "longFmt": "-900,000"
+                  },
+                  "investments": {
+                    "raw": 2000,
+                    "fmt": "2k",
+                    "longFmt": "2,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -348000,
+                    "fmt": "-348k",
+                    "longFmt": "-348,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -8008000,
+                    "fmt": "-8.01M",
+                    "longFmt": "-8,008,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -4139000,
+                    "fmt": "-4.14M",
+                    "longFmt": "-4,139,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 2470000,
+                    "fmt": "2.47M",
+                    "longFmt": "2,470,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 16821000,
+                    "fmt": "16.82M",
+                    "longFmt": "16,821,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -152000,
+                    "fmt": "-152k",
+                    "longFmt": "-152,000"
+                  },
+                  "changeInCash": {
+                    "raw": 2337000,
+                    "fmt": "2.34M",
+                    "longFmt": "2,337,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -16000,
+                    "fmt": "-16k",
+                    "longFmt": "-16,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 18490000,
+                    "fmt": "18.49M",
+                    "longFmt": "18,490,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 8.58013,
+              "pegRatio": 0.771291,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.286
+                },
+                {
+                  "period": "+1q",
+                  "growth": 1.032
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.175
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.15100001
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0827489
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            },
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": 2875855360,
+              "profitMargins": 2.70682,
+              "floatShares": 189769814,
+              "sharesOutstanding": 356187008,
+              "sharesShort": 26086914,
+              "sharesShortPriorMonth": 28728929,
+              "sharesShortPreviousMonthDate": 1609372800,
+              "dateShortInterest": 1611878400,
+              "sharesPercentSharesOut": 0.0732,
+              "heldPercentInsiders": 0.49218,
+              "heldPercentInstitutions": 0.14603,
+              "shortRatio": 4.34,
+              "shortPercentOfFloat": 0.13949999,
+              "beta": 1.990234,
+              "category": null,
+              "bookValue": 4.967,
+              "priceToBook": 2.4471712,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1577750400,
+              "nextFiscalYearEnd": 1640908800,
+              "mostRecentQuarter": 1601424000,
+              "earningsQuarterlyGrowth": -0.886,
+              "netIncomeToCommon": 100557000,
+              "trailingEps": 0.287,
+              "lastSplitFactor": null,
+              "enterpriseToRevenue": 77.766,
+              "enterpriseToEbitda": -16.254,
+              "52WeekChange": 0.6391609,
+              "SandP52WeekChange": 0.17263722
+            },
+            "quoteType": {
+              "exchange": "NMS",
+              "quoteType": "EQUITY",
+              "symbol": "CRON",
+              "underlyingSymbol": "CRON",
+              "shortName": "Cronos Group Inc. Common Share",
+              "longName": "Cronos Group Inc.",
+              "firstTradeDateEpochUtc": 1519741800,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "c16afd87-8f99-3c59-851c-860ea909059d",
+              "messageBoardId": "finmb_253038643",
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            },
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 23750000,
+                    "fmt": "23.75M",
+                    "longFmt": "23,750,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 39714000,
+                    "fmt": "39.71M",
+                    "longFmt": "39,714,000"
+                  },
+                  "grossProfit": {
+                    "raw": -15964000,
+                    "fmt": "-15.96M",
+                    "longFmt": "-15,964,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 12155000,
+                    "fmt": "12.15M",
+                    "longFmt": "12,155,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 72417000,
+                    "fmt": "72.42M",
+                    "longFmt": "72,417,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 5328000,
+                    "fmt": "5.33M",
+                    "longFmt": "5,328,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 143334000,
+                    "fmt": "143.33M",
+                    "longFmt": "143,334,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -119584000,
+                    "fmt": "-119.58M",
+                    "longFmt": "-119,584,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 1285158000,
+                    "fmt": "1.29B",
+                    "longFmt": "1,285,158,000"
+                  },
+                  "ebit": {
+                    "raw": -119584000,
+                    "fmt": "-119.58M",
+                    "longFmt": "-119,584,000"
+                  },
+                  "interestExpense": {
+                    "raw": -1244000,
+                    "fmt": "-1.24M",
+                    "longFmt": "-1,244,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 1165574000,
+                    "fmt": "1.17B",
+                    "longFmt": "1,165,574,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "minorityInterest": {
+                    "raw": -853000,
+                    "fmt": "-853k",
+                    "longFmt": "-853,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 1165574000,
+                    "fmt": "1.17B",
+                    "longFmt": "1,165,574,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 1166506000,
+                    "fmt": "1.17B",
+                    "longFmt": "1,166,506,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 1166506000,
+                    "fmt": "1.17B",
+                    "longFmt": "1,166,506,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 12121000,
+                    "fmt": "12.12M",
+                    "longFmt": "12,121,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 5908000,
+                    "fmt": "5.91M",
+                    "longFmt": "5,908,000"
+                  },
+                  "grossProfit": {
+                    "raw": 6213000,
+                    "fmt": "6.21M",
+                    "longFmt": "6,213,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 1814000,
+                    "fmt": "1.81M",
+                    "longFmt": "1,814,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 16620000,
+                    "fmt": "16.62M",
+                    "longFmt": "16,620,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 5328000,
+                    "fmt": "5.33M",
+                    "longFmt": "5,328,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 33462000,
+                    "fmt": "33.46M",
+                    "longFmt": "33,462,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -21341000,
+                    "fmt": "-21.34M",
+                    "longFmt": "-21,341,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -476000,
+                    "fmt": "-476k",
+                    "longFmt": "-476,000"
+                  },
+                  "ebit": {
+                    "raw": -21341000,
+                    "fmt": "-21.34M",
+                    "longFmt": "-21,341,000"
+                  },
+                  "interestExpense": {
+                    "raw": -139000,
+                    "fmt": "-139k",
+                    "longFmt": "-139,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -21817000,
+                    "fmt": "-21.82M",
+                    "longFmt": "-21,817,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 489000,
+                    "fmt": "489k",
+                    "longFmt": "489,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 100000,
+                    "fmt": "100k",
+                    "longFmt": "100,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -21817000,
+                    "fmt": "-21.82M",
+                    "longFmt": "-21,817,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -21636000,
+                    "fmt": "-21.64M",
+                    "longFmt": "-21,636,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -21636000,
+                    "fmt": "-21.64M",
+                    "longFmt": "-21,636,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 3147000,
+                    "fmt": "3.15M",
+                    "longFmt": "3,147,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 1573000,
+                    "fmt": "1.57M",
+                    "longFmt": "1,573,000"
+                  },
+                  "grossProfit": {
+                    "raw": 1574000,
+                    "fmt": "1.57M",
+                    "longFmt": "1,574,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 1814000,
+                    "fmt": "1.81M",
+                    "longFmt": "1,814,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 5347000,
+                    "fmt": "5.35M",
+                    "longFmt": "5,347,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 5328000,
+                    "fmt": "5.33M",
+                    "longFmt": "5,328,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 9268000,
+                    "fmt": "9.27M",
+                    "longFmt": "9,268,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -6121000,
+                    "fmt": "-6.12M",
+                    "longFmt": "-6,121,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 3776000,
+                    "fmt": "3.78M",
+                    "longFmt": "3,776,000"
+                  },
+                  "ebit": {
+                    "raw": -6121000,
+                    "fmt": "-6.12M",
+                    "longFmt": "-6,121,000"
+                  },
+                  "interestExpense": {
+                    "raw": -101000,
+                    "fmt": "-101k",
+                    "longFmt": "-101,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -2345000,
+                    "fmt": "-2.35M",
+                    "longFmt": "-2,345,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -862000,
+                    "fmt": "-862k",
+                    "longFmt": "-862,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 100000,
+                    "fmt": "100k",
+                    "longFmt": "100,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -1483000,
+                    "fmt": "-1.48M",
+                    "longFmt": "-1,483,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -1483000,
+                    "fmt": "-1.48M",
+                    "longFmt": "-1,483,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -1483000,
+                    "fmt": "-1.48M",
+                    "longFmt": "-1,483,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 554000,
+                    "fmt": "554k",
+                    "longFmt": "554,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": -1439000,
+                    "fmt": "-1.44M",
+                    "longFmt": "-1,439,000"
+                  },
+                  "grossProfit": {
+                    "raw": 1993000,
+                    "fmt": "1.99M",
+                    "longFmt": "1,993,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 1814000,
+                    "fmt": "1.81M",
+                    "longFmt": "1,814,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 3435000,
+                    "fmt": "3.44M",
+                    "longFmt": "3,435,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 5328000,
+                    "fmt": "5.33M",
+                    "longFmt": "5,328,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 2685000,
+                    "fmt": "2.69M",
+                    "longFmt": "2,685,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -2131000,
+                    "fmt": "-2.13M",
+                    "longFmt": "-2,131,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 373000,
+                    "fmt": "373k",
+                    "longFmt": "373,000"
+                  },
+                  "ebit": {
+                    "raw": -2131000,
+                    "fmt": "-2.13M",
+                    "longFmt": "-2,131,000"
+                  },
+                  "interestExpense": {
+                    "raw": -232000,
+                    "fmt": "-232k",
+                    "longFmt": "-232,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -1758000,
+                    "fmt": "-1.76M",
+                    "longFmt": "-1,758,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -568000,
+                    "fmt": "-568k",
+                    "longFmt": "-568,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 100000,
+                    "fmt": "100k",
+                    "longFmt": "100,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -1190000,
+                    "fmt": "-1.19M",
+                    "longFmt": "-1,190,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -1190000,
+                    "fmt": "-1.19M",
+                    "longFmt": "-1,190,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -1190000,
+                    "fmt": "-1.19M",
+                    "longFmt": "-1,190,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            },
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 11.72,
+              "open": 11.79,
+              "dayLow": 11.77,
+              "dayHigh": 12.38,
+              "regularMarketPreviousClose": 11.72,
+              "regularMarketOpen": 11.79,
+              "regularMarketDayLow": 11.77,
+              "regularMarketDayHigh": 12.38,
+              "payoutRatio": 0,
+              "beta": 1.990234,
+              "trailingPE": 42.352264,
+              "volume": 2580169,
+              "regularMarketVolume": 2580169,
+              "averageVolume": 6821504,
+              "averageVolume10days": 16615528,
+              "averageDailyVolume10Day": 16615528,
+              "bid": 12.17,
+              "ask": 12.18,
+              "bidSize": 2200,
+              "askSize": 1400,
+              "marketCap": 4318755840,
+              "fiftyTwoWeekLow": 4,
+              "fiftyTwoWeekHigh": 15.83,
+              "priceToSalesTrailing12Months": 116.783104,
+              "fiftyDayAverage": 10.839394,
+              "twoHundredDayAverage": 7.409601,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            },
+            "insiderHolders": {
+              "holders": [
+                {
+                  "maxAge": 1,
+                  "name": "Abraham (Todd Kevin Ph.D.)",
+                  "relation": "Senior Officer of Issuer",
+                  "url": "",
+                  "transactionDescription": "Acquisition or disposition in the public market",
+                  "latestTransDate": {
+                    "raw": 1596758400,
+                    "fmt": "2020-08-07"
+                  },
+                  "positionDirect": {
+                    "raw": 15000,
+                    "fmt": "15k",
+                    "longFmt": "15,000"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1596758400,
+                    "fmt": "2020-08-07"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Adler (Jason Marc)",
+                  "relation": "Director of Issuer",
+                  "url": "",
+                  "transactionDescription": "Acquisition or disposition in the public market",
+                  "latestTransDate": {
+                    "raw": 1605571200,
+                    "fmt": "2020-11-17"
+                  },
+                  "positionDirect": {
+                    "raw": 5479092,
+                    "fmt": "5.48M",
+                    "longFmt": "5,479,092"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605571200,
+                    "fmt": "2020-11-17"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Gorenstein (Michael Ryan)",
+                  "relation": "Director of Issuer",
+                  "url": "",
+                  "transactionDescription": "Exercise for cash",
+                  "latestTransDate": {
+                    "raw": 1605139200,
+                    "fmt": "2020-11-12"
+                  },
+                  "positionDirect": {
+                    "raw": 4512396,
+                    "fmt": "4.51M",
+                    "longFmt": "4,512,396"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605139200,
+                    "fmt": "2020-11-12"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Jacobson (Jeffrey David)",
+                  "relation": "Senior Officer of Issuer",
+                  "url": "",
+                  "transactionDescription": "Other",
+                  "latestTransDate": {
+                    "raw": 1597363200,
+                    "fmt": "2020-08-14"
+                  },
+                  "positionDirect": {
+                    "raw": 4500,
+                    "fmt": "4.5k",
+                    "longFmt": "4,500"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1597363200,
+                    "fmt": "2020-08-14"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Shlimak (Anna)",
+                  "relation": "Senior Officer of Issuer",
+                  "url": "",
+                  "transactionDescription": "Opening Balance-Initial SEDI Report",
+                  "latestTransDate": {
+                    "raw": 1582243200,
+                    "fmt": "2020-02-21"
+                  },
+                  "positionDirect": {
+                    "raw": 10000,
+                    "fmt": "10k",
+                    "longFmt": "10,000"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1582243200,
+                    "fmt": "2020-02-21"
+                  }
+                }
+              ],
+              "maxAge": 1
+            },
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": []
+              }
+            },
+            "upgradeDowngradeHistory": {
+              "history": [
+                {
+                  "epochGradeDate": 1586858114,
+                  "firm": "Piper Sandler",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1585653085,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Sell",
+                  "fromGrade": "Hold",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1573657972,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1571746972,
+                  "firm": "Piper Jaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1565696606,
+                  "firm": "Piper Jaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1565354890,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Hold",
+                  "fromGrade": "Sell",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1561724650,
+                  "firm": "Consumer Edge",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1559818772,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1559732645,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "Underperform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1555504220,
+                  "firm": "Bank of America",
+                  "toGrade": "Underperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1553687250,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Sell",
+                  "fromGrade": "Hold",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1553632930,
+                  "firm": "PI Financial",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1552307341,
+                  "firm": "BMO Capital",
+                  "toGrade": "Underperform",
+                  "fromGrade": "Market Perform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1551788043,
+                  "firm": "Cowen & Co.",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1551118944,
+                  "firm": "Jefferies",
+                  "toGrade": "Underperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1549372986,
+                  "firm": "GMP Securities",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1547822100,
+                  "firm": "CIBC",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1534329666,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Hold",
+                  "fromGrade": "Sell",
+                  "action": "up"
+                }
+              ],
+              "maxAge": 86400
+            },
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": 0.0051194085,
+              "preMarketChange": 0.059999466,
+              "preMarketTime": 1613744995,
+              "preMarketPrice": 11.78,
+              "preMarketSource": "DELAYED",
+              "regularMarketChangePercent": 0.037124537,
+              "regularMarketChange": 0.4350996,
+              "regularMarketTime": 1613754832,
+              "priceHint": 2,
+              "regularMarketPrice": 12.1551,
+              "regularMarketDayHigh": 12.38,
+              "regularMarketDayLow": 11.77,
+              "regularMarketVolume": 2580169,
+              "averageDailyVolume10Day": 16615528,
+              "averageDailyVolume3Month": 6821504,
+              "regularMarketPreviousClose": 11.72,
+              "regularMarketSource": "FREE_REALTIME",
+              "regularMarketOpen": 11.79,
+              "exchange": "NMS",
+              "exchangeName": "NasdaqGS",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "EQUITY",
+              "symbol": "CRON",
+              "underlyingSymbol": null,
+              "shortName": "Cronos Group Inc. Common Share",
+              "longName": "Cronos Group Inc.",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 4318755840
+            },
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 1199693000,
+                    "fmt": "1.2B",
+                    "longFmt": "1,199,693,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 306347000,
+                    "fmt": "306.35M",
+                    "longFmt": "306,347,000"
+                  },
+                  "netReceivables": {
+                    "raw": 16534000,
+                    "fmt": "16.53M",
+                    "longFmt": "16,534,000"
+                  },
+                  "inventory": {
+                    "raw": 38043000,
+                    "fmt": "38.04M",
+                    "longFmt": "38,043,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 1570012000,
+                    "fmt": "1.57B",
+                    "longFmt": "1,570,012,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 557000,
+                    "fmt": "557k",
+                    "longFmt": "557,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 168355000,
+                    "fmt": "168.35M",
+                    "longFmt": "168,355,000"
+                  },
+                  "goodWill": {
+                    "raw": 214794000,
+                    "fmt": "214.79M",
+                    "longFmt": "214,794,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 72320000,
+                    "fmt": "72.32M",
+                    "longFmt": "72,320,000"
+                  },
+                  "otherAssets": {
+                    "raw": 64404000,
+                    "fmt": "64.4M",
+                    "longFmt": "64,404,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2090442000,
+                    "fmt": "2.09B",
+                    "longFmt": "2,090,442,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 9194000,
+                    "fmt": "9.19M",
+                    "longFmt": "9,194,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 323267000,
+                    "fmt": "323.27M",
+                    "longFmt": "323,267,000"
+                  },
+                  "otherLiab": {
+                    "raw": 1844000,
+                    "fmt": "1.84M",
+                    "longFmt": "1,844,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -853000,
+                    "fmt": "-853k",
+                    "longFmt": "-853,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 332888000,
+                    "fmt": "332.89M",
+                    "longFmt": "332,888,000"
+                  },
+                  "totalLiab": {
+                    "raw": 341412000,
+                    "fmt": "341.41M",
+                    "longFmt": "341,412,000"
+                  },
+                  "commonStock": {
+                    "raw": 561165000,
+                    "fmt": "561.16M",
+                    "longFmt": "561,165,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 1137646000,
+                    "fmt": "1.14B",
+                    "longFmt": "1,137,646,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 27838000,
+                    "fmt": "27.84M",
+                    "longFmt": "27,838,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 23234000,
+                    "fmt": "23.23M",
+                    "longFmt": "23,234,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 27838000,
+                    "fmt": "27.84M",
+                    "longFmt": "27,838,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1749883000,
+                    "fmt": "1.75B",
+                    "longFmt": "1,749,883,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 1462769000,
+                    "fmt": "1.46B",
+                    "longFmt": "1,462,769,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "cash": {
+                    "raw": 23927000,
+                    "fmt": "23.93M",
+                    "longFmt": "23,927,000"
+                  },
+                  "netReceivables": {
+                    "raw": 5789000,
+                    "fmt": "5.79M",
+                    "longFmt": "5,789,000"
+                  },
+                  "inventory": {
+                    "raw": 7386000,
+                    "fmt": "7.39M",
+                    "longFmt": "7,386,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 39944000,
+                    "fmt": "39.94M",
+                    "longFmt": "39,944,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 3257000,
+                    "fmt": "3.26M",
+                    "longFmt": "3,257,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 126030000,
+                    "fmt": "126.03M",
+                    "longFmt": "126,030,000"
+                  },
+                  "goodWill": {
+                    "raw": 1314000,
+                    "fmt": "1.31M",
+                    "longFmt": "1,314,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 8237000,
+                    "fmt": "8.24M",
+                    "longFmt": "8,237,000"
+                  },
+                  "otherAssets": {
+                    "raw": 4689000,
+                    "fmt": "4.69M",
+                    "longFmt": "4,689,000"
+                  },
+                  "totalAssets": {
+                    "raw": 183471000,
+                    "fmt": "183.47M",
+                    "longFmt": "183,471,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1170000,
+                    "fmt": "1.17M",
+                    "longFmt": "1,170,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 15625000,
+                    "fmt": "15.62M",
+                    "longFmt": "15,625,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 16444000,
+                    "fmt": "16.44M",
+                    "longFmt": "16,444,000"
+                  },
+                  "otherLiab": {
+                    "raw": 1566000,
+                    "fmt": "1.57M",
+                    "longFmt": "1,566,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 100000,
+                    "fmt": "100k",
+                    "longFmt": "100,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 33269000,
+                    "fmt": "33.27M",
+                    "longFmt": "33,269,000"
+                  },
+                  "totalLiab": {
+                    "raw": 34922000,
+                    "fmt": "34.92M",
+                    "longFmt": "34,922,000"
+                  },
+                  "commonStock": {
+                    "raw": 175001000,
+                    "fmt": "175M",
+                    "longFmt": "175,001,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -27945000,
+                    "fmt": "-27.95M",
+                    "longFmt": "-27,945,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -9870000,
+                    "fmt": "-9.87M",
+                    "longFmt": "-9,870,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 11263000,
+                    "fmt": "11.26M",
+                    "longFmt": "11,263,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -9870000,
+                    "fmt": "-9.87M",
+                    "longFmt": "-9,870,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 148449000,
+                    "fmt": "148.45M",
+                    "longFmt": "148,449,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 138898000,
+                    "fmt": "138.9M",
+                    "longFmt": "138,898,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "cash": {
+                    "raw": 7342434,
+                    "fmt": "7.34M",
+                    "longFmt": "7,342,434"
+                  },
+                  "netReceivables": {
+                    "raw": 3642511,
+                    "fmt": "3.64M",
+                    "longFmt": "3,642,511"
+                  },
+                  "inventory": {
+                    "raw": 9678808,
+                    "fmt": "9.68M",
+                    "longFmt": "9,678,808"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 21293697,
+                    "fmt": "21.29M",
+                    "longFmt": "21,293,697"
+                  },
+                  "longTermInvestments": {
+                    "raw": 4109786,
+                    "fmt": "4.11M",
+                    "longFmt": "4,109,786"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 44791401,
+                    "fmt": "44.79M",
+                    "longFmt": "44,791,401"
+                  },
+                  "goodWill": {
+                    "raw": 1428936,
+                    "fmt": "1.43M",
+                    "longFmt": "1,428,936"
+                  },
+                  "intangibleAssets": {
+                    "raw": 8936431,
+                    "fmt": "8.94M",
+                    "longFmt": "8,936,431"
+                  },
+                  "totalAssets": {
+                    "raw": 80560251,
+                    "fmt": "80.56M",
+                    "longFmt": "80,560,251"
+                  },
+                  "accountsPayable": {
+                    "raw": 5642383,
+                    "fmt": "5.64M",
+                    "longFmt": "5,642,383"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 639513,
+                    "fmt": "639.51k",
+                    "longFmt": "639,513"
+                  },
+                  "longTermDebt": {
+                    "raw": 4279631,
+                    "fmt": "4.28M",
+                    "longFmt": "4,279,631"
+                  },
+                  "otherLiab": {
+                    "raw": 1129115,
+                    "fmt": "1.13M",
+                    "longFmt": "1,129,115"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 6281896,
+                    "fmt": "6.28M",
+                    "longFmt": "6,281,896"
+                  },
+                  "totalLiab": {
+                    "raw": 11690642,
+                    "fmt": "11.69M",
+                    "longFmt": "11,690,642"
+                  },
+                  "commonStock": {
+                    "raw": 66629721,
+                    "fmt": "66.63M",
+                    "longFmt": "66,629,721"
+                  },
+                  "retainedEarnings": {
+                    "raw": -2969508,
+                    "fmt": "-2.97M",
+                    "longFmt": "-2,969,508"
+                  },
+                  "treasuryStock": {
+                    "raw": 5209397,
+                    "fmt": "5.21M",
+                    "longFmt": "5,209,397"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 5209397,
+                    "fmt": "5.21M",
+                    "longFmt": "5,209,397"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 68869610,
+                    "fmt": "68.87M",
+                    "longFmt": "68,869,610"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 58504243,
+                    "fmt": "58.5M",
+                    "longFmt": "58,504,243"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "cash": {
+                    "raw": 3464000,
+                    "fmt": "3.46M",
+                    "longFmt": "3,464,000"
+                  },
+                  "netReceivables": {
+                    "raw": 416000,
+                    "fmt": "416k",
+                    "longFmt": "416,000"
+                  },
+                  "inventory": {
+                    "raw": 3703000,
+                    "fmt": "3.7M",
+                    "longFmt": "3,703,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 8086000,
+                    "fmt": "8.09M",
+                    "longFmt": "8,086,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 7693000,
+                    "fmt": "7.69M",
+                    "longFmt": "7,693,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 14122000,
+                    "fmt": "14.12M",
+                    "longFmt": "14,122,000"
+                  },
+                  "goodWill": {
+                    "raw": 1792000,
+                    "fmt": "1.79M",
+                    "longFmt": "1,792,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 11207000,
+                    "fmt": "11.21M",
+                    "longFmt": "11,207,000"
+                  },
+                  "totalAssets": {
+                    "raw": 42900000,
+                    "fmt": "42.9M",
+                    "longFmt": "42,900,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 586000,
+                    "fmt": "586k",
+                    "longFmt": "586,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 3180000,
+                    "fmt": "3.18M",
+                    "longFmt": "3,180,000"
+                  },
+                  "otherLiab": {
+                    "raw": 1457000,
+                    "fmt": "1.46M",
+                    "longFmt": "1,457,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 7766000,
+                    "fmt": "7.77M",
+                    "longFmt": "7,766,000"
+                  },
+                  "totalLiab": {
+                    "raw": 9223000,
+                    "fmt": "9.22M",
+                    "longFmt": "9,223,000"
+                  },
+                  "commonStock": {
+                    "raw": 33590000,
+                    "fmt": "33.59M",
+                    "longFmt": "33,590,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -6215000,
+                    "fmt": "-6.21M",
+                    "longFmt": "-6,215,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 6302000,
+                    "fmt": "6.3M",
+                    "longFmt": "6,302,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 6302000,
+                    "fmt": "6.3M",
+                    "longFmt": "6,302,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 33677000,
+                    "fmt": "33.68M",
+                    "longFmt": "33,677,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 20678000,
+                    "fmt": "20.68M",
+                    "longFmt": "20,678,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "secFilings": {
+              "filings": [
+                {
+                  "date": "2020-11-05",
+                  "epochDate": 1604579840,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001656472-20-000093&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-11-05",
+                  "epochDate": 1604579641,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001656472-20-000092&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-09-09",
+                  "epochDate": 1599656772,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001656472-20-000079&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-08-06",
+                  "epochDate": 1596717503,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001656472-20-000073&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-08-06",
+                  "epochDate": 1596717231,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001656472-20-000072&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-07-20",
+                  "epochDate": 1595250075,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001656472-20-000065&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-07-09",
+                  "epochDate": 1594330444,
+                  "type": "8-K",
+                  "title": "Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001656472-20-000063&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-06-25",
+                  "epochDate": 1593123828,
+                  "type": "8-K",
+                  "title": "Submission of Matters to a Vote of Security Holders, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001656472-20-000058&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-08",
+                  "epochDate": 1588937995,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001656472-20-000052&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-08",
+                  "epochDate": 1588937574,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and Exhibit",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001171843-20-003537&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-03-30",
+                  "epochDate": 1585599740,
+                  "type": "10-K/A",
+                  "title": "Annual Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001656472-20-000033&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-03-30",
+                  "epochDate": 1585598973,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Regulation FD Disclosure, Financ",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001656472-20-000031&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-03-17",
+                  "epochDate": 1584479569,
+                  "type": "8-K",
+                  "title": "Disclosing Change in Directors or Principal Officers",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001656472-20-000019&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-01-22",
+                  "epochDate": 1579728712,
+                  "type": "8-K",
+                  "title": "Disclosing Change in Directors or Principal Officers",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001656472-20-000005&nav=1&src=Yahoo",
+                  "maxAge": 1
+                }
+              ],
+              "maxAge": 86400
+            },
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Chescapmanager LLC",
+                  "pctHeld": {
+                    "raw": 0.024600001,
+                    "fmt": "2.46%"
+                  },
+                  "position": {
+                    "raw": 8873890,
+                    "fmt": "8.87M",
+                    "longFmt": "8,873,890"
+                  },
+                  "value": {
+                    "raw": 44458188,
+                    "fmt": "44.46M",
+                    "longFmt": "44,458,188"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "ETF Managers Group, LLC",
+                  "pctHeld": {
+                    "raw": 0.020299999,
+                    "fmt": "2.03%"
+                  },
+                  "position": {
+                    "raw": 7321147,
+                    "fmt": "7.32M",
+                    "longFmt": "7,321,147"
+                  },
+                  "value": {
+                    "raw": 36678946,
+                    "fmt": "36.68M",
+                    "longFmt": "36,678,946"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Group, Inc. (The)",
+                  "pctHeld": {
+                    "raw": 0.0146,
+                    "fmt": "1.46%"
+                  },
+                  "position": {
+                    "raw": 5272821,
+                    "fmt": "5.27M",
+                    "longFmt": "5,272,821"
+                  },
+                  "value": {
+                    "raw": 26416833,
+                    "fmt": "26.42M",
+                    "longFmt": "26,416,833"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Susquehanna International Group, LLP",
+                  "pctHeld": {
+                    "raw": 0.008,
+                    "fmt": "0.80%"
+                  },
+                  "position": {
+                    "raw": 2894379,
+                    "fmt": "2.89M",
+                    "longFmt": "2,894,379"
+                  },
+                  "value": {
+                    "raw": 14500838,
+                    "fmt": "14.5M",
+                    "longFmt": "14,500,838"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Connor Clark & Lunn Investment Management Ltd",
+                  "pctHeld": {
+                    "raw": 0.0029,
+                    "fmt": "0.29%"
+                  },
+                  "position": {
+                    "raw": 1040800,
+                    "fmt": "1.04M",
+                    "longFmt": "1,040,800"
+                  },
+                  "value": {
+                    "raw": 5214408,
+                    "fmt": "5.21M",
+                    "longFmt": "5,214,408"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Citadel Advisors LLC",
+                  "pctHeld": {
+                    "raw": 0.0023,
+                    "fmt": "0.23%"
+                  },
+                  "position": {
+                    "raw": 833915,
+                    "fmt": "833.91k",
+                    "longFmt": "833,915"
+                  },
+                  "value": {
+                    "raw": 4177914,
+                    "fmt": "4.18M",
+                    "longFmt": "4,177,914"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "TD Asset Management, Inc",
+                  "pctHeld": {
+                    "raw": 0.0021,
+                    "fmt": "0.21%"
+                  },
+                  "position": {
+                    "raw": 771934,
+                    "fmt": "771.93k",
+                    "longFmt": "771,934"
+                  },
+                  "value": {
+                    "raw": 3867389,
+                    "fmt": "3.87M",
+                    "longFmt": "3,867,389"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Shaw D.E. & Co., Inc.",
+                  "pctHeld": {
+                    "raw": 0.0021,
+                    "fmt": "0.21%"
+                  },
+                  "position": {
+                    "raw": 766059,
+                    "fmt": "766.06k",
+                    "longFmt": "766,059"
+                  },
+                  "value": {
+                    "raw": 3837955,
+                    "fmt": "3.84M",
+                    "longFmt": "3,837,955"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Man Group PLC",
+                  "pctHeld": {
+                    "raw": 0.002,
+                    "fmt": "0.20%"
+                  },
+                  "position": {
+                    "raw": 718830,
+                    "fmt": "718.83k",
+                    "longFmt": "718,830"
+                  },
+                  "value": {
+                    "raw": 3601338,
+                    "fmt": "3.6M",
+                    "longFmt": "3,601,338"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Bank of Montreal/Can/",
+                  "pctHeld": {
+                    "raw": 0.0017,
+                    "fmt": "0.17%"
+                  },
+                  "position": {
+                    "raw": 627351,
+                    "fmt": "627.35k",
+                    "longFmt": "627,351"
+                  },
+                  "value": {
+                    "raw": 3143028,
+                    "fmt": "3.14M",
+                    "longFmt": "3,143,028"
+                  }
+                }
+              ]
+            },
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.49218,
+              "institutionsPercentHeld": 0.14603,
+              "institutionsFloatPercentHeld": 0.28756002,
+              "institutionsCount": 320
+            },
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 1097846000,
+                    "fmt": "1.1B",
+                    "longFmt": "1,097,846,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 202883000,
+                    "fmt": "202.88M",
+                    "longFmt": "202,883,000"
+                  },
+                  "netReceivables": {
+                    "raw": 24268000,
+                    "fmt": "24.27M",
+                    "longFmt": "24,268,000"
+                  },
+                  "inventory": {
+                    "raw": 56359000,
+                    "fmt": "56.36M",
+                    "longFmt": "56,359,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 2066000,
+                    "fmt": "2.07M",
+                    "longFmt": "2,066,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 1393954000,
+                    "fmt": "1.39B",
+                    "longFmt": "1,393,954,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 19059000,
+                    "fmt": "19.06M",
+                    "longFmt": "19,059,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 181244000,
+                    "fmt": "181.24M",
+                    "longFmt": "181,244,000"
+                  },
+                  "goodWill": {
+                    "raw": 179459000,
+                    "fmt": "179.46M",
+                    "longFmt": "179,459,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 68604000,
+                    "fmt": "68.6M",
+                    "longFmt": "68,604,000"
+                  },
+                  "otherAssets": {
+                    "raw": 76609000,
+                    "fmt": "76.61M",
+                    "longFmt": "76,609,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1918929000,
+                    "fmt": "1.92B",
+                    "longFmt": "1,918,929,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 39012000,
+                    "fmt": "39.01M",
+                    "longFmt": "39,012,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 102655000,
+                    "fmt": "102.66M",
+                    "longFmt": "102,655,000"
+                  },
+                  "otherLiab": {
+                    "raw": 2889000,
+                    "fmt": "2.89M",
+                    "longFmt": "2,889,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -2503000,
+                    "fmt": "-2.5M",
+                    "longFmt": "-2,503,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 142941000,
+                    "fmt": "142.94M",
+                    "longFmt": "142,941,000"
+                  },
+                  "totalLiab": {
+                    "raw": 154442000,
+                    "fmt": "154.44M",
+                    "longFmt": "154,442,000"
+                  },
+                  "commonStock": {
+                    "raw": 566577000,
+                    "fmt": "566.58M",
+                    "longFmt": "566,577,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 1175742000,
+                    "fmt": "1.18B",
+                    "longFmt": "1,175,742,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -7820000,
+                    "fmt": "-7.82M",
+                    "longFmt": "-7,820,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 32491000,
+                    "fmt": "32.49M",
+                    "longFmt": "32,491,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -7820000,
+                    "fmt": "-7.82M",
+                    "longFmt": "-7,820,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1766990000,
+                    "fmt": "1.77B",
+                    "longFmt": "1,766,990,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 1518927000,
+                    "fmt": "1.52B",
+                    "longFmt": "1,518,927,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "cash": {
+                    "raw": 1109700000,
+                    "fmt": "1.11B",
+                    "longFmt": "1,109,700,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 213614000,
+                    "fmt": "213.61M",
+                    "longFmt": "213,614,000"
+                  },
+                  "netReceivables": {
+                    "raw": 17503000,
+                    "fmt": "17.5M",
+                    "longFmt": "17,503,000"
+                  },
+                  "inventory": {
+                    "raw": 53216000,
+                    "fmt": "53.22M",
+                    "longFmt": "53,216,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 1401860000,
+                    "fmt": "1.4B",
+                    "longFmt": "1,401,860,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 933000,
+                    "fmt": "933k",
+                    "longFmt": "933,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 174390000,
+                    "fmt": "174.39M",
+                    "longFmt": "174,390,000"
+                  },
+                  "goodWill": {
+                    "raw": 179736000,
+                    "fmt": "179.74M",
+                    "longFmt": "179,736,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 69399000,
+                    "fmt": "69.4M",
+                    "longFmt": "69,399,000"
+                  },
+                  "otherAssets": {
+                    "raw": 83969000,
+                    "fmt": "83.97M",
+                    "longFmt": "83,969,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1910287000,
+                    "fmt": "1.91B",
+                    "longFmt": "1,910,287,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 28316000,
+                    "fmt": "28.32M",
+                    "longFmt": "28,316,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 205714000,
+                    "fmt": "205.71M",
+                    "longFmt": "205,714,000"
+                  },
+                  "otherLiab": {
+                    "raw": 3048000,
+                    "fmt": "3.05M",
+                    "longFmt": "3,048,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -1951000,
+                    "fmt": "-1.95M",
+                    "longFmt": "-1,951,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 235236000,
+                    "fmt": "235.24M",
+                    "longFmt": "235,236,000"
+                  },
+                  "totalLiab": {
+                    "raw": 247242000,
+                    "fmt": "247.24M",
+                    "longFmt": "247,242,000"
+                  },
+                  "commonStock": {
+                    "raw": 565211000,
+                    "fmt": "565.21M",
+                    "longFmt": "565,211,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 1106709000,
+                    "fmt": "1.11B",
+                    "longFmt": "1,106,709,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -33970000,
+                    "fmt": "-33.97M",
+                    "longFmt": "-33,970,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 27046000,
+                    "fmt": "27.05M",
+                    "longFmt": "27,046,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -33970000,
+                    "fmt": "-33.97M",
+                    "longFmt": "-33,970,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1664996000,
+                    "fmt": "1.66B",
+                    "longFmt": "1,664,996,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 1415861000,
+                    "fmt": "1.42B",
+                    "longFmt": "1,415,861,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "cash": {
+                    "raw": 1128396000,
+                    "fmt": "1.13B",
+                    "longFmt": "1,128,396,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 206230000,
+                    "fmt": "206.23M",
+                    "longFmt": "206,230,000"
+                  },
+                  "netReceivables": {
+                    "raw": 14957000,
+                    "fmt": "14.96M",
+                    "longFmt": "14,957,000"
+                  },
+                  "inventory": {
+                    "raw": 43118000,
+                    "fmt": "43.12M",
+                    "longFmt": "43,118,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 1403780000,
+                    "fmt": "1.4B",
+                    "longFmt": "1,403,780,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 1089000,
+                    "fmt": "1.09M",
+                    "longFmt": "1,089,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 164543000,
+                    "fmt": "164.54M",
+                    "longFmt": "164,543,000"
+                  },
+                  "goodWill": {
+                    "raw": 214689000,
+                    "fmt": "214.69M",
+                    "longFmt": "214,689,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 72599000,
+                    "fmt": "72.6M",
+                    "longFmt": "72,599,000"
+                  },
+                  "otherAssets": {
+                    "raw": 71226000,
+                    "fmt": "71.23M",
+                    "longFmt": "71,226,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1927926000,
+                    "fmt": "1.93B",
+                    "longFmt": "1,927,926,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 34290000,
+                    "fmt": "34.29M",
+                    "longFmt": "34,290,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 166176000,
+                    "fmt": "166.18M",
+                    "longFmt": "166,176,000"
+                  },
+                  "otherLiab": {
+                    "raw": 1681000,
+                    "fmt": "1.68M",
+                    "longFmt": "1,681,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -1189000,
+                    "fmt": "-1.19M",
+                    "longFmt": "-1,189,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 201523000,
+                    "fmt": "201.52M",
+                    "longFmt": "201,523,000"
+                  },
+                  "totalLiab": {
+                    "raw": 212658000,
+                    "fmt": "212.66M",
+                    "longFmt": "212,658,000"
+                  },
+                  "commonStock": {
+                    "raw": 563165000,
+                    "fmt": "563.16M",
+                    "longFmt": "563,165,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 1213686000,
+                    "fmt": "1.21B",
+                    "longFmt": "1,213,686,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -85877000,
+                    "fmt": "-85.88M",
+                    "longFmt": "-85,877,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 25483000,
+                    "fmt": "25.48M",
+                    "longFmt": "25,483,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -85877000,
+                    "fmt": "-85.88M",
+                    "longFmt": "-85,877,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1716457000,
+                    "fmt": "1.72B",
+                    "longFmt": "1,716,457,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 1429169000,
+                    "fmt": "1.43B",
+                    "longFmt": "1,429,169,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 1199693000,
+                    "fmt": "1.2B",
+                    "longFmt": "1,199,693,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 306347000,
+                    "fmt": "306.35M",
+                    "longFmt": "306,347,000"
+                  },
+                  "netReceivables": {
+                    "raw": 16534000,
+                    "fmt": "16.53M",
+                    "longFmt": "16,534,000"
+                  },
+                  "inventory": {
+                    "raw": 38043000,
+                    "fmt": "38.04M",
+                    "longFmt": "38,043,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 1570012000,
+                    "fmt": "1.57B",
+                    "longFmt": "1,570,012,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 557000,
+                    "fmt": "557k",
+                    "longFmt": "557,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 168355000,
+                    "fmt": "168.35M",
+                    "longFmt": "168,355,000"
+                  },
+                  "goodWill": {
+                    "raw": 214794000,
+                    "fmt": "214.79M",
+                    "longFmt": "214,794,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 72320000,
+                    "fmt": "72.32M",
+                    "longFmt": "72,320,000"
+                  },
+                  "otherAssets": {
+                    "raw": 64404000,
+                    "fmt": "64.4M",
+                    "longFmt": "64,404,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2090442000,
+                    "fmt": "2.09B",
+                    "longFmt": "2,090,442,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 9194000,
+                    "fmt": "9.19M",
+                    "longFmt": "9,194,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 323267000,
+                    "fmt": "323.27M",
+                    "longFmt": "323,267,000"
+                  },
+                  "otherLiab": {
+                    "raw": 1844000,
+                    "fmt": "1.84M",
+                    "longFmt": "1,844,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -853000,
+                    "fmt": "-853k",
+                    "longFmt": "-853,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 332888000,
+                    "fmt": "332.89M",
+                    "longFmt": "332,888,000"
+                  },
+                  "totalLiab": {
+                    "raw": 341412000,
+                    "fmt": "341.41M",
+                    "longFmt": "341,412,000"
+                  },
+                  "commonStock": {
+                    "raw": 561165000,
+                    "fmt": "561.16M",
+                    "longFmt": "561,165,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 1137646000,
+                    "fmt": "1.14B",
+                    "longFmt": "1,137,646,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 27838000,
+                    "fmt": "27.84M",
+                    "longFmt": "27,838,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 23234000,
+                    "fmt": "23.23M",
+                    "longFmt": "23,234,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 27838000,
+                    "fmt": "27.84M",
+                    "longFmt": "27,838,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1749883000,
+                    "fmt": "1.75B",
+                    "longFmt": "1,749,883,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 1462769000,
+                    "fmt": "1.46B",
+                    "longFmt": "1,462,769,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            },
+            "summaryProfile": {
+              "address1": "720 King Street West",
+              "address2": "Suite 320",
+              "city": "Toronto",
+              "state": "ON",
+              "zip": "M5V 2T3",
+              "country": "Canada",
+              "phone": "416-504-0004",
+              "website": "http://www.thecronosgroup.com",
+              "industry": "Drug Manufacturers—Specialty & Generic",
+              "sector": "Healthcare",
+              "longBusinessSummary": "Cronos Group Inc. operates as a cannabinoid company in the United States and internationally. It manufactures, markets, and distributes hemp-derived supplements and cosmetic products through ecommerce, retail, and hospitality partner channels. The company is also involved in the cultivation, manufacture, and marketing of cannabis and cannabis-derived products for the medical and adult-use markets. Its brand portfolio includes PEACE NATURALS, a global wellness platform; adult-use brands comprise COVE and Spinach; and hemp-derived CBD brands consists of Lord Jones and PEACE+. Cronos Group Inc. is based in Toronto, Canada.",
+              "fullTimeEmployees": 631,
+              "companyOfficers": [],
+              "maxAge": 86400
+            },
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 0,
+              "buyInfoShares": 0,
+              "sellInfoCount": 0,
+              "netInfoCount": 0,
+              "netInfoShares": 0,
+              "netPercentInsiderShares": 0,
+              "totalInsiderShares": 175085120
+            },
+            "insiderTransactions": {
+              "transactions": [
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 100000,
+                    "fmt": "100k",
+                    "longFmt": "100,000"
+                  },
+                  "value": {
+                    "raw": 733400,
+                    "fmt": "733.4k",
+                    "longFmt": "733,400"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Acquisition or disposition in the public market at price 7.33 per share.",
+                  "filerName": "Adler (Jason Marc)",
+                  "filerRelation": "Director of Issuer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605571200,
+                    "fmt": "2020-11-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 105151,
+                    "fmt": "105.15k",
+                    "longFmt": "105,151"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "Gorenstein (Michael Ryan)",
+                  "filerRelation": "Director of Issuer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605139200,
+                    "fmt": "2020-11-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4000000,
+                    "fmt": "4M",
+                    "longFmt": "4,000,000"
+                  },
+                  "value": {
+                    "raw": 744000,
+                    "fmt": "744k",
+                    "longFmt": "744,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Exercise of warrants at price 0.19 per share.",
+                  "filerName": "Gorenstein (Michael Ryan)",
+                  "filerRelation": "Director of Issuer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605139200,
+                    "fmt": "2020-11-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9300,
+                    "fmt": "9.3k",
+                    "longFmt": "9,300"
+                  },
+                  "value": {
+                    "raw": 67890,
+                    "fmt": "67.89k",
+                    "longFmt": "67,890"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Acquisition or disposition in the public market at price 7.30 per share.",
+                  "filerName": "Adler (Jason Marc)",
+                  "filerRelation": "Director of Issuer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605052800,
+                    "fmt": "2020-11-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 21361,
+                    "fmt": "21.36k",
+                    "longFmt": "21,361"
+                  },
+                  "value": {
+                    "raw": 155956,
+                    "fmt": "155.96k",
+                    "longFmt": "155,956"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Acquisition or disposition in the public market at price 7.30 per share.",
+                  "filerName": "Adler (Jason Marc)",
+                  "filerRelation": "Director of Issuer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604966400,
+                    "fmt": "2020-11-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 769339,
+                    "fmt": "769.34k",
+                    "longFmt": "769,339"
+                  },
+                  "value": {
+                    "raw": 5946221,
+                    "fmt": "5.95M",
+                    "longFmt": "5,946,221"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Acquisition or disposition in the public market at price 7.73 per share.",
+                  "filerName": "Adler (Jason Marc)",
+                  "filerRelation": "Director of Issuer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604880000,
+                    "fmt": "2020-11-09"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 100000,
+                    "fmt": "100k",
+                    "longFmt": "100,000"
+                  },
+                  "value": {
+                    "raw": 760200,
+                    "fmt": "760.2k",
+                    "longFmt": "760,200"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Acquisition or disposition in the public market at price 7.60 per share.",
+                  "filerName": "Adler (Jason Marc)",
+                  "filerRelation": "Director of Issuer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604620800,
+                    "fmt": "2020-11-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1289350,
+                    "fmt": "1.29M",
+                    "longFmt": "1,289,350"
+                  },
+                  "value": {
+                    "raw": 9315553,
+                    "fmt": "9.32M",
+                    "longFmt": "9,315,553"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Acquisition or disposition in the public market at price 7.22 per share.",
+                  "filerName": "Gorenstein (Michael Ryan)",
+                  "filerRelation": "Director of Issuer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604620800,
+                    "fmt": "2020-11-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 645555,
+                    "fmt": "645.55k",
+                    "longFmt": "645,555"
+                  },
+                  "value": {
+                    "raw": 151705,
+                    "fmt": "151.71k",
+                    "longFmt": "151,705"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Exercise of warrants at price 0.23 per share.",
+                  "filerName": "Gorenstein (Michael Ryan)",
+                  "filerRelation": "Director of Issuer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1600128000,
+                    "fmt": "2020-09-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 28108,
+                    "fmt": "28.11k",
+                    "longFmt": "28,108"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "Gorenstein (Michael Ryan)",
+                  "filerRelation": "Director of Issuer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1600128000,
+                    "fmt": "2020-09-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2500,
+                    "fmt": "2.5k",
+                    "longFmt": "2,500"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "Jacobson (Jeffrey David)",
+                  "filerRelation": "Senior Officer of Issuer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597363200,
+                    "fmt": "2020-08-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15000,
+                    "fmt": "15k",
+                    "longFmt": "15,000"
+                  },
+                  "value": {
+                    "raw": 64830,
+                    "fmt": "64.83k",
+                    "longFmt": "64,830"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Acquisition or disposition in the public market at price 4.32 per share.",
+                  "filerName": "Abraham (Todd Kevin Ph.D.)",
+                  "filerRelation": "Senior Officer of Issuer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596758400,
+                    "fmt": "2020-08-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "Shlimak (Anna)",
+                  "filerRelation": "Senior Officer of Issuer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582243200,
+                    "fmt": "2020-02-21"
+                  },
+                  "ownership": "D"
+                }
+              ],
+              "maxAge": 1
+            },
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 11358000,
+                    "fmt": "11.36M",
+                    "longFmt": "11,358,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 12895000,
+                    "fmt": "12.89M",
+                    "longFmt": "12,895,000"
+                  },
+                  "grossProfit": {
+                    "raw": -1537000,
+                    "fmt": "-1.54M",
+                    "longFmt": "-1,537,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 4734000,
+                    "fmt": "4.73M",
+                    "longFmt": "4,734,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 26096000,
+                    "fmt": "26.1M",
+                    "longFmt": "26,096,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 52527000,
+                    "fmt": "52.53M",
+                    "longFmt": "52,527,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -41169000,
+                    "fmt": "-41.17M",
+                    "longFmt": "-41,169,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 111094000,
+                    "fmt": "111.09M",
+                    "longFmt": "111,094,000"
+                  },
+                  "ebit": {
+                    "raw": -41169000,
+                    "fmt": "-41.17M",
+                    "longFmt": "-41,169,000"
+                  },
+                  "interestExpense": {
+                    "raw": -66000,
+                    "fmt": "-66k",
+                    "longFmt": "-66,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 69925000,
+                    "fmt": "69.92M",
+                    "longFmt": "69,925,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 988000,
+                    "fmt": "988k",
+                    "longFmt": "988,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -2503000,
+                    "fmt": "-2.5M",
+                    "longFmt": "-2,503,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 68937000,
+                    "fmt": "68.94M",
+                    "longFmt": "68,937,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -473000,
+                    "fmt": "-473k",
+                    "longFmt": "-473,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 69033000,
+                    "fmt": "69.03M",
+                    "longFmt": "69,033,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 69033000,
+                    "fmt": "69.03M",
+                    "longFmt": "69,033,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 9883000,
+                    "fmt": "9.88M",
+                    "longFmt": "9,883,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 12836000,
+                    "fmt": "12.84M",
+                    "longFmt": "12,836,000"
+                  },
+                  "grossProfit": {
+                    "raw": -2953000,
+                    "fmt": "-2.95M",
+                    "longFmt": "-2,953,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 3631000,
+                    "fmt": "3.63M",
+                    "longFmt": "3,631,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 24941000,
+                    "fmt": "24.94M",
+                    "longFmt": "24,941,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 44638000,
+                    "fmt": "44.64M",
+                    "longFmt": "44,638,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -34755000,
+                    "fmt": "-34.76M",
+                    "longFmt": "-34,755,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -72948000,
+                    "fmt": "-72.95M",
+                    "longFmt": "-72,948,000"
+                  },
+                  "ebit": {
+                    "raw": -34755000,
+                    "fmt": "-34.76M",
+                    "longFmt": "-34,755,000"
+                  },
+                  "interestExpense": {
+                    "raw": -83000,
+                    "fmt": "-83k",
+                    "longFmt": "-83,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -107703000,
+                    "fmt": "-107.7M",
+                    "longFmt": "-107,703,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "minorityInterest": {
+                    "raw": -1951000,
+                    "fmt": "-1.95M",
+                    "longFmt": "-1,951,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -107703000,
+                    "fmt": "-107.7M",
+                    "longFmt": "-107,703,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -473000,
+                    "fmt": "-473k",
+                    "longFmt": "-473,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -106977000,
+                    "fmt": "-106.98M",
+                    "longFmt": "-106,977,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -106977000,
+                    "fmt": "-106.98M",
+                    "longFmt": "-106,977,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 8432000,
+                    "fmt": "8.43M",
+                    "longFmt": "8,432,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 14908000,
+                    "fmt": "14.91M",
+                    "longFmt": "14,908,000"
+                  },
+                  "grossProfit": {
+                    "raw": -6476000,
+                    "fmt": "-6.48M",
+                    "longFmt": "-6,476,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 4590000,
+                    "fmt": "4.59M",
+                    "longFmt": "4,590,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 30871000,
+                    "fmt": "30.87M",
+                    "longFmt": "30,871,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 53492000,
+                    "fmt": "53.49M",
+                    "longFmt": "53,492,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -45060000,
+                    "fmt": "-45.06M",
+                    "longFmt": "-45,060,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 120741000,
+                    "fmt": "120.74M",
+                    "longFmt": "120,741,000"
+                  },
+                  "ebit": {
+                    "raw": -45060000,
+                    "fmt": "-45.06M",
+                    "longFmt": "-45,060,000"
+                  },
+                  "interestExpense": {
+                    "raw": -83000,
+                    "fmt": "-83k",
+                    "longFmt": "-83,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 75681000,
+                    "fmt": "75.68M",
+                    "longFmt": "75,681,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "minorityInterest": {
+                    "raw": -1189000,
+                    "fmt": "-1.19M",
+                    "longFmt": "-1,189,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 75681000,
+                    "fmt": "75.68M",
+                    "longFmt": "75,681,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -473000,
+                    "fmt": "-473k",
+                    "longFmt": "-473,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 76040000,
+                    "fmt": "76.04M",
+                    "longFmt": "76,040,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 76040000,
+                    "fmt": "76.04M",
+                    "longFmt": "76,040,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 6889242,
+                    "fmt": "6.89M",
+                    "longFmt": "6,889,242"
+                  },
+                  "costOfRevenue": {
+                    "raw": 21429996,
+                    "fmt": "21.43M",
+                    "longFmt": "21,429,996"
+                  },
+                  "grossProfit": {
+                    "raw": -14540754,
+                    "fmt": "-14.54M",
+                    "longFmt": "-14,540,754"
+                  },
+                  "researchDevelopment": {
+                    "raw": 5931577,
+                    "fmt": "5.93M",
+                    "longFmt": "5,931,577"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 26950237,
+                    "fmt": "26.95M",
+                    "longFmt": "26,950,237"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 5328000,
+                    "fmt": "5.33M",
+                    "longFmt": "5,328,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 67406232,
+                    "fmt": "67.41M",
+                    "longFmt": "67,406,232"
+                  },
+                  "operatingIncome": {
+                    "raw": -60516991,
+                    "fmt": "-60.52M",
+                    "longFmt": "-60,516,991"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 97996076,
+                    "fmt": "98M",
+                    "longFmt": "97,996,076"
+                  },
+                  "ebit": {
+                    "raw": -60516991,
+                    "fmt": "-60.52M",
+                    "longFmt": "-60,516,991"
+                  },
+                  "interestExpense": {
+                    "raw": -1244000,
+                    "fmt": "-1.24M",
+                    "longFmt": "-1,244,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 37479086,
+                    "fmt": "37.48M",
+                    "longFmt": "37,479,086"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 1628329,
+                    "fmt": "1.63M",
+                    "longFmt": "1,628,329"
+                  },
+                  "minorityInterest": {
+                    "raw": -853000,
+                    "fmt": "-853k",
+                    "longFmt": "-853,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 35850757,
+                    "fmt": "35.85M",
+                    "longFmt": "35,850,757"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -473000,
+                    "fmt": "-473k",
+                    "longFmt": "-473,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 36276217,
+                    "fmt": "36.28M",
+                    "longFmt": "36,276,217"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 36276217,
+                    "fmt": "36.28M",
+                    "longFmt": "36,276,217"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 69033000,
+                    "fmt": "69.03M",
+                    "longFmt": "69,033,000"
+                  },
+                  "depreciation": {
+                    "raw": 2216000,
+                    "fmt": "2.22M",
+                    "longFmt": "2,216,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -100187000,
+                    "fmt": "-100.19M",
+                    "longFmt": "-100,187,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -2609000,
+                    "fmt": "-2.61M",
+                    "longFmt": "-2,609,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 10696000,
+                    "fmt": "10.7M",
+                    "longFmt": "10,696,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 5597000,
+                    "fmt": "5.6M",
+                    "longFmt": "5,597,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -12237000,
+                    "fmt": "-12.24M",
+                    "longFmt": "-12,237,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -27491000,
+                    "fmt": "-27.49M",
+                    "longFmt": "-27,491,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -7990000,
+                    "fmt": "-7.99M",
+                    "longFmt": "-7,990,000"
+                  },
+                  "investments": {
+                    "raw": 19368000,
+                    "fmt": "19.37M",
+                    "longFmt": "19,368,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -1988000,
+                    "fmt": "-1.99M",
+                    "longFmt": "-1,988,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -862000,
+                    "fmt": "-862k",
+                    "longFmt": "-862,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -3006000,
+                    "fmt": "-3.01M",
+                    "longFmt": "-3,006,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 20631000,
+                    "fmt": "20.63M",
+                    "longFmt": "20,631,000"
+                  },
+                  "changeInCash": {
+                    "raw": -11854000,
+                    "fmt": "-11.85M",
+                    "longFmt": "-11,854,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -2148000,
+                    "fmt": "-2.15M",
+                    "longFmt": "-2,148,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 4000,
+                    "fmt": "4k",
+                    "longFmt": "4,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "netIncome": {
+                    "raw": -106977000,
+                    "fmt": "-106.98M",
+                    "longFmt": "-106,977,000"
+                  },
+                  "depreciation": {
+                    "raw": 1717000,
+                    "fmt": "1.72M",
+                    "longFmt": "1,717,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 82053000,
+                    "fmt": "82.05M",
+                    "longFmt": "82,053,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -73000,
+                    "fmt": "-73k",
+                    "longFmt": "-73,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -5974000,
+                    "fmt": "-5.97M",
+                    "longFmt": "-5,974,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -12643000,
+                    "fmt": "-12.64M",
+                    "longFmt": "-12,643,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 3602000,
+                    "fmt": "3.6M",
+                    "longFmt": "3,602,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -38295000,
+                    "fmt": "-38.3M",
+                    "longFmt": "-38,295,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -6933000,
+                    "fmt": "-6.93M",
+                    "longFmt": "-6,933,000"
+                  },
+                  "investments": {
+                    "raw": -1243000,
+                    "fmt": "-1.24M",
+                    "longFmt": "-1,243,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -19287000,
+                    "fmt": "-19.29M",
+                    "longFmt": "-19,287,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -736000,
+                    "fmt": "-736k",
+                    "longFmt": "-736,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -735000,
+                    "fmt": "-735k",
+                    "longFmt": "-735,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 39621000,
+                    "fmt": "39.62M",
+                    "longFmt": "39,621,000"
+                  },
+                  "changeInCash": {
+                    "raw": -18696000,
+                    "fmt": "-18.7M",
+                    "longFmt": "-18,696,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -2148000,
+                    "fmt": "-2.15M",
+                    "longFmt": "-2,148,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 1000,
+                    "fmt": "1k",
+                    "longFmt": "1,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "netIncome": {
+                    "raw": 76040000,
+                    "fmt": "76.04M",
+                    "longFmt": "76,040,000"
+                  },
+                  "depreciation": {
+                    "raw": 1162000,
+                    "fmt": "1.16M",
+                    "longFmt": "1,162,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -100618000,
+                    "fmt": "-100.62M",
+                    "longFmt": "-100,618,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 1234000,
+                    "fmt": "1.23M",
+                    "longFmt": "1,234,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -1011000,
+                    "fmt": "-1.01M",
+                    "longFmt": "-1,011,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -11270000,
+                    "fmt": "-11.27M",
+                    "longFmt": "-11,270,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -4435000,
+                    "fmt": "-4.43M",
+                    "longFmt": "-4,435,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -38898000,
+                    "fmt": "-38.9M",
+                    "longFmt": "-38,898,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -6411000,
+                    "fmt": "-6.41M",
+                    "longFmt": "-6,411,000"
+                  },
+                  "investments": {
+                    "raw": 81114000,
+                    "fmt": "81.11M",
+                    "longFmt": "81,114,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 59086000,
+                    "fmt": "59.09M",
+                    "longFmt": "59,086,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -448000,
+                    "fmt": "-448k",
+                    "longFmt": "-448,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -448000,
+                    "fmt": "-448k",
+                    "longFmt": "-448,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -91037000,
+                    "fmt": "-91.04M",
+                    "longFmt": "-91,037,000"
+                  },
+                  "changeInCash": {
+                    "raw": -71297000,
+                    "fmt": "-71.3M",
+                    "longFmt": "-71,297,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -2148000,
+                    "fmt": "-2.15M",
+                    "longFmt": "-2,148,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 1000,
+                    "fmt": "1k",
+                    "longFmt": "1,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 36276217,
+                    "fmt": "36.28M",
+                    "longFmt": "36,276,217"
+                  },
+                  "depreciation": {
+                    "raw": 2455831,
+                    "fmt": "2.46M",
+                    "longFmt": "2,455,831"
+                  },
+                  "changeToNetincome": {
+                    "raw": -61557165,
+                    "fmt": "-61.56M",
+                    "longFmt": "-61,557,165"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -722046,
+                    "fmt": "-722.05k",
+                    "longFmt": "-722,046"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -14758564,
+                    "fmt": "-14.76M",
+                    "longFmt": "-14,758,564"
+                  },
+                  "changeToInventory": {
+                    "raw": -17220480,
+                    "fmt": "-17.22M",
+                    "longFmt": "-17,220,480"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 4606487,
+                    "fmt": "4.61M",
+                    "longFmt": "4,606,487"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -51044620,
+                    "fmt": "-51.04M",
+                    "longFmt": "-51,044,620"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -150015,
+                    "fmt": "-150.01k",
+                    "longFmt": "-150,015"
+                  },
+                  "investments": {
+                    "raw": 99483948,
+                    "fmt": "99.48M",
+                    "longFmt": "99,483,948"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -89000,
+                    "fmt": "-89k",
+                    "longFmt": "-89,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 95005561,
+                    "fmt": "95.01M",
+                    "longFmt": "95,005,561"
+                  },
+                  "netBorrowings": {
+                    "raw": 185553,
+                    "fmt": "185.55k",
+                    "longFmt": "185,553"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 231632,
+                    "fmt": "231.63k",
+                    "longFmt": "231,632"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -32356751,
+                    "fmt": "-32.36M",
+                    "longFmt": "-32,356,751"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 51759606,
+                    "fmt": "51.76M",
+                    "longFmt": "51,759,606"
+                  },
+                  "changeInCash": {
+                    "raw": 63363796,
+                    "fmt": "63.36M",
+                    "longFmt": "63,363,796"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -32773936,
+                    "fmt": "-32.77M",
+                    "longFmt": "-32,773,936"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 1000,
+                    "fmt": "1k",
+                    "longFmt": "1,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 12.1551,
+              "recommendationKey": "none",
+              "totalCash": 1300728960,
+              "totalCashPerShare": 3.656,
+              "ebitda": -176930000,
+              "totalDebt": 9886000,
+              "quickRatio": 9.215,
+              "currentRatio": 9.752,
+              "totalRevenue": 36981000,
+              "debtToEquity": 0.56,
+              "revenuePerShare": 0.106,
+              "returnOnAssets": -0.057150003,
+              "returnOnEquity": 0.05816,
+              "grossProfits": -15964000,
+              "freeCashflow": -456162432,
+              "operatingCashflow": -157898000,
+              "earningsGrowth": -0.886,
+              "revenueGrowth": 0.963,
+              "grossMargins": -0.79527,
+              "ebitdaMargins": 0,
+              "operatingMargins": -4.948,
+              "profitMargins": 2.70682,
+              "financialCurrency": "USD"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-all-EPAC.json
+++ b/tests/http/quoteSummary-all-EPAC.json
@@ -1,0 +1,8007 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=assetProfile%2CbalanceSheetHistory%2CbalanceSheetHistoryQuarterly%2CcalendarEvents%2CcashflowStatementHistory%2CcashflowStatementHistoryQuarterly%2CdefaultKeyStatistics%2Cearnings%2CearningsHistory%2CearningsTrend%2CfinancialData%2CfundOwnership%2CfundPerformance%2CfundProfile%2CincomeStatementHistory%2CincomeStatementHistoryQuarterly%2CindexTrend%2CindustryTrend%2CinsiderHolders%2CinsiderTransactions%2CinstitutionOwnership%2CmajorDirectHolders%2CmajorHoldersBreakdown%2CnetSharePurchaseActivity%2Cprice%2CquoteType%2CrecommendationTrend%2CsecFilings%2CsectorTrend%2CsummaryDetail%2CsummaryProfile%2CtopHoldings%2CupgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "50u4ttdg2vsf3"
+      ],
+      "x-yahoo-request-id": [
+        "50u4ttdg2vsf3"
+      ],
+      "x-request-id": [
+        "c7851f05-a2c2-43fa-a078-eb342b766305"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "10"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:10 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "N86 W12500 Westbrook Crossing",
+              "city": "Menomonee Falls",
+              "state": "WI",
+              "zip": "53051",
+              "country": "United States",
+              "phone": "262 293 1500",
+              "website": "http://www.enerpactoolgroup.com",
+              "industry": "Specialty Industrial Machinery",
+              "sector": "Industrials",
+              "longBusinessSummary": "Enerpac Tool Group Corp. manufactures and sells a range of industrial products and solutions worldwide. It operates in two segments, Industrial Tools & Services (IT&S) and Other. The IT&S segment designs, manufactures, and distributes branded hydraulic and mechanical tools; and provides services and tool rentals to the industrial, maintenance, infrastructure, oil and gas, energy, and other markets. It also offers branded tools and engineered heavy lifting technology solutions, and hydraulic torque wrenches; energy maintenance and manpower services; high-force hydraulic and mechanical tools, including cylinders, pumps, valves, and specialty tools; and bolt tensioners and other miscellaneous products. This segment markets its branded tools and services primarily under the Enerpac, Hydratight, Larzep, and Simplex brands. The Other segment designs and manufactures synthetic ropes and biomedical assemblies. The company was formerly known as Actuant Corporation and changed its name to Enerpac Tool Group Corp. in January 2020. Enerpac Tool Group Corp. was founded in 1910 and is headquartered in Menomonee Falls, Wisconsin.",
+              "fullTimeEmployees": 2300,
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Randal Wayne Baker",
+                  "age": 57,
+                  "title": "Pres, CEO & Director",
+                  "yearBorn": 1963,
+                  "fiscalYear": 2020,
+                  "totalPay": {
+                    "raw": 908956,
+                    "fmt": "908.96k",
+                    "longFmt": "908,956"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Ricky T. Dillon",
+                  "age": 49,
+                  "title": "Exec. VP & CFO",
+                  "yearBorn": 1971,
+                  "fiscalYear": 2020,
+                  "totalPay": {
+                    "raw": 545109,
+                    "fmt": "545.11k",
+                    "longFmt": "545,109"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. John Jeffrey Schmaling",
+                  "age": 61,
+                  "title": "Exec. VP & COO",
+                  "yearBorn": 1959,
+                  "fiscalYear": 2020,
+                  "totalPay": {
+                    "raw": 511032,
+                    "fmt": "511.03k",
+                    "longFmt": "511,032"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Fabrizio  Rasetti",
+                  "age": 54,
+                  "title": "Exec. VP, Gen. Counsel, Sec. & Global HR",
+                  "yearBorn": 1966,
+                  "fiscalYear": 2020,
+                  "totalPay": {
+                    "raw": 445396,
+                    "fmt": "445.4k",
+                    "longFmt": "445,396"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Barbara G. Bolens",
+                  "age": 59,
+                  "title": "Exec. VP & Chief Strategy Officer",
+                  "yearBorn": 1961,
+                  "fiscalYear": 2020,
+                  "totalPay": {
+                    "raw": 360060,
+                    "fmt": "360.06k",
+                    "longFmt": "360,060"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Bryan R. Johnson",
+                  "age": 43,
+                  "title": "VP of Fin. & Principal Accounting Officer",
+                  "yearBorn": 1977,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Scot  Stein",
+                  "title": "Chief Information Officer",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Richard  Roman",
+                  "title": "Treasurer, VP of Tax & Assistant Sec.",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. George  Scherer",
+                  "title": "Exec. VP of B W Elliott",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Art  Donaldson",
+                  "title": "VP of Engineering - Industrial Segment",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "auditRisk": 2,
+              "boardRisk": 7,
+              "compensationRisk": 4,
+              "shareHolderRightsRisk": 6,
+              "overallRisk": 6,
+              "governanceEpochDate": 1606867200,
+              "compensationAsOfEpochDate": 1609372800,
+              "maxAge": 86400
+            },
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 5,
+                  "sell": 1,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 0,
+                  "buy": 1,
+                  "hold": 4,
+                  "sell": 1,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1598832000,
+                    "fmt": "2020-08-31"
+                  },
+                  "netIncome": {
+                    "raw": 723000,
+                    "fmt": "723k",
+                    "longFmt": "723,000"
+                  },
+                  "depreciation": {
+                    "raw": 20720000,
+                    "fmt": "20.72M",
+                    "longFmt": "20,720,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -15821000,
+                    "fmt": "-15.82M",
+                    "longFmt": "-15,821,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 44749000,
+                    "fmt": "44.75M",
+                    "longFmt": "44,749,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -32081000,
+                    "fmt": "-32.08M",
+                    "longFmt": "-32,081,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 8960000,
+                    "fmt": "8.96M",
+                    "longFmt": "8,960,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -25652000,
+                    "fmt": "-25.65M",
+                    "longFmt": "-25,652,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -3159000,
+                    "fmt": "-3.16M",
+                    "longFmt": "-3,159,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -12053000,
+                    "fmt": "-12.05M",
+                    "longFmt": "-12,053,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 210490000,
+                    "fmt": "210.49M",
+                    "longFmt": "210,490,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 176073000,
+                    "fmt": "176.07M",
+                    "longFmt": "176,073,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -2419000,
+                    "fmt": "-2.42M",
+                    "longFmt": "-2,419,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -207559000,
+                    "fmt": "-207.56M",
+                    "longFmt": "-207,559,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -234000,
+                    "fmt": "-234k",
+                    "longFmt": "-234,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -238926000,
+                    "fmt": "-238.93M",
+                    "longFmt": "-238,926,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 7031000,
+                    "fmt": "7.03M",
+                    "longFmt": "7,031,000"
+                  },
+                  "changeInCash": {
+                    "raw": -58981000,
+                    "fmt": "-58.98M",
+                    "longFmt": "-58,981,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -31806000,
+                    "fmt": "-31.81M",
+                    "longFmt": "-31,806,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 3092000,
+                    "fmt": "3.09M",
+                    "longFmt": "3,092,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1567209600,
+                    "fmt": "2019-08-31"
+                  },
+                  "netIncome": {
+                    "raw": -249145000,
+                    "fmt": "-249.15M",
+                    "longFmt": "-249,145,000"
+                  },
+                  "depreciation": {
+                    "raw": 20217000,
+                    "fmt": "20.22M",
+                    "longFmt": "20,217,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 306326000,
+                    "fmt": "306.33M",
+                    "longFmt": "306,326,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -4993000,
+                    "fmt": "-4.99M",
+                    "longFmt": "-4,993,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 6858000,
+                    "fmt": "6.86M",
+                    "longFmt": "6,858,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -7760000,
+                    "fmt": "-7.76M",
+                    "longFmt": "-7,760,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -17945000,
+                    "fmt": "-17.95M",
+                    "longFmt": "-17,945,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 53845000,
+                    "fmt": "53.84M",
+                    "longFmt": "53,845,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -14923000,
+                    "fmt": "-14.92M",
+                    "longFmt": "-14,923,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 24507000,
+                    "fmt": "24.51M",
+                    "longFmt": "24,507,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 11046000,
+                    "fmt": "11.05M",
+                    "longFmt": "11,046,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -2439000,
+                    "fmt": "-2.44M",
+                    "longFmt": "-2,439,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -72500000,
+                    "fmt": "-72.5M",
+                    "longFmt": "-72,500,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -2125000,
+                    "fmt": "-2.12M",
+                    "longFmt": "-2,125,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -99517000,
+                    "fmt": "-99.52M",
+                    "longFmt": "-99,517,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -4713000,
+                    "fmt": "-4.71M",
+                    "longFmt": "-4,713,000"
+                  },
+                  "changeInCash": {
+                    "raw": -39339000,
+                    "fmt": "-39.34M",
+                    "longFmt": "-39,339,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -24353000,
+                    "fmt": "-24.35M",
+                    "longFmt": "-24,353,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 1900000,
+                    "fmt": "1.9M",
+                    "longFmt": "1,900,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1535673600,
+                    "fmt": "2018-08-31"
+                  },
+                  "netIncome": {
+                    "raw": -21648000,
+                    "fmt": "-21.65M",
+                    "longFmt": "-21,648,000"
+                  },
+                  "depreciation": {
+                    "raw": 20405000,
+                    "fmt": "20.41M",
+                    "longFmt": "20,405,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 90162000,
+                    "fmt": "90.16M",
+                    "longFmt": "90,162,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -7462000,
+                    "fmt": "-7.46M",
+                    "longFmt": "-7,462,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -1872000,
+                    "fmt": "-1.87M",
+                    "longFmt": "-1,872,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -1142000,
+                    "fmt": "-1.14M",
+                    "longFmt": "-1,142,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 7897000,
+                    "fmt": "7.9M",
+                    "longFmt": "7,897,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 106093000,
+                    "fmt": "106.09M",
+                    "longFmt": "106,093,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -11021000,
+                    "fmt": "-11.02M",
+                    "longFmt": "-11,021,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -37518000,
+                    "fmt": "-37.52M",
+                    "longFmt": "-37,518,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -62751000,
+                    "fmt": "-62.75M",
+                    "longFmt": "-62,751,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -2390000,
+                    "fmt": "-2.39M",
+                    "longFmt": "-2,390,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -30000000,
+                    "fmt": "-30M",
+                    "longFmt": "-30,000,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -2125000,
+                    "fmt": "-2.12M",
+                    "longFmt": "-2,125,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -17993000,
+                    "fmt": "-17.99M",
+                    "longFmt": "-17,993,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -4430000,
+                    "fmt": "-4.43M",
+                    "longFmt": "-4,430,000"
+                  },
+                  "changeInCash": {
+                    "raw": 20919000,
+                    "fmt": "20.92M",
+                    "longFmt": "20,919,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -1284000,
+                    "fmt": "-1.28M",
+                    "longFmt": "-1,284,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 15681000,
+                    "fmt": "15.68M",
+                    "longFmt": "15,681,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1504137600,
+                    "fmt": "2017-08-31"
+                  },
+                  "netIncome": {
+                    "raw": -66213000,
+                    "fmt": "-66.21M",
+                    "longFmt": "-66,213,000"
+                  },
+                  "depreciation": {
+                    "raw": 22925000,
+                    "fmt": "22.93M",
+                    "longFmt": "22,925,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 126943000,
+                    "fmt": "126.94M",
+                    "longFmt": "126,943,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 11230000,
+                    "fmt": "11.23M",
+                    "longFmt": "11,230,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 3128000,
+                    "fmt": "3.13M",
+                    "longFmt": "3,128,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -4502000,
+                    "fmt": "-4.5M",
+                    "longFmt": "-4,502,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -1584000,
+                    "fmt": "-1.58M",
+                    "longFmt": "-1,584,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 88499000,
+                    "fmt": "88.5M",
+                    "longFmt": "88,499,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -17238000,
+                    "fmt": "-17.24M",
+                    "longFmt": "-17,238,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -10835000,
+                    "fmt": "-10.84M",
+                    "longFmt": "-10,835,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -27625000,
+                    "fmt": "-27.62M",
+                    "longFmt": "-27,625,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -2358000,
+                    "fmt": "-2.36M",
+                    "longFmt": "-2,358,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -19250000,
+                    "fmt": "-19.25M",
+                    "longFmt": "-19,250,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -742000,
+                    "fmt": "-742k",
+                    "longFmt": "-742,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -15150000,
+                    "fmt": "-15.15M",
+                    "longFmt": "-15,150,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 4243000,
+                    "fmt": "4.24M",
+                    "longFmt": "4,243,000"
+                  },
+                  "changeInCash": {
+                    "raw": 49967000,
+                    "fmt": "49.97M",
+                    "longFmt": "49,967,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -1065000,
+                    "fmt": "-1.06M",
+                    "longFmt": "-1,065,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 8265000,
+                    "fmt": "8.27M",
+                    "longFmt": "8,265,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 8.58013,
+              "pegRatio": 0.771291,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.286
+                },
+                {
+                  "period": "+1q",
+                  "growth": 1.032
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.175
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.15100001
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0827489
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            },
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": 1456103936,
+              "forwardPE": 30.657894,
+              "profitMargins": 0.0068699997,
+              "floatShares": 59256192,
+              "sharesOutstanding": 59871100,
+              "sharesShort": 1583647,
+              "sharesShortPriorMonth": 2103413,
+              "sharesShortPreviousMonthDate": 1609372800,
+              "dateShortInterest": 1611878400,
+              "sharesPercentSharesOut": 0.026500002,
+              "heldPercentInsiders": 0.00569,
+              "heldPercentInstitutions": 1.04787,
+              "shortRatio": 5.81,
+              "shortPercentOfFloat": 0.040799998,
+              "beta": 1.450373,
+              "category": null,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1598832000,
+              "nextFiscalYearEnd": 1661904000,
+              "mostRecentQuarter": 1606694400,
+              "earningsQuarterlyGrowth": 1.168,
+              "netIncomeToCommon": 4007000,
+              "pegRatio": 3.8,
+              "lastSplitFactor": "2:1",
+              "lastSplitDate": 1194566400,
+              "enterpriseToRevenue": 3.124,
+              "enterpriseToEbitda": 33.177,
+              "52WeekChange": -0.11032587,
+              "SandP52WeekChange": 0.17263722,
+              "lastDividendValue": 0.04,
+              "lastDividendDate": 1601510400
+            },
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "quoteType": {
+              "exchange": "NYQ",
+              "quoteType": "EQUITY",
+              "symbol": "EPAC",
+              "underlyingSymbol": "EPAC",
+              "shortName": "Enerpac Tool Group Corp.",
+              "longName": "Enerpac Tool Group Corp.",
+              "firstTradeDateEpochUtc": 964445400,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "2d82682e-c536-3e44-8626-b4fbe62d66ab",
+              "messageBoardId": "finmb_251258",
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            },
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1598832000,
+                    "fmt": "2020-08-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 493292000,
+                    "fmt": "493.29M",
+                    "longFmt": "493,292,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 275299000,
+                    "fmt": "275.3M",
+                    "longFmt": "275,299,000"
+                  },
+                  "grossProfit": {
+                    "raw": 217993000,
+                    "fmt": "217.99M",
+                    "longFmt": "217,993,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 181613000,
+                    "fmt": "181.61M",
+                    "longFmt": "181,613,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 465235000,
+                    "fmt": "465.24M",
+                    "longFmt": "465,235,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 28057000,
+                    "fmt": "28.06M",
+                    "longFmt": "28,057,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -20208000,
+                    "fmt": "-20.21M",
+                    "longFmt": "-20,208,000"
+                  },
+                  "ebit": {
+                    "raw": 28057000,
+                    "fmt": "28.06M",
+                    "longFmt": "28,057,000"
+                  },
+                  "interestExpense": {
+                    "raw": -18918000,
+                    "fmt": "-18.92M",
+                    "longFmt": "-18,918,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 7849000,
+                    "fmt": "7.85M",
+                    "longFmt": "7,849,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 2292000,
+                    "fmt": "2.29M",
+                    "longFmt": "2,292,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 5557000,
+                    "fmt": "5.56M",
+                    "longFmt": "5,557,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -4834000,
+                    "fmt": "-4.83M",
+                    "longFmt": "-4,834,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 723000,
+                    "fmt": "723k",
+                    "longFmt": "723,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 723000,
+                    "fmt": "723k",
+                    "longFmt": "723,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1567209600,
+                    "fmt": "2019-08-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 654758000,
+                    "fmt": "654.76M",
+                    "longFmt": "654,758,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 362106000,
+                    "fmt": "362.11M",
+                    "longFmt": "362,106,000"
+                  },
+                  "grossProfit": {
+                    "raw": 292652000,
+                    "fmt": "292.65M",
+                    "longFmt": "292,652,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 210631000,
+                    "fmt": "210.63M",
+                    "longFmt": "210,631,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 581659000,
+                    "fmt": "581.66M",
+                    "longFmt": "581,659,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 73099000,
+                    "fmt": "73.1M",
+                    "longFmt": "73,099,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -54375000,
+                    "fmt": "-54.38M",
+                    "longFmt": "-54,375,000"
+                  },
+                  "ebit": {
+                    "raw": 73099000,
+                    "fmt": "73.1M",
+                    "longFmt": "73,099,000"
+                  },
+                  "interestExpense": {
+                    "raw": -27463000,
+                    "fmt": "-27.46M",
+                    "longFmt": "-27,463,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 18724000,
+                    "fmt": "18.72M",
+                    "longFmt": "18,724,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 10657000,
+                    "fmt": "10.66M",
+                    "longFmt": "10,657,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 8067000,
+                    "fmt": "8.07M",
+                    "longFmt": "8,067,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -257212000,
+                    "fmt": "-257.21M",
+                    "longFmt": "-257,212,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -249145000,
+                    "fmt": "-249.15M",
+                    "longFmt": "-249,145,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -249145000,
+                    "fmt": "-249.15M",
+                    "longFmt": "-249,145,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1535673600,
+                    "fmt": "2018-08-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 641303000,
+                    "fmt": "641.3M",
+                    "longFmt": "641,303,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 358019000,
+                    "fmt": "358.02M",
+                    "longFmt": "358,019,000"
+                  },
+                  "grossProfit": {
+                    "raw": 283284000,
+                    "fmt": "283.28M",
+                    "longFmt": "283,284,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 210656000,
+                    "fmt": "210.66M",
+                    "longFmt": "210,656,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 577955000,
+                    "fmt": "577.96M",
+                    "longFmt": "577,955,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 63348000,
+                    "fmt": "63.35M",
+                    "longFmt": "63,348,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -44152000,
+                    "fmt": "-44.15M",
+                    "longFmt": "-44,152,000"
+                  },
+                  "ebit": {
+                    "raw": 63348000,
+                    "fmt": "63.35M",
+                    "longFmt": "63,348,000"
+                  },
+                  "interestExpense": {
+                    "raw": -30572000,
+                    "fmt": "-30.57M",
+                    "longFmt": "-30,572,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 19196000,
+                    "fmt": "19.2M",
+                    "longFmt": "19,196,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 14450000,
+                    "fmt": "14.45M",
+                    "longFmt": "14,450,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 4746000,
+                    "fmt": "4.75M",
+                    "longFmt": "4,746,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -26394000,
+                    "fmt": "-26.39M",
+                    "longFmt": "-26,394,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -21648000,
+                    "fmt": "-21.65M",
+                    "longFmt": "-21,648,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -21648000,
+                    "fmt": "-21.65M",
+                    "longFmt": "-21,648,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1504137600,
+                    "fmt": "2017-08-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 616591000,
+                    "fmt": "616.59M",
+                    "longFmt": "616,591,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 356221000,
+                    "fmt": "356.22M",
+                    "longFmt": "356,221,000"
+                  },
+                  "grossProfit": {
+                    "raw": 260370000,
+                    "fmt": "260.37M",
+                    "longFmt": "260,370,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 209728000,
+                    "fmt": "209.73M",
+                    "longFmt": "209,728,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 575046000,
+                    "fmt": "575.05M",
+                    "longFmt": "575,046,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 41545000,
+                    "fmt": "41.55M",
+                    "longFmt": "41,545,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -159434000,
+                    "fmt": "-159.43M",
+                    "longFmt": "-159,434,000"
+                  },
+                  "ebit": {
+                    "raw": 41545000,
+                    "fmt": "41.55M",
+                    "longFmt": "41,545,000"
+                  },
+                  "interestExpense": {
+                    "raw": -28821000,
+                    "fmt": "-28.82M",
+                    "longFmt": "-28,821,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -117889000,
+                    "fmt": "-117.89M",
+                    "longFmt": "-117,889,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -22614000,
+                    "fmt": "-22.61M",
+                    "longFmt": "-22,614,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": -95275000,
+                    "fmt": "-95.28M",
+                    "longFmt": "-95,275,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": 29062000,
+                    "fmt": "29.06M",
+                    "longFmt": "29,062,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -66213000,
+                    "fmt": "-66.21M",
+                    "longFmt": "-66,213,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -66213000,
+                    "fmt": "-66.21M",
+                    "longFmt": "-66,213,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            },
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 22.66,
+              "open": 22.79,
+              "dayLow": 22.77,
+              "dayHigh": 23.3,
+              "regularMarketPreviousClose": 22.66,
+              "regularMarketOpen": 22.79,
+              "regularMarketDayLow": 22.77,
+              "regularMarketDayHigh": 23.3,
+              "dividendRate": 0.04,
+              "dividendYield": 0.0018000001,
+              "exDividendDate": 1601510400,
+              "payoutRatio": 0.6667,
+              "fiveYearAvgDividendYield": 0.17,
+              "beta": 1.450373,
+              "volume": 62262,
+              "regularMarketVolume": 62262,
+              "averageVolume": 299491,
+              "averageVolume10days": 263085,
+              "averageDailyVolume10Day": 263085,
+              "bid": 23.21,
+              "ask": 23.24,
+              "bidSize": 800,
+              "askSize": 800,
+              "marketCap": 1394996608,
+              "fiftyTwoWeekLow": 13.28,
+              "fiftyTwoWeekHigh": 25.6,
+              "priceToSalesTrailing12Months": 2.9932466,
+              "fiftyDayAverage": 22.127274,
+              "twoHundredDayAverage": 21.097826,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            },
+            "insiderHolders": {
+              "holders": [
+                {
+                  "maxAge": 1,
+                  "name": "ALTAVILLA ALFREDO",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionDirect": {
+                    "raw": 20787,
+                    "fmt": "20.79k",
+                    "longFmt": "20,787"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "ALTMAIER JUDY L",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionDirect": {
+                    "raw": 9395,
+                    "fmt": "9.39k",
+                    "longFmt": "9,395"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "BAKER RANDAL W",
+                  "relation": "Chief Executive Officer",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionDirect": {
+                    "raw": 323244,
+                    "fmt": "323.24k",
+                    "longFmt": "323,244"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "BOLENS BARBARA",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionDirect": {
+                    "raw": 29105,
+                    "fmt": "29.11k",
+                    "longFmt": "29,105"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "CLARKSON J PALMER",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionDirect": {
+                    "raw": 17787,
+                    "fmt": "17.79k",
+                    "longFmt": "17,787"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "CUNNINGHAM DANNY L.",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionDirect": {
+                    "raw": 24030,
+                    "fmt": "24.03k",
+                    "longFmt": "24,030"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "DILLON RICKY T",
+                  "relation": "Chief Financial Officer",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionDirect": {
+                    "raw": 63270,
+                    "fmt": "63.27k",
+                    "longFmt": "63,270"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "FERLAND E JAMES JR",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionDirect": {
+                    "raw": 51160,
+                    "fmt": "51.16k",
+                    "longFmt": "51,160"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "HOLDER RICHARD D",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionDirect": {
+                    "raw": 21618,
+                    "fmt": "21.62k",
+                    "longFmt": "21,618"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "SCHMALING JOHN JEFFREY",
+                  "relation": "Chief Operating Officer",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionDirect": {
+                    "raw": 48108,
+                    "fmt": "48.11k",
+                    "longFmt": "48,108"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                }
+              ],
+              "maxAge": 1
+            },
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": [
+                  1615939200,
+                  1616371200
+                ],
+                "earningsAverage": 0.12,
+                "earningsLow": 0.1,
+                "earningsHigh": 0.15,
+                "revenueAverage": 126060000,
+                "revenueLow": 119800000,
+                "revenueHigh": 130900000
+              },
+              "exDividendDate": 1601510400,
+              "dividendDate": 1603065600
+            },
+            "upgradeDowngradeHistory": {
+              "history": [
+                {
+                  "epochGradeDate": 1606297035,
+                  "firm": "Stifel",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606297035,
+                  "firm": "Wells Fargo",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "",
+                  "action": "main"
+                }
+              ],
+              "maxAge": 86400
+            },
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": 0,
+              "preMarketChange": 0,
+              "preMarketTime": 1613740999,
+              "preMarketPrice": 22.66,
+              "preMarketSource": "FREE_REALTIME",
+              "regularMarketChangePercent": 0.028243575,
+              "regularMarketChange": 0.6399994,
+              "regularMarketTime": 1613754689,
+              "priceHint": 2,
+              "regularMarketPrice": 23.3,
+              "regularMarketDayHigh": 23.3,
+              "regularMarketDayLow": 22.77,
+              "regularMarketVolume": 62262,
+              "averageDailyVolume10Day": 263085,
+              "averageDailyVolume3Month": 299491,
+              "regularMarketPreviousClose": 22.66,
+              "regularMarketSource": "FREE_REALTIME",
+              "regularMarketOpen": 22.79,
+              "exchange": "NYQ",
+              "exchangeName": "NYSE",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "EQUITY",
+              "symbol": "EPAC",
+              "underlyingSymbol": null,
+              "shortName": "Enerpac Tool Group Corp.",
+              "longName": "Enerpac Tool Group Corp.",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 1394996608
+            },
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1598832000,
+                    "fmt": "2020-08-31"
+                  },
+                  "cash": {
+                    "raw": 152170000,
+                    "fmt": "152.17M",
+                    "longFmt": "152,170,000"
+                  },
+                  "netReceivables": {
+                    "raw": 90315000,
+                    "fmt": "90.31M",
+                    "longFmt": "90,315,000"
+                  },
+                  "inventory": {
+                    "raw": 69171000,
+                    "fmt": "69.17M",
+                    "longFmt": "69,171,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 29476000,
+                    "fmt": "29.48M",
+                    "longFmt": "29,476,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 341132000,
+                    "fmt": "341.13M",
+                    "longFmt": "341,132,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 110138000,
+                    "fmt": "110.14M",
+                    "longFmt": "110,138,000"
+                  },
+                  "goodWill": {
+                    "raw": 281154000,
+                    "fmt": "281.15M",
+                    "longFmt": "281,154,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 62382000,
+                    "fmt": "62.38M",
+                    "longFmt": "62,382,000"
+                  },
+                  "otherAssets": {
+                    "raw": 29488000,
+                    "fmt": "29.49M",
+                    "longFmt": "29,488,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 22600000,
+                    "fmt": "22.6M",
+                    "longFmt": "22,600,000"
+                  },
+                  "totalAssets": {
+                    "raw": 824294000,
+                    "fmt": "824.29M",
+                    "longFmt": "824,294,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 45069000,
+                    "fmt": "45.07M",
+                    "longFmt": "45,069,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 30790000,
+                    "fmt": "30.79M",
+                    "longFmt": "30,790,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 255000000,
+                    "fmt": "255M",
+                    "longFmt": "255,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 66467000,
+                    "fmt": "66.47M",
+                    "longFmt": "66,467,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 105522000,
+                    "fmt": "105.52M",
+                    "longFmt": "105,522,000"
+                  },
+                  "totalLiab": {
+                    "raw": 465068000,
+                    "fmt": "465.07M",
+                    "longFmt": "465,068,000"
+                  },
+                  "commonStock": {
+                    "raw": 16519000,
+                    "fmt": "16.52M",
+                    "longFmt": "16,519,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 917671000,
+                    "fmt": "917.67M",
+                    "longFmt": "917,671,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -768456000,
+                    "fmt": "-768.46M",
+                    "longFmt": "-768,456,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 193492000,
+                    "fmt": "193.49M",
+                    "longFmt": "193,492,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -100724000,
+                    "fmt": "-100.72M",
+                    "longFmt": "-100,724,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 359226000,
+                    "fmt": "359.23M",
+                    "longFmt": "359,226,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 15690000,
+                    "fmt": "15.69M",
+                    "longFmt": "15,690,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1567209600,
+                    "fmt": "2019-08-31"
+                  },
+                  "cash": {
+                    "raw": 211151000,
+                    "fmt": "211.15M",
+                    "longFmt": "211,151,000"
+                  },
+                  "netReceivables": {
+                    "raw": 129630000,
+                    "fmt": "129.63M",
+                    "longFmt": "129,630,000"
+                  },
+                  "inventory": {
+                    "raw": 77187000,
+                    "fmt": "77.19M",
+                    "longFmt": "77,187,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 312357000,
+                    "fmt": "312.36M",
+                    "longFmt": "312,357,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 730325000,
+                    "fmt": "730.33M",
+                    "longFmt": "730,325,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 56729000,
+                    "fmt": "56.73M",
+                    "longFmt": "56,729,000"
+                  },
+                  "goodWill": {
+                    "raw": 260415000,
+                    "fmt": "260.42M",
+                    "longFmt": "260,415,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 52375000,
+                    "fmt": "52.38M",
+                    "longFmt": "52,375,000"
+                  },
+                  "otherAssets": {
+                    "raw": 24430000,
+                    "fmt": "24.43M",
+                    "longFmt": "24,430,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 18400000,
+                    "fmt": "18.4M",
+                    "longFmt": "18,400,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1124274000,
+                    "fmt": "1.12B",
+                    "longFmt": "1,124,274,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 76914000,
+                    "fmt": "76.91M",
+                    "longFmt": "76,914,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 7500000,
+                    "fmt": "7.5M",
+                    "longFmt": "7,500,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 189566000,
+                    "fmt": "189.57M",
+                    "longFmt": "189,566,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 452945000,
+                    "fmt": "452.94M",
+                    "longFmt": "452,945,000"
+                  },
+                  "otherLiab": {
+                    "raw": 69749000,
+                    "fmt": "69.75M",
+                    "longFmt": "69,749,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 300401000,
+                    "fmt": "300.4M",
+                    "longFmt": "300,401,000"
+                  },
+                  "totalLiab": {
+                    "raw": 823095000,
+                    "fmt": "823.1M",
+                    "longFmt": "823,095,000"
+                  },
+                  "commonStock": {
+                    "raw": 16384000,
+                    "fmt": "16.38M",
+                    "longFmt": "16,384,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 915466000,
+                    "fmt": "915.47M",
+                    "longFmt": "915,466,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -811884000,
+                    "fmt": "-811.88M",
+                    "longFmt": "-811,884,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 181213000,
+                    "fmt": "181.21M",
+                    "longFmt": "181,213,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -171672000,
+                    "fmt": "-171.67M",
+                    "longFmt": "-171,672,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 301179000,
+                    "fmt": "301.18M",
+                    "longFmt": "301,179,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -11611000,
+                    "fmt": "-11.61M",
+                    "longFmt": "-11,611,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1535673600,
+                    "fmt": "2018-08-31"
+                  },
+                  "cash": {
+                    "raw": 250490000,
+                    "fmt": "250.49M",
+                    "longFmt": "250,490,000"
+                  },
+                  "netReceivables": {
+                    "raw": 129628000,
+                    "fmt": "129.63M",
+                    "longFmt": "129,628,000"
+                  },
+                  "inventory": {
+                    "raw": 72020000,
+                    "fmt": "72.02M",
+                    "longFmt": "72,020,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 595095000,
+                    "fmt": "595.1M",
+                    "longFmt": "595,095,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 1047233000,
+                    "fmt": "1.05B",
+                    "longFmt": "1,047,233,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 54974000,
+                    "fmt": "54.97M",
+                    "longFmt": "54,974,000"
+                  },
+                  "goodWill": {
+                    "raw": 280132000,
+                    "fmt": "280.13M",
+                    "longFmt": "280,132,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 71657000,
+                    "fmt": "71.66M",
+                    "longFmt": "71,657,000"
+                  },
+                  "otherAssets": {
+                    "raw": 31221000,
+                    "fmt": "31.22M",
+                    "longFmt": "31,221,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 21300000,
+                    "fmt": "21.3M",
+                    "longFmt": "21,300,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1485217000,
+                    "fmt": "1.49B",
+                    "longFmt": "1,485,217,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 69584000,
+                    "fmt": "69.58M",
+                    "longFmt": "69,584,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 30000000,
+                    "fmt": "30M",
+                    "longFmt": "30,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 218432000,
+                    "fmt": "218.43M",
+                    "longFmt": "218,432,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 502695000,
+                    "fmt": "502.69M",
+                    "longFmt": "502,695,000"
+                  },
+                  "otherLiab": {
+                    "raw": 69802000,
+                    "fmt": "69.8M",
+                    "longFmt": "69,802,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 354008000,
+                    "fmt": "354.01M",
+                    "longFmt": "354,008,000"
+                  },
+                  "totalLiab": {
+                    "raw": 926505000,
+                    "fmt": "926.5M",
+                    "longFmt": "926,505,000"
+                  },
+                  "commonStock": {
+                    "raw": 16285000,
+                    "fmt": "16.29M",
+                    "longFmt": "16,285,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 1166955000,
+                    "fmt": "1.17B",
+                    "longFmt": "1,166,955,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -791976000,
+                    "fmt": "-791.98M",
+                    "longFmt": "-791,976,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 167448000,
+                    "fmt": "167.45M",
+                    "longFmt": "167,448,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -174245000,
+                    "fmt": "-174.25M",
+                    "longFmt": "-174,245,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 558712000,
+                    "fmt": "558.71M",
+                    "longFmt": "558,712,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 206923000,
+                    "fmt": "206.92M",
+                    "longFmt": "206,923,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1504137600,
+                    "fmt": "2017-08-31"
+                  },
+                  "cash": {
+                    "raw": 229571000,
+                    "fmt": "229.57M",
+                    "longFmt": "229,571,000"
+                  },
+                  "netReceivables": {
+                    "raw": 190206000,
+                    "fmt": "190.21M",
+                    "longFmt": "190,206,000"
+                  },
+                  "inventory": {
+                    "raw": 143651000,
+                    "fmt": "143.65M",
+                    "longFmt": "143,651,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 83498000,
+                    "fmt": "83.5M",
+                    "longFmt": "83,498,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 646926000,
+                    "fmt": "646.93M",
+                    "longFmt": "646,926,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 94521000,
+                    "fmt": "94.52M",
+                    "longFmt": "94,521,000"
+                  },
+                  "goodWill": {
+                    "raw": 530081000,
+                    "fmt": "530.08M",
+                    "longFmt": "530,081,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 220489000,
+                    "fmt": "220.49M",
+                    "longFmt": "220,489,000"
+                  },
+                  "otherAssets": {
+                    "raw": 24938000,
+                    "fmt": "24.94M",
+                    "longFmt": "24,938,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 18600000,
+                    "fmt": "18.6M",
+                    "longFmt": "18,600,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1516955000,
+                    "fmt": "1.52B",
+                    "longFmt": "1,516,955,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 133387000,
+                    "fmt": "133.39M",
+                    "longFmt": "133,387,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 30000000,
+                    "fmt": "30M",
+                    "longFmt": "30,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 164608000,
+                    "fmt": "164.61M",
+                    "longFmt": "164,608,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 531940000,
+                    "fmt": "531.94M",
+                    "longFmt": "531,940,000"
+                  },
+                  "otherLiab": {
+                    "raw": 105542000,
+                    "fmt": "105.54M",
+                    "longFmt": "105,542,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 378934000,
+                    "fmt": "378.93M",
+                    "longFmt": "378,934,000"
+                  },
+                  "totalLiab": {
+                    "raw": 1016416000,
+                    "fmt": "1.02B",
+                    "longFmt": "1,016,416,000"
+                  },
+                  "commonStock": {
+                    "raw": 16040000,
+                    "fmt": "16.04M",
+                    "longFmt": "16,040,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 1191042000,
+                    "fmt": "1.19B",
+                    "longFmt": "1,191,042,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -844992000,
+                    "fmt": "-844.99M",
+                    "longFmt": "-844,992,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 138449000,
+                    "fmt": "138.45M",
+                    "longFmt": "138,449,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -227261000,
+                    "fmt": "-227.26M",
+                    "longFmt": "-227,261,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 500539000,
+                    "fmt": "500.54M",
+                    "longFmt": "500,539,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -250031000,
+                    "fmt": "-250.03M",
+                    "longFmt": "-250,031,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": "2021-02-28",
+                  "growth": {
+                    "raw": 0.333,
+                    "fmt": "33.30%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "low": {
+                      "raw": 0.1,
+                      "fmt": "0.1"
+                    },
+                    "high": {
+                      "raw": 0.15,
+                      "fmt": "0.15"
+                    },
+                    "yearAgoEps": {
+                      "raw": 0.09,
+                      "fmt": "0.09"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "growth": {
+                      "raw": 0.333,
+                      "fmt": "33.30%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 126060000,
+                      "fmt": "126.06M",
+                      "longFmt": "126,060,000"
+                    },
+                    "low": {
+                      "raw": 119800000,
+                      "fmt": "119.8M",
+                      "longFmt": "119,800,000"
+                    },
+                    "high": {
+                      "raw": 130900000,
+                      "fmt": "130.9M",
+                      "longFmt": "130,900,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.11,
+                      "fmt": "0.11"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.11,
+                      "fmt": "0.11"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": "2021-05-31",
+                  "growth": {
+                    "raw": 3.667,
+                    "fmt": "366.70%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.16,
+                      "fmt": "0.16"
+                    },
+                    "low": {
+                      "raw": 0.14,
+                      "fmt": "0.14"
+                    },
+                    "high": {
+                      "raw": 0.2,
+                      "fmt": "0.2"
+                    },
+                    "yearAgoEps": {
+                      "raw": -0.06,
+                      "fmt": "-0.06"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "growth": {
+                      "raw": 3.667,
+                      "fmt": "366.70%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 135460000,
+                      "fmt": "135.46M",
+                      "longFmt": "135,460,000"
+                    },
+                    "low": {
+                      "raw": 128300000,
+                      "fmt": "128.3M",
+                      "longFmt": "128,300,000"
+                    },
+                    "high": {
+                      "raw": 145000000,
+                      "fmt": "145M",
+                      "longFmt": "145,000,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 125850000,
+                      "fmt": "125.85M",
+                      "longFmt": "125,850,000"
+                    },
+                    "growth": {
+                      "raw": 0.076,
+                      "fmt": "7.60%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.16,
+                      "fmt": "0.16"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.16,
+                      "fmt": "0.16"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.16,
+                      "fmt": "0.16"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.16,
+                      "fmt": "0.16"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.16,
+                      "fmt": "0.16"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": "2021-08-31",
+                  "growth": {
+                    "raw": 1.9439999,
+                    "fmt": "194.40%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.53,
+                      "fmt": "0.53"
+                    },
+                    "low": {
+                      "raw": 0.47,
+                      "fmt": "0.47"
+                    },
+                    "high": {
+                      "raw": 0.63,
+                      "fmt": "0.63"
+                    },
+                    "yearAgoEps": {
+                      "raw": 0.18,
+                      "fmt": "0.18"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 6,
+                      "fmt": "6",
+                      "longFmt": "6"
+                    },
+                    "growth": {
+                      "raw": 1.9439999,
+                      "fmt": "194.40%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 515080000,
+                      "fmt": "515.08M",
+                      "longFmt": "515,080,000"
+                    },
+                    "low": {
+                      "raw": 503400000,
+                      "fmt": "503.4M",
+                      "longFmt": "503,400,000"
+                    },
+                    "high": {
+                      "raw": 538000000,
+                      "fmt": "538M",
+                      "longFmt": "538,000,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 6,
+                      "fmt": "6",
+                      "longFmt": "6"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 493292000,
+                      "fmt": "493.29M",
+                      "longFmt": "493,292,000"
+                    },
+                    "growth": {
+                      "raw": 0.044,
+                      "fmt": "4.40%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.53,
+                      "fmt": "0.53"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.53,
+                      "fmt": "0.53"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.53,
+                      "fmt": "0.53"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.54,
+                      "fmt": "0.54"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.54,
+                      "fmt": "0.54"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": "2022-08-31",
+                  "growth": {
+                    "raw": 0.43400002,
+                    "fmt": "43.40%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.76,
+                      "fmt": "0.76"
+                    },
+                    "low": {
+                      "raw": 0.65,
+                      "fmt": "0.65"
+                    },
+                    "high": {
+                      "raw": 0.84,
+                      "fmt": "0.84"
+                    },
+                    "yearAgoEps": {
+                      "raw": 0.53,
+                      "fmt": "0.53"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 6,
+                      "fmt": "6",
+                      "longFmt": "6"
+                    },
+                    "growth": {
+                      "raw": 0.43400002,
+                      "fmt": "43.40%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 552830000,
+                      "fmt": "552.83M",
+                      "longFmt": "552,830,000"
+                    },
+                    "low": {
+                      "raw": 544400000,
+                      "fmt": "544.4M",
+                      "longFmt": "544,400,000"
+                    },
+                    "high": {
+                      "raw": 562000000,
+                      "fmt": "562M",
+                      "longFmt": "562,000,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 6,
+                      "fmt": "6",
+                      "longFmt": "6"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 515080000,
+                      "fmt": "515.08M",
+                      "longFmt": "515,080,000"
+                    },
+                    "growth": {
+                      "raw": 0.073,
+                      "fmt": "7.30%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.76,
+                      "fmt": "0.76"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.76,
+                      "fmt": "0.76"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.76,
+                      "fmt": "0.76"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.78,
+                      "fmt": "0.78"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.79,
+                      "fmt": "0.79"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": 0.122,
+                    "fmt": "12.20%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": -0.09474,
+                    "fmt": "-9.47%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            },
+            "secFilings": {
+              "filings": [
+                {
+                  "date": "2021-01-20",
+                  "epochDate": 1611165669,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers, Submission of Matters to a Vote of Security Holders, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-21-000008&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-01-05",
+                  "epochDate": 1609882964,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-21-000003&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-12-21",
+                  "epochDate": 1608557489,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001157523-20-001615&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-11-19",
+                  "epochDate": 1605783694,
+                  "type": "8-K",
+                  "title": "Changes in Registrant's Certifying Accountant",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-20-000048&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-26",
+                  "epochDate": 1603749650,
+                  "type": "10-K",
+                  "title": "Annual Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-20-000046&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-09-30",
+                  "epochDate": 1601472687,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001157523-20-001277&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-07-31",
+                  "epochDate": 1596231144,
+                  "type": "8-K",
+                  "title": "Amendments to Articles of Inc. or Bylaws; Change in Fiscal Year, Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001157523-20-001094&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-07-01",
+                  "epochDate": 1593630817,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-20-000039&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-06-25",
+                  "epochDate": 1593091882,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001157523-20-000933&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-06-15",
+                  "epochDate": 1592259576,
+                  "type": "8-K",
+                  "title": "Creation of a Direct Financial Obligation or an Obligation under an Off-Balance Sheet Arrangement of a Registrant",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-20-000026&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-14",
+                  "epochDate": 1589490150,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001157523-20-000748&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-05",
+                  "epochDate": 1588673209,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-20-000022&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-08",
+                  "epochDate": 1586349081,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001157523-20-000482&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-03-25",
+                  "epochDate": 1585153420,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-20-000020&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-03-19",
+                  "epochDate": 1584630829,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Regulation FD Disclosure, ",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001157523-20-000381&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-01-30",
+                  "epochDate": 1580421873,
+                  "type": "8-K/A",
+                  "title": "ENERPAC TOOL GROUP CORP FILES (8-K/A) Disclosing Amendments to Articles of Inc. or Bylaws; Change in Fiscal Year",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-20-000011&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-01-30",
+                  "epochDate": 1580410160,
+                  "type": "8-K",
+                  "title": "Disclosing Amendments to Articles of Inc. or Bylaws; Change in Fiscal Year",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-20-000008&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-01-06",
+                  "epochDate": 1578346014,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-20-000003&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-12-19",
+                  "epochDate": 1576762299,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001157523-19-002360&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-05",
+                  "epochDate": 1572970227,
+                  "type": "8-K",
+                  "title": "Disclosing Change in Directors or Principal Officers",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-19-000037&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-01",
+                  "epochDate": 1572622541,
+                  "type": "8-K",
+                  "title": "Disclosing Completion of Acquisition or Disposition of Assets, Other Events, Financial Statemen",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001157523-19-002172&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-10-30",
+                  "epochDate": 1572450764,
+                  "type": "8-K",
+                  "title": "Disclosing Amendments to Articles of Inc. or Bylaws; Change in Fiscal Year, Financial Statement",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-19-000035&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-10-29",
+                  "epochDate": 1572343481,
+                  "type": "10-K",
+                  "title": "Annual Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-19-000033&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-09-27",
+                  "epochDate": 1569596567,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-19-000030&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-09-26",
+                  "epochDate": 1569501070,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001157523-19-002008&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-08-07",
+                  "epochDate": 1565191960,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-19-000028&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-07-31",
+                  "epochDate": 1564595235,
+                  "type": "8-K",
+                  "title": "Disclosing Change in Directors or Principal Officers, Other Events, Financial Statements and Ex",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-19-000026&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-07-22",
+                  "epochDate": 1563807526,
+                  "type": "8-K",
+                  "title": "Disclosing Change in Directors or Principal Officers, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-19-000024&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-07-18",
+                  "epochDate": 1563449314,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-19-000022&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-07-09",
+                  "epochDate": 1562673713,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Material Impairments, Regulation FD Disc",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001157523-19-001508&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-07-01",
+                  "epochDate": 1561975814,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-19-000020&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-06-26",
+                  "epochDate": 1561552289,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001157523-19-001440&nav=1&src=Yahoo",
+                  "maxAge": 1
+                }
+              ],
+              "maxAge": 86400
+            },
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Blackrock Inc.",
+                  "pctHeld": {
+                    "raw": 0.14729999,
+                    "fmt": "14.73%"
+                  },
+                  "position": {
+                    "raw": 8821106,
+                    "fmt": "8.82M",
+                    "longFmt": "8,821,106"
+                  },
+                  "value": {
+                    "raw": 199445206,
+                    "fmt": "199.45M",
+                    "longFmt": "199,445,206"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Price (T.Rowe) Associates Inc",
+                  "pctHeld": {
+                    "raw": 0.1129,
+                    "fmt": "11.29%"
+                  },
+                  "position": {
+                    "raw": 6758433,
+                    "fmt": "6.76M",
+                    "longFmt": "6,758,433"
+                  },
+                  "value": {
+                    "raw": 127126124,
+                    "fmt": "127.13M",
+                    "longFmt": "127,126,124"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Group, Inc. (The)",
+                  "pctHeld": {
+                    "raw": 0.1042,
+                    "fmt": "10.42%"
+                  },
+                  "position": {
+                    "raw": 6236385,
+                    "fmt": "6.24M",
+                    "longFmt": "6,236,385"
+                  },
+                  "value": {
+                    "raw": 117306401,
+                    "fmt": "117.31M",
+                    "longFmt": "117,306,401"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Wellington Management Company, LLP",
+                  "pctHeld": {
+                    "raw": 0.0845,
+                    "fmt": "8.45%"
+                  },
+                  "position": {
+                    "raw": 5057252,
+                    "fmt": "5.06M",
+                    "longFmt": "5,057,252"
+                  },
+                  "value": {
+                    "raw": 95126910,
+                    "fmt": "95.13M",
+                    "longFmt": "95,126,910"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Clarkston Capital Partners LLC",
+                  "pctHeld": {
+                    "raw": 0.0792,
+                    "fmt": "7.92%"
+                  },
+                  "position": {
+                    "raw": 4743797,
+                    "fmt": "4.74M",
+                    "longFmt": "4,743,797"
+                  },
+                  "value": {
+                    "raw": 89230821,
+                    "fmt": "89.23M",
+                    "longFmt": "89,230,821"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Pzena Investment Management, LLC",
+                  "pctHeld": {
+                    "raw": 0.0704,
+                    "fmt": "7.04%"
+                  },
+                  "position": {
+                    "raw": 4214374,
+                    "fmt": "4.21M",
+                    "longFmt": "4,214,374"
+                  },
+                  "value": {
+                    "raw": 95286996,
+                    "fmt": "95.29M",
+                    "longFmt": "95,286,996"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Barrow, Hanley Mewhinney & Strauss, LLC",
+                  "pctHeld": {
+                    "raw": 0.0414,
+                    "fmt": "4.14%"
+                  },
+                  "position": {
+                    "raw": 2481485,
+                    "fmt": "2.48M",
+                    "longFmt": "2,481,485"
+                  },
+                  "value": {
+                    "raw": 46676732,
+                    "fmt": "46.68M",
+                    "longFmt": "46,676,732"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Dimensional Fund Advisors LP",
+                  "pctHeld": {
+                    "raw": 0.0323,
+                    "fmt": "3.23%"
+                  },
+                  "position": {
+                    "raw": 1936696,
+                    "fmt": "1.94M",
+                    "longFmt": "1,936,696"
+                  },
+                  "value": {
+                    "raw": 36429251,
+                    "fmt": "36.43M",
+                    "longFmt": "36,429,251"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "State Street Corporation",
+                  "pctHeld": {
+                    "raw": 0.0293,
+                    "fmt": "2.93%"
+                  },
+                  "position": {
+                    "raw": 1756727,
+                    "fmt": "1.76M",
+                    "longFmt": "1,756,727"
+                  },
+                  "value": {
+                    "raw": 33044034,
+                    "fmt": "33.04M",
+                    "longFmt": "33,044,034"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Massachusetts Financial Services Co.",
+                  "pctHeld": {
+                    "raw": 0.019299999,
+                    "fmt": "1.93%"
+                  },
+                  "position": {
+                    "raw": 1157989,
+                    "fmt": "1.16M",
+                    "longFmt": "1,157,989"
+                  },
+                  "value": {
+                    "raw": 21781773,
+                    "fmt": "21.78M",
+                    "longFmt": "21,781,773"
+                  }
+                }
+              ]
+            },
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.00569,
+              "institutionsPercentHeld": 1.04787,
+              "institutionsFloatPercentHeld": 1.05387,
+              "institutionsCount": 227
+            },
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1606694400,
+                    "fmt": "2020-11-30"
+                  },
+                  "cash": {
+                    "raw": 158568000,
+                    "fmt": "158.57M",
+                    "longFmt": "158,568,000"
+                  },
+                  "netReceivables": {
+                    "raw": 95639000,
+                    "fmt": "95.64M",
+                    "longFmt": "95,639,000"
+                  },
+                  "inventory": {
+                    "raw": 70701000,
+                    "fmt": "70.7M",
+                    "longFmt": "70,701,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 32907000,
+                    "fmt": "32.91M",
+                    "longFmt": "32,907,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 357815000,
+                    "fmt": "357.81M",
+                    "longFmt": "357,815,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 60219000,
+                    "fmt": "60.22M",
+                    "longFmt": "60,219,000"
+                  },
+                  "goodWill": {
+                    "raw": 280977000,
+                    "fmt": "280.98M",
+                    "longFmt": "280,977,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 60097000,
+                    "fmt": "60.1M",
+                    "longFmt": "60,097,000"
+                  },
+                  "otherAssets": {
+                    "raw": 79467000,
+                    "fmt": "79.47M",
+                    "longFmt": "79,467,000"
+                  },
+                  "totalAssets": {
+                    "raw": 838575000,
+                    "fmt": "838.58M",
+                    "longFmt": "838,575,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 46954000,
+                    "fmt": "46.95M",
+                    "longFmt": "46,954,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 44528000,
+                    "fmt": "44.53M",
+                    "longFmt": "44,528,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 255000000,
+                    "fmt": "255M",
+                    "longFmt": "255,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 105925000,
+                    "fmt": "105.92M",
+                    "longFmt": "105,925,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 109704000,
+                    "fmt": "109.7M",
+                    "longFmt": "109,704,000"
+                  },
+                  "totalLiab": {
+                    "raw": 470629000,
+                    "fmt": "470.63M",
+                    "longFmt": "470,629,000"
+                  },
+                  "commonStock": {
+                    "raw": 16525000,
+                    "fmt": "16.52M",
+                    "longFmt": "16,525,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 922269000,
+                    "fmt": "922.27M",
+                    "longFmt": "922,269,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -766827000,
+                    "fmt": "-766.83M",
+                    "longFmt": "-766,827,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 195979000,
+                    "fmt": "195.98M",
+                    "longFmt": "195,979,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -99095000,
+                    "fmt": "-99.09M",
+                    "longFmt": "-99,095,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 367946000,
+                    "fmt": "367.95M",
+                    "longFmt": "367,946,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 26872000,
+                    "fmt": "26.87M",
+                    "longFmt": "26,872,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1598832000,
+                    "fmt": "2020-08-31"
+                  },
+                  "cash": {
+                    "raw": 152170000,
+                    "fmt": "152.17M",
+                    "longFmt": "152,170,000"
+                  },
+                  "netReceivables": {
+                    "raw": 90315000,
+                    "fmt": "90.31M",
+                    "longFmt": "90,315,000"
+                  },
+                  "inventory": {
+                    "raw": 69171000,
+                    "fmt": "69.17M",
+                    "longFmt": "69,171,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 29476000,
+                    "fmt": "29.48M",
+                    "longFmt": "29,476,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 341132000,
+                    "fmt": "341.13M",
+                    "longFmt": "341,132,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 110138000,
+                    "fmt": "110.14M",
+                    "longFmt": "110,138,000"
+                  },
+                  "goodWill": {
+                    "raw": 281154000,
+                    "fmt": "281.15M",
+                    "longFmt": "281,154,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 62382000,
+                    "fmt": "62.38M",
+                    "longFmt": "62,382,000"
+                  },
+                  "otherAssets": {
+                    "raw": 29488000,
+                    "fmt": "29.49M",
+                    "longFmt": "29,488,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 22600000,
+                    "fmt": "22.6M",
+                    "longFmt": "22,600,000"
+                  },
+                  "totalAssets": {
+                    "raw": 824294000,
+                    "fmt": "824.29M",
+                    "longFmt": "824,294,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 45069000,
+                    "fmt": "45.07M",
+                    "longFmt": "45,069,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 30790000,
+                    "fmt": "30.79M",
+                    "longFmt": "30,790,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 255000000,
+                    "fmt": "255M",
+                    "longFmt": "255,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 66467000,
+                    "fmt": "66.47M",
+                    "longFmt": "66,467,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 105522000,
+                    "fmt": "105.52M",
+                    "longFmt": "105,522,000"
+                  },
+                  "totalLiab": {
+                    "raw": 465068000,
+                    "fmt": "465.07M",
+                    "longFmt": "465,068,000"
+                  },
+                  "commonStock": {
+                    "raw": 16519000,
+                    "fmt": "16.52M",
+                    "longFmt": "16,519,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 917671000,
+                    "fmt": "917.67M",
+                    "longFmt": "917,671,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -768456000,
+                    "fmt": "-768.46M",
+                    "longFmt": "-768,456,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 193492000,
+                    "fmt": "193.49M",
+                    "longFmt": "193,492,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -100724000,
+                    "fmt": "-100.72M",
+                    "longFmt": "-100,724,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 359226000,
+                    "fmt": "359.23M",
+                    "longFmt": "359,226,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 15690000,
+                    "fmt": "15.69M",
+                    "longFmt": "15,690,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1590883200,
+                    "fmt": "2020-05-31"
+                  },
+                  "cash": {
+                    "raw": 163603000,
+                    "fmt": "163.6M",
+                    "longFmt": "163,603,000"
+                  },
+                  "netReceivables": {
+                    "raw": 98359000,
+                    "fmt": "98.36M",
+                    "longFmt": "98,359,000"
+                  },
+                  "inventory": {
+                    "raw": 78914000,
+                    "fmt": "78.91M",
+                    "longFmt": "78,914,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 38952000,
+                    "fmt": "38.95M",
+                    "longFmt": "38,952,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 379828000,
+                    "fmt": "379.83M",
+                    "longFmt": "379,828,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 111582000,
+                    "fmt": "111.58M",
+                    "longFmt": "111,582,000"
+                  },
+                  "goodWill": {
+                    "raw": 271169000,
+                    "fmt": "271.17M",
+                    "longFmt": "271,169,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 62833000,
+                    "fmt": "62.83M",
+                    "longFmt": "62,833,000"
+                  },
+                  "otherAssets": {
+                    "raw": 26123000,
+                    "fmt": "26.12M",
+                    "longFmt": "26,123,000"
+                  },
+                  "totalAssets": {
+                    "raw": 851535000,
+                    "fmt": "851.53M",
+                    "longFmt": "851,535,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 52091000,
+                    "fmt": "52.09M",
+                    "longFmt": "52,091,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 43349000,
+                    "fmt": "43.35M",
+                    "longFmt": "43,349,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 286497000,
+                    "fmt": "286.5M",
+                    "longFmt": "286,497,000"
+                  },
+                  "otherLiab": {
+                    "raw": 66278000,
+                    "fmt": "66.28M",
+                    "longFmt": "66,278,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 122539000,
+                    "fmt": "122.54M",
+                    "longFmt": "122,539,000"
+                  },
+                  "totalLiab": {
+                    "raw": 515253000,
+                    "fmt": "515.25M",
+                    "longFmt": "515,253,000"
+                  },
+                  "commonStock": {
+                    "raw": 16513000,
+                    "fmt": "16.51M",
+                    "longFmt": "16,513,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 918623000,
+                    "fmt": "918.62M",
+                    "longFmt": "918,623,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -791782000,
+                    "fmt": "-791.78M",
+                    "longFmt": "-791,782,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 192928000,
+                    "fmt": "192.93M",
+                    "longFmt": "192,928,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -124050000,
+                    "fmt": "-124.05M",
+                    "longFmt": "-124,050,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 336282000,
+                    "fmt": "336.28M",
+                    "longFmt": "336,282,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 2280000,
+                    "fmt": "2.28M",
+                    "longFmt": "2,280,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1582934400,
+                    "fmt": "2020-02-29"
+                  },
+                  "cash": {
+                    "raw": 163437000,
+                    "fmt": "163.44M",
+                    "longFmt": "163,437,000"
+                  },
+                  "netReceivables": {
+                    "raw": 118471000,
+                    "fmt": "118.47M",
+                    "longFmt": "118,471,000"
+                  },
+                  "inventory": {
+                    "raw": 78046000,
+                    "fmt": "78.05M",
+                    "longFmt": "78,046,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 38209000,
+                    "fmt": "38.21M",
+                    "longFmt": "38,209,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 398163000,
+                    "fmt": "398.16M",
+                    "longFmt": "398,163,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 116620000,
+                    "fmt": "116.62M",
+                    "longFmt": "116,620,000"
+                  },
+                  "goodWill": {
+                    "raw": 271828000,
+                    "fmt": "271.83M",
+                    "longFmt": "271,828,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 66501000,
+                    "fmt": "66.5M",
+                    "longFmt": "66,501,000"
+                  },
+                  "otherAssets": {
+                    "raw": 26230000,
+                    "fmt": "26.23M",
+                    "longFmt": "26,230,000"
+                  },
+                  "totalAssets": {
+                    "raw": 879342000,
+                    "fmt": "879.34M",
+                    "longFmt": "879,342,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 62291000,
+                    "fmt": "62.29M",
+                    "longFmt": "62,291,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 34806000,
+                    "fmt": "34.81M",
+                    "longFmt": "34,806,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 286367000,
+                    "fmt": "286.37M",
+                    "longFmt": "286,367,000"
+                  },
+                  "otherLiab": {
+                    "raw": 66944000,
+                    "fmt": "66.94M",
+                    "longFmt": "66,944,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 129561000,
+                    "fmt": "129.56M",
+                    "longFmt": "129,561,000"
+                  },
+                  "totalLiab": {
+                    "raw": 524977000,
+                    "fmt": "524.98M",
+                    "longFmt": "524,977,000"
+                  },
+                  "commonStock": {
+                    "raw": 16508000,
+                    "fmt": "16.51M",
+                    "longFmt": "16,508,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 923622000,
+                    "fmt": "923.62M",
+                    "longFmt": "923,622,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -775481000,
+                    "fmt": "-775.48M",
+                    "longFmt": "-775,481,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 189716000,
+                    "fmt": "189.72M",
+                    "longFmt": "189,716,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -117464000,
+                    "fmt": "-117.46M",
+                    "longFmt": "-117,464,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 354365000,
+                    "fmt": "354.37M",
+                    "longFmt": "354,365,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 16036000,
+                    "fmt": "16.04M",
+                    "longFmt": "16,036,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.09,
+                    "fmt": "0.09"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.12,
+                    "fmt": "0.12"
+                  },
+                  "epsDifference": {
+                    "raw": -0.03,
+                    "fmt": "-0.03"
+                  },
+                  "surprisePercent": {
+                    "raw": -0.25,
+                    "fmt": "-25.00%"
+                  },
+                  "quarter": {
+                    "raw": 1582934400,
+                    "fmt": "2020-02-29"
+                  },
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": -0.06,
+                    "fmt": "-0.06"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.11,
+                    "fmt": "0.11"
+                  },
+                  "epsDifference": {
+                    "raw": -0.17,
+                    "fmt": "-0.17"
+                  },
+                  "surprisePercent": {
+                    "raw": -1.545,
+                    "fmt": "-154.50%"
+                  },
+                  "quarter": {
+                    "raw": 1590883200,
+                    "fmt": "2020-05-31"
+                  },
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.02,
+                    "fmt": "0.02"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.08,
+                    "fmt": "0.08"
+                  },
+                  "epsDifference": {
+                    "raw": -0.06,
+                    "fmt": "-0.06"
+                  },
+                  "surprisePercent": {
+                    "raw": -0.75,
+                    "fmt": "-75.00%"
+                  },
+                  "quarter": {
+                    "raw": 1598832000,
+                    "fmt": "2020-08-31"
+                  },
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.09,
+                    "fmt": "0.09"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.1,
+                    "fmt": "0.1"
+                  },
+                  "epsDifference": {
+                    "raw": -0.01,
+                    "fmt": "-0.01"
+                  },
+                  "surprisePercent": {
+                    "raw": -0.1,
+                    "fmt": "-10.00%"
+                  },
+                  "quarter": {
+                    "raw": 1606694400,
+                    "fmt": "2020-11-30"
+                  },
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            },
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            },
+            "summaryProfile": {
+              "address1": "N86 W12500 Westbrook Crossing",
+              "city": "Menomonee Falls",
+              "state": "WI",
+              "zip": "53051",
+              "country": "United States",
+              "phone": "262 293 1500",
+              "website": "http://www.enerpactoolgroup.com",
+              "industry": "Specialty Industrial Machinery",
+              "sector": "Industrials",
+              "longBusinessSummary": "Enerpac Tool Group Corp. manufactures and sells a range of industrial products and solutions worldwide. It operates in two segments, Industrial Tools & Services (IT&S) and Other. The IT&S segment designs, manufactures, and distributes branded hydraulic and mechanical tools; and provides services and tool rentals to the industrial, maintenance, infrastructure, oil and gas, energy, and other markets. It also offers branded tools and engineered heavy lifting technology solutions, and hydraulic torque wrenches; energy maintenance and manpower services; high-force hydraulic and mechanical tools, including cylinders, pumps, valves, and specialty tools; and bolt tensioners and other miscellaneous products. This segment markets its branded tools and services primarily under the Enerpac, Hydratight, Larzep, and Simplex brands. The Other segment designs and manufactures synthetic ropes and biomedical assemblies. The company was formerly known as Actuant Corporation and changed its name to Enerpac Tool Group Corp. in January 2020. Enerpac Tool Group Corp. was founded in 1910 and is headquartered in Menomonee Falls, Wisconsin.",
+              "fullTimeEmployees": 2300,
+              "companyOfficers": [],
+              "maxAge": 86400
+            },
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 19,
+              "buyInfoShares": 183357,
+              "buyPercentInsiderShares": 1.151,
+              "sellInfoCount": 1,
+              "sellInfoShares": 2005,
+              "sellPercentInsiderShares": 0.012999999,
+              "netInfoCount": 20,
+              "netInfoShares": 181352,
+              "netPercentInsiderShares": 1.138,
+              "totalInsiderShares": 340666
+            },
+            "insiderTransactions": {
+              "transactions": [
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15672,
+                    "fmt": "15.67k",
+                    "longFmt": "15,672"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DILLON RICKY T",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7124,
+                    "fmt": "7.12k",
+                    "longFmt": "7,124"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BOLENS BARBARA",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4480,
+                    "fmt": "4.48k",
+                    "longFmt": "4,480"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "HOLDER RICHARD D",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8961,
+                    "fmt": "8.96k",
+                    "longFmt": "8,961"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "FERLAND E JAMES JR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4480,
+                    "fmt": "4.48k",
+                    "longFmt": "4,480"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALTMAIER JUDY L",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 61744,
+                    "fmt": "61.74k",
+                    "longFmt": "61,744"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BAKER RANDAL W",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4480,
+                    "fmt": "4.48k",
+                    "longFmt": "4,480"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALTAVILLA ALFREDO",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4480,
+                    "fmt": "4.48k",
+                    "longFmt": "4,480"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CUNNINGHAM DANNY L.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4480,
+                    "fmt": "4.48k",
+                    "longFmt": "4,480"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CLARKSON J PALMER",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15672,
+                    "fmt": "15.67k",
+                    "longFmt": "15,672"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SCHMALING JOHN JEFFREY",
+                  "filerRelation": "Chief Operating Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4480,
+                    "fmt": "4.48k",
+                    "longFmt": "4,480"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SIMMONS SIDNEY S. II",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 11828,
+                    "fmt": "11.83k",
+                    "longFmt": "11,828"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RASETTI FABRIZIO",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8961,
+                    "fmt": "8.96k",
+                    "longFmt": "8,961"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JOHNSON BRYAN R.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2005,
+                    "fmt": "2k",
+                    "longFmt": "2,005"
+                  },
+                  "value": {
+                    "raw": 40352,
+                    "fmt": "40.35k",
+                    "longFmt": "40,352"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 20.13 per share.",
+                  "filerName": "DILLON RICKY T",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604880000,
+                    "fmt": "2020-11-09"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2588,
+                    "fmt": "2.59k",
+                    "longFmt": "2,588"
+                  },
+                  "value": {
+                    "raw": 46248,
+                    "fmt": "46.25k",
+                    "longFmt": "46,248"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 17.87 per share.",
+                  "filerName": "BOLENS BARBARA",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1603929600,
+                    "fmt": "2020-10-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3514,
+                    "fmt": "3.51k",
+                    "longFmt": "3,514"
+                  },
+                  "value": {
+                    "raw": 67609,
+                    "fmt": "67.61k",
+                    "longFmt": "67,609"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 19.24 per share.",
+                  "filerName": "DILLON RICKY T",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1603670400,
+                    "fmt": "2020-10-26"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 16769,
+                    "fmt": "16.77k",
+                    "longFmt": "16,769"
+                  },
+                  "value": {
+                    "raw": 322636,
+                    "fmt": "322.64k",
+                    "longFmt": "322,636"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 19.24 per share.",
+                  "filerName": "BAKER RANDAL W",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1603670400,
+                    "fmt": "2020-10-26"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3571,
+                    "fmt": "3.57k",
+                    "longFmt": "3,571"
+                  },
+                  "value": {
+                    "raw": 68706,
+                    "fmt": "68.71k",
+                    "longFmt": "68,706"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 19.24 per share.",
+                  "filerName": "SCHMALING JOHN JEFFREY",
+                  "filerRelation": "Chief Operating Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1603670400,
+                    "fmt": "2020-10-26"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 341,
+                    "fmt": "341",
+                    "longFmt": "341"
+                  },
+                  "value": {
+                    "raw": 6786,
+                    "fmt": "6.79k",
+                    "longFmt": "6,786"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 19.90 per share.",
+                  "filerName": "JOHNSON BRYAN R.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596153600,
+                    "fmt": "2020-07-31"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2128,
+                    "fmt": "2.13k",
+                    "longFmt": "2,128"
+                  },
+                  "value": {
+                    "raw": 50753,
+                    "fmt": "50.75k",
+                    "longFmt": "50,753"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 23.85 per share.",
+                  "filerName": "DILLON RICKY T",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580774400,
+                    "fmt": "2020-02-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12420,
+                    "fmt": "12.42k",
+                    "longFmt": "12,420"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DILLON RICKY T",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580169600,
+                    "fmt": "2020-01-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5646,
+                    "fmt": "5.65k",
+                    "longFmt": "5,646"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BOLENS BARBARA",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580169600,
+                    "fmt": "2020-01-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4261,
+                    "fmt": "4.26k",
+                    "longFmt": "4,261"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "HOLDER RICHARD D",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580169600,
+                    "fmt": "2020-01-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8522,
+                    "fmt": "8.52k",
+                    "longFmt": "8,522"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "FERLAND E JAMES JR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580169600,
+                    "fmt": "2020-01-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4261,
+                    "fmt": "4.26k",
+                    "longFmt": "4,261"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALTMAIER JUDY L",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580169600,
+                    "fmt": "2020-01-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 58719,
+                    "fmt": "58.72k",
+                    "longFmt": "58,719"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BAKER RANDAL W",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580169600,
+                    "fmt": "2020-01-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4261,
+                    "fmt": "4.26k",
+                    "longFmt": "4,261"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALTAVILLA ALFREDO",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580169600,
+                    "fmt": "2020-01-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4261,
+                    "fmt": "4.26k",
+                    "longFmt": "4,261"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CUNNINGHAM DANNY L.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580169600,
+                    "fmt": "2020-01-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4261,
+                    "fmt": "4.26k",
+                    "longFmt": "4,261"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CLARKSON J PALMER",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580169600,
+                    "fmt": "2020-01-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12420,
+                    "fmt": "12.42k",
+                    "longFmt": "12,420"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SCHMALING JOHN JEFFREY",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580169600,
+                    "fmt": "2020-01-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4261,
+                    "fmt": "4.26k",
+                    "longFmt": "4,261"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SIMMONS SIDNEY S. II",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580169600,
+                    "fmt": "2020-01-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9374,
+                    "fmt": "9.37k",
+                    "longFmt": "9,374"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RASETTI FABRIZIO",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580169600,
+                    "fmt": "2020-01-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8522,
+                    "fmt": "8.52k",
+                    "longFmt": "8,522"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JOHNSON BRYAN R.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580169600,
+                    "fmt": "2020-01-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15000,
+                    "fmt": "15k",
+                    "longFmt": "15,000"
+                  },
+                  "value": {
+                    "raw": 375315,
+                    "fmt": "375.31k",
+                    "longFmt": "375,315"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 25.02 per share.",
+                  "filerName": "BAKER RANDAL W",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1579132800,
+                    "fmt": "2020-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2432,
+                    "fmt": "2.43k",
+                    "longFmt": "2,432"
+                  },
+                  "value": {
+                    "raw": 62963,
+                    "fmt": "62.96k",
+                    "longFmt": "62,963"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 25.89 per share.",
+                  "filerName": "DILLON RICKY T",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1572912000,
+                    "fmt": "2019-11-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2432,
+                    "fmt": "2.43k",
+                    "longFmt": "2,432"
+                  },
+                  "value": {
+                    "raw": 62963,
+                    "fmt": "62.96k",
+                    "longFmt": "62,963"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 25.89 per share.",
+                  "filerName": "DILLON RICKY T",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1572912000,
+                    "fmt": "2019-11-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 654,
+                    "fmt": "654",
+                    "longFmt": "654"
+                  },
+                  "value": {
+                    "raw": 16716,
+                    "fmt": "16.72k",
+                    "longFmt": "16,716"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 25.56 per share.",
+                  "filerName": "ALTMAIER JUDY L",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1572566400,
+                    "fmt": "2019-11-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 20990,
+                    "fmt": "20.99k",
+                    "longFmt": "20,990"
+                  },
+                  "value": {
+                    "raw": 519922,
+                    "fmt": "519.92k",
+                    "longFmt": "519,922"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 24.77 per share.",
+                  "filerName": "ROUNDHOUSE ROGER A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1572480000,
+                    "fmt": "2019-10-31"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3582,
+                    "fmt": "3.58k",
+                    "longFmt": "3,582"
+                  },
+                  "value": {
+                    "raw": 88834,
+                    "fmt": "88.83k",
+                    "longFmt": "88,834"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 24.80 per share.",
+                  "filerName": "DILLON RICKY T",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1572307200,
+                    "fmt": "2019-10-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 19716,
+                    "fmt": "19.72k",
+                    "longFmt": "19,716"
+                  },
+                  "value": {
+                    "raw": 488957,
+                    "fmt": "488.96k",
+                    "longFmt": "488,957"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 24.80 per share.",
+                  "filerName": "BAKER RANDAL W",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1572307200,
+                    "fmt": "2019-10-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4101,
+                    "fmt": "4.1k",
+                    "longFmt": "4,101"
+                  },
+                  "value": {
+                    "raw": 101705,
+                    "fmt": "101.7k",
+                    "longFmt": "101,705"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 24.80 per share.",
+                  "filerName": "ROUNDHOUSE ROGER A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1572307200,
+                    "fmt": "2019-10-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1919,
+                    "fmt": "1.92k",
+                    "longFmt": "1,919"
+                  },
+                  "value": {
+                    "raw": 43369,
+                    "fmt": "43.37k",
+                    "longFmt": "43,369"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 22.60 per share.",
+                  "filerName": "JOHNSON BRYAN R.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1571270400,
+                    "fmt": "2019-10-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3275,
+                    "fmt": "3.27k",
+                    "longFmt": "3,275"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JOHNSON BRYAN R.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1564531200,
+                    "fmt": "2019-07-31"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10266,
+                    "fmt": "10.27k",
+                    "longFmt": "10,266"
+                  },
+                  "value": {
+                    "raw": 231901,
+                    "fmt": "231.9k",
+                    "longFmt": "231,901"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 22.59 per share.",
+                  "filerName": "ROUNDHOUSE ROGER A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548806400,
+                    "fmt": "2019-01-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12438,
+                    "fmt": "12.44k",
+                    "longFmt": "12,438"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DILLON RICKY T",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9046,
+                    "fmt": "9.05k",
+                    "longFmt": "9,046"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "HOLDER RICHARD D",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 14114,
+                    "fmt": "14.11k",
+                    "longFmt": "14,114"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "VAN DEURSEN HOLLY A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 13569,
+                    "fmt": "13.57k",
+                    "longFmt": "13,569"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "FERLAND E JAMES JR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 62330,
+                    "fmt": "62.33k",
+                    "longFmt": "62,330"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BAKER RANDAL W",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9046,
+                    "fmt": "9.05k",
+                    "longFmt": "9,046"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALTAVILLA ALFREDO",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12438,
+                    "fmt": "12.44k",
+                    "longFmt": "12,438"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROUNDHOUSE ROGER A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9046,
+                    "fmt": "9.05k",
+                    "longFmt": "9,046"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CUNNINGHAM DANNY L.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9046,
+                    "fmt": "9.05k",
+                    "longFmt": "9,046"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CLARKSON J PALMER",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5654,
+                    "fmt": "5.65k",
+                    "longFmt": "5,654"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WILLIAMS ANDRE L",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12438,
+                    "fmt": "12.44k",
+                    "longFmt": "12,438"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SCHMALING JOHN JEFFREY",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9046,
+                    "fmt": "9.05k",
+                    "longFmt": "9,046"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SIMMONS SIDNEY S. II",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9046,
+                    "fmt": "9.05k",
+                    "longFmt": "9,046"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RASETTI FABRIZIO",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6491,
+                    "fmt": "6.49k",
+                    "longFmt": "6,491"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JOHNSON BRYAN R.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6784,
+                    "fmt": "6.78k",
+                    "longFmt": "6,784"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JOHNSON BRYAN R.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6939,
+                    "fmt": "6.94k",
+                    "longFmt": "6,939"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROUNDHOUSE ROGER A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1540771200,
+                    "fmt": "2018-10-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12500,
+                    "fmt": "12.5k",
+                    "longFmt": "12,500"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RASETTI FABRIZIO",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525651200,
+                    "fmt": "2018-05-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10730,
+                    "fmt": "10.73k",
+                    "longFmt": "10,730"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SCHMALING JOHN JEFFREY",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518393600,
+                    "fmt": "2018-02-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3831,
+                    "fmt": "3.83k",
+                    "longFmt": "3,831"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "HUNTER R ALAN JR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1516665600,
+                    "fmt": "2018-01-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3831,
+                    "fmt": "3.83k",
+                    "longFmt": "3,831"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BEDI GURMINDER S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1516665600,
+                    "fmt": "2018-01-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3831,
+                    "fmt": "3.83k",
+                    "longFmt": "3,831"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WILLIAMS DENNIS K",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1516665600,
+                    "fmt": "2018-01-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4693,
+                    "fmt": "4.69k",
+                    "longFmt": "4,693"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETERSON ROBERT A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1516665600,
+                    "fmt": "2018-01-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3831,
+                    "fmt": "3.83k",
+                    "longFmt": "3,831"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "HOLDER RICHARD D",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1516665600,
+                    "fmt": "2018-01-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3831,
+                    "fmt": "3.83k",
+                    "longFmt": "3,831"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "VAN DEURSEN HOLLY A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1516665600,
+                    "fmt": "2018-01-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3831,
+                    "fmt": "3.83k",
+                    "longFmt": "3,831"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "FERLAND E JAMES JR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1516665600,
+                    "fmt": "2018-01-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3831,
+                    "fmt": "3.83k",
+                    "longFmt": "3,831"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CUNNINGHAM DANNY L.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1516665600,
+                    "fmt": "2018-01-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10516,
+                    "fmt": "10.52k",
+                    "longFmt": "10,516"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DILLON RICKY T",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1516579200,
+                    "fmt": "2018-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 50191,
+                    "fmt": "50.19k",
+                    "longFmt": "50,191"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BAKER RANDAL W",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1516579200,
+                    "fmt": "2018-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10516,
+                    "fmt": "10.52k",
+                    "longFmt": "10,516"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROUNDHOUSE ROGER A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1516579200,
+                    "fmt": "2018-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2868,
+                    "fmt": "2.87k",
+                    "longFmt": "2,868"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WROCKLAGE ROBERT A.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1516579200,
+                    "fmt": "2018-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4780,
+                    "fmt": "4.78k",
+                    "longFmt": "4,780"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WILLIAMS ANDRE L",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1516579200,
+                    "fmt": "2018-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6000,
+                    "fmt": "6k",
+                    "longFmt": "6,000"
+                  },
+                  "value": {
+                    "raw": 153960,
+                    "fmt": "153.96k",
+                    "longFmt": "153,960"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 25.66 per share.",
+                  "filerName": "WOZNIAK THEODORE C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1514419200,
+                    "fmt": "2017-12-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3002,
+                    "fmt": "3k",
+                    "longFmt": "3,002"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROUNDHOUSE ROGER A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1508112000,
+                    "fmt": "2017-10-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5000,
+                    "fmt": "5k",
+                    "longFmt": "5,000"
+                  },
+                  "value": {
+                    "raw": 130950,
+                    "fmt": "130.95k",
+                    "longFmt": "130,950"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 26.19 per share.",
+                  "filerName": "WOZNIAK THEODORE C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1507593600,
+                    "fmt": "2017-10-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 876,
+                    "fmt": "876",
+                    "longFmt": "876"
+                  },
+                  "value": {
+                    "raw": 22268,
+                    "fmt": "22.27k",
+                    "longFmt": "22,268"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 25.42 per share.",
+                  "filerName": "RENNIE STEPHEN J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1506556800,
+                    "fmt": "2017-09-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 500,
+                    "fmt": "500",
+                    "longFmt": "500"
+                  },
+                  "value": {
+                    "raw": 12665,
+                    "fmt": "12.66k",
+                    "longFmt": "12,665"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 25.33 per share.",
+                  "filerName": "WOZNIAK THEODORE C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1491350400,
+                    "fmt": "2017-04-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1000,
+                    "fmt": "1k",
+                    "longFmt": "1,000"
+                  },
+                  "value": {
+                    "raw": 25640,
+                    "fmt": "25.64k",
+                    "longFmt": "25,640"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 25.64 per share.",
+                  "filerName": "WOZNIAK THEODORE C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1490832000,
+                    "fmt": "2017-03-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2647,
+                    "fmt": "2.65k",
+                    "longFmt": "2,647"
+                  },
+                  "value": {
+                    "raw": 66704,
+                    "fmt": "66.7k",
+                    "longFmt": "66,704"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 25.20 per share.",
+                  "filerName": "RENNIE STEPHEN J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1490745600,
+                    "fmt": "2017-03-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2412,
+                    "fmt": "2.41k",
+                    "longFmt": "2,412"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "HUNTER R ALAN JR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2412,
+                    "fmt": "2.41k",
+                    "longFmt": "2,412"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BEDI GURMINDER S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2412,
+                    "fmt": "2.41k",
+                    "longFmt": "2,412"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WILLIAMS DENNIS K",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2955,
+                    "fmt": "2.96k",
+                    "longFmt": "2,955"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETERSON ROBERT A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7143,
+                    "fmt": "7.14k",
+                    "longFmt": "7,143"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DILLON RICKY T",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6680,
+                    "fmt": "6.68k",
+                    "longFmt": "6,680"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WOZNIAK THEODORE C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2412,
+                    "fmt": "2.41k",
+                    "longFmt": "2,412"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "VAN DEURSEN HOLLY A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2412,
+                    "fmt": "2.41k",
+                    "longFmt": "2,412"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "FERLAND E JAMES JR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 32468,
+                    "fmt": "32.47k",
+                    "longFmt": "32,468"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BAKER RANDAL W",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12987,
+                    "fmt": "12.99k",
+                    "longFmt": "12,987"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PAULI MATTHEW",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6753,
+                    "fmt": "6.75k",
+                    "longFmt": "6,753"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROUNDHOUSE ROGER A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4675,
+                    "fmt": "4.67k",
+                    "longFmt": "4,675"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SKOGG EUGENE EDWARD",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2412,
+                    "fmt": "2.41k",
+                    "longFmt": "2,412"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CUNNINGHAM DANNY L.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5520,
+                    "fmt": "5.52k",
+                    "longFmt": "5,520"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BOCKHORST KENNETH C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5520,
+                    "fmt": "5.52k",
+                    "longFmt": "5,520"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RENNIE STEPHEN J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15000,
+                    "fmt": "15k",
+                    "longFmt": "15,000"
+                  },
+                  "value": {
+                    "raw": 397255,
+                    "fmt": "397.25k",
+                    "longFmt": "397,255"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 26.10 - 26.64 per share.",
+                  "filerName": "WOZNIAK THEODORE C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484006400,
+                    "fmt": "2017-01-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15000,
+                    "fmt": "15k",
+                    "longFmt": "15,000"
+                  },
+                  "value": {
+                    "raw": 354600,
+                    "fmt": "354.6k",
+                    "longFmt": "354,600"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 23.64 per share.",
+                  "filerName": "WOZNIAK THEODORE C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484006400,
+                    "fmt": "2017-01-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4339,
+                    "fmt": "4.34k",
+                    "longFmt": "4,339"
+                  },
+                  "value": {
+                    "raw": 115417,
+                    "fmt": "115.42k",
+                    "longFmt": "115,417"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 26.60 per share.",
+                  "filerName": "SKOGG EUGENE EDWARD",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484006400,
+                    "fmt": "2017-01-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 183865,
+                    "fmt": "183.87k",
+                    "longFmt": "183,865"
+                  },
+                  "value": {
+                    "raw": 4846835,
+                    "fmt": "4.85M",
+                    "longFmt": "4,846,835"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 26.24 - 26.56 per share.",
+                  "filerName": "ARZBAECHER ROBERT C",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1483401600,
+                    "fmt": "2017-01-03"
+                  },
+                  "ownership": "D/I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8000,
+                    "fmt": "8k",
+                    "longFmt": "8,000"
+                  },
+                  "value": {
+                    "raw": 213440,
+                    "fmt": "213.44k",
+                    "longFmt": "213,440"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 26.68 per share.",
+                  "filerName": "WILLIAMS DENNIS K",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1483401600,
+                    "fmt": "2017-01-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8000,
+                    "fmt": "8k",
+                    "longFmt": "8,000"
+                  },
+                  "value": {
+                    "raw": 189120,
+                    "fmt": "189.12k",
+                    "longFmt": "189,120"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 23.64 per share.",
+                  "filerName": "WILLIAMS DENNIS K",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1483401600,
+                    "fmt": "2017-01-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5000,
+                    "fmt": "5k",
+                    "longFmt": "5,000"
+                  },
+                  "value": {
+                    "raw": 130200,
+                    "fmt": "130.2k",
+                    "longFmt": "130,200"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 26.04 per share.",
+                  "filerName": "WOZNIAK THEODORE C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1483056000,
+                    "fmt": "2016-12-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5000,
+                    "fmt": "5k",
+                    "longFmt": "5,000"
+                  },
+                  "value": {
+                    "raw": 118200,
+                    "fmt": "118.2k",
+                    "longFmt": "118,200"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 23.64 per share.",
+                  "filerName": "WOZNIAK THEODORE C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1483056000,
+                    "fmt": "2016-12-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 11900,
+                    "fmt": "11.9k",
+                    "longFmt": "11,900"
+                  },
+                  "value": {
+                    "raw": 318087,
+                    "fmt": "318.09k",
+                    "longFmt": "318,087"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 26.73 per share.",
+                  "filerName": "ARZBAECHER ROBERT C",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1482796800,
+                    "fmt": "2016-12-27"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8000,
+                    "fmt": "8k",
+                    "longFmt": "8,000"
+                  },
+                  "value": {
+                    "raw": 215360,
+                    "fmt": "215.36k",
+                    "longFmt": "215,360"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 26.92 per share.",
+                  "filerName": "FISCHER THOMAS J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1482796800,
+                    "fmt": "2016-12-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8000,
+                    "fmt": "8k",
+                    "longFmt": "8,000"
+                  },
+                  "value": {
+                    "raw": 189120,
+                    "fmt": "189.12k",
+                    "longFmt": "189,120"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 23.64 per share.",
+                  "filerName": "FISCHER THOMAS J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1482796800,
+                    "fmt": "2016-12-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8000,
+                    "fmt": "8k",
+                    "longFmt": "8,000"
+                  },
+                  "value": {
+                    "raw": 214400,
+                    "fmt": "214.4k",
+                    "longFmt": "214,400"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 26.80 per share.",
+                  "filerName": "PETERSON ROBERT A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1482796800,
+                    "fmt": "2016-12-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8000,
+                    "fmt": "8k",
+                    "longFmt": "8,000"
+                  },
+                  "value": {
+                    "raw": 189120,
+                    "fmt": "189.12k",
+                    "longFmt": "189,120"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 23.64 per share.",
+                  "filerName": "PETERSON ROBERT A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1482796800,
+                    "fmt": "2016-12-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 22263,
+                    "fmt": "22.26k",
+                    "longFmt": "22,263"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DILLON RICKY T",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1482796800,
+                    "fmt": "2016-12-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1926,
+                    "fmt": "1.93k",
+                    "longFmt": "1,926"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PAULI MATTHEW",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1479427200,
+                    "fmt": "2016-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2963,
+                    "fmt": "2.96k",
+                    "longFmt": "2,963"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "LAMPEREUR ANDREW G",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1476662400,
+                    "fmt": "2016-10-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12500,
+                    "fmt": "12.5k",
+                    "longFmt": "12,500"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BAKER RANDAL W",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1476403200,
+                    "fmt": "2016-10-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5397,
+                    "fmt": "5.4k",
+                    "longFmt": "5,397"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BAKER RANDAL W",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1468195200,
+                    "fmt": "2016-07-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2031,
+                    "fmt": "2.03k",
+                    "longFmt": "2,031"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BAKER RANDAL W",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1459728000,
+                    "fmt": "2016-04-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3250,
+                    "fmt": "3.25k",
+                    "longFmt": "3,250"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SEFCIK MARK",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1459728000,
+                    "fmt": "2016-04-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5000,
+                    "fmt": "5k",
+                    "longFmt": "5,000"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SKOGG EUGENE EDWARD",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1459728000,
+                    "fmt": "2016-04-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1934,
+                    "fmt": "1.93k",
+                    "longFmt": "1,934"
+                  },
+                  "value": {
+                    "raw": 48195,
+                    "fmt": "48.2k",
+                    "longFmt": "48,195"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 24.92 per share.",
+                  "filerName": "PAULI MATTHEW",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1459296000,
+                    "fmt": "2016-03-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 47092,
+                    "fmt": "47.09k",
+                    "longFmt": "47,092"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BAKER RANDAL W",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1458518400,
+                    "fmt": "2016-03-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 20000,
+                    "fmt": "20k",
+                    "longFmt": "20,000"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "KOBYLINSKI BRIAN K",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1458172800,
+                    "fmt": "2016-03-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 20000,
+                    "fmt": "20k",
+                    "longFmt": "20,000"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROUNDHOUSE ROGER A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1458172800,
+                    "fmt": "2016-03-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3036,
+                    "fmt": "3.04k",
+                    "longFmt": "3,036"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "HUNTER R ALAN JR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 11035,
+                    "fmt": "11.04k",
+                    "longFmt": "11,035"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "LAMPEREUR ANDREW G",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3036,
+                    "fmt": "3.04k",
+                    "longFmt": "3,036"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BEDI GURMINDER S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3036,
+                    "fmt": "3.04k",
+                    "longFmt": "3,036"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WILLIAMS DENNIS K",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9400,
+                    "fmt": "9.4k",
+                    "longFmt": "9,400"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "KOBYLINSKI BRIAN K",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3036,
+                    "fmt": "3.04k",
+                    "longFmt": "3,036"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "FISCHER THOMAS J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3036,
+                    "fmt": "3.04k",
+                    "longFmt": "3,036"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETERSON ROBERT A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7006,
+                    "fmt": "7.01k",
+                    "longFmt": "7,006"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WOZNIAK THEODORE C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3036,
+                    "fmt": "3.04k",
+                    "longFmt": "3,036"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "VAN DEURSEN HOLLY A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3036,
+                    "fmt": "3.04k",
+                    "longFmt": "3,036"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "FERLAND E JAMES JR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6539,
+                    "fmt": "6.54k",
+                    "longFmt": "6,539"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PAULI MATTHEW",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7356,
+                    "fmt": "7.36k",
+                    "longFmt": "7,356"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SEFCIK MARK",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7519,
+                    "fmt": "7.52k",
+                    "longFmt": "7,519"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROUNDHOUSE ROGER A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4904,
+                    "fmt": "4.9k",
+                    "longFmt": "4,904"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SKOGG EUGENE EDWARD",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 105000,
+                    "fmt": "105k",
+                    "longFmt": "105,000"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ARZBAECHER ROBERT C",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1452038400,
+                    "fmt": "2016-01-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 28174,
+                    "fmt": "28.17k",
+                    "longFmt": "28,174"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "LAMPEREUR ANDREW G",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1452038400,
+                    "fmt": "2016-01-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15000,
+                    "fmt": "15k",
+                    "longFmt": "15,000"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SKOGG EUGENE EDWARD",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1452038400,
+                    "fmt": "2016-01-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 93,
+                    "fmt": "93",
+                    "longFmt": "93"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 0.00 per share.",
+                  "filerName": "ARZBAECHER ROBERT C",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1446508800,
+                    "fmt": "2015-11-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15450,
+                    "fmt": "15.45k",
+                    "longFmt": "15,450"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "LAMPEREUR ANDREW G",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1446163200,
+                    "fmt": "2015-10-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15000,
+                    "fmt": "15k",
+                    "longFmt": "15,000"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "KOBYLINSKI BRIAN K",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1446163200,
+                    "fmt": "2015-10-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2650,
+                    "fmt": "2.65k",
+                    "longFmt": "2,650"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WOZNIAK THEODORE C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1446163200,
+                    "fmt": "2015-10-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4600,
+                    "fmt": "4.6k",
+                    "longFmt": "4,600"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROUNDHOUSE ROGER A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1446163200,
+                    "fmt": "2015-10-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6257,
+                    "fmt": "6.26k",
+                    "longFmt": "6,257"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SKOGG EUGENE EDWARD",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1446163200,
+                    "fmt": "2015-10-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 46840,
+                    "fmt": "46.84k",
+                    "longFmt": "46,840"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ARZBAECHER ROBERT C",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1445212800,
+                    "fmt": "2015-10-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3819,
+                    "fmt": "3.82k",
+                    "longFmt": "3,819"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "LAMPEREUR ANDREW G",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1445212800,
+                    "fmt": "2015-10-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2749,
+                    "fmt": "2.75k",
+                    "longFmt": "2,749"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "KOBYLINSKI BRIAN K",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1445212800,
+                    "fmt": "2015-10-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1833,
+                    "fmt": "1.83k",
+                    "longFmt": "1,833"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WOZNIAK THEODORE C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1445212800,
+                    "fmt": "2015-10-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 70256,
+                    "fmt": "70.26k",
+                    "longFmt": "70,256"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 0.00 per share.",
+                  "filerName": "ARZBAECHER ROBERT C",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1442448000,
+                    "fmt": "2015-09-17"
+                  },
+                  "ownership": "D"
+                }
+              ],
+              "maxAge": 1
+            },
+            "sectorTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1606694400,
+                    "fmt": "2020-11-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 119430000,
+                    "fmt": "119.43M",
+                    "longFmt": "119,430,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 64166000,
+                    "fmt": "64.17M",
+                    "longFmt": "64,166,000"
+                  },
+                  "grossProfit": {
+                    "raw": 55264000,
+                    "fmt": "55.26M",
+                    "longFmt": "55,264,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 43710000,
+                    "fmt": "43.71M",
+                    "longFmt": "43,710,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 110012000,
+                    "fmt": "110.01M",
+                    "longFmt": "110,012,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 9418000,
+                    "fmt": "9.42M",
+                    "longFmt": "9,418,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -2338000,
+                    "fmt": "-2.34M",
+                    "longFmt": "-2,338,000"
+                  },
+                  "ebit": {
+                    "raw": 9418000,
+                    "fmt": "9.42M",
+                    "longFmt": "9,418,000"
+                  },
+                  "interestExpense": {
+                    "raw": -1716000,
+                    "fmt": "-1.72M",
+                    "longFmt": "-1,716,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 7080000,
+                    "fmt": "7.08M",
+                    "longFmt": "7,080,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 2258000,
+                    "fmt": "2.26M",
+                    "longFmt": "2,258,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 4822000,
+                    "fmt": "4.82M",
+                    "longFmt": "4,822,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -224000,
+                    "fmt": "-224k",
+                    "longFmt": "-224,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 4598000,
+                    "fmt": "4.6M",
+                    "longFmt": "4,598,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 4598000,
+                    "fmt": "4.6M",
+                    "longFmt": "4,598,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1598832000,
+                    "fmt": "2020-08-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 111353000,
+                    "fmt": "111.35M",
+                    "longFmt": "111,353,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 66888000,
+                    "fmt": "66.89M",
+                    "longFmt": "66,888,000"
+                  },
+                  "grossProfit": {
+                    "raw": 44465000,
+                    "fmt": "44.47M",
+                    "longFmt": "44,465,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 38771000,
+                    "fmt": "38.77M",
+                    "longFmt": "38,771,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 107815000,
+                    "fmt": "107.81M",
+                    "longFmt": "107,815,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 3538000,
+                    "fmt": "3.54M",
+                    "longFmt": "3,538,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -2398000,
+                    "fmt": "-2.4M",
+                    "longFmt": "-2,398,000"
+                  },
+                  "ebit": {
+                    "raw": 3538000,
+                    "fmt": "3.54M",
+                    "longFmt": "3,538,000"
+                  },
+                  "interestExpense": {
+                    "raw": -3607000,
+                    "fmt": "-3.61M",
+                    "longFmt": "-3,607,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 1140000,
+                    "fmt": "1.14M",
+                    "longFmt": "1,140,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 943000,
+                    "fmt": "943k",
+                    "longFmt": "943,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 197000,
+                    "fmt": "197k",
+                    "longFmt": "197,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": 1242000,
+                    "fmt": "1.24M",
+                    "longFmt": "1,242,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 1439000,
+                    "fmt": "1.44M",
+                    "longFmt": "1,439,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 1439000,
+                    "fmt": "1.44M",
+                    "longFmt": "1,439,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1590883200,
+                    "fmt": "2020-05-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 101879000,
+                    "fmt": "101.88M",
+                    "longFmt": "101,879,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 59132000,
+                    "fmt": "59.13M",
+                    "longFmt": "59,132,000"
+                  },
+                  "grossProfit": {
+                    "raw": 42747000,
+                    "fmt": "42.75M",
+                    "longFmt": "42,747,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 40766000,
+                    "fmt": "40.77M",
+                    "longFmt": "40,766,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 102072000,
+                    "fmt": "102.07M",
+                    "longFmt": "102,072,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -193000,
+                    "fmt": "-193k",
+                    "longFmt": "-193,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -5144000,
+                    "fmt": "-5.14M",
+                    "longFmt": "-5,144,000"
+                  },
+                  "ebit": {
+                    "raw": -193000,
+                    "fmt": "-193k",
+                    "longFmt": "-193,000"
+                  },
+                  "interestExpense": {
+                    "raw": -4552000,
+                    "fmt": "-4.55M",
+                    "longFmt": "-4,552,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -5337000,
+                    "fmt": "-5.34M",
+                    "longFmt": "-5,337,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -407000,
+                    "fmt": "-407k",
+                    "longFmt": "-407,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": -4930000,
+                    "fmt": "-4.93M",
+                    "longFmt": "-4,930,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -69000,
+                    "fmt": "-69k",
+                    "longFmt": "-69,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -4999000,
+                    "fmt": "-5M",
+                    "longFmt": "-4,999,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -4999000,
+                    "fmt": "-5M",
+                    "longFmt": "-4,999,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1582934400,
+                    "fmt": "2020-02-29"
+                  },
+                  "totalRevenue": {
+                    "raw": 133386000,
+                    "fmt": "133.39M",
+                    "longFmt": "133,386,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 71293000,
+                    "fmt": "71.29M",
+                    "longFmt": "71,293,000"
+                  },
+                  "grossProfit": {
+                    "raw": 62093000,
+                    "fmt": "62.09M",
+                    "longFmt": "62,093,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 50045000,
+                    "fmt": "50.05M",
+                    "longFmt": "50,045,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 123458000,
+                    "fmt": "123.46M",
+                    "longFmt": "123,458,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 9928000,
+                    "fmt": "9.93M",
+                    "longFmt": "9,928,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -5204000,
+                    "fmt": "-5.2M",
+                    "longFmt": "-5,204,000"
+                  },
+                  "ebit": {
+                    "raw": 9928000,
+                    "fmt": "9.93M",
+                    "longFmt": "9,928,000"
+                  },
+                  "interestExpense": {
+                    "raw": -4630000,
+                    "fmt": "-4.63M",
+                    "longFmt": "-4,630,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 4724000,
+                    "fmt": "4.72M",
+                    "longFmt": "4,724,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 806000,
+                    "fmt": "806k",
+                    "longFmt": "806,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 3918000,
+                    "fmt": "3.92M",
+                    "longFmt": "3,918,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -1756000,
+                    "fmt": "-1.76M",
+                    "longFmt": "-1,756,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 2162000,
+                    "fmt": "2.16M",
+                    "longFmt": "2,162,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 2162000,
+                    "fmt": "2.16M",
+                    "longFmt": "2,162,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1606694400,
+                    "fmt": "2020-11-30"
+                  },
+                  "netIncome": {
+                    "raw": 4598000,
+                    "fmt": "4.6M",
+                    "longFmt": "4,598,000"
+                  },
+                  "depreciation": {
+                    "raw": 5458000,
+                    "fmt": "5.46M",
+                    "longFmt": "5,458,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 2681000,
+                    "fmt": "2.68M",
+                    "longFmt": "2,681,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -6268000,
+                    "fmt": "-6.27M",
+                    "longFmt": "-6,268,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 1847000,
+                    "fmt": "1.85M",
+                    "longFmt": "1,847,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -1387000,
+                    "fmt": "-1.39M",
+                    "longFmt": "-1,387,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -848000,
+                    "fmt": "-848k",
+                    "longFmt": "-848,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 8667000,
+                    "fmt": "8.67M",
+                    "longFmt": "8,667,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -1905000,
+                    "fmt": "-1.91M",
+                    "longFmt": "-1,905,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -1858000,
+                    "fmt": "-1.86M",
+                    "longFmt": "-1,858,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -2394000,
+                    "fmt": "-2.39M",
+                    "longFmt": "-2,394,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 750000,
+                    "fmt": "750k",
+                    "longFmt": "750,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -1818000,
+                    "fmt": "-1.82M",
+                    "longFmt": "-1,818,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 1407000,
+                    "fmt": "1.41M",
+                    "longFmt": "1,407,000"
+                  },
+                  "changeInCash": {
+                    "raw": 6398000,
+                    "fmt": "6.4M",
+                    "longFmt": "6,398,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -275000,
+                    "fmt": "-275k",
+                    "longFmt": "-275,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 101000,
+                    "fmt": "101k",
+                    "longFmt": "101,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1598832000,
+                    "fmt": "2020-08-31"
+                  },
+                  "netIncome": {
+                    "raw": 1439000,
+                    "fmt": "1.44M",
+                    "longFmt": "1,439,000"
+                  },
+                  "depreciation": {
+                    "raw": 5347000,
+                    "fmt": "5.35M",
+                    "longFmt": "5,347,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -9632000,
+                    "fmt": "-9.63M",
+                    "longFmt": "-9,632,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 12004000,
+                    "fmt": "12M",
+                    "longFmt": "12,004,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -7835000,
+                    "fmt": "-7.83M",
+                    "longFmt": "-7,835,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 13126000,
+                    "fmt": "13.13M",
+                    "longFmt": "13,126,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -9767000,
+                    "fmt": "-9.77M",
+                    "longFmt": "-9,767,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 12544000,
+                    "fmt": "12.54M",
+                    "longFmt": "12,544,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -2745000,
+                    "fmt": "-2.75M",
+                    "longFmt": "-2,745,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 2674000,
+                    "fmt": "2.67M",
+                    "longFmt": "2,674,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 138000,
+                    "fmt": "138k",
+                    "longFmt": "138,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -2394000,
+                    "fmt": "-2.39M",
+                    "longFmt": "-2,394,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -32559000,
+                    "fmt": "-32.56M",
+                    "longFmt": "-32,559,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 750000,
+                    "fmt": "750k",
+                    "longFmt": "750,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -32528000,
+                    "fmt": "-32.53M",
+                    "longFmt": "-32,528,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 8413000,
+                    "fmt": "8.41M",
+                    "longFmt": "8,413,000"
+                  },
+                  "changeInCash": {
+                    "raw": -11433000,
+                    "fmt": "-11.43M",
+                    "longFmt": "-11,433,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -76000,
+                    "fmt": "-76k",
+                    "longFmt": "-76,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 107000,
+                    "fmt": "107k",
+                    "longFmt": "107,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1590883200,
+                    "fmt": "2020-05-31"
+                  },
+                  "netIncome": {
+                    "raw": -4999000,
+                    "fmt": "-5M",
+                    "longFmt": "-4,999,000"
+                  },
+                  "depreciation": {
+                    "raw": 5317000,
+                    "fmt": "5.32M",
+                    "longFmt": "5,317,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 4610000,
+                    "fmt": "4.61M",
+                    "longFmt": "4,610,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 18789000,
+                    "fmt": "18.79M",
+                    "longFmt": "18,789,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -9882000,
+                    "fmt": "-9.88M",
+                    "longFmt": "-9,882,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -2268000,
+                    "fmt": "-2.27M",
+                    "longFmt": "-2,268,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 5295000,
+                    "fmt": "5.29M",
+                    "longFmt": "5,295,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 13038000,
+                    "fmt": "13.04M",
+                    "longFmt": "13,038,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -2341000,
+                    "fmt": "-2.34M",
+                    "longFmt": "-2,341,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 2674000,
+                    "fmt": "2.67M",
+                    "longFmt": "2,674,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -646000,
+                    "fmt": "-646k",
+                    "longFmt": "-646,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -2394000,
+                    "fmt": "-2.39M",
+                    "longFmt": "-2,394,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -32559000,
+                    "fmt": "-32.56M",
+                    "longFmt": "-32,559,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -234000,
+                    "fmt": "-234k",
+                    "longFmt": "-234,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -9999000,
+                    "fmt": "-10M",
+                    "longFmt": "-9,999,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -2227000,
+                    "fmt": "-2.23M",
+                    "longFmt": "-2,227,000"
+                  },
+                  "changeInCash": {
+                    "raw": 166000,
+                    "fmt": "166k",
+                    "longFmt": "166,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -9862000,
+                    "fmt": "-9.86M",
+                    "longFmt": "-9,862,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 97000,
+                    "fmt": "97k",
+                    "longFmt": "97,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1582934400,
+                    "fmt": "2020-02-29"
+                  },
+                  "netIncome": {
+                    "raw": 2162000,
+                    "fmt": "2.16M",
+                    "longFmt": "2,162,000"
+                  },
+                  "depreciation": {
+                    "raw": 5277000,
+                    "fmt": "5.28M",
+                    "longFmt": "5,277,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 2496000,
+                    "fmt": "2.5M",
+                    "longFmt": "2,496,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 10805000,
+                    "fmt": "10.8M",
+                    "longFmt": "10,805,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -8278000,
+                    "fmt": "-8.28M",
+                    "longFmt": "-8,278,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 3869000,
+                    "fmt": "3.87M",
+                    "longFmt": "3,869,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -17714000,
+                    "fmt": "-17.71M",
+                    "longFmt": "-17,714,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -5814000,
+                    "fmt": "-5.81M",
+                    "longFmt": "-5,814,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -3780000,
+                    "fmt": "-3.78M",
+                    "longFmt": "-3,780,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 175000,
+                    "fmt": "175k",
+                    "longFmt": "175,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -36761000,
+                    "fmt": "-36.76M",
+                    "longFmt": "-36,761,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -2394000,
+                    "fmt": "-2.39M",
+                    "longFmt": "-2,394,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -32559000,
+                    "fmt": "-32.56M",
+                    "longFmt": "-32,559,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -234000,
+                    "fmt": "-234k",
+                    "longFmt": "-234,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -1177000,
+                    "fmt": "-1.18M",
+                    "longFmt": "-1,177,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 409000,
+                    "fmt": "409k",
+                    "longFmt": "409,000"
+                  },
+                  "changeInCash": {
+                    "raw": -43343000,
+                    "fmt": "-43.34M",
+                    "longFmt": "-43,343,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -1425000,
+                    "fmt": "-1.43M",
+                    "longFmt": "-1,425,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 248000,
+                    "fmt": "248k",
+                    "longFmt": "248,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [
+                  {
+                    "date": "1Q2020",
+                    "actual": 0.09,
+                    "estimate": 0.12
+                  },
+                  {
+                    "date": "2Q2020",
+                    "actual": -0.06,
+                    "estimate": 0.11
+                  },
+                  {
+                    "date": "3Q2020",
+                    "actual": 0.02,
+                    "estimate": 0.08
+                  },
+                  {
+                    "date": "4Q2020",
+                    "actual": 0.09,
+                    "estimate": 0.1
+                  }
+                ],
+                "currentQuarterEstimate": 0.12,
+                "currentQuarterEstimateDate": "1Q",
+                "currentQuarterEstimateYear": 2021,
+                "earningsDate": [
+                  1615939200,
+                  1616371200
+                ]
+              },
+              "financialsChart": {
+                "yearly": [
+                  {
+                    "date": 2017,
+                    "revenue": 616591000,
+                    "earnings": -66213000
+                  },
+                  {
+                    "date": 2018,
+                    "revenue": 641303000,
+                    "earnings": -21648000
+                  },
+                  {
+                    "date": 2019,
+                    "revenue": 654758000,
+                    "earnings": -249145000
+                  },
+                  {
+                    "date": 2020,
+                    "revenue": 493292000,
+                    "earnings": 723000
+                  }
+                ],
+                "quarterly": [
+                  {
+                    "date": "1Q2020",
+                    "revenue": 133386000,
+                    "earnings": 2162000
+                  },
+                  {
+                    "date": "2Q2020",
+                    "revenue": 101879000,
+                    "earnings": -4999000
+                  },
+                  {
+                    "date": "3Q2020",
+                    "revenue": 111353000,
+                    "earnings": 1439000
+                  },
+                  {
+                    "date": "4Q2020",
+                    "revenue": 119430000,
+                    "earnings": 4598000
+                  }
+                ]
+              },
+              "financialCurrency": "USD"
+            },
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 23.3,
+              "targetHighPrice": 20,
+              "targetLowPrice": 16,
+              "targetMeanPrice": 18.75,
+              "targetMedianPrice": 19.5,
+              "recommendationMean": 3.2,
+              "recommendationKey": "hold",
+              "numberOfAnalystOpinions": 4,
+              "totalCash": 158568000,
+              "totalCashPerShare": 2.648,
+              "ebitda": 43889000,
+              "totalDebt": 255000000,
+              "quickRatio": 2.317,
+              "currentRatio": 3.262,
+              "totalRevenue": 466048000,
+              "debtToEquity": 69.304,
+              "revenuePerShare": 7.782,
+              "returnOnAssets": 0.01609,
+              "returnOnEquity": 0.011109999,
+              "grossProfits": 217993000,
+              "freeCashflow": 39089624,
+              "operatingCashflow": 28435000,
+              "earningsGrowth": 1.161,
+              "revenueGrowth": -0.186,
+              "grossMargins": 0.43894002,
+              "ebitdaMargins": 0.09417,
+              "operatingMargins": 0.048260003,
+              "profitMargins": 0.0068699997,
+              "financialCurrency": "USD"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-all-MDLY.json
+++ b/tests/http/quoteSummary-all-MDLY.json
@@ -1,0 +1,5121 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=assetProfile%2CbalanceSheetHistory%2CbalanceSheetHistoryQuarterly%2CcalendarEvents%2CcashflowStatementHistory%2CcashflowStatementHistoryQuarterly%2CdefaultKeyStatistics%2Cearnings%2CearningsHistory%2CearningsTrend%2CfinancialData%2CfundOwnership%2CfundPerformance%2CfundProfile%2CincomeStatementHistory%2CincomeStatementHistoryQuarterly%2CindexTrend%2CindustryTrend%2CinsiderHolders%2CinsiderTransactions%2CinstitutionOwnership%2CmajorDirectHolders%2CmajorHoldersBreakdown%2CnetSharePurchaseActivity%2Cprice%2CquoteType%2CrecommendationTrend%2CsecFilings%2CsectorTrend%2CsummaryDetail%2CsummaryProfile%2CtopHoldings%2CupgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "02s250lg2vsf2"
+      ],
+      "x-yahoo-request-id": [
+        "02s250lg2vsf2"
+      ],
+      "x-request-id": [
+        "d7f6968a-3961-41de-aa99-73e38fde130a"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "12"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:09 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "280 Park Avenue",
+              "address2": "6th Floor East",
+              "city": "New York",
+              "state": "NY",
+              "zip": "10017",
+              "country": "United States",
+              "phone": "212-759-0777",
+              "website": "http://www.mdly.com",
+              "industry": "Asset Management",
+              "sector": "Financial Services",
+              "longBusinessSummary": "Medley Management Inc. is an investment holding company and operate and control all of the business and affairs of Medley LLC and its subsidiaries. Medley Management Inc. was incorporated on June 13, 2014 and is based in New York, New York.",
+              "fullTimeEmployees": 65,
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Seth  Taube CFA",
+                  "age": 50,
+                  "title": "Co-CEO & Co-Chairman",
+                  "yearBorn": 1970,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 54828,
+                    "fmt": "54.83k",
+                    "longFmt": "54,828"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Brook  Taube CFA",
+                  "age": 50,
+                  "title": "Co-Chairman, Co-CEO & Chief Investment Officer",
+                  "yearBorn": 1970,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 54319,
+                    "fmt": "54.32k",
+                    "longFmt": "54,319"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Richard Thomas Allorto Jr., CPA, CPA",
+                  "age": 48,
+                  "title": "Chief Financial Officer",
+                  "yearBorn": 1972,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 355052,
+                    "fmt": "355.05k",
+                    "longFmt": "355,052"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Samuel  Anderson",
+                  "title": "Sr. MD, Head of Capital Markets & Risk Management",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Nathan  Bryce",
+                  "title": "Gen. Counsel & Sec.",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Brian  Dohmen",
+                  "title": "Sr. Managing Director and Head of Direct Lending & Origination New York",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Howard  Liao",
+                  "title": "Sr. MD & Head of Corp. Credit",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Mark  Smith",
+                  "title": "MD & Member of the Institutional Fundraising Group",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. James  Frank",
+                  "age": 44,
+                  "title": "Sr. MD & Head of Tactical Opportunities",
+                  "yearBorn": 1976,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Dean Christopher Crowe",
+                  "age": 57,
+                  "title": "Head of Investing and Sr. Managing Director",
+                  "yearBorn": 1963,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "compensationAsOfEpochDate": 1577750400,
+              "maxAge": 86400
+            },
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 1,
+                  "buy": 0,
+                  "hold": 3,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 1,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 1,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 1,
+                  "buy": 0,
+                  "hold": 3,
+                  "sell": 0,
+                  "strongSell": 0
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -3379000,
+                    "fmt": "-3.38M",
+                    "longFmt": "-3,379,000"
+                  },
+                  "depreciation": {
+                    "raw": 702000,
+                    "fmt": "702k",
+                    "longFmt": "702,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 6148000,
+                    "fmt": "6.15M",
+                    "longFmt": "6,148,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 2170000,
+                    "fmt": "2.17M",
+                    "longFmt": "2,170,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -4199000,
+                    "fmt": "-4.2M",
+                    "longFmt": "-4,199,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -1348000,
+                    "fmt": "-1.35M",
+                    "longFmt": "-1,348,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 2145000,
+                    "fmt": "2.15M",
+                    "longFmt": "2,145,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -126000,
+                    "fmt": "-126k",
+                    "longFmt": "-126,000"
+                  },
+                  "investments": {
+                    "raw": -3000,
+                    "fmt": "-3k",
+                    "longFmt": "-3,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 222000,
+                    "fmt": "222k",
+                    "longFmt": "222,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 93000,
+                    "fmt": "93k",
+                    "longFmt": "93,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -238000,
+                    "fmt": "-238k",
+                    "longFmt": "-238,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -7694000,
+                    "fmt": "-7.69M",
+                    "longFmt": "-7,694,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -8899000,
+                    "fmt": "-8.9M",
+                    "longFmt": "-8,899,000"
+                  },
+                  "changeInCash": {
+                    "raw": -6661000,
+                    "fmt": "-6.66M",
+                    "longFmt": "-6,661,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -967000,
+                    "fmt": "-967k",
+                    "longFmt": "-967,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -2432000,
+                    "fmt": "-2.43M",
+                    "longFmt": "-2,432,000"
+                  },
+                  "depreciation": {
+                    "raw": 1076000,
+                    "fmt": "1.08M",
+                    "longFmt": "1,076,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 7136000,
+                    "fmt": "7.14M",
+                    "longFmt": "7,136,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 4440000,
+                    "fmt": "4.44M",
+                    "longFmt": "4,440,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 1686000,
+                    "fmt": "1.69M",
+                    "longFmt": "1,686,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 2903000,
+                    "fmt": "2.9M",
+                    "longFmt": "2,903,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 16217000,
+                    "fmt": "16.22M",
+                    "longFmt": "16,217,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -56000,
+                    "fmt": "-56k",
+                    "longFmt": "-56,000"
+                  },
+                  "investments": {
+                    "raw": -1538000,
+                    "fmt": "-1.54M",
+                    "longFmt": "-1,538,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 222000,
+                    "fmt": "222k",
+                    "longFmt": "222,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -1594000,
+                    "fmt": "-1.59M",
+                    "longFmt": "-1,594,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -5750000,
+                    "fmt": "-5.75M",
+                    "longFmt": "-5,750,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -27288000,
+                    "fmt": "-27.29M",
+                    "longFmt": "-27,288,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -33731000,
+                    "fmt": "-33.73M",
+                    "longFmt": "-33,731,000"
+                  },
+                  "changeInCash": {
+                    "raw": -19108000,
+                    "fmt": "-19.11M",
+                    "longFmt": "-19,108,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -693000,
+                    "fmt": "-693k",
+                    "longFmt": "-693,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 927000,
+                    "fmt": "927k",
+                    "longFmt": "927,000"
+                  },
+                  "depreciation": {
+                    "raw": 911000,
+                    "fmt": "911k",
+                    "longFmt": "911,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 20511000,
+                    "fmt": "20.51M",
+                    "longFmt": "20,511,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -110000,
+                    "fmt": "-110k",
+                    "longFmt": "-110,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -12014000,
+                    "fmt": "-12.01M",
+                    "longFmt": "-12,014,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -367000,
+                    "fmt": "-367k",
+                    "longFmt": "-367,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 12563000,
+                    "fmt": "12.56M",
+                    "longFmt": "12,563,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -73000,
+                    "fmt": "-73k",
+                    "longFmt": "-73,000"
+                  },
+                  "investments": {
+                    "raw": -35130000,
+                    "fmt": "-35.13M",
+                    "longFmt": "-35,130,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 222000,
+                    "fmt": "222k",
+                    "longFmt": "222,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -35203000,
+                    "fmt": "-35.2M",
+                    "longFmt": "-35,203,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -5766000,
+                    "fmt": "-5.77M",
+                    "longFmt": "-5,766,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 24308000,
+                    "fmt": "24.31M",
+                    "longFmt": "24,308,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -9836000,
+                    "fmt": "-9.84M",
+                    "longFmt": "-9,836,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 4404000,
+                    "fmt": "4.4M",
+                    "longFmt": "4,404,000"
+                  },
+                  "changeInCash": {
+                    "raw": -18236000,
+                    "fmt": "-18.24M",
+                    "longFmt": "-18,236,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -4302000,
+                    "fmt": "-4.3M",
+                    "longFmt": "-4,302,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 997000,
+                    "fmt": "997k",
+                    "longFmt": "997,000"
+                  },
+                  "depreciation": {
+                    "raw": 913000,
+                    "fmt": "913k",
+                    "longFmt": "913,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 12734000,
+                    "fmt": "12.73M",
+                    "longFmt": "12,734,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 1099000,
+                    "fmt": "1.1M",
+                    "longFmt": "1,099,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -1682000,
+                    "fmt": "-1.68M",
+                    "longFmt": "-1,682,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -142000,
+                    "fmt": "-142k",
+                    "longFmt": "-142,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 15895000,
+                    "fmt": "15.89M",
+                    "longFmt": "15,895,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -1935000,
+                    "fmt": "-1.94M",
+                    "longFmt": "-1,935,000"
+                  },
+                  "investments": {
+                    "raw": -16891000,
+                    "fmt": "-16.89M",
+                    "longFmt": "-16,891,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 222000,
+                    "fmt": "222k",
+                    "longFmt": "222,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -18826000,
+                    "fmt": "-18.83M",
+                    "longFmt": "-18,826,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -5521000,
+                    "fmt": "-5.52M",
+                    "longFmt": "-5,521,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 2075000,
+                    "fmt": "2.08M",
+                    "longFmt": "2,075,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -9550000,
+                    "fmt": "-9.55M",
+                    "longFmt": "-9,550,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -14194000,
+                    "fmt": "-14.19M",
+                    "longFmt": "-14,194,000"
+                  },
+                  "changeInCash": {
+                    "raw": -17125000,
+                    "fmt": "-17.12M",
+                    "longFmt": "-17,125,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -1198000,
+                    "fmt": "-1.2M",
+                    "longFmt": "-1,198,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 8.58013,
+              "pegRatio": 0.771291,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.286
+                },
+                {
+                  "period": "+1q",
+                  "growth": 1.032
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.175
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.15100001
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0827489
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            },
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": 13253203,
+              "profitMargins": -0.13196,
+              "floatShares": 219759,
+              "sharesOutstanding": 3045180,
+              "sharesShort": 77266,
+              "sharesShortPriorMonth": 37908,
+              "sharesShortPreviousMonthDate": 1609372800,
+              "dateShortInterest": 1611878400,
+              "sharesPercentSharesOut": 0.0135,
+              "heldPercentInsiders": 0.12206,
+              "heldPercentInstitutions": 0.17618999,
+              "shortRatio": 0.25,
+              "shortPercentOfFloat": 0.0257,
+              "beta": 1.89381,
+              "impliedSharesOutstanding": 5718700,
+              "category": null,
+              "bookValue": -12.142,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1577750400,
+              "nextFiscalYearEnd": 1640908800,
+              "mostRecentQuarter": 1601424000,
+              "netIncomeToCommon": -4901000,
+              "trailingEps": -7.855,
+              "forwardEps": 0.25,
+              "lastSplitFactor": "1:10",
+              "lastSplitDate": 1604275200,
+              "enterpriseToRevenue": 0.374,
+              "enterpriseToEbitda": 4.634,
+              "52WeekChange": -0.6452632,
+              "SandP52WeekChange": 0.17263722,
+              "lastDividendValue": 0.035,
+              "lastDividendDate": 1585267200
+            },
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "quoteType": {
+              "exchange": "NYQ",
+              "quoteType": "EQUITY",
+              "symbol": "MDLY",
+              "underlyingSymbol": "MDLY",
+              "shortName": "Medley Management Inc.",
+              "longName": "Medley Management Inc.",
+              "firstTradeDateEpochUtc": 1411565400,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "5c7a2af9-da78-3b57-8755-1c4c2ec9ea8b",
+              "messageBoardId": "finmb_269214791",
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            },
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 48841000,
+                    "fmt": "48.84M",
+                    "longFmt": "48,841,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 27367000,
+                    "fmt": "27.37M",
+                    "longFmt": "27,367,000"
+                  },
+                  "grossProfit": {
+                    "raw": 21474000,
+                    "fmt": "21.47M",
+                    "longFmt": "21,474,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 12586000,
+                    "fmt": "12.59M",
+                    "longFmt": "12,586,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 39953000,
+                    "fmt": "39.95M",
+                    "longFmt": "39,953,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 8888000,
+                    "fmt": "8.89M",
+                    "longFmt": "8,888,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -20948000,
+                    "fmt": "-20.95M",
+                    "longFmt": "-20,948,000"
+                  },
+                  "ebit": {
+                    "raw": 8888000,
+                    "fmt": "8.89M",
+                    "longFmt": "8,888,000"
+                  },
+                  "interestExpense": {
+                    "raw": -11497000,
+                    "fmt": "-11.5M",
+                    "longFmt": "-11,497,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -12060000,
+                    "fmt": "-12.06M",
+                    "longFmt": "-12,060,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 4710000,
+                    "fmt": "4.71M",
+                    "longFmt": "4,710,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -109714000,
+                    "fmt": "-109.71M",
+                    "longFmt": "-109,714,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -16770000,
+                    "fmt": "-16.77M",
+                    "longFmt": "-16,770,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -3379000,
+                    "fmt": "-3.38M",
+                    "longFmt": "-3,379,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -3529000,
+                    "fmt": "-3.53M",
+                    "longFmt": "-3,529,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 56509000,
+                    "fmt": "56.51M",
+                    "longFmt": "56,509,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 28936000,
+                    "fmt": "28.94M",
+                    "longFmt": "28,936,000"
+                  },
+                  "grossProfit": {
+                    "raw": 27573000,
+                    "fmt": "27.57M",
+                    "longFmt": "27,573,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 15566000,
+                    "fmt": "15.57M",
+                    "longFmt": "15,566,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 44502000,
+                    "fmt": "44.5M",
+                    "longFmt": "44,502,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 12007000,
+                    "fmt": "12.01M",
+                    "longFmt": "12,007,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -33275000,
+                    "fmt": "-33.27M",
+                    "longFmt": "-33,275,000"
+                  },
+                  "ebit": {
+                    "raw": 12007000,
+                    "fmt": "12.01M",
+                    "longFmt": "12,007,000"
+                  },
+                  "interestExpense": {
+                    "raw": -10806000,
+                    "fmt": "-10.81M",
+                    "longFmt": "-10,806,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -21268000,
+                    "fmt": "-21.27M",
+                    "longFmt": "-21,268,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 258000,
+                    "fmt": "258k",
+                    "longFmt": "258,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -75403000,
+                    "fmt": "-75.4M",
+                    "longFmt": "-75,403,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -21526000,
+                    "fmt": "-21.53M",
+                    "longFmt": "-21,526,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -2432000,
+                    "fmt": "-2.43M",
+                    "longFmt": "-2,432,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -3629000,
+                    "fmt": "-3.63M",
+                    "longFmt": "-3,629,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 65033000,
+                    "fmt": "65.03M",
+                    "longFmt": "65,033,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 25374000,
+                    "fmt": "25.37M",
+                    "longFmt": "25,374,000"
+                  },
+                  "grossProfit": {
+                    "raw": 39659000,
+                    "fmt": "39.66M",
+                    "longFmt": "39,659,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 13045000,
+                    "fmt": "13.04M",
+                    "longFmt": "13,045,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 38419000,
+                    "fmt": "38.42M",
+                    "longFmt": "38,419,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 26614000,
+                    "fmt": "26.61M",
+                    "longFmt": "26,614,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -7349000,
+                    "fmt": "-7.35M",
+                    "longFmt": "-7,349,000"
+                  },
+                  "ebit": {
+                    "raw": 26614000,
+                    "fmt": "26.61M",
+                    "longFmt": "26,614,000"
+                  },
+                  "interestExpense": {
+                    "raw": -11855000,
+                    "fmt": "-11.86M",
+                    "longFmt": "-11,855,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 19265000,
+                    "fmt": "19.27M",
+                    "longFmt": "19,265,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 1956000,
+                    "fmt": "1.96M",
+                    "longFmt": "1,956,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -15362000,
+                    "fmt": "-15.36M",
+                    "longFmt": "-15,362,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 17309000,
+                    "fmt": "17.31M",
+                    "longFmt": "17,309,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 927000,
+                    "fmt": "927k",
+                    "longFmt": "927,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 376000,
+                    "fmt": "376k",
+                    "longFmt": "376,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 75941000,
+                    "fmt": "75.94M",
+                    "longFmt": "75,941,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 27263000,
+                    "fmt": "27.26M",
+                    "longFmt": "27,263,000"
+                  },
+                  "grossProfit": {
+                    "raw": 48678000,
+                    "fmt": "48.68M",
+                    "longFmt": "48,678,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 28540000,
+                    "fmt": "28.54M",
+                    "longFmt": "28,540,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 55803000,
+                    "fmt": "55.8M",
+                    "longFmt": "55,803,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 20138000,
+                    "fmt": "20.14M",
+                    "longFmt": "20,138,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -9123000,
+                    "fmt": "-9.12M",
+                    "longFmt": "-9,123,000"
+                  },
+                  "ebit": {
+                    "raw": 20138000,
+                    "fmt": "20.14M",
+                    "longFmt": "20,138,000"
+                  },
+                  "interestExpense": {
+                    "raw": -9226000,
+                    "fmt": "-9.23M",
+                    "longFmt": "-9,226,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 11015000,
+                    "fmt": "11.02M",
+                    "longFmt": "11,015,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 1063000,
+                    "fmt": "1.06M",
+                    "longFmt": "1,063,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -15004000,
+                    "fmt": "-15M",
+                    "longFmt": "-15,004,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 9952000,
+                    "fmt": "9.95M",
+                    "longFmt": "9,952,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 997000,
+                    "fmt": "997k",
+                    "longFmt": "997,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 105000,
+                    "fmt": "105k",
+                    "longFmt": "105,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            },
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 10.11,
+              "open": 10.22,
+              "dayLow": 10.14,
+              "dayHigh": 10.42,
+              "regularMarketPreviousClose": 10.11,
+              "regularMarketOpen": 10.22,
+              "regularMarketDayLow": 10.14,
+              "regularMarketDayHigh": 10.42,
+              "exDividendDate": 1585267200,
+              "fiveYearAvgDividendYield": 14.12,
+              "beta": 1.89381,
+              "forwardPE": 41.648,
+              "volume": 19267,
+              "regularMarketVolume": 19267,
+              "averageVolume": 205062,
+              "averageVolume10days": 167414,
+              "averageDailyVolume10Day": 167414,
+              "bid": 10.3,
+              "ask": 10.41,
+              "bidSize": 1400,
+              "askSize": 1200,
+              "marketCap": 59543104,
+              "fiftyTwoWeekLow": 2.8,
+              "fiftyTwoWeekHigh": 29,
+              "priceToSalesTrailing12Months": 1.6806792,
+              "fiftyDayAverage": 9.882728,
+              "twoHundredDayAverage": 7.6748624,
+              "trailingAnnualDividendRate": 0.03,
+              "trailingAnnualDividendYield": 0.002967359,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            },
+            "insiderHolders": {
+              "holders": [
+                {
+                  "maxAge": 1,
+                  "name": "ALLORTO RICHARD T JR",
+                  "relation": "Chief Financial Officer",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionIndirect": {
+                    "raw": 192977,
+                    "fmt": "192.98k",
+                    "longFmt": "192,977"
+                  },
+                  "positionIndirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "EATON JAMES GEORGE",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1590710400,
+                    "fmt": "2020-05-29"
+                  },
+                  "positionDirect": {
+                    "raw": 57356,
+                    "fmt": "57.36k",
+                    "longFmt": "57,356"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1590710400,
+                    "fmt": "2020-05-29"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "FREEDOM 2021 L.L.C.",
+                  "relation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionDirect": {
+                    "raw": 450000,
+                    "fmt": "450k",
+                    "longFmt": "450,000"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "JAM PARTNERS, L.P.",
+                  "relation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1564444800,
+                    "fmt": "2019-07-30"
+                  },
+                  "positionIndirect": {
+                    "raw": 574718,
+                    "fmt": "574.72k",
+                    "longFmt": "574,718"
+                  },
+                  "positionIndirectDate": {
+                    "raw": 1564444800,
+                    "fmt": "2019-07-30"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "LEEDS JEFFREY T",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1597104000,
+                    "fmt": "2020-08-11"
+                  },
+                  "positionDirect": {
+                    "raw": 98989,
+                    "fmt": "98.99k",
+                    "longFmt": "98,989"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1597104000,
+                    "fmt": "2020-08-11"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "ROUNSAVILLE GUYJR",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1590710400,
+                    "fmt": "2020-05-29"
+                  },
+                  "positionDirect": {
+                    "raw": 38125,
+                    "fmt": "38.12k",
+                    "longFmt": "38,125"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1590710400,
+                    "fmt": "2020-05-29"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "SANDY POINT L.L.C.",
+                  "relation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionDirect": {
+                    "raw": 999999,
+                    "fmt": "1,000k",
+                    "longFmt": "999,999"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "TAUBE ANGELIC DIAZ",
+                  "relation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionDirect": {
+                    "raw": 500000,
+                    "fmt": "500k",
+                    "longFmt": "500,000"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "TAUBE BROOK",
+                  "relation": "Chief Executive Officer",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionIndirect": {
+                    "raw": 999999,
+                    "fmt": "1,000k",
+                    "longFmt": "999,999"
+                  },
+                  "positionIndirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "TAUBE SETH",
+                  "relation": "Chief Executive Officer",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionIndirect": {
+                    "raw": 450000,
+                    "fmt": "450k",
+                    "longFmt": "450,000"
+                  },
+                  "positionIndirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                }
+              ],
+              "maxAge": 1
+            },
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": [
+                  1605484800
+                ],
+                "revenueAverage": 8326000,
+                "revenueLow": 8310000,
+                "revenueHigh": 8310000
+              },
+              "exDividendDate": 1585267200,
+              "dividendDate": 1556841600
+            },
+            "upgradeDowngradeHistory": {
+              "history": [
+                {
+                  "epochGradeDate": 1606297020,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Neutral",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606297004,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1606297004,
+                  "firm": "Ladenburg Thalmann",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Compass Point",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Ladenburg Thalmann",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Keefe Bruyette & Woods",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Keefe Bruyette & Woods",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Keefe Bruyette & Woods",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Keefe Bruyette & Woods",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "FBR Capital",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Keefe Bruyette & Woods",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Keefe Bruyette & Woods",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Keefe Bruyette & Woods",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Keefe Bruyette & Woods",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Keefe Bruyette & Woods",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Gilford Securities",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                }
+              ],
+              "maxAge": 86400
+            },
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": 0.0375866,
+              "preMarketChange": 0.38,
+              "preMarketTime": 1613744144,
+              "preMarketPrice": 10.49,
+              "preMarketSource": "FREE_REALTIME",
+              "regularMarketChangePercent": 0.029871421,
+              "regularMarketChange": 0.30200005,
+              "regularMarketTime": 1613753447,
+              "priceHint": 2,
+              "regularMarketPrice": 10.412,
+              "regularMarketDayHigh": 10.42,
+              "regularMarketDayLow": 10.14,
+              "regularMarketVolume": 19267,
+              "averageDailyVolume10Day": 167414,
+              "averageDailyVolume3Month": 205062,
+              "regularMarketPreviousClose": 10.11,
+              "regularMarketSource": "FREE_REALTIME",
+              "regularMarketOpen": 10.22,
+              "exchange": "NYQ",
+              "exchangeName": "NYSE",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "EQUITY",
+              "symbol": "MDLY",
+              "underlyingSymbol": null,
+              "shortName": "Medley Management Inc.",
+              "longName": "Medley Management Inc.",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 59543104
+            },
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 10558000,
+                    "fmt": "10.56M",
+                    "longFmt": "10,558,000"
+                  },
+                  "netReceivables": {
+                    "raw": 10964000,
+                    "fmt": "10.96M",
+                    "longFmt": "10,964,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 1975000,
+                    "fmt": "1.98M",
+                    "longFmt": "1,975,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 25519000,
+                    "fmt": "25.52M",
+                    "longFmt": "25,519,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 13287000,
+                    "fmt": "13.29M",
+                    "longFmt": "13,287,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 9128000,
+                    "fmt": "9.13M",
+                    "longFmt": "9,128,000"
+                  },
+                  "otherAssets": {
+                    "raw": 862000,
+                    "fmt": "862k",
+                    "longFmt": "862,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 185000,
+                    "fmt": "185k",
+                    "longFmt": "185,000"
+                  },
+                  "totalAssets": {
+                    "raw": 48796000,
+                    "fmt": "48.8M",
+                    "longFmt": "48,796,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1829000,
+                    "fmt": "1.83M",
+                    "longFmt": "1,829,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 10000000,
+                    "fmt": "10M",
+                    "longFmt": "10,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 2927000,
+                    "fmt": "2.93M",
+                    "longFmt": "2,927,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 118382000,
+                    "fmt": "118.38M",
+                    "longFmt": "118,382,000"
+                  },
+                  "otherLiab": {
+                    "raw": 17119000,
+                    "fmt": "17.12M",
+                    "longFmt": "17,119,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -109714000,
+                    "fmt": "-109.71M",
+                    "longFmt": "-109,714,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 26707000,
+                    "fmt": "26.71M",
+                    "longFmt": "26,707,000"
+                  },
+                  "totalLiab": {
+                    "raw": 167629000,
+                    "fmt": "167.63M",
+                    "longFmt": "167,629,000"
+                  },
+                  "commonStock": {
+                    "raw": 62000,
+                    "fmt": "62k",
+                    "longFmt": "62,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -22960000,
+                    "fmt": "-22.96M",
+                    "longFmt": "-22,960,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 13779000,
+                    "fmt": "13.78M",
+                    "longFmt": "13,779,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -9119000,
+                    "fmt": "-9.12M",
+                    "longFmt": "-9,119,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -9119000,
+                    "fmt": "-9.12M",
+                    "longFmt": "-9,119,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "cash": {
+                    "raw": 17219000,
+                    "fmt": "17.22M",
+                    "longFmt": "17,219,000"
+                  },
+                  "netReceivables": {
+                    "raw": 13340000,
+                    "fmt": "13.34M",
+                    "longFmt": "13,340,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 1975000,
+                    "fmt": "1.98M",
+                    "longFmt": "1,975,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 33647000,
+                    "fmt": "33.65M",
+                    "longFmt": "33,647,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 36425000,
+                    "fmt": "36.42M",
+                    "longFmt": "36,425,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 3140000,
+                    "fmt": "3.14M",
+                    "longFmt": "3,140,000"
+                  },
+                  "otherAssets": {
+                    "raw": 5004000,
+                    "fmt": "5M",
+                    "longFmt": "5,004,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 3739000,
+                    "fmt": "3.74M",
+                    "longFmt": "3,739,000"
+                  },
+                  "totalAssets": {
+                    "raw": 78216000,
+                    "fmt": "78.22M",
+                    "longFmt": "78,216,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 2499000,
+                    "fmt": "2.5M",
+                    "longFmt": "2,499,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 9892000,
+                    "fmt": "9.89M",
+                    "longFmt": "9,892,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 117618000,
+                    "fmt": "117.62M",
+                    "longFmt": "117,618,000"
+                  },
+                  "otherLiab": {
+                    "raw": 24108000,
+                    "fmt": "24.11M",
+                    "longFmt": "24,108,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -75403000,
+                    "fmt": "-75.4M",
+                    "longFmt": "-75,403,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 23925000,
+                    "fmt": "23.93M",
+                    "longFmt": "23,925,000"
+                  },
+                  "totalLiab": {
+                    "raw": 165651000,
+                    "fmt": "165.65M",
+                    "longFmt": "165,651,000"
+                  },
+                  "commonStock": {
+                    "raw": 57000,
+                    "fmt": "57k",
+                    "longFmt": "57,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -19618000,
+                    "fmt": "-19.62M",
+                    "longFmt": "-19,618,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 7529000,
+                    "fmt": "7.53M",
+                    "longFmt": "7,529,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -12032000,
+                    "fmt": "-12.03M",
+                    "longFmt": "-12,032,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -12032000,
+                    "fmt": "-12.03M",
+                    "longFmt": "-12,032,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "cash": {
+                    "raw": 36327000,
+                    "fmt": "36.33M",
+                    "longFmt": "36,327,000"
+                  },
+                  "netReceivables": {
+                    "raw": 22583000,
+                    "fmt": "22.58M",
+                    "longFmt": "22,583,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 1975000,
+                    "fmt": "1.98M",
+                    "longFmt": "1,975,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 62238000,
+                    "fmt": "62.24M",
+                    "longFmt": "62,238,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 56632000,
+                    "fmt": "56.63M",
+                    "longFmt": "56,632,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 4160000,
+                    "fmt": "4.16M",
+                    "longFmt": "4,160,000"
+                  },
+                  "otherAssets": {
+                    "raw": 4892000,
+                    "fmt": "4.89M",
+                    "longFmt": "4,892,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 2777000,
+                    "fmt": "2.78M",
+                    "longFmt": "2,777,000"
+                  },
+                  "totalAssets": {
+                    "raw": 127922000,
+                    "fmt": "127.92M",
+                    "longFmt": "127,922,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1770000,
+                    "fmt": "1.77M",
+                    "longFmt": "1,770,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 126125000,
+                    "fmt": "126.12M",
+                    "longFmt": "126,125,000"
+                  },
+                  "otherLiab": {
+                    "raw": 13754000,
+                    "fmt": "13.75M",
+                    "longFmt": "13,754,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -15362000,
+                    "fmt": "-15.36M",
+                    "longFmt": "-15,362,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 11376000,
+                    "fmt": "11.38M",
+                    "longFmt": "11,376,000"
+                  },
+                  "totalLiab": {
+                    "raw": 151255000,
+                    "fmt": "151.25M",
+                    "longFmt": "151,255,000"
+                  },
+                  "commonStock": {
+                    "raw": 55000,
+                    "fmt": "55k",
+                    "longFmt": "55,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -9545000,
+                    "fmt": "-9.54M",
+                    "longFmt": "-9,545,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -1301000,
+                    "fmt": "-1.3M",
+                    "longFmt": "-1,301,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 2820000,
+                    "fmt": "2.82M",
+                    "longFmt": "2,820,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -1301000,
+                    "fmt": "-1.3M",
+                    "longFmt": "-1,301,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -7971000,
+                    "fmt": "-7.97M",
+                    "longFmt": "-7,971,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -7971000,
+                    "fmt": "-7.97M",
+                    "longFmt": "-7,971,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "cash": {
+                    "raw": 49666000,
+                    "fmt": "49.67M",
+                    "longFmt": "49,666,000"
+                  },
+                  "netReceivables": {
+                    "raw": 21792000,
+                    "fmt": "21.79M",
+                    "longFmt": "21,792,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 6872000,
+                    "fmt": "6.87M",
+                    "longFmt": "6,872,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 81408000,
+                    "fmt": "81.41M",
+                    "longFmt": "81,408,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 31904000,
+                    "fmt": "31.9M",
+                    "longFmt": "31,904,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 4998000,
+                    "fmt": "5M",
+                    "longFmt": "4,998,000"
+                  },
+                  "otherAssets": {
+                    "raw": 4059000,
+                    "fmt": "4.06M",
+                    "longFmt": "4,059,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 2001000,
+                    "fmt": "2M",
+                    "longFmt": "2,001,000"
+                  },
+                  "totalAssets": {
+                    "raw": 122369000,
+                    "fmt": "122.37M",
+                    "longFmt": "122,369,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1657000,
+                    "fmt": "1.66M",
+                    "longFmt": "1,657,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 101971000,
+                    "fmt": "101.97M",
+                    "longFmt": "101,971,000"
+                  },
+                  "otherLiab": {
+                    "raw": 16650000,
+                    "fmt": "16.65M",
+                    "longFmt": "16,650,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -15004000,
+                    "fmt": "-15M",
+                    "longFmt": "-15,004,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 20605000,
+                    "fmt": "20.61M",
+                    "longFmt": "20,605,000"
+                  },
+                  "totalLiab": {
+                    "raw": 139226000,
+                    "fmt": "139.23M",
+                    "longFmt": "139,226,000"
+                  },
+                  "commonStock": {
+                    "raw": 58000,
+                    "fmt": "58k",
+                    "longFmt": "58,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -5254000,
+                    "fmt": "-5.25M",
+                    "longFmt": "-5,254,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 33000,
+                    "fmt": "33k",
+                    "longFmt": "33,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 3310000,
+                    "fmt": "3.31M",
+                    "longFmt": "3,310,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 33000,
+                    "fmt": "33k",
+                    "longFmt": "33,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -1853000,
+                    "fmt": "-1.85M",
+                    "longFmt": "-1,853,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -1853000,
+                    "fmt": "-1.85M",
+                    "longFmt": "-1,853,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": "2020-09-30",
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {
+                      "raw": -0.23,
+                      "fmt": "-0.23"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 8326000,
+                      "fmt": "8.33M",
+                      "longFmt": "8,326,000"
+                    },
+                    "low": {
+                      "raw": 8310000,
+                      "fmt": "8.31M",
+                      "longFmt": "8,310,000"
+                    },
+                    "high": {
+                      "raw": 8310000,
+                      "fmt": "8.31M",
+                      "longFmt": "8,310,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 11536000,
+                      "fmt": "11.54M",
+                      "longFmt": "11,536,000"
+                    },
+                    "growth": {
+                      "raw": -0.278,
+                      "fmt": "-27.80%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": -0.04,
+                      "fmt": "-0.04"
+                    },
+                    "30daysAgo": {
+                      "raw": -0.04,
+                      "fmt": "-0.04"
+                    },
+                    "60daysAgo": {
+                      "raw": -0.04,
+                      "fmt": "-0.04"
+                    },
+                    "90daysAgo": {
+                      "raw": -0.04,
+                      "fmt": "-0.04"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": "2020-12-31",
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {
+                      "raw": -0.4,
+                      "fmt": "-0.4"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 8310000,
+                      "fmt": "8.31M",
+                      "longFmt": "8,310,000"
+                    },
+                    "low": {
+                      "raw": 8310000,
+                      "fmt": "8.31M",
+                      "longFmt": "8,310,000"
+                    },
+                    "high": {
+                      "raw": 8310000,
+                      "fmt": "8.31M",
+                      "longFmt": "8,310,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 10654000,
+                      "fmt": "10.65M",
+                      "longFmt": "10,654,000"
+                    },
+                    "growth": {
+                      "raw": -0.22,
+                      "fmt": "-22.00%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": -0.02,
+                      "fmt": "-0.02"
+                    },
+                    "30daysAgo": {
+                      "raw": -0.02,
+                      "fmt": "-0.02"
+                    },
+                    "60daysAgo": {
+                      "raw": -0.02,
+                      "fmt": "-0.02"
+                    },
+                    "90daysAgo": {
+                      "raw": -0.02,
+                      "fmt": "-0.02"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": "2020-12-31",
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 34960000,
+                      "fmt": "34.96M",
+                      "longFmt": "34,960,000"
+                    },
+                    "low": {
+                      "raw": 34960000,
+                      "fmt": "34.96M",
+                      "longFmt": "34,960,000"
+                    },
+                    "high": {
+                      "raw": 34960000,
+                      "fmt": "34.96M",
+                      "longFmt": "34,960,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 48841000,
+                      "fmt": "48.84M",
+                      "longFmt": "48,841,000"
+                    },
+                    "growth": {
+                      "raw": -0.284,
+                      "fmt": "-28.40%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": -0.14,
+                      "fmt": "-0.14"
+                    },
+                    "30daysAgo": {
+                      "raw": -0.14,
+                      "fmt": "-0.14"
+                    },
+                    "60daysAgo": {
+                      "raw": -0.14,
+                      "fmt": "-0.14"
+                    },
+                    "90daysAgo": {
+                      "raw": -0.14,
+                      "fmt": "-0.14"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": "2021-12-31",
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 34960000,
+                      "fmt": "34.96M",
+                      "longFmt": "34,960,000"
+                    },
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": 0.0201,
+                    "fmt": "2.01%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": -0.33367002,
+                    "fmt": "-33.37%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            },
+            "secFilings": {
+              "filings": [
+                {
+                  "date": "2021-02-16",
+                  "epochDate": 1613511368,
+                  "type": "8-K",
+                  "title": "Triggering Events That Accelerate or Increase a Direct Financial Obligation or an Obligation under an Off-Balance Sheet Arrangement",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001437749-21-003006&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-02-09",
+                  "epochDate": 1612905812,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers, Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001437749-21-002335&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-02-02",
+                  "epochDate": 1612263998,
+                  "type": "8-K",
+                  "title": "Triggering Events That Accelerate or Increase a Direct Financial Obligation or an Obligation under an Off-Balance Sheet Arrangement",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001437749-21-001699&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-01-19",
+                  "epochDate": 1611095408,
+                  "type": "8-K",
+                  "title": "Triggering Events That Accelerate or Increase a Direct Financial Obligation or an Obligation under an Off-Balance Sheet Arrangement, Unregistered Sale of Equity Securities, Change in Directors or Principal Officers",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001437749-21-000889&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-11-24",
+                  "epochDate": 1606256428,
+                  "type": "8-K",
+                  "title": "Other Events",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-20-000046&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-11-16",
+                  "epochDate": 1605526545,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-20-000039&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-11-16",
+                  "epochDate": 1605526078,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-20-000037&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-22",
+                  "epochDate": 1603403147,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers, Amendments to Articles of Inc. or Bylaws; Change in Fiscal Year, Submission of Matters to a Vote of Security Holders, Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-20-000035&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-08-14",
+                  "epochDate": 1597442037,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-20-000025&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-08-14",
+                  "epochDate": 1597441613,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-20-000024&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-15",
+                  "epochDate": 1589575423,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-20-000019&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-15",
+                  "epochDate": 1589575228,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-20-000018&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-05",
+                  "epochDate": 1588682528,
+                  "type": "8-K",
+                  "title": "Disclosing Termination of a Material Definitive Agreement, Financial Statements and E",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001213900-20-010961&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-23",
+                  "epochDate": 1587674506,
+                  "type": "8-K",
+                  "title": "Disclosing Notice of Delisting or Failure to Satisfy a Continued Listing Rule or Stan",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-20-000010&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-03-30",
+                  "epochDate": 1585562909,
+                  "type": "10-K",
+                  "title": "Annual Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-20-000006&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-03-30",
+                  "epochDate": 1585562908,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-20-000007&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-14",
+                  "epochDate": 1573766649,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-19-000047&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-14",
+                  "epochDate": 1573766303,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-19-000046&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-10-29",
+                  "epochDate": 1572343509,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001213900-19-021319&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-08-14",
+                  "epochDate": 1565813757,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-19-000042&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-08-14",
+                  "epochDate": 1565813391,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-19-000041&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-08-02",
+                  "epochDate": 1564780767,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Financial Statements and Exhib",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001213900-19-014504&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-07-29",
+                  "epochDate": 1564400949,
+                  "type": "8-K",
+                  "title": "Disclosing Change in Directors or Principal Officers, Other Events, Financial Stateme",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001213900-19-013820&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-05-31",
+                  "epochDate": 1559333651,
+                  "type": "8-K",
+                  "title": "Disclosing Change in Directors or Principal Officers, Submission of Matters to a Vote",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-19-000029&nav=1&src=Yahoo",
+                  "maxAge": 1
+                }
+              ],
+              "maxAge": 86400
+            },
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "American Financial Group Inc.",
+                  "pctHeld": {
+                    "raw": 0.0865,
+                    "fmt": "8.65%"
+                  },
+                  "position": {
+                    "raw": 57910,
+                    "fmt": "57.91k",
+                    "longFmt": "57,910"
+                  },
+                  "value": {
+                    "raw": 337036,
+                    "fmt": "337.04k",
+                    "longFmt": "337,036"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Group, Inc. (The)",
+                  "pctHeld": {
+                    "raw": 0.0148,
+                    "fmt": "1.48%"
+                  },
+                  "position": {
+                    "raw": 9945,
+                    "fmt": "9.95k",
+                    "longFmt": "9,945"
+                  },
+                  "value": {
+                    "raw": 57879,
+                    "fmt": "57.88k",
+                    "longFmt": "57,879"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Virtu Financial LLC",
+                  "pctHeld": {
+                    "raw": 0.0115,
+                    "fmt": "1.15%"
+                  },
+                  "position": {
+                    "raw": 7685,
+                    "fmt": "7.68k",
+                    "longFmt": "7,685"
+                  },
+                  "value": {
+                    "raw": 44726,
+                    "fmt": "44.73k",
+                    "longFmt": "44,726"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Advisor Group, Inc.",
+                  "pctHeld": {
+                    "raw": 0.0083,
+                    "fmt": "0.83%"
+                  },
+                  "position": {
+                    "raw": 5528,
+                    "fmt": "5.53k",
+                    "longFmt": "5,528"
+                  },
+                  "value": {
+                    "raw": 44168,
+                    "fmt": "44.17k",
+                    "longFmt": "44,168"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "West Family Investments, Inc.",
+                  "pctHeld": {
+                    "raw": 0.006,
+                    "fmt": "0.60%"
+                  },
+                  "position": {
+                    "raw": 4013,
+                    "fmt": "4.01k",
+                    "longFmt": "4,013"
+                  },
+                  "value": {
+                    "raw": 23355,
+                    "fmt": "23.36k",
+                    "longFmt": "23,355"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Geode Capital Management, LLC",
+                  "pctHeld": {
+                    "raw": 0.0049,
+                    "fmt": "0.49%"
+                  },
+                  "position": {
+                    "raw": 3271,
+                    "fmt": "3.27k",
+                    "longFmt": "3,271"
+                  },
+                  "value": {
+                    "raw": 19037,
+                    "fmt": "19.04k",
+                    "longFmt": "19,037"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Tower Research Capital LLC (TRC)",
+                  "pctHeld": {
+                    "raw": 0.0044,
+                    "fmt": "0.44%"
+                  },
+                  "position": {
+                    "raw": 2934,
+                    "fmt": "2.93k",
+                    "longFmt": "2,934"
+                  },
+                  "value": {
+                    "raw": 17075,
+                    "fmt": "17.07k",
+                    "longFmt": "17,075"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Shelton Capital Management LLC",
+                  "pctHeld": {
+                    "raw": 0.0028,
+                    "fmt": "0.28%"
+                  },
+                  "position": {
+                    "raw": 1864,
+                    "fmt": "1.86k",
+                    "longFmt": "1,864"
+                  },
+                  "value": {
+                    "raw": 10848,
+                    "fmt": "10.85k",
+                    "longFmt": "10,848"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "UBS Group AG",
+                  "pctHeld": {
+                    "raw": 0.0026,
+                    "fmt": "0.26%"
+                  },
+                  "position": {
+                    "raw": 1761,
+                    "fmt": "1.76k",
+                    "longFmt": "1,761"
+                  },
+                  "value": {
+                    "raw": 10249,
+                    "fmt": "10.25k",
+                    "longFmt": "10,249"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Citadel Advisors LLC",
+                  "pctHeld": {
+                    "raw": 0.0023,
+                    "fmt": "0.23%"
+                  },
+                  "position": {
+                    "raw": 1529,
+                    "fmt": "1.53k",
+                    "longFmt": "1,529"
+                  },
+                  "value": {
+                    "raw": 8898,
+                    "fmt": "8.9k",
+                    "longFmt": "8,898"
+                  }
+                }
+              ]
+            },
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.12206,
+              "institutionsPercentHeld": 0.17618999,
+              "institutionsFloatPercentHeld": 0.20068,
+              "institutionsCount": 21
+            },
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 6048000,
+                    "fmt": "6.05M",
+                    "longFmt": "6,048,000"
+                  },
+                  "netReceivables": {
+                    "raw": 7449000,
+                    "fmt": "7.45M",
+                    "longFmt": "7,449,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 1975000,
+                    "fmt": "1.98M",
+                    "longFmt": "1,975,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 21257000,
+                    "fmt": "21.26M",
+                    "longFmt": "21,257,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 9637000,
+                    "fmt": "9.64M",
+                    "longFmt": "9,637,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 7247000,
+                    "fmt": "7.25M",
+                    "longFmt": "7,247,000"
+                  },
+                  "otherAssets": {
+                    "raw": 570000,
+                    "fmt": "570k",
+                    "longFmt": "570,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 268000,
+                    "fmt": "268k",
+                    "longFmt": "268,000"
+                  },
+                  "totalAssets": {
+                    "raw": 38711000,
+                    "fmt": "38.71M",
+                    "longFmt": "38,711,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 2593000,
+                    "fmt": "2.59M",
+                    "longFmt": "2,593,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 10000000,
+                    "fmt": "10M",
+                    "longFmt": "10,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 781000,
+                    "fmt": "781k",
+                    "longFmt": "781,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 118958000,
+                    "fmt": "118.96M",
+                    "longFmt": "118,958,000"
+                  },
+                  "otherLiab": {
+                    "raw": 21781000,
+                    "fmt": "21.78M",
+                    "longFmt": "21,781,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -123848000,
+                    "fmt": "-123.85M",
+                    "longFmt": "-123,848,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 23260000,
+                    "fmt": "23.26M",
+                    "longFmt": "23,260,000"
+                  },
+                  "totalLiab": {
+                    "raw": 170691000,
+                    "fmt": "170.69M",
+                    "longFmt": "170,691,000"
+                  },
+                  "commonStock": {
+                    "raw": 7000,
+                    "fmt": "7k",
+                    "longFmt": "7,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -24796000,
+                    "fmt": "-24.8M",
+                    "longFmt": "-24,796,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 16657000,
+                    "fmt": "16.66M",
+                    "longFmt": "16,657,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -8132000,
+                    "fmt": "-8.13M",
+                    "longFmt": "-8,132,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -8132000,
+                    "fmt": "-8.13M",
+                    "longFmt": "-8,132,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "cash": {
+                    "raw": 7653000,
+                    "fmt": "7.65M",
+                    "longFmt": "7,653,000"
+                  },
+                  "netReceivables": {
+                    "raw": 7802000,
+                    "fmt": "7.8M",
+                    "longFmt": "7,802,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 1975000,
+                    "fmt": "1.98M",
+                    "longFmt": "1,975,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 21674000,
+                    "fmt": "21.67M",
+                    "longFmt": "21,674,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 9479000,
+                    "fmt": "9.48M",
+                    "longFmt": "9,479,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 7883000,
+                    "fmt": "7.88M",
+                    "longFmt": "7,883,000"
+                  },
+                  "otherAssets": {
+                    "raw": 679000,
+                    "fmt": "679k",
+                    "longFmt": "679,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 230000,
+                    "fmt": "230k",
+                    "longFmt": "230,000"
+                  },
+                  "totalAssets": {
+                    "raw": 39715000,
+                    "fmt": "39.72M",
+                    "longFmt": "39,715,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1699000,
+                    "fmt": "1.7M",
+                    "longFmt": "1,699,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 10000000,
+                    "fmt": "10M",
+                    "longFmt": "10,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 631000,
+                    "fmt": "631k",
+                    "longFmt": "631,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 118766000,
+                    "fmt": "118.77M",
+                    "longFmt": "118,766,000"
+                  },
+                  "otherLiab": {
+                    "raw": 22403000,
+                    "fmt": "22.4M",
+                    "longFmt": "22,403,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -122161000,
+                    "fmt": "-122.16M",
+                    "longFmt": "-122,161,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 23354000,
+                    "fmt": "23.35M",
+                    "longFmt": "23,354,000"
+                  },
+                  "totalLiab": {
+                    "raw": 171071000,
+                    "fmt": "171.07M",
+                    "longFmt": "171,071,000"
+                  },
+                  "commonStock": {
+                    "raw": 64000,
+                    "fmt": "64k",
+                    "longFmt": "64,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -24674000,
+                    "fmt": "-24.67M",
+                    "longFmt": "-24,674,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 15415000,
+                    "fmt": "15.41M",
+                    "longFmt": "15,415,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -9195000,
+                    "fmt": "-9.2M",
+                    "longFmt": "-9,195,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -9195000,
+                    "fmt": "-9.2M",
+                    "longFmt": "-9,195,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "cash": {
+                    "raw": 6599000,
+                    "fmt": "6.6M",
+                    "longFmt": "6,599,000"
+                  },
+                  "netReceivables": {
+                    "raw": 11117000,
+                    "fmt": "11.12M",
+                    "longFmt": "11,117,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 1975000,
+                    "fmt": "1.98M",
+                    "longFmt": "1,975,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 21476000,
+                    "fmt": "21.48M",
+                    "longFmt": "21,476,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 10605000,
+                    "fmt": "10.61M",
+                    "longFmt": "10,605,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 8508000,
+                    "fmt": "8.51M",
+                    "longFmt": "8,508,000"
+                  },
+                  "otherAssets": {
+                    "raw": 562000,
+                    "fmt": "562k",
+                    "longFmt": "562,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 210000,
+                    "fmt": "210k",
+                    "longFmt": "210,000"
+                  },
+                  "totalAssets": {
+                    "raw": 41151000,
+                    "fmt": "41.15M",
+                    "longFmt": "41,151,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 2230000,
+                    "fmt": "2.23M",
+                    "longFmt": "2,230,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 10000000,
+                    "fmt": "10M",
+                    "longFmt": "10,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 2682000,
+                    "fmt": "2.68M",
+                    "longFmt": "2,682,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 118573000,
+                    "fmt": "118.57M",
+                    "longFmt": "118,573,000"
+                  },
+                  "otherLiab": {
+                    "raw": 16347000,
+                    "fmt": "16.35M",
+                    "longFmt": "16,347,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -114679000,
+                    "fmt": "-114.68M",
+                    "longFmt": "-114,679,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 24358000,
+                    "fmt": "24.36M",
+                    "longFmt": "24,358,000"
+                  },
+                  "totalLiab": {
+                    "raw": 164865000,
+                    "fmt": "164.87M",
+                    "longFmt": "164,865,000"
+                  },
+                  "commonStock": {
+                    "raw": 63000,
+                    "fmt": "63k",
+                    "longFmt": "63,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -24235000,
+                    "fmt": "-24.23M",
+                    "longFmt": "-24,235,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 15137000,
+                    "fmt": "15.14M",
+                    "longFmt": "15,137,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -9035000,
+                    "fmt": "-9.04M",
+                    "longFmt": "-9,035,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -9035000,
+                    "fmt": "-9.04M",
+                    "longFmt": "-9,035,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 10558000,
+                    "fmt": "10.56M",
+                    "longFmt": "10,558,000"
+                  },
+                  "netReceivables": {
+                    "raw": 10964000,
+                    "fmt": "10.96M",
+                    "longFmt": "10,964,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 1975000,
+                    "fmt": "1.98M",
+                    "longFmt": "1,975,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 25519000,
+                    "fmt": "25.52M",
+                    "longFmt": "25,519,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 13287000,
+                    "fmt": "13.29M",
+                    "longFmt": "13,287,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 9128000,
+                    "fmt": "9.13M",
+                    "longFmt": "9,128,000"
+                  },
+                  "otherAssets": {
+                    "raw": 862000,
+                    "fmt": "862k",
+                    "longFmt": "862,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 185000,
+                    "fmt": "185k",
+                    "longFmt": "185,000"
+                  },
+                  "totalAssets": {
+                    "raw": 48796000,
+                    "fmt": "48.8M",
+                    "longFmt": "48,796,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1829000,
+                    "fmt": "1.83M",
+                    "longFmt": "1,829,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 10000000,
+                    "fmt": "10M",
+                    "longFmt": "10,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 2927000,
+                    "fmt": "2.93M",
+                    "longFmt": "2,927,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 118382000,
+                    "fmt": "118.38M",
+                    "longFmt": "118,382,000"
+                  },
+                  "otherLiab": {
+                    "raw": 17119000,
+                    "fmt": "17.12M",
+                    "longFmt": "17,119,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -109714000,
+                    "fmt": "-109.71M",
+                    "longFmt": "-109,714,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 26707000,
+                    "fmt": "26.71M",
+                    "longFmt": "26,707,000"
+                  },
+                  "totalLiab": {
+                    "raw": 167629000,
+                    "fmt": "167.63M",
+                    "longFmt": "167,629,000"
+                  },
+                  "commonStock": {
+                    "raw": 62000,
+                    "fmt": "62k",
+                    "longFmt": "62,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -22960000,
+                    "fmt": "-22.96M",
+                    "longFmt": "-22,960,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 13779000,
+                    "fmt": "13.78M",
+                    "longFmt": "13,779,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -9119000,
+                    "fmt": "-9.12M",
+                    "longFmt": "-9,119,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -9119000,
+                    "fmt": "-9.12M",
+                    "longFmt": "-9,119,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": -0.23,
+                    "fmt": "-0.23"
+                  },
+                  "epsEstimate": {
+                    "raw": -0.01,
+                    "fmt": "-0.01"
+                  },
+                  "epsDifference": {
+                    "raw": -0.22,
+                    "fmt": "-0.22"
+                  },
+                  "surprisePercent": {
+                    "raw": -22,
+                    "fmt": "-2,200.00%"
+                  },
+                  "quarter": {
+                    "raw": 1569801600,
+                    "fmt": "2019-09-30"
+                  },
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": -0.4,
+                    "fmt": "-0.4"
+                  },
+                  "epsEstimate": {
+                    "raw": -0.02,
+                    "fmt": "-0.02"
+                  },
+                  "epsDifference": {
+                    "raw": -0.38,
+                    "fmt": "-0.38"
+                  },
+                  "surprisePercent": {
+                    "raw": -19,
+                    "fmt": "-1,900.00%"
+                  },
+                  "quarter": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": -0.7,
+                    "fmt": "-0.7"
+                  },
+                  "epsEstimate": {
+                    "raw": -0.04,
+                    "fmt": "-0.04"
+                  },
+                  "epsDifference": {
+                    "raw": -0.66,
+                    "fmt": "-0.66"
+                  },
+                  "surprisePercent": {
+                    "raw": -16.5,
+                    "fmt": "-1,650.00%"
+                  },
+                  "quarter": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": -1.1,
+                    "fmt": "-1.1"
+                  },
+                  "epsEstimate": {
+                    "raw": -0.05,
+                    "fmt": "-0.05"
+                  },
+                  "epsDifference": {
+                    "raw": -1.05,
+                    "fmt": "-1.05"
+                  },
+                  "surprisePercent": {
+                    "raw": -21,
+                    "fmt": "-2,100.00%"
+                  },
+                  "quarter": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            },
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            },
+            "summaryProfile": {
+              "address1": "280 Park Avenue",
+              "address2": "6th Floor East",
+              "city": "New York",
+              "state": "NY",
+              "zip": "10017",
+              "country": "United States",
+              "phone": "212-759-0777",
+              "website": "http://www.mdly.com",
+              "industry": "Asset Management",
+              "sector": "Financial Services",
+              "longBusinessSummary": "Medley Management Inc. is an investment holding company and operate and control all of the business and affairs of Medley LLC and its subsidiaries. Medley Management Inc. was incorporated on June 13, 2014 and is based in New York, New York.",
+              "fullTimeEmployees": 65,
+              "companyOfficers": [],
+              "maxAge": 86400
+            },
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 8,
+              "buyInfoShares": 3543679,
+              "sellInfoCount": 0,
+              "netInfoCount": 8,
+              "netInfoShares": 3543679,
+              "netPercentInsiderShares": -1.024,
+              "totalInsiderShares": 81750
+            },
+            "insiderTransactions": {
+              "transactions": [
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 73471,
+                    "fmt": "73.47k",
+                    "longFmt": "73,471"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "ALLORTO RICHARD T JR",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 999999,
+                    "fmt": "1,000k",
+                    "longFmt": "999,999"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "TAUBE BROOK",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 450000,
+                    "fmt": "450k",
+                    "longFmt": "450,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "TAUBE SETH",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 999999,
+                    "fmt": "1,000k",
+                    "longFmt": "999,999"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "SANDY POINT L.L.C.",
+                  "filerRelation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 450000,
+                    "fmt": "450k",
+                    "longFmt": "450,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "FREEDOM 2021 L.L.C.",
+                  "filerRelation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 500000,
+                    "fmt": "500k",
+                    "longFmt": "500,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "TAUBE ANGELIC DIAZ",
+                  "filerRelation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 59753,
+                    "fmt": "59.75k",
+                    "longFmt": "59,753"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALLORTO RICHARD T JR",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1610668800,
+                    "fmt": "2021-01-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10457,
+                    "fmt": "10.46k",
+                    "longFmt": "10,457"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "LEEDS JEFFREY T",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597104000,
+                    "fmt": "2020-08-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 30465,
+                    "fmt": "30.46k",
+                    "longFmt": "30,465"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "LEEDS JEFFREY T",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1590710400,
+                    "fmt": "2020-05-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12544,
+                    "fmt": "12.54k",
+                    "longFmt": "12,544"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "ROUNSAVILLE GUYJR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1590710400,
+                    "fmt": "2020-05-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 25089,
+                    "fmt": "25.09k",
+                    "longFmt": "25,089"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "EATON JAMES GEORGE",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1590710400,
+                    "fmt": "2020-05-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 51336,
+                    "fmt": "51.34k",
+                    "longFmt": "51,336"
+                  },
+                  "value": {
+                    "raw": 161987,
+                    "fmt": "161.99k",
+                    "longFmt": "161,987"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3.14 - 3.17 per share.",
+                  "filerName": "JAM PARTNERS, L.P.",
+                  "filerRelation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1564444800,
+                    "fmt": "2019-07-30"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 23944,
+                    "fmt": "23.94k",
+                    "longFmt": "23,944"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "LEEDS JEFFREY T",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1557446400,
+                    "fmt": "2019-05-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9860,
+                    "fmt": "9.86k",
+                    "longFmt": "9,860"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "ROUNSAVILLE GUYJR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1557446400,
+                    "fmt": "2019-05-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 19719,
+                    "fmt": "19.72k",
+                    "longFmt": "19,719"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "EATON JAMES GEORGE",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1557446400,
+                    "fmt": "2019-05-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 300,
+                    "fmt": "300",
+                    "longFmt": "300"
+                  },
+                  "value": {
+                    "raw": 1020,
+                    "fmt": "1.02k",
+                    "longFmt": "1,020"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3.40 per share.",
+                  "filerName": "JAM PARTNERS, L.P.",
+                  "filerRelation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1555459200,
+                    "fmt": "2019-04-17"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4223,
+                    "fmt": "4.22k",
+                    "longFmt": "4,223"
+                  },
+                  "value": {
+                    "raw": 14316,
+                    "fmt": "14.32k",
+                    "longFmt": "14,316"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3.39 per share.",
+                  "filerName": "JAM PARTNERS, L.P.",
+                  "filerRelation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1554422400,
+                    "fmt": "2019-04-05"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 32737,
+                    "fmt": "32.74k",
+                    "longFmt": "32,737"
+                  },
+                  "value": {
+                    "raw": 110334,
+                    "fmt": "110.33k",
+                    "longFmt": "110,334"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3.32 - 3.56 per share.",
+                  "filerName": "JAM PARTNERS, L.P.",
+                  "filerRelation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1553731200,
+                    "fmt": "2019-03-28"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 11808,
+                    "fmt": "11.81k",
+                    "longFmt": "11,808"
+                  },
+                  "value": {
+                    "raw": 47822,
+                    "fmt": "47.82k",
+                    "longFmt": "47,822"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 4.05 per share.",
+                  "filerName": "JAM PARTNERS, L.P.",
+                  "filerRelation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550188800,
+                    "fmt": "2019-02-15"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 78436,
+                    "fmt": "78.44k",
+                    "longFmt": "78,436"
+                  },
+                  "value": {
+                    "raw": 315718,
+                    "fmt": "315.72k",
+                    "longFmt": "315,718"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 4.01 - 4.05 per share.",
+                  "filerName": "JAM PARTNERS, L.P.",
+                  "filerRelation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1549929600,
+                    "fmt": "2019-02-12"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9788,
+                    "fmt": "9.79k",
+                    "longFmt": "9,788"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "LEEDS JEFFREY T",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1533600000,
+                    "fmt": "2018-08-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3703,
+                    "fmt": "3.7k",
+                    "longFmt": "3,703"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "ROUNSAVILLE GUYJR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1533600000,
+                    "fmt": "2018-08-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 11111,
+                    "fmt": "11.11k",
+                    "longFmt": "11,111"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "EATON JAMES GEORGE",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1533600000,
+                    "fmt": "2018-08-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2860,
+                    "fmt": "2.86k",
+                    "longFmt": "2,860"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "LEEDS JEFFREY T",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1506643200,
+                    "fmt": "2017-09-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1430,
+                    "fmt": "1.43k",
+                    "longFmt": "1,430"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "ROUNSAVILLE GUYJR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1506643200,
+                    "fmt": "2017-09-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6017,
+                    "fmt": "6.02k",
+                    "longFmt": "6,017"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "LEEDS JEFFREY T",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1494374400,
+                    "fmt": "2017-05-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1437,
+                    "fmt": "1.44k",
+                    "longFmt": "1,437"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "EATON JAMES GEORGE",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1494374400,
+                    "fmt": "2017-05-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4792,
+                    "fmt": "4.79k",
+                    "longFmt": "4,792"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "RYAN PHILIP K",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1489708800,
+                    "fmt": "2017-03-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 11570,
+                    "fmt": "11.57k",
+                    "longFmt": "11,570"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 0.00 per share.",
+                  "filerName": "LEEDS JEFFREY T",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1475107200,
+                    "fmt": "2016-09-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5785,
+                    "fmt": "5.79k",
+                    "longFmt": "5,785"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 0.00 per share.",
+                  "filerName": "ROUNSAVILLE GUYJR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1475107200,
+                    "fmt": "2016-09-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 14049,
+                    "fmt": "14.05k",
+                    "longFmt": "14,049"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 0.00 per share.",
+                  "filerName": "RYAN PHILIP K",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1475107200,
+                    "fmt": "2016-09-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 95370,
+                    "fmt": "95.37k",
+                    "longFmt": "95,370"
+                  },
+                  "value": {
+                    "raw": 700433,
+                    "fmt": "700.43k",
+                    "longFmt": "700,433"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 7.32 - 7.41 per share.",
+                  "filerName": "MANGROVE PARTNERS MASTER FUND, LTD.",
+                  "filerRelation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1471910400,
+                    "fmt": "2016-08-23"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1866,
+                    "fmt": "1.87k",
+                    "longFmt": "1,866"
+                  },
+                  "value": {
+                    "raw": 13437,
+                    "fmt": "13.44k",
+                    "longFmt": "13,437"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 7.20 per share.",
+                  "filerName": "MANGROVE PARTNERS MASTER FUND, LTD.",
+                  "filerRelation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1471824000,
+                    "fmt": "2016-08-22"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5400,
+                    "fmt": "5.4k",
+                    "longFmt": "5,400"
+                  },
+                  "value": {
+                    "raw": 40814,
+                    "fmt": "40.81k",
+                    "longFmt": "40,814"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 7.55 - 7.56 per share.",
+                  "filerName": "MANGROVE PARTNERS MASTER FUND, LTD.",
+                  "filerRelation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1471564800,
+                    "fmt": "2016-08-19"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 926,
+                    "fmt": "926",
+                    "longFmt": "926"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 0.00 per share.",
+                  "filerName": "RYAN PHILIP K",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1447200000,
+                    "fmt": "2015-11-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3888,
+                    "fmt": "3.89k",
+                    "longFmt": "3,888"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 0.00 per share.",
+                  "filerName": "LEEDS JEFFREY T",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1443484800,
+                    "fmt": "2015-09-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1944,
+                    "fmt": "1.94k",
+                    "longFmt": "1,944"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 0.00 per share.",
+                  "filerName": "ROUNSAVILLE GUYJR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1443484800,
+                    "fmt": "2015-09-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3888,
+                    "fmt": "3.89k",
+                    "longFmt": "3,888"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 0.00 per share.",
+                  "filerName": "RYAN PHILIP K",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1443484800,
+                    "fmt": "2015-09-29"
+                  },
+                  "ownership": "D"
+                }
+              ],
+              "maxAge": 1
+            },
+            "sectorTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 8326000,
+                    "fmt": "8.33M",
+                    "longFmt": "8,326,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 4054000,
+                    "fmt": "4.05M",
+                    "longFmt": "4,054,000"
+                  },
+                  "grossProfit": {
+                    "raw": 4272000,
+                    "fmt": "4.27M",
+                    "longFmt": "4,272,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 2599000,
+                    "fmt": "2.6M",
+                    "longFmt": "2,599,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 6653000,
+                    "fmt": "6.65M",
+                    "longFmt": "6,653,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 1673000,
+                    "fmt": "1.67M",
+                    "longFmt": "1,673,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -3688000,
+                    "fmt": "-3.69M",
+                    "longFmt": "-3,688,000"
+                  },
+                  "ebit": {
+                    "raw": 1673000,
+                    "fmt": "1.67M",
+                    "longFmt": "1,673,000"
+                  },
+                  "interestExpense": {
+                    "raw": -2535000,
+                    "fmt": "-2.54M",
+                    "longFmt": "-2,535,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -2015000,
+                    "fmt": "-2.02M",
+                    "longFmt": "-2,015,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -320000,
+                    "fmt": "-320k",
+                    "longFmt": "-320,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -123848000,
+                    "fmt": "-123.85M",
+                    "longFmt": "-123,848,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -1695000,
+                    "fmt": "-1.7M",
+                    "longFmt": "-1,695,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -122000,
+                    "fmt": "-122k",
+                    "longFmt": "-122,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -122000,
+                    "fmt": "-122k",
+                    "longFmt": "-122,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 8577000,
+                    "fmt": "8.58M",
+                    "longFmt": "8,577,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 4905000,
+                    "fmt": "4.91M",
+                    "longFmt": "4,905,000"
+                  },
+                  "grossProfit": {
+                    "raw": 3672000,
+                    "fmt": "3.67M",
+                    "longFmt": "3,672,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 2546000,
+                    "fmt": "2.55M",
+                    "longFmt": "2,546,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 7451000,
+                    "fmt": "7.45M",
+                    "longFmt": "7,451,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 1126000,
+                    "fmt": "1.13M",
+                    "longFmt": "1,126,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -10742000,
+                    "fmt": "-10.74M",
+                    "longFmt": "-10,742,000"
+                  },
+                  "ebit": {
+                    "raw": 1126000,
+                    "fmt": "1.13M",
+                    "longFmt": "1,126,000"
+                  },
+                  "interestExpense": {
+                    "raw": -2622000,
+                    "fmt": "-2.62M",
+                    "longFmt": "-2,622,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -9616000,
+                    "fmt": "-9.62M",
+                    "longFmt": "-9,616,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -1356000,
+                    "fmt": "-1.36M",
+                    "longFmt": "-1,356,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -122161000,
+                    "fmt": "-122.16M",
+                    "longFmt": "-122,161,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -8260000,
+                    "fmt": "-8.26M",
+                    "longFmt": "-8,260,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -814000,
+                    "fmt": "-814k",
+                    "longFmt": "-814,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -742000,
+                    "fmt": "-742k",
+                    "longFmt": "-742,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 7872000,
+                    "fmt": "7.87M",
+                    "longFmt": "7,872,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 6202000,
+                    "fmt": "6.2M",
+                    "longFmt": "6,202,000"
+                  },
+                  "grossProfit": {
+                    "raw": 1670000,
+                    "fmt": "1.67M",
+                    "longFmt": "1,670,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 3037000,
+                    "fmt": "3.04M",
+                    "longFmt": "3,037,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 9239000,
+                    "fmt": "9.24M",
+                    "longFmt": "9,239,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -1367000,
+                    "fmt": "-1.37M",
+                    "longFmt": "-1,367,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -4433000,
+                    "fmt": "-4.43M",
+                    "longFmt": "-4,433,000"
+                  },
+                  "ebit": {
+                    "raw": -1367000,
+                    "fmt": "-1.37M",
+                    "longFmt": "-1,367,000"
+                  },
+                  "interestExpense": {
+                    "raw": -2793000,
+                    "fmt": "-2.79M",
+                    "longFmt": "-2,793,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -5800000,
+                    "fmt": "-5.8M",
+                    "longFmt": "-5,800,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 39000,
+                    "fmt": "39k",
+                    "longFmt": "39,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -114679000,
+                    "fmt": "-114.68M",
+                    "longFmt": "-114,679,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -5839000,
+                    "fmt": "-5.84M",
+                    "longFmt": "-5,839,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -1130000,
+                    "fmt": "-1.13M",
+                    "longFmt": "-1,130,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -1275000,
+                    "fmt": "-1.27M",
+                    "longFmt": "-1,275,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 10653000,
+                    "fmt": "10.65M",
+                    "longFmt": "10,653,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 5298000,
+                    "fmt": "5.3M",
+                    "longFmt": "5,298,000"
+                  },
+                  "grossProfit": {
+                    "raw": 5355000,
+                    "fmt": "5.36M",
+                    "longFmt": "5,355,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 3323000,
+                    "fmt": "3.32M",
+                    "longFmt": "3,323,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 8621000,
+                    "fmt": "8.62M",
+                    "longFmt": "8,621,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 2032000,
+                    "fmt": "2.03M",
+                    "longFmt": "2,032,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -9103000,
+                    "fmt": "-9.1M",
+                    "longFmt": "-9,103,000"
+                  },
+                  "ebit": {
+                    "raw": 2032000,
+                    "fmt": "2.03M",
+                    "longFmt": "2,032,000"
+                  },
+                  "interestExpense": {
+                    "raw": -2851000,
+                    "fmt": "-2.85M",
+                    "longFmt": "-2,851,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -7071000,
+                    "fmt": "-7.07M",
+                    "longFmt": "-7,071,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 4991000,
+                    "fmt": "4.99M",
+                    "longFmt": "4,991,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -109714000,
+                    "fmt": "-109.71M",
+                    "longFmt": "-109,714,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -12062000,
+                    "fmt": "-12.06M",
+                    "longFmt": "-12,062,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -2609000,
+                    "fmt": "-2.61M",
+                    "longFmt": "-2,609,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -2760000,
+                    "fmt": "-2.76M",
+                    "longFmt": "-2,760,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": -122000,
+                    "fmt": "-122k",
+                    "longFmt": "-122,000"
+                  },
+                  "depreciation": {
+                    "raw": 180000,
+                    "fmt": "180k",
+                    "longFmt": "180,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -178000,
+                    "fmt": "-178k",
+                    "longFmt": "-178,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -144000,
+                    "fmt": "-144k",
+                    "longFmt": "-144,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 98000,
+                    "fmt": "98k",
+                    "longFmt": "98,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -956000,
+                    "fmt": "-956k",
+                    "longFmt": "-956,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -760000,
+                    "fmt": "-760k",
+                    "longFmt": "-760,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -8000,
+                    "fmt": "-8k",
+                    "longFmt": "-8,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -8000,
+                    "fmt": "-8k",
+                    "longFmt": "-8,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -814000,
+                    "fmt": "-814k",
+                    "longFmt": "-814,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -837000,
+                    "fmt": "-837k",
+                    "longFmt": "-837,000"
+                  },
+                  "changeInCash": {
+                    "raw": -1605000,
+                    "fmt": "-1.6M",
+                    "longFmt": "-1,605,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -23000,
+                    "fmt": "-23k",
+                    "longFmt": "-23,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "netIncome": {
+                    "raw": -814000,
+                    "fmt": "-814k",
+                    "longFmt": "-814,000"
+                  },
+                  "depreciation": {
+                    "raw": 181000,
+                    "fmt": "181k",
+                    "longFmt": "181,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -6474000,
+                    "fmt": "-6.47M",
+                    "longFmt": "-6,474,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 1953000,
+                    "fmt": "1.95M",
+                    "longFmt": "1,953,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 7370000,
+                    "fmt": "7.37M",
+                    "longFmt": "7,370,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -1072000,
+                    "fmt": "-1.07M",
+                    "longFmt": "-1,072,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 1571000,
+                    "fmt": "1.57M",
+                    "longFmt": "1,571,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -8000,
+                    "fmt": "-8k",
+                    "longFmt": "-8,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -479000,
+                    "fmt": "-479k",
+                    "longFmt": "-479,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -36000,
+                    "fmt": "-36k",
+                    "longFmt": "-36,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -38000,
+                    "fmt": "-38k",
+                    "longFmt": "-38,000"
+                  },
+                  "changeInCash": {
+                    "raw": 1054000,
+                    "fmt": "1.05M",
+                    "longFmt": "1,054,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -2000,
+                    "fmt": "-2k",
+                    "longFmt": "-2,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "netIncome": {
+                    "raw": -1130000,
+                    "fmt": "-1.13M",
+                    "longFmt": "-1,130,000"
+                  },
+                  "depreciation": {
+                    "raw": 178000,
+                    "fmt": "178k",
+                    "longFmt": "178,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 123000,
+                    "fmt": "123k",
+                    "longFmt": "123,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 496000,
+                    "fmt": "496k",
+                    "longFmt": "496,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -2130000,
+                    "fmt": "-2.13M",
+                    "longFmt": "-2,130,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -599000,
+                    "fmt": "-599k",
+                    "longFmt": "-599,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -2612000,
+                    "fmt": "-2.61M",
+                    "longFmt": "-2,612,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -8000,
+                    "fmt": "-8k",
+                    "longFmt": "-8,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 27000,
+                    "fmt": "27k",
+                    "longFmt": "27,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 27000,
+                    "fmt": "27k",
+                    "longFmt": "27,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -1276000,
+                    "fmt": "-1.28M",
+                    "longFmt": "-1,276,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -1374000,
+                    "fmt": "-1.37M",
+                    "longFmt": "-1,374,000"
+                  },
+                  "changeInCash": {
+                    "raw": -3959000,
+                    "fmt": "-3.96M",
+                    "longFmt": "-3,959,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -98000,
+                    "fmt": "-98k",
+                    "longFmt": "-98,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -2609000,
+                    "fmt": "-2.61M",
+                    "longFmt": "-2,609,000"
+                  },
+                  "depreciation": {
+                    "raw": 174000,
+                    "fmt": "174k",
+                    "longFmt": "174,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 2124000,
+                    "fmt": "2.12M",
+                    "longFmt": "2,124,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 422000,
+                    "fmt": "422k",
+                    "longFmt": "422,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 130000,
+                    "fmt": "130k",
+                    "longFmt": "130,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 137000,
+                    "fmt": "137k",
+                    "longFmt": "137,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 855000,
+                    "fmt": "855k",
+                    "longFmt": "855,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -89000,
+                    "fmt": "-89k",
+                    "longFmt": "-89,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 27000,
+                    "fmt": "27k",
+                    "longFmt": "27,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -89000,
+                    "fmt": "-89k",
+                    "longFmt": "-89,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -877000,
+                    "fmt": "-877k",
+                    "longFmt": "-877,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -1333000,
+                    "fmt": "-1.33M",
+                    "longFmt": "-1,333,000"
+                  },
+                  "changeInCash": {
+                    "raw": -567000,
+                    "fmt": "-567k",
+                    "longFmt": "-567,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -456000,
+                    "fmt": "-456k",
+                    "longFmt": "-456,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [
+                  {
+                    "date": "3Q2019",
+                    "actual": -0.23,
+                    "estimate": -0.01
+                  },
+                  {
+                    "date": "4Q2019",
+                    "actual": -0.4,
+                    "estimate": -0.02
+                  },
+                  {
+                    "date": "1Q2020",
+                    "actual": -0.7,
+                    "estimate": -0.04
+                  },
+                  {
+                    "date": "2Q2020",
+                    "actual": -1.1,
+                    "estimate": -0.05
+                  }
+                ],
+                "currentQuarterEstimateDate": "3Q",
+                "currentQuarterEstimateYear": 2020,
+                "earningsDate": [
+                  1605484800
+                ]
+              },
+              "financialsChart": {
+                "yearly": [
+                  {
+                    "date": 2016,
+                    "revenue": 75941000,
+                    "earnings": 997000
+                  },
+                  {
+                    "date": 2017,
+                    "revenue": 65033000,
+                    "earnings": 927000
+                  },
+                  {
+                    "date": 2018,
+                    "revenue": 56509000,
+                    "earnings": -2432000
+                  },
+                  {
+                    "date": 2019,
+                    "revenue": 48841000,
+                    "earnings": -3379000
+                  }
+                ],
+                "quarterly": [
+                  {
+                    "date": "4Q2019",
+                    "revenue": 10653000,
+                    "earnings": -2609000
+                  },
+                  {
+                    "date": "1Q2020",
+                    "revenue": 7872000,
+                    "earnings": -1130000
+                  },
+                  {
+                    "date": "2Q2020",
+                    "revenue": 8577000,
+                    "earnings": -814000
+                  },
+                  {
+                    "date": "3Q2020",
+                    "revenue": 8326000,
+                    "earnings": -122000
+                  }
+                ]
+              },
+              "financialCurrency": "USD"
+            },
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 10.412,
+              "recommendationMean": 3,
+              "recommendationKey": "hold",
+              "totalCash": 6048000,
+              "totalCashPerShare": 9.03,
+              "ebitda": 2860000,
+              "totalDebt": 136378000,
+              "quickRatio": 0.58,
+              "currentRatio": 0.914,
+              "totalRevenue": 35428000,
+              "revenuePerShare": 56.78,
+              "returnOnAssets": 0.023510002,
+              "grossProfits": 21474000,
+              "freeCashflow": 2893250,
+              "operatingCashflow": -946000,
+              "revenueGrowth": -0.278,
+              "grossMargins": 0.38534,
+              "ebitdaMargins": 0.08073,
+              "operatingMargins": 0.060599998,
+              "profitMargins": -0.13196,
+              "financialCurrency": "USD"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-all-SI.json
+++ b/tests/http/quoteSummary-all-SI.json
@@ -1,0 +1,5511 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=assetProfile%2CbalanceSheetHistory%2CbalanceSheetHistoryQuarterly%2CcalendarEvents%2CcashflowStatementHistory%2CcashflowStatementHistoryQuarterly%2CdefaultKeyStatistics%2Cearnings%2CearningsHistory%2CearningsTrend%2CfinancialData%2CfundOwnership%2CfundPerformance%2CfundProfile%2CincomeStatementHistory%2CincomeStatementHistoryQuarterly%2CindexTrend%2CindustryTrend%2CinsiderHolders%2CinsiderTransactions%2CinstitutionOwnership%2CmajorDirectHolders%2CmajorHoldersBreakdown%2CnetSharePurchaseActivity%2Cprice%2CquoteType%2CrecommendationTrend%2CsecFilings%2CsectorTrend%2CsummaryDetail%2CsummaryProfile%2CtopHoldings%2CupgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "cr29dapg2vsf2"
+      ],
+      "x-yahoo-request-id": [
+        "cr29dapg2vsf2"
+      ],
+      "x-request-id": [
+        "5fda3676-c8ed-45c6-a186-44105ab8ac67"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "11"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:10 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "4250 Executive Square",
+              "address2": "Suite 300",
+              "city": "La Jolla",
+              "state": "CA",
+              "zip": "92037",
+              "country": "United States",
+              "phone": "858-362-6300",
+              "website": "http://www.silvergatebank.com",
+              "industry": "Banks—Regional",
+              "sector": "Financial Services",
+              "longBusinessSummary": "Silvergate Capital Corporation operates as a bank holding company for Silvergate Bank that provides banking products and services to business and individual clients in the United States and internationally. The company accepts deposit products, including interest and noninterest bearing demand accounts, money market and savings accounts, and certificates of deposit accounts. Its loan products include one-to-four family real estate loans, multi-family real estate loans, commercial real estate loans, construction loans, commercial and industrial loans, mortgage warehouse loans, and reverse mortgage loans, as well as consumer loans and other loans secured by personal property. The company also provides cash management services for digital currency-related businesses. The company was founded in 1988 and is headquartered in La Jolla, California.",
+              "fullTimeEmployees": 218,
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Alan J. Lane",
+                  "age": 58,
+                  "title": "Pres, CEO & Director",
+                  "yearBorn": 1962,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 706590,
+                    "fmt": "706.59k",
+                    "longFmt": "706,590"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 3444743,
+                    "fmt": "3.44M",
+                    "longFmt": "3,444,743"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Benjamin C. Reynolds",
+                  "age": 42,
+                  "title": "Exec. VP of Corp. Devel.",
+                  "yearBorn": 1978,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 1017387,
+                    "fmt": "1.02M",
+                    "longFmt": "1,017,387"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 19550,
+                    "fmt": "19.55k",
+                    "longFmt": "19,550"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Derek J. Eisele",
+                  "age": 54,
+                  "title": "Exec. VP",
+                  "yearBorn": 1966,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 537896,
+                    "fmt": "537.9k",
+                    "longFmt": "537,896"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 1476900,
+                    "fmt": "1.48M",
+                    "longFmt": "1,476,900"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Antonio R. Martino",
+                  "age": 53,
+                  "title": "Chief Financial Officer",
+                  "yearBorn": 1967,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Kathleen M. Fraher",
+                  "age": 41,
+                  "title": "Exec. VP & COO",
+                  "yearBorn": 1979,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Jeffery T. Hurtik",
+                  "title": "Exec. VP & Chief Information Officer",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Shannon  Devine",
+                  "title": "Head of Investor Relations",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. John M. Bonino",
+                  "age": 70,
+                  "title": "Exec. VP & Chief Legal Officer",
+                  "yearBorn": 1950,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Cole  Williamson",
+                  "title": "Sr. VP & Director of People and Culture Services",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Maria P. Kunac",
+                  "title": "Exec. VP, Chief Lending Officer & Commercial Real Estate Division",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "auditRisk": 2,
+              "boardRisk": 9,
+              "compensationRisk": 5,
+              "shareHolderRightsRisk": 9,
+              "overallRisk": 8,
+              "governanceEpochDate": 1606867200,
+              "compensationAsOfEpochDate": 1577750400,
+              "maxAge": 86400
+            },
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 3,
+                  "buy": 2,
+                  "hold": 1,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 2,
+                  "buy": 3,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 26038000,
+                    "fmt": "26.04M",
+                    "longFmt": "26,038,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 24846000,
+                    "fmt": "24.85M",
+                    "longFmt": "24,846,000"
+                  },
+                  "depreciation": {
+                    "raw": 2673000,
+                    "fmt": "2.67M",
+                    "longFmt": "2,673,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -149830000,
+                    "fmt": "-149.83M",
+                    "longFmt": "-149,830,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -3328000,
+                    "fmt": "-3.33M",
+                    "longFmt": "-3,328,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -126862000,
+                    "fmt": "-126.86M",
+                    "longFmt": "-126,862,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -1213000,
+                    "fmt": "-1.21M",
+                    "longFmt": "-1,213,000"
+                  },
+                  "investments": {
+                    "raw": -534336000,
+                    "fmt": "-534.34M",
+                    "longFmt": "-534,336,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -20764000,
+                    "fmt": "-20.76M",
+                    "longFmt": "-20,764,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -574501000,
+                    "fmt": "-574.5M",
+                    "longFmt": "-574,501,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 47857000,
+                    "fmt": "47.86M",
+                    "longFmt": "47,857,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 106385000,
+                    "fmt": "106.39M",
+                    "longFmt": "106,385,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 160547000,
+                    "fmt": "160.55M",
+                    "longFmt": "160,547,000"
+                  },
+                  "changeInCash": {
+                    "raw": -540816000,
+                    "fmt": "-540.82M",
+                    "longFmt": "-540,816,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -157000,
+                    "fmt": "-157k",
+                    "longFmt": "-157,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 6462000,
+                    "fmt": "6.46M",
+                    "longFmt": "6,462,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 22333000,
+                    "fmt": "22.33M",
+                    "longFmt": "22,333,000"
+                  },
+                  "depreciation": {
+                    "raw": 1178000,
+                    "fmt": "1.18M",
+                    "longFmt": "1,178,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -27184000,
+                    "fmt": "-27.18M",
+                    "longFmt": "-27,184,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 2967000,
+                    "fmt": "2.97M",
+                    "longFmt": "2,967,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -3067000,
+                    "fmt": "-3.07M",
+                    "longFmt": "-3,067,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -2664000,
+                    "fmt": "-2.66M",
+                    "longFmt": "-2,664,000"
+                  },
+                  "investments": {
+                    "raw": -167763000,
+                    "fmt": "-167.76M",
+                    "longFmt": "-167,763,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -2268000,
+                    "fmt": "-2.27M",
+                    "longFmt": "-2,268,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -206633000,
+                    "fmt": "-206.63M",
+                    "longFmt": "-206,633,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -16143000,
+                    "fmt": "-16.14M",
+                    "longFmt": "-16,143,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 6750000,
+                    "fmt": "6.75M",
+                    "longFmt": "6,750,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 86452000,
+                    "fmt": "86.45M",
+                    "longFmt": "86,452,000"
+                  },
+                  "changeInCash": {
+                    "raw": -123248000,
+                    "fmt": "-123.25M",
+                    "longFmt": "-123,248,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -12158000,
+                    "fmt": "-12.16M",
+                    "longFmt": "-12,158,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 108003000,
+                    "fmt": "108M",
+                    "longFmt": "108,003,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 7643000,
+                    "fmt": "7.64M",
+                    "longFmt": "7,643,000"
+                  },
+                  "depreciation": {
+                    "raw": 1103000,
+                    "fmt": "1.1M",
+                    "longFmt": "1,103,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -22200000,
+                    "fmt": "-22.2M",
+                    "longFmt": "-22,200,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -3806000,
+                    "fmt": "-3.81M",
+                    "longFmt": "-3,806,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -18246000,
+                    "fmt": "-18.25M",
+                    "longFmt": "-18,246,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -1119000,
+                    "fmt": "-1.12M",
+                    "longFmt": "-1,119,000"
+                  },
+                  "investments": {
+                    "raw": -101576000,
+                    "fmt": "-101.58M",
+                    "longFmt": "-101,576,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -170000,
+                    "fmt": "-170k",
+                    "longFmt": "-170,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -124868000,
+                    "fmt": "-124.87M",
+                    "longFmt": "-124,868,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -101143000,
+                    "fmt": "-101.14M",
+                    "longFmt": "-101,143,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 1007284000,
+                    "fmt": "1.01B",
+                    "longFmt": "1,007,284,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 906133000,
+                    "fmt": "906.13M",
+                    "longFmt": "906,133,000"
+                  },
+                  "changeInCash": {
+                    "raw": 763019000,
+                    "fmt": "763.02M",
+                    "longFmt": "763,019,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -8000,
+                    "fmt": "-8k",
+                    "longFmt": "-8,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 108003000,
+                    "fmt": "108M",
+                    "longFmt": "108,003,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 8.58013,
+              "pegRatio": 0.771291,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.286
+                },
+                {
+                  "period": "+1q",
+                  "growth": 1.032
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.175
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.15100001
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0827489
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            },
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": -95470000,
+              "forwardPE": 68.581635,
+              "profitMargins": 0.28972,
+              "floatShares": 15552272,
+              "sharesOutstanding": 22754500,
+              "sharesShort": 1076061,
+              "sharesShortPriorMonth": 995808,
+              "sharesShortPreviousMonthDate": 1609372800,
+              "dateShortInterest": 1611878400,
+              "sharesPercentSharesOut": 0.047199998,
+              "heldPercentInsiders": 0.05487,
+              "heldPercentInstitutions": 0.65436995,
+              "shortRatio": 0.76,
+              "shortPercentOfFloat": 0.053400002,
+              "impliedSharesOutstanding": 22818700,
+              "category": null,
+              "bookValue": 15.701,
+              "priceToBook": 10.963626,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1609372800,
+              "nextFiscalYearEnd": 1672444800,
+              "mostRecentQuarter": 1609372800,
+              "earningsQuarterlyGrowth": 1.534,
+              "netIncomeToCommon": 26038000,
+              "trailingEps": 1.36,
+              "forwardEps": 2.51,
+              "lastSplitFactor": null,
+              "enterpriseToRevenue": -1.062,
+              "52WeekChange": 8.262048,
+              "SandP52WeekChange": 0.17263722
+            },
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "quoteType": {
+              "exchange": "NYQ",
+              "quoteType": "EQUITY",
+              "symbol": "SI",
+              "underlyingSymbol": "SI",
+              "shortName": "Silvergate Capital Corporation",
+              "longName": "Silvergate Capital Corporation",
+              "firstTradeDateEpochUtc": 1573137000,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "ce774d9c-ab3a-30bd-b522-cd0839bed364",
+              "messageBoardId": "finmb_53838840",
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            },
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 89874000,
+                    "fmt": "89.87M",
+                    "longFmt": "89,874,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "grossProfit": {
+                    "raw": 89874000,
+                    "fmt": "89.87M",
+                    "longFmt": "89,874,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 56574000,
+                    "fmt": "56.57M",
+                    "longFmt": "56,574,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 1859000,
+                    "fmt": "1.86M",
+                    "longFmt": "1,859,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 58433000,
+                    "fmt": "58.43M",
+                    "longFmt": "58,433,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 31441000,
+                    "fmt": "31.44M",
+                    "longFmt": "31,441,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -247000,
+                    "fmt": "-247k",
+                    "longFmt": "-247,000"
+                  },
+                  "ebit": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "interestExpense": {},
+                  "incomeBeforeTax": {
+                    "raw": 31194000,
+                    "fmt": "31.19M",
+                    "longFmt": "31,194,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 5156000,
+                    "fmt": "5.16M",
+                    "longFmt": "5,156,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 26038000,
+                    "fmt": "26.04M",
+                    "longFmt": "26,038,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 26038000,
+                    "fmt": "26.04M",
+                    "longFmt": "26,038,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 26038000,
+                    "fmt": "26.04M",
+                    "longFmt": "26,038,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 87150000,
+                    "fmt": "87.15M",
+                    "longFmt": "87,150,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "grossProfit": {
+                    "raw": 87150000,
+                    "fmt": "87.15M",
+                    "longFmt": "87,150,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 50290000,
+                    "fmt": "50.29M",
+                    "longFmt": "50,290,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 1603000,
+                    "fmt": "1.6M",
+                    "longFmt": "1,603,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 51893000,
+                    "fmt": "51.89M",
+                    "longFmt": "51,893,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 35257000,
+                    "fmt": "35.26M",
+                    "longFmt": "35,257,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -585000,
+                    "fmt": "-585k",
+                    "longFmt": "-585,000"
+                  },
+                  "ebit": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "interestExpense": {},
+                  "incomeBeforeTax": {
+                    "raw": 34672000,
+                    "fmt": "34.67M",
+                    "longFmt": "34,672,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 9826000,
+                    "fmt": "9.83M",
+                    "longFmt": "9,826,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 24846000,
+                    "fmt": "24.85M",
+                    "longFmt": "24,846,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 24846000,
+                    "fmt": "24.85M",
+                    "longFmt": "24,846,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 24846000,
+                    "fmt": "24.85M",
+                    "longFmt": "24,846,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 78713000,
+                    "fmt": "78.71M",
+                    "longFmt": "78,713,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "grossProfit": {
+                    "raw": 78713000,
+                    "fmt": "78.71M",
+                    "longFmt": "78,713,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 45475000,
+                    "fmt": "45.48M",
+                    "longFmt": "45,475,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 1582000,
+                    "fmt": "1.58M",
+                    "longFmt": "1,582,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 47057000,
+                    "fmt": "47.06M",
+                    "longFmt": "47,057,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 31656000,
+                    "fmt": "31.66M",
+                    "longFmt": "31,656,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -1257000,
+                    "fmt": "-1.26M",
+                    "longFmt": "-1,257,000"
+                  },
+                  "ebit": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "interestExpense": {},
+                  "incomeBeforeTax": {
+                    "raw": 30399000,
+                    "fmt": "30.4M",
+                    "longFmt": "30,399,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 8066000,
+                    "fmt": "8.07M",
+                    "longFmt": "8,066,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 22333000,
+                    "fmt": "22.33M",
+                    "longFmt": "22,333,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 22333000,
+                    "fmt": "22.33M",
+                    "longFmt": "22,333,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 22333000,
+                    "fmt": "22.33M",
+                    "longFmt": "22,333,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 45137000,
+                    "fmt": "45.14M",
+                    "longFmt": "45,137,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "grossProfit": {
+                    "raw": 45137000,
+                    "fmt": "45.14M",
+                    "longFmt": "45,137,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 28631000,
+                    "fmt": "28.63M",
+                    "longFmt": "28,631,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 1370000,
+                    "fmt": "1.37M",
+                    "longFmt": "1,370,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 30001000,
+                    "fmt": "30M",
+                    "longFmt": "30,001,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 15136000,
+                    "fmt": "15.14M",
+                    "longFmt": "15,136,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -705000,
+                    "fmt": "-705k",
+                    "longFmt": "-705,000"
+                  },
+                  "ebit": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "interestExpense": {},
+                  "incomeBeforeTax": {
+                    "raw": 14431000,
+                    "fmt": "14.43M",
+                    "longFmt": "14,431,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 6788000,
+                    "fmt": "6.79M",
+                    "longFmt": "6,788,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 7643000,
+                    "fmt": "7.64M",
+                    "longFmt": "7,643,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 7643000,
+                    "fmt": "7.64M",
+                    "longFmt": "7,643,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 7643000,
+                    "fmt": "7.64M",
+                    "longFmt": "7,643,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            },
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 153.75,
+              "open": 157.91,
+              "dayLow": 154.0101,
+              "dayHigh": 174.5,
+              "regularMarketPreviousClose": 153.75,
+              "regularMarketOpen": 157.91,
+              "regularMarketDayLow": 154.0101,
+              "regularMarketDayHigh": 174.5,
+              "payoutRatio": 0,
+              "trailingPE": 126.57345,
+              "forwardPE": 68.581635,
+              "volume": 571007,
+              "regularMarketVolume": 571007,
+              "averageVolume": 1145291,
+              "averageVolume10days": 1460285,
+              "averageDailyVolume10Day": 1460285,
+              "bid": 171.5,
+              "ask": 172.21,
+              "bidSize": 3100,
+              "askSize": 1400,
+              "marketCap": 3928008448,
+              "fiftyTwoWeekLow": 7.6,
+              "fiftyTwoWeekHigh": 187.864,
+              "priceToSalesTrailing12Months": 43.705727,
+              "fiftyDayAverage": 99.940605,
+              "twoHundredDayAverage": 43.128407,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            },
+            "insiderHolders": {
+              "holders": [
+                {
+                  "maxAge": 1,
+                  "name": "BONINO JOHN M",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1611273600,
+                    "fmt": "2021-01-22"
+                  },
+                  "positionDirect": {
+                    "raw": 40643,
+                    "fmt": "40.64k",
+                    "longFmt": "40,643"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611273600,
+                    "fmt": "2021-01-22"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "BRASSFIELD KAREN F",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1610064000,
+                    "fmt": "2021-01-08"
+                  },
+                  "positionDirect": {
+                    "raw": 32742,
+                    "fmt": "32.74k",
+                    "longFmt": "32,742"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1610064000,
+                    "fmt": "2021-01-08"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "COLUCCI PAUL D",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "positionDirect": {
+                    "raw": 92706,
+                    "fmt": "92.71k",
+                    "longFmt": "92,706"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "DIRCKS THOMAS C",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Gift",
+                  "latestTransDate": {
+                    "raw": 1608595200,
+                    "fmt": "2020-12-22"
+                  },
+                  "positionDirect": {
+                    "raw": 178147,
+                    "fmt": "178.15k",
+                    "longFmt": "178,147"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1608595200,
+                    "fmt": "2020-12-22"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "EISELE DEREK J",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1607299200,
+                    "fmt": "2020-12-07"
+                  },
+                  "positionIndirect": {
+                    "raw": 109969,
+                    "fmt": "109.97k",
+                    "longFmt": "109,969"
+                  },
+                  "positionIndirectDate": {
+                    "raw": 1607299200,
+                    "fmt": "2020-12-07"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "FRAHER KATHLEEN",
+                  "relation": "Chief Operating Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1606694400,
+                    "fmt": "2020-11-30"
+                  },
+                  "positionDirect": {
+                    "raw": 20084,
+                    "fmt": "20.08k",
+                    "longFmt": "20,084"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1606694400,
+                    "fmt": "2020-11-30"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "FRANK DENNIS S",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "positionDirect": {
+                    "raw": 227344,
+                    "fmt": "227.34k",
+                    "longFmt": "227,344"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "LANE ALAN J",
+                  "relation": "Chief Executive Officer",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1606435200,
+                    "fmt": "2020-11-27"
+                  },
+                  "positionDirect": {
+                    "raw": 228993,
+                    "fmt": "228.99k",
+                    "longFmt": "228,993"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1606435200,
+                    "fmt": "2020-11-27"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "LEMPRES MICHAEL",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "positionDirect": {
+                    "raw": 1833,
+                    "fmt": "1.83k",
+                    "longFmt": "1,833"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "REED SCOTT A",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1607904000,
+                    "fmt": "2020-12-14"
+                  },
+                  "positionIndirect": {
+                    "raw": 1004700,
+                    "fmt": "1M",
+                    "longFmt": "1,004,700"
+                  },
+                  "positionIndirectDate": {
+                    "raw": 1607904000,
+                    "fmt": "2020-12-14"
+                  }
+                }
+              ],
+              "maxAge": 1
+            },
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": [
+                  1611187200
+                ],
+                "earningsAverage": 0.45,
+                "earningsLow": 0.33,
+                "earningsHigh": 0.5,
+                "revenueAverage": 29700000,
+                "revenueLow": 27310000,
+                "revenueHigh": 31800000
+              }
+            },
+            "upgradeDowngradeHistory": {
+              "history": [
+                {
+                  "epochGradeDate": 1612458732,
+                  "firm": "Craig-Hallum",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1610627376,
+                  "firm": "Barclays",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1608636683,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1608213697,
+                  "firm": "Keefe, Bruyette & Woods",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1606925964,
+                  "firm": "Craig-Hallum",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1606751191,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1603810743,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1602849526,
+                  "firm": "Compass Point",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1584353166,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1575285676,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1574080657,
+                  "firm": "Compass Point",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1415606400,
+                  "firm": "JP Morgan",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1408515831,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1405064577,
+                  "firm": "LBBW Research",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1405064288,
+                  "firm": "RBC Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Sector Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1396944000,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1395233052,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1395041376,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1395041356,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1389888000,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1389342600,
+                  "firm": "Berenberg",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1384760022,
+                  "firm": "LBBW Research",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1384759980,
+                  "firm": "Mainfirst",
+                  "toGrade": "Underperform",
+                  "fromGrade": "",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1384416656,
+                  "firm": "Banco Sabadell",
+                  "toGrade": "Sell",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1383214628,
+                  "firm": "Commerzbank",
+                  "toGrade": "Hold",
+                  "fromGrade": "Add",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1381476786,
+                  "firm": "DZ Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1378452356,
+                  "firm": "Societe Generale",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1378370193,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Equal-Weight",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1378287044,
+                  "firm": "Exane BNP Paribas",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1377590268,
+                  "firm": "Kepler Cheuvreux",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1375718400,
+                  "firm": "LBBW Research",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1375281738,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1373358756,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Hold",
+                  "fromGrade": "Sell",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1371641896,
+                  "firm": "Nomura",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1370249424,
+                  "firm": "Commerzbank",
+                  "toGrade": "Add",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1365580525,
+                  "firm": "Exane BNP Paribas",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Underperform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1363775998,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Equal-weight",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1363587670,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1353425280,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Sell",
+                  "fromGrade": "Hold",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1350030360,
+                  "firm": "Societe Generale",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1349885100,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1337928240,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "up"
+                }
+              ],
+              "maxAge": 86400
+            },
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": 0.024390198,
+              "preMarketChange": 3.75,
+              "preMarketTime": 1613744822,
+              "preMarketPrice": 157.5,
+              "preMarketSource": "FREE_REALTIME",
+              "regularMarketChangePercent": 0.11960906,
+              "regularMarketChange": 18.389893,
+              "regularMarketTime": 1613754825,
+              "priceHint": 2,
+              "regularMarketPrice": 172.1399,
+              "regularMarketDayHigh": 174.5,
+              "regularMarketDayLow": 154.0101,
+              "regularMarketVolume": 571007,
+              "averageDailyVolume10Day": 1460285,
+              "averageDailyVolume3Month": 1145291,
+              "regularMarketPreviousClose": 153.75,
+              "regularMarketSource": "FREE_REALTIME",
+              "regularMarketOpen": 157.91,
+              "exchange": "NYQ",
+              "exchangeName": "NYSE",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "EQUITY",
+              "symbol": "SI",
+              "underlyingSymbol": null,
+              "shortName": "Silvergate Capital Corporation",
+              "longName": "Silvergate Capital Corporation",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 3928008448
+            },
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "cash": {
+                    "raw": 2962087000,
+                    "fmt": "2.96B",
+                    "longFmt": "2,962,087,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 874659000,
+                    "fmt": "874.66M",
+                    "longFmt": "874,659,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 3867850000,
+                    "fmt": "3.87B",
+                    "longFmt": "3,867,850,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 953866000,
+                    "fmt": "953.87M",
+                    "longFmt": "953,866,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 2072000,
+                    "fmt": "2.07M",
+                    "longFmt": "2,072,000"
+                  },
+                  "otherAssets": {
+                    "raw": 762447000,
+                    "fmt": "762.45M",
+                    "longFmt": "762,447,000"
+                  },
+                  "totalAssets": {
+                    "raw": 5586235000,
+                    "fmt": "5.59B",
+                    "longFmt": "5,586,235,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 5248026000,
+                    "fmt": "5.25B",
+                    "longFmt": "5,248,026,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 15831000,
+                    "fmt": "15.83M",
+                    "longFmt": "15,831,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 5276105000,
+                    "fmt": "5.28B",
+                    "longFmt": "5,276,105,000"
+                  },
+                  "totalLiab": {
+                    "raw": 5291936000,
+                    "fmt": "5.29B",
+                    "longFmt": "5,291,936,000"
+                  },
+                  "commonStock": {
+                    "raw": 189000,
+                    "fmt": "189k",
+                    "longFmt": "189,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 118348000,
+                    "fmt": "118.35M",
+                    "longFmt": "118,348,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 46036000,
+                    "fmt": "46.04M",
+                    "longFmt": "46,036,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 129726000,
+                    "fmt": "129.73M",
+                    "longFmt": "129,726,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 46036000,
+                    "fmt": "46.04M",
+                    "longFmt": "46,036,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 294299000,
+                    "fmt": "294.3M",
+                    "longFmt": "294,299,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 294299000,
+                    "fmt": "294.3M",
+                    "longFmt": "294,299,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 133604000,
+                    "fmt": "133.6M",
+                    "longFmt": "133,604,000"
+                  },
+                  "inventory": {
+                    "raw": 128000,
+                    "fmt": "128k",
+                    "longFmt": "128,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 381872000,
+                    "fmt": "381.87M",
+                    "longFmt": "381,872,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 539044000,
+                    "fmt": "539.04M",
+                    "longFmt": "539,044,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 908984000,
+                    "fmt": "908.98M",
+                    "longFmt": "908,984,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 7830000,
+                    "fmt": "7.83M",
+                    "longFmt": "7,830,000"
+                  },
+                  "otherAssets": {
+                    "raw": 672269000,
+                    "fmt": "672.27M",
+                    "longFmt": "672,269,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2128127000,
+                    "fmt": "2.13B",
+                    "longFmt": "2,128,127,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1814654000,
+                    "fmt": "1.81B",
+                    "longFmt": "1,814,654,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 1143000,
+                    "fmt": "1.14M",
+                    "longFmt": "1,143,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 18387000,
+                    "fmt": "18.39M",
+                    "longFmt": "18,387,000"
+                  },
+                  "otherLiab": {
+                    "raw": 524000,
+                    "fmt": "524k",
+                    "longFmt": "524,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 1874975000,
+                    "fmt": "1.87B",
+                    "longFmt": "1,874,975,000"
+                  },
+                  "totalLiab": {
+                    "raw": 1897091000,
+                    "fmt": "1.9B",
+                    "longFmt": "1,897,091,000"
+                  },
+                  "commonStock": {
+                    "raw": 187000,
+                    "fmt": "187k",
+                    "longFmt": "187,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 92310000,
+                    "fmt": "92.31M",
+                    "longFmt": "92,310,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 6401000,
+                    "fmt": "6.4M",
+                    "longFmt": "6,401,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 132138000,
+                    "fmt": "132.14M",
+                    "longFmt": "132,138,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 6401000,
+                    "fmt": "6.4M",
+                    "longFmt": "6,401,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 231036000,
+                    "fmt": "231.04M",
+                    "longFmt": "231,036,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 231036000,
+                    "fmt": "231.04M",
+                    "longFmt": "231,036,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "cash": {
+                    "raw": 674420000,
+                    "fmt": "674.42M",
+                    "longFmt": "674,420,000"
+                  },
+                  "inventory": {
+                    "raw": 31000,
+                    "fmt": "31k",
+                    "longFmt": "31,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 356406000,
+                    "fmt": "356.41M",
+                    "longFmt": "356,406,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 1031856000,
+                    "fmt": "1.03B",
+                    "longFmt": "1,031,856,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 367955000,
+                    "fmt": "367.95M",
+                    "longFmt": "367,955,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 3656000,
+                    "fmt": "3.66M",
+                    "longFmt": "3,656,000"
+                  },
+                  "otherAssets": {
+                    "raw": 600851000,
+                    "fmt": "600.85M",
+                    "longFmt": "600,851,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 3329000,
+                    "fmt": "3.33M",
+                    "longFmt": "3,329,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2004318000,
+                    "fmt": "2B",
+                    "longFmt": "2,004,318,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1783005000,
+                    "fmt": "1.78B",
+                    "longFmt": "1,783,005,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 20659000,
+                    "fmt": "20.66M",
+                    "longFmt": "20,659,000"
+                  },
+                  "otherLiab": {
+                    "raw": 100000,
+                    "fmt": "100k",
+                    "longFmt": "100,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 1500000,
+                    "fmt": "1.5M",
+                    "longFmt": "1,500,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 1792313000,
+                    "fmt": "1.79B",
+                    "longFmt": "1,792,313,000"
+                  },
+                  "totalLiab": {
+                    "raw": 1813072000,
+                    "fmt": "1.81B",
+                    "longFmt": "1,813,072,000"
+                  },
+                  "commonStock": {
+                    "raw": 178000,
+                    "fmt": "178k",
+                    "longFmt": "178,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 67464000,
+                    "fmt": "67.46M",
+                    "longFmt": "67,464,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -2061000,
+                    "fmt": "-2.06M",
+                    "longFmt": "-2,061,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 125665000,
+                    "fmt": "125.67M",
+                    "longFmt": "125,665,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -2061000,
+                    "fmt": "-2.06M",
+                    "longFmt": "-2,061,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 191246000,
+                    "fmt": "191.25M",
+                    "longFmt": "191,246,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 191246000,
+                    "fmt": "191.25M",
+                    "longFmt": "191,246,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "cash": {
+                    "raw": 797668000,
+                    "fmt": "797.67M",
+                    "longFmt": "797,668,000"
+                  },
+                  "inventory": {
+                    "raw": 2308000,
+                    "fmt": "2.31M",
+                    "longFmt": "2,308,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 194302000,
+                    "fmt": "194.3M",
+                    "longFmt": "194,302,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 995369000,
+                    "fmt": "995.37M",
+                    "longFmt": "995,369,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 200410000,
+                    "fmt": "200.41M",
+                    "longFmt": "200,410,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 1753000,
+                    "fmt": "1.75M",
+                    "longFmt": "1,753,000"
+                  },
+                  "otherAssets": {
+                    "raw": 694416000,
+                    "fmt": "694.42M",
+                    "longFmt": "694,416,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 2840000,
+                    "fmt": "2.84M",
+                    "longFmt": "2,840,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1891948000,
+                    "fmt": "1.89B",
+                    "longFmt": "1,891,948,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1775146000,
+                    "fmt": "1.78B",
+                    "longFmt": "1,775,146,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 15000000,
+                    "fmt": "15M",
+                    "longFmt": "15,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 21788000,
+                    "fmt": "21.79M",
+                    "longFmt": "21,788,000"
+                  },
+                  "otherLiab": {
+                    "raw": 100000,
+                    "fmt": "100k",
+                    "longFmt": "100,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 1796260000,
+                    "fmt": "1.8B",
+                    "longFmt": "1,796,260,000"
+                  },
+                  "totalLiab": {
+                    "raw": 1818148000,
+                    "fmt": "1.82B",
+                    "longFmt": "1,818,148,000"
+                  },
+                  "commonStock": {
+                    "raw": 92000,
+                    "fmt": "92k",
+                    "longFmt": "92,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 45131000,
+                    "fmt": "45.13M",
+                    "longFmt": "45,131,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -1217000,
+                    "fmt": "-1.22M",
+                    "longFmt": "-1,217,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 29794000,
+                    "fmt": "29.79M",
+                    "longFmt": "29,794,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -1217000,
+                    "fmt": "-1.22M",
+                    "longFmt": "-1,217,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 73800000,
+                    "fmt": "73.8M",
+                    "longFmt": "73,800,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 73800000,
+                    "fmt": "73.8M",
+                    "longFmt": "73,800,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": "2021-03-31",
+                  "growth": {
+                    "raw": 0.95699996,
+                    "fmt": "95.70%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.45,
+                      "fmt": "0.45"
+                    },
+                    "low": {
+                      "raw": 0.33,
+                      "fmt": "0.33"
+                    },
+                    "high": {
+                      "raw": 0.5,
+                      "fmt": "0.5"
+                    },
+                    "yearAgoEps": {
+                      "raw": 0.23,
+                      "fmt": "0.23"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "growth": {
+                      "raw": 0.95699996,
+                      "fmt": "95.70%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 29700000,
+                      "fmt": "29.7M",
+                      "longFmt": "29,700,000"
+                    },
+                    "low": {
+                      "raw": 27310000,
+                      "fmt": "27.31M",
+                      "longFmt": "27,310,000"
+                    },
+                    "high": {
+                      "raw": 31800000,
+                      "fmt": "31.8M",
+                      "longFmt": "31,800,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 3,
+                      "fmt": "3",
+                      "longFmt": "3"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 20409000,
+                      "fmt": "20.41M",
+                      "longFmt": "20,409,000"
+                    },
+                    "growth": {
+                      "raw": 0.455,
+                      "fmt": "45.50%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.45,
+                      "fmt": "0.45"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.45,
+                      "fmt": "0.45"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.33,
+                      "fmt": "0.33"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.33,
+                      "fmt": "0.33"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.3,
+                      "fmt": "0.3"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 4,
+                      "fmt": "4",
+                      "longFmt": "4"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": "2021-06-30",
+                  "growth": {
+                    "raw": 0.58599997,
+                    "fmt": "58.60%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.46,
+                      "fmt": "0.46"
+                    },
+                    "low": {
+                      "raw": 0.33,
+                      "fmt": "0.33"
+                    },
+                    "high": {
+                      "raw": 0.51,
+                      "fmt": "0.51"
+                    },
+                    "yearAgoEps": {
+                      "raw": 0.29,
+                      "fmt": "0.29"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "growth": {
+                      "raw": 0.58599997,
+                      "fmt": "58.60%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 30300000,
+                      "fmt": "30.3M",
+                      "longFmt": "30,300,000"
+                    },
+                    "low": {
+                      "raw": 27900000,
+                      "fmt": "27.9M",
+                      "longFmt": "27,900,000"
+                    },
+                    "high": {
+                      "raw": 32900000,
+                      "fmt": "32.9M",
+                      "longFmt": "32,900,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 3,
+                      "fmt": "3",
+                      "longFmt": "3"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 21486000,
+                      "fmt": "21.49M",
+                      "longFmt": "21,486,000"
+                    },
+                    "growth": {
+                      "raw": 0.41,
+                      "fmt": "41.00%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.46,
+                      "fmt": "0.46"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.46,
+                      "fmt": "0.46"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.34,
+                      "fmt": "0.34"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.33,
+                      "fmt": "0.33"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.3,
+                      "fmt": "0.3"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 4,
+                      "fmt": "4",
+                      "longFmt": "4"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": "2021-12-31",
+                  "growth": {
+                    "raw": 0.404,
+                    "fmt": "40.40%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 1.91,
+                      "fmt": "1.91"
+                    },
+                    "low": {
+                      "raw": 1.36,
+                      "fmt": "1.36"
+                    },
+                    "high": {
+                      "raw": 2.15,
+                      "fmt": "2.15"
+                    },
+                    "yearAgoEps": {
+                      "raw": 1.36,
+                      "fmt": "1.36"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "growth": {
+                      "raw": 0.404,
+                      "fmt": "40.40%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 123430000,
+                      "fmt": "123.43M",
+                      "longFmt": "123,430,000"
+                    },
+                    "low": {
+                      "raw": 114800000,
+                      "fmt": "114.8M",
+                      "longFmt": "114,800,000"
+                    },
+                    "high": {
+                      "raw": 136200000,
+                      "fmt": "136.2M",
+                      "longFmt": "136,200,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 3,
+                      "fmt": "3",
+                      "longFmt": "3"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 91541000,
+                      "fmt": "91.54M",
+                      "longFmt": "91,541,000"
+                    },
+                    "growth": {
+                      "raw": 0.348,
+                      "fmt": "34.80%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 1.91,
+                      "fmt": "1.91"
+                    },
+                    "7daysAgo": {
+                      "raw": 1.91,
+                      "fmt": "1.91"
+                    },
+                    "30daysAgo": {
+                      "raw": 1.43,
+                      "fmt": "1.43"
+                    },
+                    "60daysAgo": {
+                      "raw": 1.39,
+                      "fmt": "1.39"
+                    },
+                    "90daysAgo": {
+                      "raw": 1.27,
+                      "fmt": "1.27"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": "2022-12-31",
+                  "growth": {
+                    "raw": 0.314,
+                    "fmt": "31.40%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 2.51,
+                      "fmt": "2.51"
+                    },
+                    "low": {
+                      "raw": 1.54,
+                      "fmt": "1.54"
+                    },
+                    "high": {
+                      "raw": 3.1,
+                      "fmt": "3.1"
+                    },
+                    "yearAgoEps": {
+                      "raw": 1.91,
+                      "fmt": "1.91"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "growth": {
+                      "raw": 0.314,
+                      "fmt": "31.40%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 147430000,
+                      "fmt": "147.43M",
+                      "longFmt": "147,430,000"
+                    },
+                    "low": {
+                      "raw": 129410000,
+                      "fmt": "129.41M",
+                      "longFmt": "129,410,000"
+                    },
+                    "high": {
+                      "raw": 170600000,
+                      "fmt": "170.6M",
+                      "longFmt": "170,600,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 3,
+                      "fmt": "3",
+                      "longFmt": "3"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 123430000,
+                      "fmt": "123.43M",
+                      "longFmt": "123,430,000"
+                    },
+                    "growth": {
+                      "raw": 0.19399999,
+                      "fmt": "19.40%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 2.51,
+                      "fmt": "2.51"
+                    },
+                    "7daysAgo": {
+                      "raw": 2.51,
+                      "fmt": "2.51"
+                    },
+                    "30daysAgo": {
+                      "raw": 1.81,
+                      "fmt": "1.81"
+                    },
+                    "60daysAgo": {
+                      "raw": 1.75,
+                      "fmt": "1.75"
+                    },
+                    "90daysAgo": {
+                      "raw": 1.49,
+                      "fmt": "1.49"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            },
+            "secFilings": {
+              "filings": [
+                {
+                  "date": "2021-02-17",
+                  "epochDate": 1613601023,
+                  "type": "8-K",
+                  "title": "Other Events",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-21-000026&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-01-28",
+                  "epochDate": 1611868524,
+                  "type": "8-K",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-21-000017&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-01-25",
+                  "epochDate": 1611613361,
+                  "type": "8-K",
+                  "title": "Entry into a Material Definitive Agreement, Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-21-007264&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-01-22",
+                  "epochDate": 1611332199,
+                  "type": "8-K",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-21-000010&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-01-20",
+                  "epochDate": 1611178399,
+                  "type": "8-K",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-21-005855&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-01-20",
+                  "epochDate": 1611176650,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-21-000008&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-01-12",
+                  "epochDate": 1610460116,
+                  "type": "8-K",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-21-000006&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-11-20",
+                  "epochDate": 1605878768,
+                  "type": "8-K",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000153&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-11-10",
+                  "epochDate": 1605042651,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000150&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-29",
+                  "epochDate": 1604005600,
+                  "type": "8-K",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000146&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-26",
+                  "epochDate": 1603711694,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000142&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-13",
+                  "epochDate": 1602623893,
+                  "type": "8-K",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000137&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-06",
+                  "epochDate": 1601991249,
+                  "type": "8-K",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000135&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-08-11",
+                  "epochDate": 1597180409,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000125&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-08-10",
+                  "epochDate": 1597094145,
+                  "type": "8-K",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000121&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-07-30",
+                  "epochDate": 1596117405,
+                  "type": "8-K",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000109&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-07-15",
+                  "epochDate": 1594849919,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000099&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-07-13",
+                  "epochDate": 1594674899,
+                  "type": "8-K",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000095&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-06-16",
+                  "epochDate": 1592341966,
+                  "type": "8-K",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000088&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-06-02",
+                  "epochDate": 1591102186,
+                  "type": "8-K",
+                  "title": "Disclosing Submission of Matters to a Vote of Security Holders",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000056&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-12",
+                  "epochDate": 1589316194,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000041&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-05",
+                  "epochDate": 1588672961,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000037&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-29",
+                  "epochDate": 1588156121,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Regulation FD Disclosure, ",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000035&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-16",
+                  "epochDate": 1587042217,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000028&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-03-10",
+                  "epochDate": 1583871811,
+                  "type": "10-K",
+                  "title": "Annual Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000020&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-02-04",
+                  "epochDate": 1580851173,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000015&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-01-29",
+                  "epochDate": 1580297803,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Change in Directors or Pri",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000012&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-01-15",
+                  "epochDate": 1579122854,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000009&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-01-14",
+                  "epochDate": 1579036654,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000006&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-12-04",
+                  "epochDate": 1575496467,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-19-000064&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-12-04",
+                  "epochDate": 1575494130,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and E",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-19-000062&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-18",
+                  "epochDate": 1574080314,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure, Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001193125-19-293950&nav=1&src=Yahoo",
+                  "maxAge": 1
+                }
+              ],
+              "maxAge": 86400
+            },
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Senvest Management LLC",
+                  "pctHeld": {
+                    "raw": 0.0842,
+                    "fmt": "8.42%"
+                  },
+                  "position": {
+                    "raw": 1581333,
+                    "fmt": "1.58M",
+                    "longFmt": "1,581,333"
+                  },
+                  "value": {
+                    "raw": 22771195,
+                    "fmt": "22.77M",
+                    "longFmt": "22,771,195"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Park West Asset Management LLC",
+                  "pctHeld": {
+                    "raw": 0.082600005,
+                    "fmt": "8.26%"
+                  },
+                  "position": {
+                    "raw": 1552000,
+                    "fmt": "1.55M",
+                    "longFmt": "1,552,000"
+                  },
+                  "value": {
+                    "raw": 22348800,
+                    "fmt": "22.35M",
+                    "longFmt": "22,348,800"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Blackrock Inc.",
+                  "pctHeld": {
+                    "raw": 0.060900003,
+                    "fmt": "6.09%"
+                  },
+                  "position": {
+                    "raw": 1144811,
+                    "fmt": "1.14M",
+                    "longFmt": "1,144,811"
+                  },
+                  "value": {
+                    "raw": 85070905,
+                    "fmt": "85.07M",
+                    "longFmt": "85,070,905"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "EJF Capital LLC",
+                  "pctHeld": {
+                    "raw": 0.0444,
+                    "fmt": "4.44%"
+                  },
+                  "position": {
+                    "raw": 833350,
+                    "fmt": "833.35k",
+                    "longFmt": "833,350"
+                  },
+                  "value": {
+                    "raw": 12000240,
+                    "fmt": "12M",
+                    "longFmt": "12,000,240"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Group, Inc. (The)",
+                  "pctHeld": {
+                    "raw": 0.0337,
+                    "fmt": "3.37%"
+                  },
+                  "position": {
+                    "raw": 633506,
+                    "fmt": "633.51k",
+                    "longFmt": "633,506"
+                  },
+                  "value": {
+                    "raw": 9122486,
+                    "fmt": "9.12M",
+                    "longFmt": "9,122,486"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Bank Of New York Mellon Corporation",
+                  "pctHeld": {
+                    "raw": 0.0216,
+                    "fmt": "2.16%"
+                  },
+                  "position": {
+                    "raw": 404851,
+                    "fmt": "404.85k",
+                    "longFmt": "404,851"
+                  },
+                  "value": {
+                    "raw": 30084477,
+                    "fmt": "30.08M",
+                    "longFmt": "30,084,477"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Ameriprise Financial, Inc.",
+                  "pctHeld": {
+                    "raw": 0.021300001,
+                    "fmt": "2.13%"
+                  },
+                  "position": {
+                    "raw": 399968,
+                    "fmt": "399.97k",
+                    "longFmt": "399,968"
+                  },
+                  "value": {
+                    "raw": 5759539,
+                    "fmt": "5.76M",
+                    "longFmt": "5,759,539"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "CSat Investment Advisory, L.P.",
+                  "pctHeld": {
+                    "raw": 0.0128,
+                    "fmt": "1.28%"
+                  },
+                  "position": {
+                    "raw": 239754,
+                    "fmt": "239.75k",
+                    "longFmt": "239,754"
+                  },
+                  "value": {
+                    "raw": 3452457,
+                    "fmt": "3.45M",
+                    "longFmt": "3,452,457"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "State Street Corporation",
+                  "pctHeld": {
+                    "raw": 0.0128,
+                    "fmt": "1.28%"
+                  },
+                  "position": {
+                    "raw": 239536,
+                    "fmt": "239.54k",
+                    "longFmt": "239,536"
+                  },
+                  "value": {
+                    "raw": 3449318,
+                    "fmt": "3.45M",
+                    "longFmt": "3,449,318"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "ARK Investment Management, LLC",
+                  "pctHeld": {
+                    "raw": 0.0121,
+                    "fmt": "1.21%"
+                  },
+                  "position": {
+                    "raw": 226764,
+                    "fmt": "226.76k",
+                    "longFmt": "226,764"
+                  },
+                  "value": {
+                    "raw": 3265401,
+                    "fmt": "3.27M",
+                    "longFmt": "3,265,401"
+                  }
+                }
+              ]
+            },
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.05487,
+              "institutionsPercentHeld": 0.65436995,
+              "institutionsFloatPercentHeld": 0.69236,
+              "institutionsCount": 108
+            },
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "cash": {
+                    "raw": 2962087000,
+                    "fmt": "2.96B",
+                    "longFmt": "2,962,087,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 874659000,
+                    "fmt": "874.66M",
+                    "longFmt": "874,659,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 3867850000,
+                    "fmt": "3.87B",
+                    "longFmt": "3,867,850,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 953866000,
+                    "fmt": "953.87M",
+                    "longFmt": "953,866,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 2072000,
+                    "fmt": "2.07M",
+                    "longFmt": "2,072,000"
+                  },
+                  "otherAssets": {
+                    "raw": 762447000,
+                    "fmt": "762.45M",
+                    "longFmt": "762,447,000"
+                  },
+                  "totalAssets": {
+                    "raw": 5586235000,
+                    "fmt": "5.59B",
+                    "longFmt": "5,586,235,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 5248026000,
+                    "fmt": "5.25B",
+                    "longFmt": "5,248,026,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 15831000,
+                    "fmt": "15.83M",
+                    "longFmt": "15,831,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 5276105000,
+                    "fmt": "5.28B",
+                    "longFmt": "5,276,105,000"
+                  },
+                  "totalLiab": {
+                    "raw": 5291936000,
+                    "fmt": "5.29B",
+                    "longFmt": "5,291,936,000"
+                  },
+                  "commonStock": {
+                    "raw": 189000,
+                    "fmt": "189k",
+                    "longFmt": "189,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 118348000,
+                    "fmt": "118.35M",
+                    "longFmt": "118,348,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 46036000,
+                    "fmt": "46.04M",
+                    "longFmt": "46,036,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 129726000,
+                    "fmt": "129.73M",
+                    "longFmt": "129,726,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 46036000,
+                    "fmt": "46.04M",
+                    "longFmt": "46,036,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 294299000,
+                    "fmt": "294.3M",
+                    "longFmt": "294,299,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 294299000,
+                    "fmt": "294.3M",
+                    "longFmt": "294,299,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 197482000,
+                    "fmt": "197.48M",
+                    "longFmt": "197,482,000"
+                  },
+                  "inventory": {
+                    "raw": 27000,
+                    "fmt": "27k",
+                    "longFmt": "27,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 673227000,
+                    "fmt": "673.23M",
+                    "longFmt": "673,227,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 904874000,
+                    "fmt": "904.87M",
+                    "longFmt": "904,874,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 959890000,
+                    "fmt": "959.89M",
+                    "longFmt": "959,890,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6600000,
+                    "fmt": "6.6M",
+                    "longFmt": "6,600,000"
+                  },
+                  "otherAssets": {
+                    "raw": 749209000,
+                    "fmt": "749.21M",
+                    "longFmt": "749,209,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2620573000,
+                    "fmt": "2.62B",
+                    "longFmt": "2,620,573,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 2281108000,
+                    "fmt": "2.28B",
+                    "longFmt": "2,281,108,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 15827000,
+                    "fmt": "15.83M",
+                    "longFmt": "15,827,000"
+                  },
+                  "otherLiab": {
+                    "raw": 100000,
+                    "fmt": "100k",
+                    "longFmt": "100,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 2317115000,
+                    "fmt": "2.32B",
+                    "longFmt": "2,317,115,000"
+                  },
+                  "totalLiab": {
+                    "raw": 2336812000,
+                    "fmt": "2.34B",
+                    "longFmt": "2,336,812,000"
+                  },
+                  "commonStock": {
+                    "raw": 187000,
+                    "fmt": "187k",
+                    "longFmt": "187,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 109229000,
+                    "fmt": "109.23M",
+                    "longFmt": "109,229,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 41698000,
+                    "fmt": "41.7M",
+                    "longFmt": "41,698,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 132647000,
+                    "fmt": "132.65M",
+                    "longFmt": "132,647,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 41698000,
+                    "fmt": "41.7M",
+                    "longFmt": "41,698,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 283761000,
+                    "fmt": "283.76M",
+                    "longFmt": "283,761,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 283761000,
+                    "fmt": "283.76M",
+                    "longFmt": "283,761,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "cash": {
+                    "raw": 199444000,
+                    "fmt": "199.44M",
+                    "longFmt": "199,444,000"
+                  },
+                  "inventory": {
+                    "raw": 51000,
+                    "fmt": "51k",
+                    "longFmt": "51,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 329535000,
+                    "fmt": "329.54M",
+                    "longFmt": "329,535,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 564800000,
+                    "fmt": "564.8M",
+                    "longFmt": "564,800,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 965510000,
+                    "fmt": "965.51M",
+                    "longFmt": "965,510,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 7172000,
+                    "fmt": "7.17M",
+                    "longFmt": "7,172,000"
+                  },
+                  "otherAssets": {
+                    "raw": 803231000,
+                    "fmt": "803.23M",
+                    "longFmt": "803,231,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2340713000,
+                    "fmt": "2.34B",
+                    "longFmt": "2,340,713,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1670909000,
+                    "fmt": "1.67B",
+                    "longFmt": "1,670,909,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 15823000,
+                    "fmt": "15.82M",
+                    "longFmt": "15,823,000"
+                  },
+                  "otherLiab": {
+                    "raw": 100000,
+                    "fmt": "100k",
+                    "longFmt": "100,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 2052539000,
+                    "fmt": "2.05B",
+                    "longFmt": "2,052,539,000"
+                  },
+                  "totalLiab": {
+                    "raw": 2072608000,
+                    "fmt": "2.07B",
+                    "longFmt": "2,072,608,000"
+                  },
+                  "commonStock": {
+                    "raw": 187000,
+                    "fmt": "187k",
+                    "longFmt": "187,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 102169000,
+                    "fmt": "102.17M",
+                    "longFmt": "102,169,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 33270000,
+                    "fmt": "33.27M",
+                    "longFmt": "33,270,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 132479000,
+                    "fmt": "132.48M",
+                    "longFmt": "132,479,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 33270000,
+                    "fmt": "33.27M",
+                    "longFmt": "33,270,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 268105000,
+                    "fmt": "268.11M",
+                    "longFmt": "268,105,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 268105000,
+                    "fmt": "268.11M",
+                    "longFmt": "268,105,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "cash": {
+                    "raw": 166200000,
+                    "fmt": "166.2M",
+                    "longFmt": "166,200,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 441367000,
+                    "fmt": "441.37M",
+                    "longFmt": "441,367,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 641073000,
+                    "fmt": "641.07M",
+                    "longFmt": "641,073,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 975513000,
+                    "fmt": "975.51M",
+                    "longFmt": "975,513,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 7616000,
+                    "fmt": "7.62M",
+                    "longFmt": "7,616,000"
+                  },
+                  "otherAssets": {
+                    "raw": 686506000,
+                    "fmt": "686.51M",
+                    "longFmt": "686,506,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2310708000,
+                    "fmt": "2.31B",
+                    "longFmt": "2,310,708,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 2002957000,
+                    "fmt": "2B",
+                    "longFmt": "2,002,957,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 15820000,
+                    "fmt": "15.82M",
+                    "longFmt": "15,820,000"
+                  },
+                  "otherLiab": {
+                    "raw": 200000,
+                    "fmt": "200k",
+                    "longFmt": "200,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 2045421000,
+                    "fmt": "2.05B",
+                    "longFmt": "2,045,421,000"
+                  },
+                  "totalLiab": {
+                    "raw": 2065956000,
+                    "fmt": "2.07B",
+                    "longFmt": "2,065,956,000"
+                  },
+                  "commonStock": {
+                    "raw": 187000,
+                    "fmt": "187k",
+                    "longFmt": "187,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 96703000,
+                    "fmt": "96.7M",
+                    "longFmt": "96,703,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 15526000,
+                    "fmt": "15.53M",
+                    "longFmt": "15,526,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 132336000,
+                    "fmt": "132.34M",
+                    "longFmt": "132,336,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 15526000,
+                    "fmt": "15.53M",
+                    "longFmt": "15,526,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 244752000,
+                    "fmt": "244.75M",
+                    "longFmt": "244,752,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 244752000,
+                    "fmt": "244.75M",
+                    "longFmt": "244,752,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.23,
+                    "fmt": "0.23"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.18,
+                    "fmt": "0.18"
+                  },
+                  "epsDifference": {
+                    "raw": 0.05,
+                    "fmt": "0.05"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.278,
+                    "fmt": "27.80%"
+                  },
+                  "quarter": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.29,
+                    "fmt": "0.29"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.19,
+                    "fmt": "0.19"
+                  },
+                  "epsDifference": {
+                    "raw": 0.1,
+                    "fmt": "0.1"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.52599996,
+                    "fmt": "52.60%"
+                  },
+                  "quarter": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.37,
+                    "fmt": "0.37"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.22,
+                    "fmt": "0.22"
+                  },
+                  "epsDifference": {
+                    "raw": 0.15,
+                    "fmt": "0.15"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.682,
+                    "fmt": "68.20%"
+                  },
+                  "quarter": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.47,
+                    "fmt": "0.47"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.38,
+                    "fmt": "0.38"
+                  },
+                  "epsDifference": {
+                    "raw": 0.09,
+                    "fmt": "0.09"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.237,
+                    "fmt": "23.70%"
+                  },
+                  "quarter": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            },
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            },
+            "summaryProfile": {
+              "address1": "4250 Executive Square",
+              "address2": "Suite 300",
+              "city": "La Jolla",
+              "state": "CA",
+              "zip": "92037",
+              "country": "United States",
+              "phone": "858-362-6300",
+              "website": "http://www.silvergatebank.com",
+              "industry": "Banks—Regional",
+              "sector": "Financial Services",
+              "longBusinessSummary": "Silvergate Capital Corporation operates as a bank holding company for Silvergate Bank that provides banking products and services to business and individual clients in the United States and internationally. The company accepts deposit products, including interest and noninterest bearing demand accounts, money market and savings accounts, and certificates of deposit accounts. Its loan products include one-to-four family real estate loans, multi-family real estate loans, commercial real estate loans, construction loans, commercial and industrial loans, mortgage warehouse loans, and reverse mortgage loans, as well as consumer loans and other loans secured by personal property. The company also provides cash management services for digital currency-related businesses. The company was founded in 1988 and is headquartered in La Jolla, California.",
+              "fullTimeEmployees": 218,
+              "companyOfficers": [],
+              "maxAge": 86400
+            },
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 22,
+              "buyInfoShares": 357238,
+              "buyPercentInsiderShares": 0.30200002,
+              "sellInfoCount": 8,
+              "sellInfoShares": 510148,
+              "sellPercentInsiderShares": 0.432,
+              "netInfoCount": 30,
+              "netInfoShares": -152910,
+              "netPercentInsiderShares": -0.129,
+              "totalInsiderShares": 1028483
+            },
+            "insiderTransactions": {
+              "transactions": [
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 22263,
+                    "fmt": "22.26k",
+                    "longFmt": "22,263"
+                  },
+                  "value": {
+                    "raw": 118212,
+                    "fmt": "118.21k",
+                    "longFmt": "118,212"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 4.09 - 16.09 per share.",
+                  "filerName": "BONINO JOHN M",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611273600,
+                    "fmt": "2021-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 27500,
+                    "fmt": "27.5k",
+                    "longFmt": "27,500"
+                  },
+                  "value": {
+                    "raw": 112475,
+                    "fmt": "112.47k",
+                    "longFmt": "112,475"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 4.09 per share.",
+                  "filerName": "BRASSFIELD KAREN F",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1610064000,
+                    "fmt": "2021-01-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10000,
+                    "fmt": "10k",
+                    "longFmt": "10,000"
+                  },
+                  "value": {
+                    "raw": 40900,
+                    "fmt": "40.9k",
+                    "longFmt": "40,900"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 4.09 per share.",
+                  "filerName": "BONINO JOHN M",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1608681600,
+                    "fmt": "2020-12-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 46299,
+                    "fmt": "46.3k",
+                    "longFmt": "46,299"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "DIRCKS THOMAS C",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1608595200,
+                    "fmt": "2020-12-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 426488,
+                    "fmt": "426.49k",
+                    "longFmt": "426,488"
+                  },
+                  "value": {
+                    "raw": 17059520,
+                    "fmt": "17.06M",
+                    "longFmt": "17,059,520"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 40.00 per share.",
+                  "filerName": "REED SCOTT A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1607904000,
+                    "fmt": "2020-12-14"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 60000,
+                    "fmt": "60k",
+                    "longFmt": "60,000"
+                  },
+                  "value": {
+                    "raw": 2439626,
+                    "fmt": "2.44M",
+                    "longFmt": "2,439,626"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 39.67 - 42.51 per share.",
+                  "filerName": "DIRCKS THOMAS C",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1607385600,
+                    "fmt": "2020-12-08"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 595,
+                    "fmt": "595",
+                    "longFmt": "595"
+                  },
+                  "value": {
+                    "raw": 26507,
+                    "fmt": "26.51k",
+                    "longFmt": "26,507"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 44.55 per share.",
+                  "filerName": "EISELE DEREK J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1607299200,
+                    "fmt": "2020-12-07"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5000,
+                    "fmt": "5k",
+                    "longFmt": "5,000"
+                  },
+                  "value": {
+                    "raw": 196500,
+                    "fmt": "196.5k",
+                    "longFmt": "196,500"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 39.30 per share.",
+                  "filerName": "EISELE DEREK J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606867200,
+                    "fmt": "2020-12-02"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2500,
+                    "fmt": "2.5k",
+                    "longFmt": "2,500"
+                  },
+                  "value": {
+                    "raw": 90000,
+                    "fmt": "90k",
+                    "longFmt": "90,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 36.00 per share.",
+                  "filerName": "BRASSFIELD KAREN F",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606780800,
+                    "fmt": "2020-12-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 565,
+                    "fmt": "565",
+                    "longFmt": "565"
+                  },
+                  "value": {
+                    "raw": 20260,
+                    "fmt": "20.26k",
+                    "longFmt": "20,260"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 35.86 per share.",
+                  "filerName": "FRAHER KATHLEEN",
+                  "filerRelation": "Chief Operating Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606694400,
+                    "fmt": "2020-11-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 119964,
+                    "fmt": "119.96k",
+                    "longFmt": "119,964"
+                  },
+                  "value": {
+                    "raw": 482255,
+                    "fmt": "482.25k",
+                    "longFmt": "482,255"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 4.02 per share.",
+                  "filerName": "LANE ALAN J",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606435200,
+                    "fmt": "2020-11-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 44789,
+                    "fmt": "44.79k",
+                    "longFmt": "44,789"
+                  },
+                  "value": {
+                    "raw": 452193,
+                    "fmt": "452.19k",
+                    "longFmt": "452,193"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 4.09 - 16.09 per share.",
+                  "filerName": "FRAHER KATHLEEN",
+                  "filerRelation": "Chief Operating Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606176000,
+                    "fmt": "2020-11-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 33183,
+                    "fmt": "33.18k",
+                    "longFmt": "33,183"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "DIRCKS THOMAS C",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606089600,
+                    "fmt": "2020-11-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2500,
+                    "fmt": "2.5k",
+                    "longFmt": "2,500"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "DIRCKS THOMAS C",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2500,
+                    "fmt": "2.5k",
+                    "longFmt": "2,500"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "FRANK DENNIS S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2774,
+                    "fmt": "2.77k",
+                    "longFmt": "2,774"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "LANE ALAN J",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2500,
+                    "fmt": "2.5k",
+                    "longFmt": "2,500"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "REED SCOTT A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2500,
+                    "fmt": "2.5k",
+                    "longFmt": "2,500"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "COLUCCI PAUL D",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 833,
+                    "fmt": "833",
+                    "longFmt": "833"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "LEMPRES MICHAEL",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1166,
+                    "fmt": "1.17k",
+                    "longFmt": "1,166"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "MARTINO ANTONIO",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 583,
+                    "fmt": "583",
+                    "longFmt": "583"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "REYNOLDS BEN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1203,
+                    "fmt": "1.2k",
+                    "longFmt": "1,203"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "FRAHER KATHLEEN",
+                  "filerRelation": "Chief Operating Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2500,
+                    "fmt": "2.5k",
+                    "longFmt": "2,500"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "BRASSFIELD KAREN F",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2500,
+                    "fmt": "2.5k",
+                    "longFmt": "2,500"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "CAMPBELL ROBERT CHARLES",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 770,
+                    "fmt": "770",
+                    "longFmt": "770"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "BONINO JOHN M",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 911,
+                    "fmt": "911",
+                    "longFmt": "911"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "EISELE DEREK J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10000,
+                    "fmt": "10k",
+                    "longFmt": "10,000"
+                  },
+                  "value": {
+                    "raw": 300828,
+                    "fmt": "300.83k",
+                    "longFmt": "300,828"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 30.08 per share.",
+                  "filerName": "COLUCCI PAUL D",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5000,
+                    "fmt": "5k",
+                    "longFmt": "5,000"
+                  },
+                  "value": {
+                    "raw": 76044,
+                    "fmt": "76.04k",
+                    "longFmt": "76,044"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 15.21 per share.",
+                  "filerName": "EISELE DEREK J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598486400,
+                    "fmt": "2020-08-27"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 20000,
+                    "fmt": "20k",
+                    "longFmt": "20,000"
+                  },
+                  "value": {
+                    "raw": 81800,
+                    "fmt": "81.8k",
+                    "longFmt": "81,800"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 4.09 per share.",
+                  "filerName": "BRASSFIELD KAREN F",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598400000,
+                    "fmt": "2020-08-26"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 225000,
+                    "fmt": "225k",
+                    "longFmt": "225,000"
+                  },
+                  "value": {
+                    "raw": 3181380,
+                    "fmt": "3.18M",
+                    "longFmt": "3,181,380"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 14.04 - 14.19 per share.",
+                  "filerName": "FRANK DENNIS S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596672000,
+                    "fmt": "2020-08-06"
+                  },
+                  "ownership": "D/I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7000,
+                    "fmt": "7k",
+                    "longFmt": "7,000"
+                  },
+                  "value": {
+                    "raw": 103734,
+                    "fmt": "103.73k",
+                    "longFmt": "103,734"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 14.80 - 14.90 per share.",
+                  "filerName": "CAMPBELL ROBERT CHARLES",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1591660800,
+                    "fmt": "2020-06-09"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5000,
+                    "fmt": "5k",
+                    "longFmt": "5,000"
+                  },
+                  "value": {
+                    "raw": 75156,
+                    "fmt": "75.16k",
+                    "longFmt": "75,156"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 15.00 - 15.10 per share.",
+                  "filerName": "CAMPBELL ROBERT CHARLES",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1591574400,
+                    "fmt": "2020-06-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5000,
+                    "fmt": "5k",
+                    "longFmt": "5,000"
+                  },
+                  "value": {
+                    "raw": 74254,
+                    "fmt": "74.25k",
+                    "longFmt": "74,254"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 14.85 - 14.86 per share.",
+                  "filerName": "CAMPBELL ROBERT CHARLES",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1591315200,
+                    "fmt": "2020-06-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 14680,
+                    "fmt": "14.68k",
+                    "longFmt": "14,680"
+                  },
+                  "value": {
+                    "raw": 217895,
+                    "fmt": "217.9k",
+                    "longFmt": "217,895"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 14.81 - 14.87 per share.",
+                  "filerName": "CAMPBELL ROBERT CHARLES",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1591228800,
+                    "fmt": "2020-06-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10297,
+                    "fmt": "10.3k",
+                    "longFmt": "10,297"
+                  },
+                  "value": {
+                    "raw": 151445,
+                    "fmt": "151.44k",
+                    "longFmt": "151,445"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 14.70 - 14.80 per share.",
+                  "filerName": "CAMPBELL ROBERT CHARLES",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1591142400,
+                    "fmt": "2020-06-03"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 20023,
+                    "fmt": "20.02k",
+                    "longFmt": "20,023"
+                  },
+                  "value": {
+                    "raw": 286590,
+                    "fmt": "286.59k",
+                    "longFmt": "286,590"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 14.10 - 14.80 per share.",
+                  "filerName": "CAMPBELL ROBERT CHARLES",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1591056000,
+                    "fmt": "2020-06-02"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5000,
+                    "fmt": "5k",
+                    "longFmt": "5,000"
+                  },
+                  "value": {
+                    "raw": 73150,
+                    "fmt": "73.15k",
+                    "longFmt": "73,150"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 14.63 per share.",
+                  "filerName": "CAMPBELL ROBERT CHARLES",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1590710400,
+                    "fmt": "2020-05-29"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 14921,
+                    "fmt": "14.92k",
+                    "longFmt": "14,921"
+                  },
+                  "value": {
+                    "raw": 218203,
+                    "fmt": "218.2k",
+                    "longFmt": "218,203"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 14.56 - 14.90 per share.",
+                  "filerName": "CAMPBELL ROBERT CHARLES",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1590624000,
+                    "fmt": "2020-05-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10431,
+                    "fmt": "10.43k",
+                    "longFmt": "10,431"
+                  },
+                  "value": {
+                    "raw": 155086,
+                    "fmt": "155.09k",
+                    "longFmt": "155,086"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 14.80 - 14.93 per share.",
+                  "filerName": "CAMPBELL ROBERT CHARLES",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1590537600,
+                    "fmt": "2020-05-27"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9248,
+                    "fmt": "9.25k",
+                    "longFmt": "9,248"
+                  },
+                  "value": {
+                    "raw": 141019,
+                    "fmt": "141.02k",
+                    "longFmt": "141,019"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 14.85 - 15.40 per share.",
+                  "filerName": "CAMPBELL ROBERT CHARLES",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1590451200,
+                    "fmt": "2020-05-26"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10922,
+                    "fmt": "10.92k",
+                    "longFmt": "10,922"
+                  },
+                  "value": {
+                    "raw": 166129,
+                    "fmt": "166.13k",
+                    "longFmt": "166,129"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 14.85 - 15.40 per share.",
+                  "filerName": "CAMPBELL ROBERT CHARLES",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1590451200,
+                    "fmt": "2020-05-26"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10922,
+                    "fmt": "10.92k",
+                    "longFmt": "10,922"
+                  },
+                  "value": {
+                    "raw": 166129,
+                    "fmt": "166.13k",
+                    "longFmt": "166,129"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 14.85 - 15.40 per share.",
+                  "filerName": "CAMPBELL ROBERT CHARLES",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1590451200,
+                    "fmt": "2020-05-26"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5000,
+                    "fmt": "5k",
+                    "longFmt": "5,000"
+                  },
+                  "value": {
+                    "raw": 75500,
+                    "fmt": "75.5k",
+                    "longFmt": "75,500"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 15.10 per share.",
+                  "filerName": "EISELE DEREK J",
+                  "filerRelation": "Officer and Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1590105600,
+                    "fmt": "2020-05-22"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10000,
+                    "fmt": "10k",
+                    "longFmt": "10,000"
+                  },
+                  "value": {
+                    "raw": 40900,
+                    "fmt": "40.9k",
+                    "longFmt": "40,900"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 4.09 per share.",
+                  "filerName": "BRASSFIELD KAREN F",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589932800,
+                    "fmt": "2020-05-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2500,
+                    "fmt": "2.5k",
+                    "longFmt": "2,500"
+                  },
+                  "value": {
+                    "raw": 10225,
+                    "fmt": "10.22k",
+                    "longFmt": "10,225"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 4.09 per share.",
+                  "filerName": "BRASSFIELD KAREN F",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589414400,
+                    "fmt": "2020-05-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 78561,
+                    "fmt": "78.56k",
+                    "longFmt": "78,561"
+                  },
+                  "value": {
+                    "raw": 1186271,
+                    "fmt": "1.19M",
+                    "longFmt": "1,186,271"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 15.10 per share.",
+                  "filerName": "FRANK DENNIS S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D/I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 63915,
+                    "fmt": "63.91k",
+                    "longFmt": "63,915"
+                  },
+                  "value": {
+                    "raw": 965116,
+                    "fmt": "965.12k",
+                    "longFmt": "965,116"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 15.10 per share.",
+                  "filerName": "FRIEDMAN MARTIN S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 41834,
+                    "fmt": "41.83k",
+                    "longFmt": "41,834"
+                  },
+                  "value": {
+                    "raw": 631693,
+                    "fmt": "631.69k",
+                    "longFmt": "631,693"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 15.10 per share.",
+                  "filerName": "REED SCOTT A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9462,
+                    "fmt": "9.46k",
+                    "longFmt": "9,462"
+                  },
+                  "value": {
+                    "raw": 142876,
+                    "fmt": "142.88k",
+                    "longFmt": "142,876"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 15.10 per share.",
+                  "filerName": "COLUCCI PAUL D",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 394181,
+                    "fmt": "394.18k",
+                    "longFmt": "394,181"
+                  },
+                  "value": {
+                    "raw": 4399060,
+                    "fmt": "4.4M",
+                    "longFmt": "4,399,060"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 11.16 per share.",
+                  "filerName": "FRANK DENNIS S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573516800,
+                    "fmt": "2019-11-12"
+                  },
+                  "ownership": "D/I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 320693,
+                    "fmt": "320.69k",
+                    "longFmt": "320,693"
+                  },
+                  "value": {
+                    "raw": 3578934,
+                    "fmt": "3.58M",
+                    "longFmt": "3,578,934"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 11.16 per share.",
+                  "filerName": "FRIEDMAN MARTIN S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573516800,
+                    "fmt": "2019-11-12"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 62079,
+                    "fmt": "62.08k",
+                    "longFmt": "62,079"
+                  },
+                  "value": {
+                    "raw": 692802,
+                    "fmt": "692.8k",
+                    "longFmt": "692,802"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 11.16 per share.",
+                  "filerName": "REED SCOTT A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573516800,
+                    "fmt": "2019-11-12"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 47474,
+                    "fmt": "47.47k",
+                    "longFmt": "47,474"
+                  },
+                  "value": {
+                    "raw": 529810,
+                    "fmt": "529.81k",
+                    "longFmt": "529,810"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 11.16 per share.",
+                  "filerName": "COLUCCI PAUL D",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573516800,
+                    "fmt": "2019-11-12"
+                  },
+                  "ownership": "D"
+                }
+              ],
+              "maxAge": 1
+            },
+            "sectorTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            },
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 26603000,
+                    "fmt": "26.6M",
+                    "longFmt": "26,603,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "grossProfit": {
+                    "raw": 26603000,
+                    "fmt": "26.6M",
+                    "longFmt": "26,603,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 16512000,
+                    "fmt": "16.51M",
+                    "longFmt": "16,512,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 455000,
+                    "fmt": "455k",
+                    "longFmt": "455,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 16967000,
+                    "fmt": "16.97M",
+                    "longFmt": "16,967,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 9636000,
+                    "fmt": "9.64M",
+                    "longFmt": "9,636,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -658000,
+                    "fmt": "-658k",
+                    "longFmt": "-658,000"
+                  },
+                  "ebit": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "interestExpense": {},
+                  "incomeBeforeTax": {
+                    "raw": 8978000,
+                    "fmt": "8.98M",
+                    "longFmt": "8,978,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -141000,
+                    "fmt": "-141k",
+                    "longFmt": "-141,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 9119000,
+                    "fmt": "9.12M",
+                    "longFmt": "9,119,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 9119000,
+                    "fmt": "9.12M",
+                    "longFmt": "9,119,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 9119000,
+                    "fmt": "9.12M",
+                    "longFmt": "9,119,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 22890000,
+                    "fmt": "22.89M",
+                    "longFmt": "22,890,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "grossProfit": {
+                    "raw": 22890000,
+                    "fmt": "22.89M",
+                    "longFmt": "22,890,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 13438000,
+                    "fmt": "13.44M",
+                    "longFmt": "13,438,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 463000,
+                    "fmt": "463k",
+                    "longFmt": "463,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 13901000,
+                    "fmt": "13.9M",
+                    "longFmt": "13,901,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 8989000,
+                    "fmt": "8.99M",
+                    "longFmt": "8,989,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -232000,
+                    "fmt": "-232k",
+                    "longFmt": "-232,000"
+                  },
+                  "ebit": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "interestExpense": {},
+                  "incomeBeforeTax": {
+                    "raw": 8757000,
+                    "fmt": "8.76M",
+                    "longFmt": "8,757,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 1697000,
+                    "fmt": "1.7M",
+                    "longFmt": "1,697,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 7060000,
+                    "fmt": "7.06M",
+                    "longFmt": "7,060,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 7060000,
+                    "fmt": "7.06M",
+                    "longFmt": "7,060,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 7060000,
+                    "fmt": "7.06M",
+                    "longFmt": "7,060,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 21264000,
+                    "fmt": "21.26M",
+                    "longFmt": "21,264,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "grossProfit": {
+                    "raw": 21264000,
+                    "fmt": "21.26M",
+                    "longFmt": "21,264,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 13344000,
+                    "fmt": "13.34M",
+                    "longFmt": "13,344,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 446000,
+                    "fmt": "446k",
+                    "longFmt": "446,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 13790000,
+                    "fmt": "13.79M",
+                    "longFmt": "13,790,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 7474000,
+                    "fmt": "7.47M",
+                    "longFmt": "7,474,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -182000,
+                    "fmt": "-182k",
+                    "longFmt": "-182,000"
+                  },
+                  "ebit": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "interestExpense": {},
+                  "incomeBeforeTax": {
+                    "raw": 7292000,
+                    "fmt": "7.29M",
+                    "longFmt": "7,292,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 1826000,
+                    "fmt": "1.83M",
+                    "longFmt": "1,826,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 5466000,
+                    "fmt": "5.47M",
+                    "longFmt": "5,466,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 5466000,
+                    "fmt": "5.47M",
+                    "longFmt": "5,466,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 5466000,
+                    "fmt": "5.47M",
+                    "longFmt": "5,466,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 19117000,
+                    "fmt": "19.12M",
+                    "longFmt": "19,117,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "grossProfit": {
+                    "raw": 19117000,
+                    "fmt": "19.12M",
+                    "longFmt": "19,117,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 13257000,
+                    "fmt": "13.26M",
+                    "longFmt": "13,257,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 495000,
+                    "fmt": "495k",
+                    "longFmt": "495,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 13752000,
+                    "fmt": "13.75M",
+                    "longFmt": "13,752,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 5365000,
+                    "fmt": "5.37M",
+                    "longFmt": "5,365,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 802000,
+                    "fmt": "802k",
+                    "longFmt": "802,000"
+                  },
+                  "ebit": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "interestExpense": {},
+                  "incomeBeforeTax": {
+                    "raw": 6167000,
+                    "fmt": "6.17M",
+                    "longFmt": "6,167,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 1774000,
+                    "fmt": "1.77M",
+                    "longFmt": "1,774,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 4393000,
+                    "fmt": "4.39M",
+                    "longFmt": "4,393,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 4393000,
+                    "fmt": "4.39M",
+                    "longFmt": "4,393,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 4393000,
+                    "fmt": "4.39M",
+                    "longFmt": "4,393,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 9119000,
+                    "fmt": "9.12M",
+                    "longFmt": "9,119,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 7060000,
+                    "fmt": "7.06M",
+                    "longFmt": "7,060,000"
+                  },
+                  "depreciation": {
+                    "raw": 965000,
+                    "fmt": "965k",
+                    "longFmt": "965,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -344055000,
+                    "fmt": "-344.06M",
+                    "longFmt": "-344,055,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 2250000,
+                    "fmt": "2.25M",
+                    "longFmt": "2,250,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -338620000,
+                    "fmt": "-338.62M",
+                    "longFmt": "-338,620,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -123000,
+                    "fmt": "-123k",
+                    "longFmt": "-123,000"
+                  },
+                  "investments": {
+                    "raw": 19433000,
+                    "fmt": "19.43M",
+                    "longFmt": "19,433,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -289000,
+                    "fmt": "-289k",
+                    "longFmt": "-289,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 76540000,
+                    "fmt": "76.54M",
+                    "longFmt": "76,540,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -350000000,
+                    "fmt": "-350M",
+                    "longFmt": "-350,000,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 610209000,
+                    "fmt": "610.21M",
+                    "longFmt": "610,209,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 260118000,
+                    "fmt": "260.12M",
+                    "longFmt": "260,118,000"
+                  },
+                  "changeInCash": {
+                    "raw": -1962000,
+                    "fmt": "-1.96M",
+                    "longFmt": "-1,962,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -91000,
+                    "fmt": "-91k",
+                    "longFmt": "-91,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "netIncome": {
+                    "raw": 5466000,
+                    "fmt": "5.47M",
+                    "longFmt": "5,466,000"
+                  },
+                  "depreciation": {
+                    "raw": 740000,
+                    "fmt": "740k",
+                    "longFmt": "740,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 111623000,
+                    "fmt": "111.62M",
+                    "longFmt": "111,623,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 297000,
+                    "fmt": "297k",
+                    "longFmt": "297,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 116244000,
+                    "fmt": "116.24M",
+                    "longFmt": "116,244,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -274000,
+                    "fmt": "-274k",
+                    "longFmt": "-274,000"
+                  },
+                  "investments": {
+                    "raw": 36230000,
+                    "fmt": "36.23M",
+                    "longFmt": "36,230,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -2340000,
+                    "fmt": "-2.34M",
+                    "longFmt": "-2,340,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -80927000,
+                    "fmt": "-80.93M",
+                    "longFmt": "-80,927,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 330000000,
+                    "fmt": "330M",
+                    "longFmt": "330,000,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -332015000,
+                    "fmt": "-332.01M",
+                    "longFmt": "-332,015,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -2073000,
+                    "fmt": "-2.07M",
+                    "longFmt": "-2,073,000"
+                  },
+                  "changeInCash": {
+                    "raw": 33244000,
+                    "fmt": "33.24M",
+                    "longFmt": "33,244,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -58000,
+                    "fmt": "-58k",
+                    "longFmt": "-58,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "netIncome": {
+                    "raw": 4393000,
+                    "fmt": "4.39M",
+                    "longFmt": "4,393,000"
+                  },
+                  "depreciation": {
+                    "raw": 830000,
+                    "fmt": "830k",
+                    "longFmt": "830,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -69966000,
+                    "fmt": "-69.97M",
+                    "longFmt": "-69,966,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 87000,
+                    "fmt": "87k",
+                    "longFmt": "87,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -65176000,
+                    "fmt": "-65.18M",
+                    "longFmt": "-65,176,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -391000,
+                    "fmt": "-391k",
+                    "longFmt": "-391,000"
+                  },
+                  "investments": {
+                    "raw": -77034000,
+                    "fmt": "-77.03M",
+                    "longFmt": "-77,034,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 13365000,
+                    "fmt": "13.37M",
+                    "longFmt": "13,365,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -68786000,
+                    "fmt": "-68.79M",
+                    "longFmt": "-68,786,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -21789000,
+                    "fmt": "-21.79M",
+                    "longFmt": "-21,789,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 188348000,
+                    "fmt": "188.35M",
+                    "longFmt": "188,348,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 166558000,
+                    "fmt": "166.56M",
+                    "longFmt": "166,558,000"
+                  },
+                  "changeInCash": {
+                    "raw": 32596000,
+                    "fmt": "32.6M",
+                    "longFmt": "32,596,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -1000,
+                    "fmt": "-1k",
+                    "longFmt": "-1,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            },
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [
+                  {
+                    "date": "1Q2020",
+                    "actual": 0.23,
+                    "estimate": 0.18
+                  },
+                  {
+                    "date": "2Q2020",
+                    "actual": 0.29,
+                    "estimate": 0.19
+                  },
+                  {
+                    "date": "3Q2020",
+                    "actual": 0.37,
+                    "estimate": 0.22
+                  },
+                  {
+                    "date": "4Q2020",
+                    "actual": 0.47,
+                    "estimate": 0.38
+                  }
+                ],
+                "currentQuarterEstimate": 0.45,
+                "currentQuarterEstimateDate": "1Q",
+                "currentQuarterEstimateYear": 2021,
+                "earningsDate": [
+                  1611187200
+                ]
+              },
+              "financialsChart": {
+                "yearly": [
+                  {
+                    "date": 2017,
+                    "revenue": 45137000,
+                    "earnings": 7643000
+                  },
+                  {
+                    "date": 2018,
+                    "revenue": 78713000,
+                    "earnings": 22333000
+                  },
+                  {
+                    "date": 2019,
+                    "revenue": 87150000,
+                    "earnings": 24846000
+                  },
+                  {
+                    "date": 2020,
+                    "revenue": 89874000,
+                    "earnings": 26038000
+                  }
+                ],
+                "quarterly": [
+                  {
+                    "date": "1Q2020",
+                    "revenue": 19117000,
+                    "earnings": 4393000
+                  },
+                  {
+                    "date": "2Q2020",
+                    "revenue": 21264000,
+                    "earnings": 5466000
+                  },
+                  {
+                    "date": "3Q2020",
+                    "revenue": 22890000,
+                    "earnings": 7060000
+                  },
+                  {
+                    "date": "4Q2020",
+                    "revenue": 26603000,
+                    "earnings": 9119000
+                  }
+                ]
+              },
+              "financialCurrency": "USD"
+            },
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 172.1399,
+              "targetHighPrice": 150,
+              "targetLowPrice": 85,
+              "targetMeanPrice": 111.67,
+              "targetMedianPrice": 105,
+              "recommendationMean": 1.7,
+              "recommendationKey": "buy",
+              "numberOfAnalystOpinions": 6,
+              "totalCash": 2993190912,
+              "totalCashPerShare": 159.688,
+              "totalDebt": 15831000,
+              "totalRevenue": 89874000,
+              "revenuePerShare": 4.808,
+              "returnOnAssets": 0.00675,
+              "returnOnEquity": 0.099130005,
+              "grossProfits": 89874000,
+              "earningsGrowth": 1.42,
+              "revenueGrowth": 0.418,
+              "grossMargins": 0,
+              "ebitdaMargins": 0,
+              "operatingMargins": 0.34983003,
+              "profitMargins": 0.28972,
+              "financialCurrency": "USD"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-assetProfile-ABBV.json
+++ b/tests/http/quoteSummary-assetProfile-ABBV.json
@@ -1,0 +1,300 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=assetProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "bj2bj35g2vsdu"
+      ],
+      "x-yahoo-request-id": [
+        "bj2bj35g2vsdu"
+      ],
+      "x-request-id": [
+        "b7417f35-eaa9-4dcc-be74-6b32cdf72429"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "2090"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:34 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "3"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "1 North Waukegan Road",
+              "city": "North Chicago",
+              "state": "IL",
+              "zip": "60064",
+              "country": "United States",
+              "phone": "847 932 7900",
+              "website": "http://www.abbvie.com",
+              "industry": "Drug Manufacturers—General",
+              "sector": "Healthcare",
+              "longBusinessSummary": "AbbVie Inc. discovers, develops, manufactures, and sells pharmaceuticals in the United States, Japan, Germany, Canada, France, Spain, Italy, the Netherlands, the United Kingdom, Brazil, and internationally. The company offers HUMIRA, a therapy administered as an injection for autoimmune and intestinal BehÃ§et's diseases; SKYRIZI to treat moderate to severe plaque psoriasis in adults; RINVOQ, a JAK inhibitor for the treatment of moderate to severe active rheumatoid arthritis in adult patients; IMBRUVICA to treat adult patients with chronic lymphocytic leukemia (CLL), small lymphocytic lymphoma (SLL), mantle cell lymphoma, waldenstrÃ¶m's macroglobulinemia, marginal zone lymphoma, and chronic graft versus host disease; VENCLEXTA, a BCL-2 inhibitor used to treat adults with CLL or SLL; VIEKIRA PAK, an interferon-free therapy to treat adults with genotype 1 chronic hepatitis C virus (HCV); TECHNIVIE to treat adults with genotype 4 HCV infection; and MAVYRET to treat patients with chronic HCV genotype 1-6 infection. It also provides SYNAGIS that protects at-risk infants from severe respiratory disease; KALETRA, a prescription anti-HIV-1 medicine; CREON, a pancreatic enzyme therapy for exocrine pancreatic insufficiency; Synthroid used in the treatment of hypothyroidism; AndroGel for males diagnosed with symptomatic low testosterone; and Lupron, a product for the palliative treatment of advanced prostate cancer, endometriosis and central precocious puberty, and patients with anemia caused by uterine fibroids. In addition, the company offers ORILISSA, a nonpeptide small molecule gonadotropin-releasing hormone antagonist; Duopa and Duodopa, a levodopa-carbidopa intestinal gel to treat Parkinson's disease; and Sevoflurane, an anesthesia product. It has collaborations with Calico Life Sciences LLC; Alector, Inc.; Janssen Biotech, Inc.; Frontier Medicines, Corp.; Jacobio Pharmaceuticals; I-Mab; and Genmab A/S. The company was incorporated in 2012 and is based in North Chicago, Illinois.",
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Richard A. Gonzalez",
+                  "age": 66,
+                  "title": "Chairman & CEO",
+                  "yearBorn": 1954,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 7110537,
+                    "fmt": "7.11M",
+                    "longFmt": "7,110,537"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 16561981,
+                    "fmt": "16.56M",
+                    "longFmt": "16,561,981"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Michael E. Severino",
+                  "age": 54,
+                  "title": "Vice Chairman & Pres",
+                  "yearBorn": 1966,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 3975467,
+                    "fmt": "3.98M",
+                    "longFmt": "3,975,467"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 10544840,
+                    "fmt": "10.54M",
+                    "longFmt": "10,544,840"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Robert A. Michael",
+                  "age": 50,
+                  "title": "Exec. VP & CFO",
+                  "yearBorn": 1970,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 2762336,
+                    "fmt": "2.76M",
+                    "longFmt": "2,762,336"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 548437,
+                    "fmt": "548.44k",
+                    "longFmt": "548,437"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Laura J. Schumacher",
+                  "age": 57,
+                  "title": "Vice Chairman of External Affairs, Chief Legal Officer & Corp. Sec.",
+                  "yearBorn": 1963,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 4303763,
+                    "fmt": "4.3M",
+                    "longFmt": "4,303,763"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 7517504,
+                    "fmt": "7.52M",
+                    "longFmt": "7,517,504"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Carlos  Alban",
+                  "age": 57,
+                  "title": "Vice Chairman & Chief Commercial Officer",
+                  "yearBorn": 1963,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 4076821,
+                    "fmt": "4.08M",
+                    "longFmt": "4,076,821"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 16574024,
+                    "fmt": "16.57M",
+                    "longFmt": "16,574,024"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Azita  Saleki-Gerhardt",
+                  "age": 57,
+                  "title": "Exec. VP of Operations",
+                  "yearBorn": 1963,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Thomas J. Hudson",
+                  "age": 58,
+                  "title": "Sr. VP of R&D and Chief Scientific Officer",
+                  "yearBorn": 1962,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Elizabeth  Shea",
+                  "title": "VP of Investor Relations",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Timothy J. Richmond",
+                  "age": 54,
+                  "title": "Exec. VP & Chief HR Officer",
+                  "yearBorn": 1966,
+                  "fiscalYear": 2013,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Scott C. Brun M.D.",
+                  "title": "VP of Scientific Affairs & Head of AbbVie Ventures",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "auditRisk": 2,
+              "boardRisk": 7,
+              "compensationRisk": 3,
+              "shareHolderRightsRisk": 9,
+              "overallRisk": 8,
+              "governanceEpochDate": 1606867200,
+              "compensationAsOfEpochDate": 1577750400,
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-assetProfile-BRKS.json
+++ b/tests/http/quoteSummary-assetProfile-BRKS.json
@@ -1,0 +1,304 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=assetProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "38ssdgpg2vsdv"
+      ],
+      "x-yahoo-request-id": [
+        "38ssdgpg2vsdv"
+      ],
+      "x-request-id": [
+        "6c711cc5-882b-4049-9b6b-e38e8140e07b"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1771"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:34 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "15 Elizabeth Drive",
+              "city": "Chelmsford",
+              "state": "MA",
+              "zip": "01824",
+              "country": "United States",
+              "phone": "978 262 2400",
+              "fax": "978 262 2500",
+              "website": "http://www.brooks.com",
+              "industry": "Semiconductor Equipment & Materials",
+              "sector": "Technology",
+              "longBusinessSummary": "Brooks Automation, Inc. provides manufacturing automation solutions for the semiconductor industry, and life science sample-based services and solutions for the life sciences market worldwide. The company operates in three segments: Brooks Semiconductor Solutions Group, Brooks Life Sciences Services, and Brooks Life Sciences Products. The Brooks Semiconductor Solutions Group segment offers wafer automation and contamination controls solutions and services. Its products include atmospheric and vacuum robots, robotic modules, and tool automation systems that offer precision handling and clean wafer environments; and automated cleaning and inspection systems for wafer carriers, reticle pod cleaners, and stockers. It also offers repair and refurbishment, diagnostics, and installation services, as well as spare parts and productivity enhancement upgrade services. The Brooks Life Sciences Services segment provides gene sequencing and gene synthesis services, including next generation sequencing, sanger sequencing, gene synthesis, bioinformatics, and good laboratory practices regulatory services; on-site and off-site sample storage, cold chain logistics, sample transport and collection relocation, bio-processing solutions, disaster recovery, and business continuity, as well as project management and consulting services; and sample intelligence software solutions and integration of customer technology. The Brooks Life Sciences Products segment offers automated cold storage systems; consumables, such as various formats of racks, tubes, caps, plates, and foils used for the storage and handling of samples in cold storage environments; and instruments used for labeling, bar coding, capping, de-capping, auditing, sealing, peeling, and piercing tubes and plates. The company serves semiconductor capital equipment and life sciences sample management markets in approximately 50 countries. Brooks Automation, Inc. was founded in 1978 and is headquartered in Chelmsford, Massachusetts.",
+              "fullTimeEmployees": 3200,
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Stephen S. Schwartz",
+                  "age": 61,
+                  "title": "CEO, Pres & Director",
+                  "yearBorn": 1959,
+                  "fiscalYear": 2020,
+                  "totalPay": {
+                    "raw": 1417517,
+                    "fmt": "1.42M",
+                    "longFmt": "1,417,517"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Lindon G. Robertson",
+                  "age": 58,
+                  "title": "Exec. VP & CFO",
+                  "yearBorn": 1962,
+                  "fiscalYear": 2020,
+                  "totalPay": {
+                    "raw": 1004200,
+                    "fmt": "1M",
+                    "longFmt": "1,004,200"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Jason W. Joseph",
+                  "age": 49,
+                  "title": "Sr. VP, Gen. Counsel & Sec.",
+                  "yearBorn": 1971,
+                  "fiscalYear": 2020,
+                  "totalPay": {
+                    "raw": 586543,
+                    "fmt": "586.54k",
+                    "longFmt": "586,543"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Guojuan  Liao Ph.D.",
+                  "age": 55,
+                  "title": "Pres of Life Sciences Services",
+                  "yearBorn": 1965,
+                  "fiscalYear": 2020,
+                  "totalPay": {
+                    "raw": 713921,
+                    "fmt": "713.92k",
+                    "longFmt": "713,921"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. David E. Jarzynka",
+                  "age": 52,
+                  "title": "Pres of Semiconductor Solutions Group",
+                  "yearBorn": 1968,
+                  "fiscalYear": 2020,
+                  "totalPay": {
+                    "raw": 770351,
+                    "fmt": "770.35k",
+                    "longFmt": "770,351"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. David F. Pietrantoni",
+                  "age": 47,
+                  "title": "VP of Fin., Corp. Controller & Principal Accounting Officer",
+                  "yearBorn": 1973,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Mark  Namaroff",
+                  "age": 57,
+                  "title": "Director of Investor Relations",
+                  "yearBorn": 1963,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. John E. O'Brien",
+                  "age": 50,
+                  "title": "VP of Corp. Devel.",
+                  "yearBorn": 1970,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. William T. Montone",
+                  "age": 68,
+                  "title": "Sr. VP of HR",
+                  "yearBorn": 1952,
+                  "fiscalYear": 2014,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. J. Robert Woodward",
+                  "title": "Sr. VP of Quality & Engineering",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "auditRisk": 5,
+              "boardRisk": 1,
+              "compensationRisk": 3,
+              "shareHolderRightsRisk": 6,
+              "overallRisk": 3,
+              "governanceEpochDate": 1606867200,
+              "compensationAsOfEpochDate": 1609372800,
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-assetProfile-CRON.json
+++ b/tests/http/quoteSummary-assetProfile-CRON.json
@@ -1,0 +1,287 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=assetProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "cehjv91g2vsdv"
+      ],
+      "x-yahoo-request-id": [
+        "cehjv91g2vsdv"
+      ],
+      "x-request-id": [
+        "0023b059-b0de-453e-8bff-bac23b975202"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1301"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:35 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "720 King Street West",
+              "address2": "Suite 320",
+              "city": "Toronto",
+              "state": "ON",
+              "zip": "M5V 2T3",
+              "country": "Canada",
+              "phone": "416-504-0004",
+              "website": "http://www.thecronosgroup.com",
+              "industry": "Drug Manufacturers—Specialty & Generic",
+              "sector": "Healthcare",
+              "longBusinessSummary": "Cronos Group Inc. operates as a cannabinoid company in the United States and internationally. It manufactures, markets, and distributes hemp-derived supplements and cosmetic products through ecommerce, retail, and hospitality partner channels. The company is also involved in the cultivation, manufacture, and marketing of cannabis and cannabis-derived products for the medical and adult-use markets. Its brand portfolio includes PEACE NATURALS, a global wellness platform; adult-use brands comprise COVE and Spinach; and hemp-derived CBD brands consists of Lord Jones and PEACE+. Cronos Group Inc. is based in Toronto, Canada.",
+              "fullTimeEmployees": 631,
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Michael Ryan Gorenstein",
+                  "age": 33,
+                  "title": "Exec. Chairman",
+                  "yearBorn": 1987,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 333571,
+                    "fmt": "333.57k",
+                    "longFmt": "333,571"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 15739047,
+                    "fmt": "15.74M",
+                    "longFmt": "15,739,047"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Jerry Filomena Barbato",
+                  "age": 44,
+                  "title": "Chief Financial Officer",
+                  "yearBorn": 1976,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 299626,
+                    "fmt": "299.63k",
+                    "longFmt": "299,626"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Xiuming  Shum",
+                  "age": 34,
+                  "title": "Exec. VP of Legal and Regulatory Affairs & Corp. Sec.",
+                  "yearBorn": 1986,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 190178,
+                    "fmt": "190.18k",
+                    "longFmt": "190,178"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 1076139,
+                    "fmt": "1.08M",
+                    "longFmt": "1,076,139"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Kurt Thomas Schmidt B.Sc., M.B.A.",
+                  "age": 63,
+                  "title": "Pres & CEO",
+                  "yearBorn": 1957,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Shayne J. Laidlaw",
+                  "title": "Director of Investor Relations & Strategy",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Shannon  Buggy",
+                  "title": "Sr. VP & Global Head of People",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Anna  Shlimak",
+                  "age": 34,
+                  "title": "Sr. VP of Corp. Affairs",
+                  "yearBorn": 1986,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Dr. Todd K. Abraham",
+                  "age": 65,
+                  "title": "Chief Innovation Officer",
+                  "yearBorn": 1955,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Puneet  Mathur",
+                  "title": "VP & Controller",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Summer  Frein",
+                  "age": 36,
+                  "title": "Gen. Mang. of USA",
+                  "yearBorn": 1984,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "auditRisk": 10,
+              "boardRisk": 5,
+              "compensationRisk": 5,
+              "shareHolderRightsRisk": 5,
+              "overallRisk": 7,
+              "governanceEpochDate": 1606867200,
+              "compensationAsOfEpochDate": 1577750400,
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-assetProfile-EPAC.json
+++ b/tests/http/quoteSummary-assetProfile-EPAC.json
@@ -1,0 +1,296 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=assetProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "60hblolg2vsdv"
+      ],
+      "x-yahoo-request-id": [
+        "60hblolg2vsdv"
+      ],
+      "x-request-id": [
+        "98f14a46-57ee-9319-a10e-09c5bc6b0792"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1449"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:35 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "N86 W12500 Westbrook Crossing",
+              "city": "Menomonee Falls",
+              "state": "WI",
+              "zip": "53051",
+              "country": "United States",
+              "phone": "262 293 1500",
+              "website": "http://www.enerpactoolgroup.com",
+              "industry": "Specialty Industrial Machinery",
+              "sector": "Industrials",
+              "longBusinessSummary": "Enerpac Tool Group Corp. manufactures and sells a range of industrial products and solutions worldwide. It operates in two segments, Industrial Tools & Services (IT&S) and Other. The IT&S segment designs, manufactures, and distributes branded hydraulic and mechanical tools; and provides services and tool rentals to the industrial, maintenance, infrastructure, oil and gas, energy, and other markets. It also offers branded tools and engineered heavy lifting technology solutions, and hydraulic torque wrenches; energy maintenance and manpower services; high-force hydraulic and mechanical tools, including cylinders, pumps, valves, and specialty tools; and bolt tensioners and other miscellaneous products. This segment markets its branded tools and services primarily under the Enerpac, Hydratight, Larzep, and Simplex brands. The Other segment designs and manufactures synthetic ropes and biomedical assemblies. The company was formerly known as Actuant Corporation and changed its name to Enerpac Tool Group Corp. in January 2020. Enerpac Tool Group Corp. was founded in 1910 and is headquartered in Menomonee Falls, Wisconsin.",
+              "fullTimeEmployees": 2300,
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Randal Wayne Baker",
+                  "age": 57,
+                  "title": "Pres, CEO & Director",
+                  "yearBorn": 1963,
+                  "fiscalYear": 2020,
+                  "totalPay": {
+                    "raw": 908956,
+                    "fmt": "908.96k",
+                    "longFmt": "908,956"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Ricky T. Dillon",
+                  "age": 49,
+                  "title": "Exec. VP & CFO",
+                  "yearBorn": 1971,
+                  "fiscalYear": 2020,
+                  "totalPay": {
+                    "raw": 545109,
+                    "fmt": "545.11k",
+                    "longFmt": "545,109"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. John Jeffrey Schmaling",
+                  "age": 61,
+                  "title": "Exec. VP & COO",
+                  "yearBorn": 1959,
+                  "fiscalYear": 2020,
+                  "totalPay": {
+                    "raw": 511032,
+                    "fmt": "511.03k",
+                    "longFmt": "511,032"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Fabrizio  Rasetti",
+                  "age": 54,
+                  "title": "Exec. VP, Gen. Counsel, Sec. & Global HR",
+                  "yearBorn": 1966,
+                  "fiscalYear": 2020,
+                  "totalPay": {
+                    "raw": 445396,
+                    "fmt": "445.4k",
+                    "longFmt": "445,396"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Barbara G. Bolens",
+                  "age": 59,
+                  "title": "Exec. VP & Chief Strategy Officer",
+                  "yearBorn": 1961,
+                  "fiscalYear": 2020,
+                  "totalPay": {
+                    "raw": 360060,
+                    "fmt": "360.06k",
+                    "longFmt": "360,060"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Bryan R. Johnson",
+                  "age": 43,
+                  "title": "VP of Fin. & Principal Accounting Officer",
+                  "yearBorn": 1977,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Scot  Stein",
+                  "title": "Chief Information Officer",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Richard  Roman",
+                  "title": "Treasurer, VP of Tax & Assistant Sec.",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. George  Scherer",
+                  "title": "Exec. VP of B W Elliott",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Art  Donaldson",
+                  "title": "VP of Engineering - Industrial Segment",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "auditRisk": 2,
+              "boardRisk": 7,
+              "compensationRisk": 4,
+              "shareHolderRightsRisk": 6,
+              "overallRisk": 6,
+              "governanceEpochDate": 1606867200,
+              "compensationAsOfEpochDate": 1609372800,
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-assetProfile-MDLY.json
+++ b/tests/http/quoteSummary-assetProfile-MDLY.json
@@ -1,0 +1,277 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=assetProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "fih4r7tg2vsdu"
+      ],
+      "x-yahoo-request-id": [
+        "fih4r7tg2vsdu"
+      ],
+      "x-request-id": [
+        "9a5c0d39-46ef-4f23-b3b3-3057220c58fb"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "950"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:34 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "280 Park Avenue",
+              "address2": "6th Floor East",
+              "city": "New York",
+              "state": "NY",
+              "zip": "10017",
+              "country": "United States",
+              "phone": "212-759-0777",
+              "website": "http://www.mdly.com",
+              "industry": "Asset Management",
+              "sector": "Financial Services",
+              "longBusinessSummary": "Medley Management Inc. is an investment holding company and operate and control all of the business and affairs of Medley LLC and its subsidiaries. Medley Management Inc. was incorporated on June 13, 2014 and is based in New York, New York.",
+              "fullTimeEmployees": 65,
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Seth  Taube CFA",
+                  "age": 50,
+                  "title": "Co-CEO & Co-Chairman",
+                  "yearBorn": 1970,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 54828,
+                    "fmt": "54.83k",
+                    "longFmt": "54,828"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Brook  Taube CFA",
+                  "age": 50,
+                  "title": "Co-Chairman, Co-CEO & Chief Investment Officer",
+                  "yearBorn": 1970,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 54319,
+                    "fmt": "54.32k",
+                    "longFmt": "54,319"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Richard Thomas Allorto Jr., CPA, CPA",
+                  "age": 48,
+                  "title": "Chief Financial Officer",
+                  "yearBorn": 1972,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 355052,
+                    "fmt": "355.05k",
+                    "longFmt": "355,052"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Samuel  Anderson",
+                  "title": "Sr. MD, Head of Capital Markets & Risk Management",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Nathan  Bryce",
+                  "title": "Gen. Counsel & Sec.",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Brian  Dohmen",
+                  "title": "Sr. Managing Director and Head of Direct Lending & Origination New York",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Howard  Liao",
+                  "title": "Sr. MD & Head of Corp. Credit",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Mark  Smith",
+                  "title": "MD & Member of the Institutional Fundraising Group",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. James  Frank",
+                  "age": 44,
+                  "title": "Sr. MD & Head of Tactical Opportunities",
+                  "yearBorn": 1976,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Dean Christopher Crowe",
+                  "age": 57,
+                  "title": "Head of Investing and Sr. Managing Director",
+                  "yearBorn": 1963,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "compensationAsOfEpochDate": 1577750400,
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-assetProfile-SI.json
+++ b/tests/http/quoteSummary-assetProfile-SI.json
@@ -1,0 +1,285 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=assetProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "6gfmg8pg2vsdu"
+      ],
+      "x-yahoo-request-id": [
+        "6gfmg8pg2vsdu"
+      ],
+      "x-request-id": [
+        "72c98374-dc8d-4fc4-8640-a436a46d86ab"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1326"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:34 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "assetProfile": {
+              "address1": "4250 Executive Square",
+              "address2": "Suite 300",
+              "city": "La Jolla",
+              "state": "CA",
+              "zip": "92037",
+              "country": "United States",
+              "phone": "858-362-6300",
+              "website": "http://www.silvergatebank.com",
+              "industry": "Banks—Regional",
+              "sector": "Financial Services",
+              "longBusinessSummary": "Silvergate Capital Corporation operates as a bank holding company for Silvergate Bank that provides banking products and services to business and individual clients in the United States and internationally. The company accepts deposit products, including interest and noninterest bearing demand accounts, money market and savings accounts, and certificates of deposit accounts. Its loan products include one-to-four family real estate loans, multi-family real estate loans, commercial real estate loans, construction loans, commercial and industrial loans, mortgage warehouse loans, and reverse mortgage loans, as well as consumer loans and other loans secured by personal property. The company also provides cash management services for digital currency-related businesses. The company was founded in 1988 and is headquartered in La Jolla, California.",
+              "fullTimeEmployees": 218,
+              "companyOfficers": [
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Alan J. Lane",
+                  "age": 58,
+                  "title": "Pres, CEO & Director",
+                  "yearBorn": 1962,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 706590,
+                    "fmt": "706.59k",
+                    "longFmt": "706,590"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 3444743,
+                    "fmt": "3.44M",
+                    "longFmt": "3,444,743"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Benjamin C. Reynolds",
+                  "age": 42,
+                  "title": "Exec. VP of Corp. Devel.",
+                  "yearBorn": 1978,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 1017387,
+                    "fmt": "1.02M",
+                    "longFmt": "1,017,387"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 19550,
+                    "fmt": "19.55k",
+                    "longFmt": "19,550"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Derek J. Eisele",
+                  "age": 54,
+                  "title": "Exec. VP",
+                  "yearBorn": 1966,
+                  "fiscalYear": 2019,
+                  "totalPay": {
+                    "raw": 537896,
+                    "fmt": "537.9k",
+                    "longFmt": "537,896"
+                  },
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 1476900,
+                    "fmt": "1.48M",
+                    "longFmt": "1,476,900"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Antonio R. Martino",
+                  "age": 53,
+                  "title": "Chief Financial Officer",
+                  "yearBorn": 1967,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Kathleen M. Fraher",
+                  "age": 41,
+                  "title": "Exec. VP & COO",
+                  "yearBorn": 1979,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Jeffery T. Hurtik",
+                  "title": "Exec. VP & Chief Information Officer",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Shannon  Devine",
+                  "title": "Head of Investor Relations",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. John M. Bonino",
+                  "age": 70,
+                  "title": "Exec. VP & Chief Legal Officer",
+                  "yearBorn": 1950,
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Mr. Cole  Williamson",
+                  "title": "Sr. VP & Director of People and Culture Services",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Ms. Maria P. Kunac",
+                  "title": "Exec. VP, Chief Lending Officer & Commercial Real Estate Division",
+                  "exercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "unexercisedValue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                }
+              ],
+              "auditRisk": 2,
+              "boardRisk": 9,
+              "compensationRisk": 5,
+              "shareHolderRightsRisk": 9,
+              "overallRisk": 8,
+              "governanceEpochDate": 1606867200,
+              "compensationAsOfEpochDate": 1577750400,
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistory-ABBV.json
+++ b/tests/http/quoteSummary-balanceSheetHistory-ABBV.json
@@ -1,0 +1,509 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=balanceSheetHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "005qb09g2vse0"
+      ],
+      "x-yahoo-request-id": [
+        "005qb09g2vse0"
+      ],
+      "x-request-id": [
+        "0a4affbf-4733-4d22-9e33-e993ce0b0700"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1468"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:36 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 15270000000,
+                    "fmt": "15.27B",
+                    "longFmt": "15,270,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -102174000000,
+                    "fmt": "-102.17B",
+                    "longFmt": "-102,174,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 39924000000,
+                    "fmt": "39.92B",
+                    "longFmt": "39,924,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 5428000000,
+                    "fmt": "5.43B",
+                    "longFmt": "5,428,000,000"
+                  },
+                  "inventory": {
+                    "raw": 1813000000,
+                    "fmt": "1.81B",
+                    "longFmt": "1,813,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 22000000,
+                    "fmt": "22M",
+                    "longFmt": "22,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 49519000000,
+                    "fmt": "49.52B",
+                    "longFmt": "49,519,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 124000000,
+                    "fmt": "124M",
+                    "longFmt": "124,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 3306000000,
+                    "fmt": "3.31B",
+                    "longFmt": "3,306,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 15604000000,
+                    "fmt": "15.6B",
+                    "longFmt": "15,604,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 18649000000,
+                    "fmt": "18.65B",
+                    "longFmt": "18,649,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 1913000000,
+                    "fmt": "1.91B",
+                    "longFmt": "1,913,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 89115000000,
+                    "fmt": "89.11B",
+                    "longFmt": "89,115,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1452000000,
+                    "fmt": "1.45B",
+                    "longFmt": "1,452,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 3746000000,
+                    "fmt": "3.75B",
+                    "longFmt": "3,746,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 4633000000,
+                    "fmt": "4.63B",
+                    "longFmt": "4,633,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 62955000000,
+                    "fmt": "62.95B",
+                    "longFmt": "62,955,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 18476000000,
+                    "fmt": "18.48B",
+                    "longFmt": "18,476,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 15585000000,
+                    "fmt": "15.59B",
+                    "longFmt": "15,585,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 97287000000,
+                    "fmt": "97.29B",
+                    "longFmt": "97,287,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 18000000,
+                    "fmt": "18M",
+                    "longFmt": "18,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 4717000000,
+                    "fmt": "4.72B",
+                    "longFmt": "4,717,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -28100000000,
+                    "fmt": "-28.1B",
+                    "longFmt": "-28,100,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 15193000000,
+                    "fmt": "15.19B",
+                    "longFmt": "15,193,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -3596000000,
+                    "fmt": "-3.6B",
+                    "longFmt": "-3,596,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -8172000000,
+                    "fmt": "-8.17B",
+                    "longFmt": "-8,172,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -42425000000,
+                    "fmt": "-42.42B",
+                    "longFmt": "-42,425,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "cash": {
+                    "raw": 7289000000,
+                    "fmt": "7.29B",
+                    "longFmt": "7,289,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 772000000,
+                    "fmt": "772M",
+                    "longFmt": "772,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 5384000000,
+                    "fmt": "5.38B",
+                    "longFmt": "5,384,000,000"
+                  },
+                  "inventory": {
+                    "raw": 1605000000,
+                    "fmt": "1.6B",
+                    "longFmt": "1,605,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 132000000,
+                    "fmt": "132M",
+                    "longFmt": "132,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 16945000000,
+                    "fmt": "16.95B",
+                    "longFmt": "16,945,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 1420000000,
+                    "fmt": "1.42B",
+                    "longFmt": "1,420,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 2883000000,
+                    "fmt": "2.88B",
+                    "longFmt": "2,883,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 15663000000,
+                    "fmt": "15.66B",
+                    "longFmt": "15,663,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 21233000000,
+                    "fmt": "21.23B",
+                    "longFmt": "21,233,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 1208000000,
+                    "fmt": "1.21B",
+                    "longFmt": "1,208,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 59352000000,
+                    "fmt": "59.35B",
+                    "longFmt": "59,352,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1546000000,
+                    "fmt": "1.55B",
+                    "longFmt": "1,546,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 1609000000,
+                    "fmt": "1.61B",
+                    "longFmt": "1,609,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 5355000000,
+                    "fmt": "5.36B",
+                    "longFmt": "5,355,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 35002000000,
+                    "fmt": "35B",
+                    "longFmt": "35,002,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 15557000000,
+                    "fmt": "15.56B",
+                    "longFmt": "15,557,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 17239000000,
+                    "fmt": "17.24B",
+                    "longFmt": "17,239,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 67798000000,
+                    "fmt": "67.8B",
+                    "longFmt": "67,798,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 18000000,
+                    "fmt": "18M",
+                    "longFmt": "18,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 3368000000,
+                    "fmt": "3.37B",
+                    "longFmt": "3,368,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -26588000000,
+                    "fmt": "-26.59B",
+                    "longFmt": "-26,588,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 14756000000,
+                    "fmt": "14.76B",
+                    "longFmt": "14,756,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -2480000000,
+                    "fmt": "-2.48B",
+                    "longFmt": "-2,480,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -8446000000,
+                    "fmt": "-8.45B",
+                    "longFmt": "-8,446,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -45342000000,
+                    "fmt": "-45.34B",
+                    "longFmt": "-45,342,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "cash": {
+                    "raw": 9303000000,
+                    "fmt": "9.3B",
+                    "longFmt": "9,303,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 486000000,
+                    "fmt": "486M",
+                    "longFmt": "486,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 7188000000,
+                    "fmt": "7.19B",
+                    "longFmt": "7,188,000,000"
+                  },
+                  "inventory": {
+                    "raw": 1605000000,
+                    "fmt": "1.6B",
+                    "longFmt": "1,605,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 23000000,
+                    "fmt": "23M",
+                    "longFmt": "23,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 21223000000,
+                    "fmt": "21.22B",
+                    "longFmt": "21,223,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2090000000,
+                    "fmt": "2.09B",
+                    "longFmt": "2,090,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 2803000000,
+                    "fmt": "2.8B",
+                    "longFmt": "2,803,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 15785000000,
+                    "fmt": "15.79B",
+                    "longFmt": "15,785,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 27559000000,
+                    "fmt": "27.56B",
+                    "longFmt": "27,559,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 1326000000,
+                    "fmt": "1.33B",
+                    "longFmt": "1,326,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 70786000000,
+                    "fmt": "70.79B",
+                    "longFmt": "70,786,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1474000000,
+                    "fmt": "1.47B",
+                    "longFmt": "1,474,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 6015000000,
+                    "fmt": "6.01B",
+                    "longFmt": "6,015,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 4406000000,
+                    "fmt": "4.41B",
+                    "longFmt": "4,406,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 30953000000,
+                    "fmt": "30.95B",
+                    "longFmt": "30,953,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 18095000000,
+                    "fmt": "18.09B",
+                    "longFmt": "18,095,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 16641000000,
+                    "fmt": "16.64B",
+                    "longFmt": "16,641,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 65689000000,
+                    "fmt": "65.69B",
+                    "longFmt": "65,689,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 18000000,
+                    "fmt": "18M",
+                    "longFmt": "18,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 5459000000,
+                    "fmt": "5.46B",
+                    "longFmt": "5,459,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -14650000000,
+                    "fmt": "-14.65B",
+                    "longFmt": "-14,650,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 14270000000,
+                    "fmt": "14.27B",
+                    "longFmt": "14,270,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -2727000000,
+                    "fmt": "-2.73B",
+                    "longFmt": "-2,727,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 5097000000,
+                    "fmt": "5.1B",
+                    "longFmt": "5,097,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -38247000000,
+                    "fmt": "-38.25B",
+                    "longFmt": "-38,247,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistory-BRKS.json
+++ b/tests/http/quoteSummary-balanceSheetHistory-BRKS.json
@@ -1,0 +1,664 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=balanceSheetHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "bp601elg2vse0"
+      ],
+      "x-yahoo-request-id": [
+        "bp601elg2vse0"
+      ],
+      "x-request-id": [
+        "df1004c5-d9a1-416e-acd0-f9a2304fb5db"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:36 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 295649000,
+                    "fmt": "295.65M",
+                    "longFmt": "295,649,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 67000,
+                    "fmt": "67k",
+                    "longFmt": "67,000"
+                  },
+                  "netReceivables": {
+                    "raw": 205091000,
+                    "fmt": "205.09M",
+                    "longFmt": "205,091,000"
+                  },
+                  "inventory": {
+                    "raw": 114834000,
+                    "fmt": "114.83M",
+                    "longFmt": "114,834,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 3937000,
+                    "fmt": "3.94M",
+                    "longFmt": "3,937,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 649453000,
+                    "fmt": "649.45M",
+                    "longFmt": "649,453,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 3101000,
+                    "fmt": "3.1M",
+                    "longFmt": "3,101,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 156736000,
+                    "fmt": "156.74M",
+                    "longFmt": "156,736,000"
+                  },
+                  "goodWill": {
+                    "raw": 501536000,
+                    "fmt": "501.54M",
+                    "longFmt": "501,536,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 218325000,
+                    "fmt": "218.32M",
+                    "longFmt": "218,325,000"
+                  },
+                  "otherAssets": {
+                    "raw": 29974000,
+                    "fmt": "29.97M",
+                    "longFmt": "29,974,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 4979000,
+                    "fmt": "4.98M",
+                    "longFmt": "4,979,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1559125000,
+                    "fmt": "1.56B",
+                    "longFmt": "1,559,125,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 61758000,
+                    "fmt": "61.76M",
+                    "longFmt": "61,758,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 827000,
+                    "fmt": "827k",
+                    "longFmt": "827,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 50071000,
+                    "fmt": "50.07M",
+                    "longFmt": "50,071,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 49588000,
+                    "fmt": "49.59M",
+                    "longFmt": "49,588,000"
+                  },
+                  "otherLiab": {
+                    "raw": 52602000,
+                    "fmt": "52.6M",
+                    "longFmt": "52,602,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 400000,
+                    "fmt": "400k",
+                    "longFmt": "400,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 211118000,
+                    "fmt": "211.12M",
+                    "longFmt": "211,118,000"
+                  },
+                  "totalLiab": {
+                    "raw": 345511000,
+                    "fmt": "345.51M",
+                    "longFmt": "345,511,000"
+                  },
+                  "commonStock": {
+                    "raw": 873000,
+                    "fmt": "873k",
+                    "longFmt": "873,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -551072000,
+                    "fmt": "-551.07M",
+                    "longFmt": "-551,072,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -179037000,
+                    "fmt": "-179.04M",
+                    "longFmt": "-179,037,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1942850000,
+                    "fmt": "1.94B",
+                    "longFmt": "1,942,850,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 21919000,
+                    "fmt": "21.92M",
+                    "longFmt": "21,919,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1213614000,
+                    "fmt": "1.21B",
+                    "longFmt": "1,213,614,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 493753000,
+                    "fmt": "493.75M",
+                    "longFmt": "493,753,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1569801600,
+                    "fmt": "2019-09-30"
+                  },
+                  "cash": {
+                    "raw": 301642000,
+                    "fmt": "301.64M",
+                    "longFmt": "301,642,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 34124000,
+                    "fmt": "34.12M",
+                    "longFmt": "34,124,000"
+                  },
+                  "netReceivables": {
+                    "raw": 179602000,
+                    "fmt": "179.6M",
+                    "longFmt": "179,602,000"
+                  },
+                  "inventory": {
+                    "raw": 99445000,
+                    "fmt": "99.44M",
+                    "longFmt": "99,445,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 3546000,
+                    "fmt": "3.55M",
+                    "longFmt": "3,546,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 647145000,
+                    "fmt": "647.14M",
+                    "longFmt": "647,145,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2845000,
+                    "fmt": "2.85M",
+                    "longFmt": "2,845,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 100669000,
+                    "fmt": "100.67M",
+                    "longFmt": "100,669,000"
+                  },
+                  "goodWill": {
+                    "raw": 488602000,
+                    "fmt": "488.6M",
+                    "longFmt": "488,602,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 251168000,
+                    "fmt": "251.17M",
+                    "longFmt": "251,168,000"
+                  },
+                  "otherAssets": {
+                    "raw": 25570000,
+                    "fmt": "25.57M",
+                    "longFmt": "25,570,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 5064000,
+                    "fmt": "5.06M",
+                    "longFmt": "5,064,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1515999000,
+                    "fmt": "1.52B",
+                    "longFmt": "1,515,999,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 58919000,
+                    "fmt": "58.92M",
+                    "longFmt": "58,919,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 829000,
+                    "fmt": "829k",
+                    "longFmt": "829,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 137253000,
+                    "fmt": "137.25M",
+                    "longFmt": "137,253,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 50315000,
+                    "fmt": "50.31M",
+                    "longFmt": "50,315,000"
+                  },
+                  "otherLiab": {
+                    "raw": 53076000,
+                    "fmt": "53.08M",
+                    "longFmt": "53,076,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 800000,
+                    "fmt": "800k",
+                    "longFmt": "800,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 272270000,
+                    "fmt": "272.27M",
+                    "longFmt": "272,270,000"
+                  },
+                  "totalLiab": {
+                    "raw": 377045000,
+                    "fmt": "377.05M",
+                    "longFmt": "377,045,000"
+                  },
+                  "commonStock": {
+                    "raw": 857000,
+                    "fmt": "857k",
+                    "longFmt": "857,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -586412000,
+                    "fmt": "-586.41M",
+                    "longFmt": "-586,412,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -197445000,
+                    "fmt": "-197.44M",
+                    "longFmt": "-197,445,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1921954000,
+                    "fmt": "1.92B",
+                    "longFmt": "1,921,954,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 3511000,
+                    "fmt": "3.51M",
+                    "longFmt": "3,511,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1138954000,
+                    "fmt": "1.14B",
+                    "longFmt": "1,138,954,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 399184000,
+                    "fmt": "399.18M",
+                    "longFmt": "399,184,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1538265600,
+                    "fmt": "2018-09-30"
+                  },
+                  "cash": {
+                    "raw": 197708000,
+                    "fmt": "197.71M",
+                    "longFmt": "197,708,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 46281000,
+                    "fmt": "46.28M",
+                    "longFmt": "46,281,000"
+                  },
+                  "netReceivables": {
+                    "raw": 137992000,
+                    "fmt": "137.99M",
+                    "longFmt": "137,992,000"
+                  },
+                  "inventory": {
+                    "raw": 96986000,
+                    "fmt": "96.99M",
+                    "longFmt": "96,986,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 66318000,
+                    "fmt": "66.32M",
+                    "longFmt": "66,318,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 564056000,
+                    "fmt": "564.06M",
+                    "longFmt": "564,056,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 7237000,
+                    "fmt": "7.24M",
+                    "longFmt": "7,237,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 59988000,
+                    "fmt": "59.99M",
+                    "longFmt": "59,988,000"
+                  },
+                  "goodWill": {
+                    "raw": 255876000,
+                    "fmt": "255.88M",
+                    "longFmt": "255,876,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 99956000,
+                    "fmt": "99.96M",
+                    "longFmt": "99,956,000"
+                  },
+                  "otherAssets": {
+                    "raw": 108144000,
+                    "fmt": "108.14M",
+                    "longFmt": "108,144,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 43798000,
+                    "fmt": "43.8M",
+                    "longFmt": "43,798,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1095257000,
+                    "fmt": "1.1B",
+                    "longFmt": "1,095,257,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 44724000,
+                    "fmt": "44.72M",
+                    "longFmt": "44,724,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 2000000,
+                    "fmt": "2M",
+                    "longFmt": "2,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 58343000,
+                    "fmt": "58.34M",
+                    "longFmt": "58,343,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 194071000,
+                    "fmt": "194.07M",
+                    "longFmt": "194,071,000"
+                  },
+                  "otherLiab": {
+                    "raw": 18737000,
+                    "fmt": "18.74M",
+                    "longFmt": "18,737,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 1500000,
+                    "fmt": "1.5M",
+                    "longFmt": "1,500,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 164617000,
+                    "fmt": "164.62M",
+                    "longFmt": "164,617,000"
+                  },
+                  "totalLiab": {
+                    "raw": 377425000,
+                    "fmt": "377.43M",
+                    "longFmt": "377,425,000"
+                  },
+                  "commonStock": {
+                    "raw": 841000,
+                    "fmt": "841k",
+                    "longFmt": "841,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -994074000,
+                    "fmt": "-994.07M",
+                    "longFmt": "-994,074,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -187369000,
+                    "fmt": "-187.37M",
+                    "longFmt": "-187,369,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1898434000,
+                    "fmt": "1.9B",
+                    "longFmt": "1,898,434,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 13587000,
+                    "fmt": "13.59M",
+                    "longFmt": "13,587,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 717832000,
+                    "fmt": "717.83M",
+                    "longFmt": "717,832,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 362000000,
+                    "fmt": "362M",
+                    "longFmt": "362,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1506729600,
+                    "fmt": "2017-09-30"
+                  },
+                  "cash": {
+                    "raw": 101622000,
+                    "fmt": "101.62M",
+                    "longFmt": "101,622,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 28000,
+                    "fmt": "28k",
+                    "longFmt": "28,000"
+                  },
+                  "netReceivables": {
+                    "raw": 93465000,
+                    "fmt": "93.47M",
+                    "longFmt": "93,465,000"
+                  },
+                  "inventory": {
+                    "raw": 73397000,
+                    "fmt": "73.4M",
+                    "longFmt": "73,397,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 60675000,
+                    "fmt": "60.67M",
+                    "longFmt": "60,675,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 351777000,
+                    "fmt": "351.78M",
+                    "longFmt": "351,777,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2642000,
+                    "fmt": "2.64M",
+                    "longFmt": "2,642,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 56981000,
+                    "fmt": "56.98M",
+                    "longFmt": "56,981,000"
+                  },
+                  "goodWill": {
+                    "raw": 207154000,
+                    "fmt": "207.15M",
+                    "longFmt": "207,154,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 83504000,
+                    "fmt": "83.5M",
+                    "longFmt": "83,504,000"
+                  },
+                  "otherAssets": {
+                    "raw": 64570000,
+                    "fmt": "64.57M",
+                    "longFmt": "64,570,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 1692000,
+                    "fmt": "1.69M",
+                    "longFmt": "1,692,000"
+                  },
+                  "totalAssets": {
+                    "raw": 766628000,
+                    "fmt": "766.63M",
+                    "longFmt": "766,628,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 49100000,
+                    "fmt": "49.1M",
+                    "longFmt": "49,100,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 49139000,
+                    "fmt": "49.14M",
+                    "longFmt": "49,139,000"
+                  },
+                  "otherLiab": {
+                    "raw": 12206000,
+                    "fmt": "12.21M",
+                    "longFmt": "12,206,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 500000,
+                    "fmt": "500k",
+                    "longFmt": "500,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 146778000,
+                    "fmt": "146.78M",
+                    "longFmt": "146,778,000"
+                  },
+                  "totalLiab": {
+                    "raw": 158984000,
+                    "fmt": "158.98M",
+                    "longFmt": "158,984,000"
+                  },
+                  "commonStock": {
+                    "raw": 833000,
+                    "fmt": "833k",
+                    "longFmt": "833,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -1082364000,
+                    "fmt": "-1.08B",
+                    "longFmt": "-1,082,364,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -185743000,
+                    "fmt": "-185.74M",
+                    "longFmt": "-185,743,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1874918000,
+                    "fmt": "1.87B",
+                    "longFmt": "1,874,918,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 15213000,
+                    "fmt": "15.21M",
+                    "longFmt": "15,213,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 607644000,
+                    "fmt": "607.64M",
+                    "longFmt": "607,644,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 316986000,
+                    "fmt": "316.99M",
+                    "longFmt": "316,986,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistory-CRON.json
+++ b/tests/http/quoteSummary-balanceSheetHistory-CRON.json
@@ -1,0 +1,559 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=balanceSheetHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "co13s69g2vse0"
+      ],
+      "x-yahoo-request-id": [
+        "co13s69g2vse0"
+      ],
+      "x-request-id": [
+        "ee572f2d-c45a-406c-ab9e-754b5315326d"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1720"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:36 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 1199693000,
+                    "fmt": "1.2B",
+                    "longFmt": "1,199,693,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 306347000,
+                    "fmt": "306.35M",
+                    "longFmt": "306,347,000"
+                  },
+                  "netReceivables": {
+                    "raw": 16534000,
+                    "fmt": "16.53M",
+                    "longFmt": "16,534,000"
+                  },
+                  "inventory": {
+                    "raw": 38043000,
+                    "fmt": "38.04M",
+                    "longFmt": "38,043,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 1570012000,
+                    "fmt": "1.57B",
+                    "longFmt": "1,570,012,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 557000,
+                    "fmt": "557k",
+                    "longFmt": "557,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 168355000,
+                    "fmt": "168.35M",
+                    "longFmt": "168,355,000"
+                  },
+                  "goodWill": {
+                    "raw": 214794000,
+                    "fmt": "214.79M",
+                    "longFmt": "214,794,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 72320000,
+                    "fmt": "72.32M",
+                    "longFmt": "72,320,000"
+                  },
+                  "otherAssets": {
+                    "raw": 64404000,
+                    "fmt": "64.4M",
+                    "longFmt": "64,404,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2090442000,
+                    "fmt": "2.09B",
+                    "longFmt": "2,090,442,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 9194000,
+                    "fmt": "9.19M",
+                    "longFmt": "9,194,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 323267000,
+                    "fmt": "323.27M",
+                    "longFmt": "323,267,000"
+                  },
+                  "otherLiab": {
+                    "raw": 1844000,
+                    "fmt": "1.84M",
+                    "longFmt": "1,844,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -853000,
+                    "fmt": "-853k",
+                    "longFmt": "-853,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 332888000,
+                    "fmt": "332.89M",
+                    "longFmt": "332,888,000"
+                  },
+                  "totalLiab": {
+                    "raw": 341412000,
+                    "fmt": "341.41M",
+                    "longFmt": "341,412,000"
+                  },
+                  "commonStock": {
+                    "raw": 561165000,
+                    "fmt": "561.16M",
+                    "longFmt": "561,165,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 1137646000,
+                    "fmt": "1.14B",
+                    "longFmt": "1,137,646,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 27838000,
+                    "fmt": "27.84M",
+                    "longFmt": "27,838,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 23234000,
+                    "fmt": "23.23M",
+                    "longFmt": "23,234,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 27838000,
+                    "fmt": "27.84M",
+                    "longFmt": "27,838,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1749883000,
+                    "fmt": "1.75B",
+                    "longFmt": "1,749,883,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 1462769000,
+                    "fmt": "1.46B",
+                    "longFmt": "1,462,769,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "cash": {
+                    "raw": 23927000,
+                    "fmt": "23.93M",
+                    "longFmt": "23,927,000"
+                  },
+                  "netReceivables": {
+                    "raw": 5789000,
+                    "fmt": "5.79M",
+                    "longFmt": "5,789,000"
+                  },
+                  "inventory": {
+                    "raw": 7386000,
+                    "fmt": "7.39M",
+                    "longFmt": "7,386,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 39944000,
+                    "fmt": "39.94M",
+                    "longFmt": "39,944,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 3257000,
+                    "fmt": "3.26M",
+                    "longFmt": "3,257,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 126030000,
+                    "fmt": "126.03M",
+                    "longFmt": "126,030,000"
+                  },
+                  "goodWill": {
+                    "raw": 1314000,
+                    "fmt": "1.31M",
+                    "longFmt": "1,314,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 8237000,
+                    "fmt": "8.24M",
+                    "longFmt": "8,237,000"
+                  },
+                  "otherAssets": {
+                    "raw": 4689000,
+                    "fmt": "4.69M",
+                    "longFmt": "4,689,000"
+                  },
+                  "totalAssets": {
+                    "raw": 183471000,
+                    "fmt": "183.47M",
+                    "longFmt": "183,471,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1170000,
+                    "fmt": "1.17M",
+                    "longFmt": "1,170,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 15625000,
+                    "fmt": "15.62M",
+                    "longFmt": "15,625,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 16444000,
+                    "fmt": "16.44M",
+                    "longFmt": "16,444,000"
+                  },
+                  "otherLiab": {
+                    "raw": 1566000,
+                    "fmt": "1.57M",
+                    "longFmt": "1,566,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 100000,
+                    "fmt": "100k",
+                    "longFmt": "100,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 33269000,
+                    "fmt": "33.27M",
+                    "longFmt": "33,269,000"
+                  },
+                  "totalLiab": {
+                    "raw": 34922000,
+                    "fmt": "34.92M",
+                    "longFmt": "34,922,000"
+                  },
+                  "commonStock": {
+                    "raw": 175001000,
+                    "fmt": "175M",
+                    "longFmt": "175,001,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -27945000,
+                    "fmt": "-27.95M",
+                    "longFmt": "-27,945,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -9870000,
+                    "fmt": "-9.87M",
+                    "longFmt": "-9,870,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 11263000,
+                    "fmt": "11.26M",
+                    "longFmt": "11,263,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -9870000,
+                    "fmt": "-9.87M",
+                    "longFmt": "-9,870,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 148449000,
+                    "fmt": "148.45M",
+                    "longFmt": "148,449,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 138898000,
+                    "fmt": "138.9M",
+                    "longFmt": "138,898,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "cash": {
+                    "raw": 7342434,
+                    "fmt": "7.34M",
+                    "longFmt": "7,342,434"
+                  },
+                  "netReceivables": {
+                    "raw": 3642511,
+                    "fmt": "3.64M",
+                    "longFmt": "3,642,511"
+                  },
+                  "inventory": {
+                    "raw": 9678808,
+                    "fmt": "9.68M",
+                    "longFmt": "9,678,808"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 21293697,
+                    "fmt": "21.29M",
+                    "longFmt": "21,293,697"
+                  },
+                  "longTermInvestments": {
+                    "raw": 4109786,
+                    "fmt": "4.11M",
+                    "longFmt": "4,109,786"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 44791401,
+                    "fmt": "44.79M",
+                    "longFmt": "44,791,401"
+                  },
+                  "goodWill": {
+                    "raw": 1428936,
+                    "fmt": "1.43M",
+                    "longFmt": "1,428,936"
+                  },
+                  "intangibleAssets": {
+                    "raw": 8936431,
+                    "fmt": "8.94M",
+                    "longFmt": "8,936,431"
+                  },
+                  "totalAssets": {
+                    "raw": 80560251,
+                    "fmt": "80.56M",
+                    "longFmt": "80,560,251"
+                  },
+                  "accountsPayable": {
+                    "raw": 5642383,
+                    "fmt": "5.64M",
+                    "longFmt": "5,642,383"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 639513,
+                    "fmt": "639.51k",
+                    "longFmt": "639,513"
+                  },
+                  "longTermDebt": {
+                    "raw": 4279631,
+                    "fmt": "4.28M",
+                    "longFmt": "4,279,631"
+                  },
+                  "otherLiab": {
+                    "raw": 1129115,
+                    "fmt": "1.13M",
+                    "longFmt": "1,129,115"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 6281896,
+                    "fmt": "6.28M",
+                    "longFmt": "6,281,896"
+                  },
+                  "totalLiab": {
+                    "raw": 11690642,
+                    "fmt": "11.69M",
+                    "longFmt": "11,690,642"
+                  },
+                  "commonStock": {
+                    "raw": 66629721,
+                    "fmt": "66.63M",
+                    "longFmt": "66,629,721"
+                  },
+                  "retainedEarnings": {
+                    "raw": -2969508,
+                    "fmt": "-2.97M",
+                    "longFmt": "-2,969,508"
+                  },
+                  "treasuryStock": {
+                    "raw": 5209397,
+                    "fmt": "5.21M",
+                    "longFmt": "5,209,397"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 5209397,
+                    "fmt": "5.21M",
+                    "longFmt": "5,209,397"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 68869610,
+                    "fmt": "68.87M",
+                    "longFmt": "68,869,610"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 58504243,
+                    "fmt": "58.5M",
+                    "longFmt": "58,504,243"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "cash": {
+                    "raw": 3464000,
+                    "fmt": "3.46M",
+                    "longFmt": "3,464,000"
+                  },
+                  "netReceivables": {
+                    "raw": 416000,
+                    "fmt": "416k",
+                    "longFmt": "416,000"
+                  },
+                  "inventory": {
+                    "raw": 3703000,
+                    "fmt": "3.7M",
+                    "longFmt": "3,703,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 8086000,
+                    "fmt": "8.09M",
+                    "longFmt": "8,086,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 7693000,
+                    "fmt": "7.69M",
+                    "longFmt": "7,693,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 14122000,
+                    "fmt": "14.12M",
+                    "longFmt": "14,122,000"
+                  },
+                  "goodWill": {
+                    "raw": 1792000,
+                    "fmt": "1.79M",
+                    "longFmt": "1,792,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 11207000,
+                    "fmt": "11.21M",
+                    "longFmt": "11,207,000"
+                  },
+                  "totalAssets": {
+                    "raw": 42900000,
+                    "fmt": "42.9M",
+                    "longFmt": "42,900,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 586000,
+                    "fmt": "586k",
+                    "longFmt": "586,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 3180000,
+                    "fmt": "3.18M",
+                    "longFmt": "3,180,000"
+                  },
+                  "otherLiab": {
+                    "raw": 1457000,
+                    "fmt": "1.46M",
+                    "longFmt": "1,457,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 7766000,
+                    "fmt": "7.77M",
+                    "longFmt": "7,766,000"
+                  },
+                  "totalLiab": {
+                    "raw": 9223000,
+                    "fmt": "9.22M",
+                    "longFmt": "9,223,000"
+                  },
+                  "commonStock": {
+                    "raw": 33590000,
+                    "fmt": "33.59M",
+                    "longFmt": "33,590,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -6215000,
+                    "fmt": "-6.21M",
+                    "longFmt": "-6,215,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 6302000,
+                    "fmt": "6.3M",
+                    "longFmt": "6,302,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 6302000,
+                    "fmt": "6.3M",
+                    "longFmt": "6,302,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 33677000,
+                    "fmt": "33.68M",
+                    "longFmt": "33,677,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 20678000,
+                    "fmt": "20.68M",
+                    "longFmt": "20,678,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistory-EPAC.json
+++ b/tests/http/quoteSummary-balanceSheetHistory-EPAC.json
@@ -1,0 +1,609 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=balanceSheetHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "eh0tp55g2vse0"
+      ],
+      "x-yahoo-request-id": [
+        "eh0tp55g2vse0"
+      ],
+      "x-request-id": [
+        "2d3f47cb-2501-405e-8923-30ed61d86e34"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1915"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:36 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "3"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1598832000,
+                    "fmt": "2020-08-31"
+                  },
+                  "cash": {
+                    "raw": 152170000,
+                    "fmt": "152.17M",
+                    "longFmt": "152,170,000"
+                  },
+                  "netReceivables": {
+                    "raw": 90315000,
+                    "fmt": "90.31M",
+                    "longFmt": "90,315,000"
+                  },
+                  "inventory": {
+                    "raw": 69171000,
+                    "fmt": "69.17M",
+                    "longFmt": "69,171,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 29476000,
+                    "fmt": "29.48M",
+                    "longFmt": "29,476,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 341132000,
+                    "fmt": "341.13M",
+                    "longFmt": "341,132,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 110138000,
+                    "fmt": "110.14M",
+                    "longFmt": "110,138,000"
+                  },
+                  "goodWill": {
+                    "raw": 281154000,
+                    "fmt": "281.15M",
+                    "longFmt": "281,154,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 62382000,
+                    "fmt": "62.38M",
+                    "longFmt": "62,382,000"
+                  },
+                  "otherAssets": {
+                    "raw": 29488000,
+                    "fmt": "29.49M",
+                    "longFmt": "29,488,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 22600000,
+                    "fmt": "22.6M",
+                    "longFmt": "22,600,000"
+                  },
+                  "totalAssets": {
+                    "raw": 824294000,
+                    "fmt": "824.29M",
+                    "longFmt": "824,294,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 45069000,
+                    "fmt": "45.07M",
+                    "longFmt": "45,069,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 30790000,
+                    "fmt": "30.79M",
+                    "longFmt": "30,790,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 255000000,
+                    "fmt": "255M",
+                    "longFmt": "255,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 66467000,
+                    "fmt": "66.47M",
+                    "longFmt": "66,467,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 105522000,
+                    "fmt": "105.52M",
+                    "longFmt": "105,522,000"
+                  },
+                  "totalLiab": {
+                    "raw": 465068000,
+                    "fmt": "465.07M",
+                    "longFmt": "465,068,000"
+                  },
+                  "commonStock": {
+                    "raw": 16519000,
+                    "fmt": "16.52M",
+                    "longFmt": "16,519,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 917671000,
+                    "fmt": "917.67M",
+                    "longFmt": "917,671,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -768456000,
+                    "fmt": "-768.46M",
+                    "longFmt": "-768,456,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 193492000,
+                    "fmt": "193.49M",
+                    "longFmt": "193,492,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -100724000,
+                    "fmt": "-100.72M",
+                    "longFmt": "-100,724,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 359226000,
+                    "fmt": "359.23M",
+                    "longFmt": "359,226,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 15690000,
+                    "fmt": "15.69M",
+                    "longFmt": "15,690,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1567209600,
+                    "fmt": "2019-08-31"
+                  },
+                  "cash": {
+                    "raw": 211151000,
+                    "fmt": "211.15M",
+                    "longFmt": "211,151,000"
+                  },
+                  "netReceivables": {
+                    "raw": 129630000,
+                    "fmt": "129.63M",
+                    "longFmt": "129,630,000"
+                  },
+                  "inventory": {
+                    "raw": 77187000,
+                    "fmt": "77.19M",
+                    "longFmt": "77,187,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 312357000,
+                    "fmt": "312.36M",
+                    "longFmt": "312,357,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 730325000,
+                    "fmt": "730.33M",
+                    "longFmt": "730,325,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 56729000,
+                    "fmt": "56.73M",
+                    "longFmt": "56,729,000"
+                  },
+                  "goodWill": {
+                    "raw": 260415000,
+                    "fmt": "260.42M",
+                    "longFmt": "260,415,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 52375000,
+                    "fmt": "52.38M",
+                    "longFmt": "52,375,000"
+                  },
+                  "otherAssets": {
+                    "raw": 24430000,
+                    "fmt": "24.43M",
+                    "longFmt": "24,430,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 18400000,
+                    "fmt": "18.4M",
+                    "longFmt": "18,400,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1124274000,
+                    "fmt": "1.12B",
+                    "longFmt": "1,124,274,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 76914000,
+                    "fmt": "76.91M",
+                    "longFmt": "76,914,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 7500000,
+                    "fmt": "7.5M",
+                    "longFmt": "7,500,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 189566000,
+                    "fmt": "189.57M",
+                    "longFmt": "189,566,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 452945000,
+                    "fmt": "452.94M",
+                    "longFmt": "452,945,000"
+                  },
+                  "otherLiab": {
+                    "raw": 69749000,
+                    "fmt": "69.75M",
+                    "longFmt": "69,749,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 300401000,
+                    "fmt": "300.4M",
+                    "longFmt": "300,401,000"
+                  },
+                  "totalLiab": {
+                    "raw": 823095000,
+                    "fmt": "823.1M",
+                    "longFmt": "823,095,000"
+                  },
+                  "commonStock": {
+                    "raw": 16384000,
+                    "fmt": "16.38M",
+                    "longFmt": "16,384,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 915466000,
+                    "fmt": "915.47M",
+                    "longFmt": "915,466,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -811884000,
+                    "fmt": "-811.88M",
+                    "longFmt": "-811,884,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 181213000,
+                    "fmt": "181.21M",
+                    "longFmt": "181,213,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -171672000,
+                    "fmt": "-171.67M",
+                    "longFmt": "-171,672,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 301179000,
+                    "fmt": "301.18M",
+                    "longFmt": "301,179,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -11611000,
+                    "fmt": "-11.61M",
+                    "longFmt": "-11,611,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1535673600,
+                    "fmt": "2018-08-31"
+                  },
+                  "cash": {
+                    "raw": 250490000,
+                    "fmt": "250.49M",
+                    "longFmt": "250,490,000"
+                  },
+                  "netReceivables": {
+                    "raw": 129628000,
+                    "fmt": "129.63M",
+                    "longFmt": "129,628,000"
+                  },
+                  "inventory": {
+                    "raw": 72020000,
+                    "fmt": "72.02M",
+                    "longFmt": "72,020,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 595095000,
+                    "fmt": "595.1M",
+                    "longFmt": "595,095,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 1047233000,
+                    "fmt": "1.05B",
+                    "longFmt": "1,047,233,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 54974000,
+                    "fmt": "54.97M",
+                    "longFmt": "54,974,000"
+                  },
+                  "goodWill": {
+                    "raw": 280132000,
+                    "fmt": "280.13M",
+                    "longFmt": "280,132,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 71657000,
+                    "fmt": "71.66M",
+                    "longFmt": "71,657,000"
+                  },
+                  "otherAssets": {
+                    "raw": 31221000,
+                    "fmt": "31.22M",
+                    "longFmt": "31,221,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 21300000,
+                    "fmt": "21.3M",
+                    "longFmt": "21,300,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1485217000,
+                    "fmt": "1.49B",
+                    "longFmt": "1,485,217,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 69584000,
+                    "fmt": "69.58M",
+                    "longFmt": "69,584,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 30000000,
+                    "fmt": "30M",
+                    "longFmt": "30,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 218432000,
+                    "fmt": "218.43M",
+                    "longFmt": "218,432,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 502695000,
+                    "fmt": "502.69M",
+                    "longFmt": "502,695,000"
+                  },
+                  "otherLiab": {
+                    "raw": 69802000,
+                    "fmt": "69.8M",
+                    "longFmt": "69,802,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 354008000,
+                    "fmt": "354.01M",
+                    "longFmt": "354,008,000"
+                  },
+                  "totalLiab": {
+                    "raw": 926505000,
+                    "fmt": "926.5M",
+                    "longFmt": "926,505,000"
+                  },
+                  "commonStock": {
+                    "raw": 16285000,
+                    "fmt": "16.29M",
+                    "longFmt": "16,285,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 1166955000,
+                    "fmt": "1.17B",
+                    "longFmt": "1,166,955,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -791976000,
+                    "fmt": "-791.98M",
+                    "longFmt": "-791,976,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 167448000,
+                    "fmt": "167.45M",
+                    "longFmt": "167,448,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -174245000,
+                    "fmt": "-174.25M",
+                    "longFmt": "-174,245,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 558712000,
+                    "fmt": "558.71M",
+                    "longFmt": "558,712,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 206923000,
+                    "fmt": "206.92M",
+                    "longFmt": "206,923,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1504137600,
+                    "fmt": "2017-08-31"
+                  },
+                  "cash": {
+                    "raw": 229571000,
+                    "fmt": "229.57M",
+                    "longFmt": "229,571,000"
+                  },
+                  "netReceivables": {
+                    "raw": 190206000,
+                    "fmt": "190.21M",
+                    "longFmt": "190,206,000"
+                  },
+                  "inventory": {
+                    "raw": 143651000,
+                    "fmt": "143.65M",
+                    "longFmt": "143,651,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 83498000,
+                    "fmt": "83.5M",
+                    "longFmt": "83,498,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 646926000,
+                    "fmt": "646.93M",
+                    "longFmt": "646,926,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 94521000,
+                    "fmt": "94.52M",
+                    "longFmt": "94,521,000"
+                  },
+                  "goodWill": {
+                    "raw": 530081000,
+                    "fmt": "530.08M",
+                    "longFmt": "530,081,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 220489000,
+                    "fmt": "220.49M",
+                    "longFmt": "220,489,000"
+                  },
+                  "otherAssets": {
+                    "raw": 24938000,
+                    "fmt": "24.94M",
+                    "longFmt": "24,938,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 18600000,
+                    "fmt": "18.6M",
+                    "longFmt": "18,600,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1516955000,
+                    "fmt": "1.52B",
+                    "longFmt": "1,516,955,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 133387000,
+                    "fmt": "133.39M",
+                    "longFmt": "133,387,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 30000000,
+                    "fmt": "30M",
+                    "longFmt": "30,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 164608000,
+                    "fmt": "164.61M",
+                    "longFmt": "164,608,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 531940000,
+                    "fmt": "531.94M",
+                    "longFmt": "531,940,000"
+                  },
+                  "otherLiab": {
+                    "raw": 105542000,
+                    "fmt": "105.54M",
+                    "longFmt": "105,542,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 378934000,
+                    "fmt": "378.93M",
+                    "longFmt": "378,934,000"
+                  },
+                  "totalLiab": {
+                    "raw": 1016416000,
+                    "fmt": "1.02B",
+                    "longFmt": "1,016,416,000"
+                  },
+                  "commonStock": {
+                    "raw": 16040000,
+                    "fmt": "16.04M",
+                    "longFmt": "16,040,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 1191042000,
+                    "fmt": "1.19B",
+                    "longFmt": "1,191,042,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -844992000,
+                    "fmt": "-844.99M",
+                    "longFmt": "-844,992,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 138449000,
+                    "fmt": "138.45M",
+                    "longFmt": "138,449,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -227261000,
+                    "fmt": "-227.26M",
+                    "longFmt": "-227,261,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 500539000,
+                    "fmt": "500.54M",
+                    "longFmt": "500,539,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -250031000,
+                    "fmt": "-250.03M",
+                    "longFmt": "-250,031,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistory-MDLY.json
+++ b/tests/http/quoteSummary-balanceSheetHistory-MDLY.json
@@ -1,0 +1,549 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=balanceSheetHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "4am3s1pg2vse0"
+      ],
+      "x-yahoo-request-id": [
+        "4am3s1pg2vse0"
+      ],
+      "x-request-id": [
+        "07cff243-f860-4dcd-9b95-f850c344b349"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1522"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:35 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 10558000,
+                    "fmt": "10.56M",
+                    "longFmt": "10,558,000"
+                  },
+                  "netReceivables": {
+                    "raw": 10964000,
+                    "fmt": "10.96M",
+                    "longFmt": "10,964,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 1975000,
+                    "fmt": "1.98M",
+                    "longFmt": "1,975,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 25519000,
+                    "fmt": "25.52M",
+                    "longFmt": "25,519,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 13287000,
+                    "fmt": "13.29M",
+                    "longFmt": "13,287,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 9128000,
+                    "fmt": "9.13M",
+                    "longFmt": "9,128,000"
+                  },
+                  "otherAssets": {
+                    "raw": 862000,
+                    "fmt": "862k",
+                    "longFmt": "862,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 185000,
+                    "fmt": "185k",
+                    "longFmt": "185,000"
+                  },
+                  "totalAssets": {
+                    "raw": 48796000,
+                    "fmt": "48.8M",
+                    "longFmt": "48,796,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1829000,
+                    "fmt": "1.83M",
+                    "longFmt": "1,829,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 10000000,
+                    "fmt": "10M",
+                    "longFmt": "10,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 2927000,
+                    "fmt": "2.93M",
+                    "longFmt": "2,927,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 118382000,
+                    "fmt": "118.38M",
+                    "longFmt": "118,382,000"
+                  },
+                  "otherLiab": {
+                    "raw": 17119000,
+                    "fmt": "17.12M",
+                    "longFmt": "17,119,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -109714000,
+                    "fmt": "-109.71M",
+                    "longFmt": "-109,714,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 26707000,
+                    "fmt": "26.71M",
+                    "longFmt": "26,707,000"
+                  },
+                  "totalLiab": {
+                    "raw": 167629000,
+                    "fmt": "167.63M",
+                    "longFmt": "167,629,000"
+                  },
+                  "commonStock": {
+                    "raw": 62000,
+                    "fmt": "62k",
+                    "longFmt": "62,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -22960000,
+                    "fmt": "-22.96M",
+                    "longFmt": "-22,960,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 13779000,
+                    "fmt": "13.78M",
+                    "longFmt": "13,779,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -9119000,
+                    "fmt": "-9.12M",
+                    "longFmt": "-9,119,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -9119000,
+                    "fmt": "-9.12M",
+                    "longFmt": "-9,119,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "cash": {
+                    "raw": 17219000,
+                    "fmt": "17.22M",
+                    "longFmt": "17,219,000"
+                  },
+                  "netReceivables": {
+                    "raw": 13340000,
+                    "fmt": "13.34M",
+                    "longFmt": "13,340,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 1975000,
+                    "fmt": "1.98M",
+                    "longFmt": "1,975,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 33647000,
+                    "fmt": "33.65M",
+                    "longFmt": "33,647,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 36425000,
+                    "fmt": "36.42M",
+                    "longFmt": "36,425,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 3140000,
+                    "fmt": "3.14M",
+                    "longFmt": "3,140,000"
+                  },
+                  "otherAssets": {
+                    "raw": 5004000,
+                    "fmt": "5M",
+                    "longFmt": "5,004,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 3739000,
+                    "fmt": "3.74M",
+                    "longFmt": "3,739,000"
+                  },
+                  "totalAssets": {
+                    "raw": 78216000,
+                    "fmt": "78.22M",
+                    "longFmt": "78,216,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 2499000,
+                    "fmt": "2.5M",
+                    "longFmt": "2,499,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 9892000,
+                    "fmt": "9.89M",
+                    "longFmt": "9,892,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 117618000,
+                    "fmt": "117.62M",
+                    "longFmt": "117,618,000"
+                  },
+                  "otherLiab": {
+                    "raw": 24108000,
+                    "fmt": "24.11M",
+                    "longFmt": "24,108,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -75403000,
+                    "fmt": "-75.4M",
+                    "longFmt": "-75,403,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 23925000,
+                    "fmt": "23.93M",
+                    "longFmt": "23,925,000"
+                  },
+                  "totalLiab": {
+                    "raw": 165651000,
+                    "fmt": "165.65M",
+                    "longFmt": "165,651,000"
+                  },
+                  "commonStock": {
+                    "raw": 57000,
+                    "fmt": "57k",
+                    "longFmt": "57,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -19618000,
+                    "fmt": "-19.62M",
+                    "longFmt": "-19,618,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 7529000,
+                    "fmt": "7.53M",
+                    "longFmt": "7,529,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -12032000,
+                    "fmt": "-12.03M",
+                    "longFmt": "-12,032,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -12032000,
+                    "fmt": "-12.03M",
+                    "longFmt": "-12,032,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "cash": {
+                    "raw": 36327000,
+                    "fmt": "36.33M",
+                    "longFmt": "36,327,000"
+                  },
+                  "netReceivables": {
+                    "raw": 22583000,
+                    "fmt": "22.58M",
+                    "longFmt": "22,583,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 1975000,
+                    "fmt": "1.98M",
+                    "longFmt": "1,975,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 62238000,
+                    "fmt": "62.24M",
+                    "longFmt": "62,238,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 56632000,
+                    "fmt": "56.63M",
+                    "longFmt": "56,632,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 4160000,
+                    "fmt": "4.16M",
+                    "longFmt": "4,160,000"
+                  },
+                  "otherAssets": {
+                    "raw": 4892000,
+                    "fmt": "4.89M",
+                    "longFmt": "4,892,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 2777000,
+                    "fmt": "2.78M",
+                    "longFmt": "2,777,000"
+                  },
+                  "totalAssets": {
+                    "raw": 127922000,
+                    "fmt": "127.92M",
+                    "longFmt": "127,922,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1770000,
+                    "fmt": "1.77M",
+                    "longFmt": "1,770,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 126125000,
+                    "fmt": "126.12M",
+                    "longFmt": "126,125,000"
+                  },
+                  "otherLiab": {
+                    "raw": 13754000,
+                    "fmt": "13.75M",
+                    "longFmt": "13,754,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -15362000,
+                    "fmt": "-15.36M",
+                    "longFmt": "-15,362,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 11376000,
+                    "fmt": "11.38M",
+                    "longFmt": "11,376,000"
+                  },
+                  "totalLiab": {
+                    "raw": 151255000,
+                    "fmt": "151.25M",
+                    "longFmt": "151,255,000"
+                  },
+                  "commonStock": {
+                    "raw": 55000,
+                    "fmt": "55k",
+                    "longFmt": "55,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -9545000,
+                    "fmt": "-9.54M",
+                    "longFmt": "-9,545,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -1301000,
+                    "fmt": "-1.3M",
+                    "longFmt": "-1,301,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 2820000,
+                    "fmt": "2.82M",
+                    "longFmt": "2,820,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -1301000,
+                    "fmt": "-1.3M",
+                    "longFmt": "-1,301,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -7971000,
+                    "fmt": "-7.97M",
+                    "longFmt": "-7,971,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -7971000,
+                    "fmt": "-7.97M",
+                    "longFmt": "-7,971,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "cash": {
+                    "raw": 49666000,
+                    "fmt": "49.67M",
+                    "longFmt": "49,666,000"
+                  },
+                  "netReceivables": {
+                    "raw": 21792000,
+                    "fmt": "21.79M",
+                    "longFmt": "21,792,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 6872000,
+                    "fmt": "6.87M",
+                    "longFmt": "6,872,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 81408000,
+                    "fmt": "81.41M",
+                    "longFmt": "81,408,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 31904000,
+                    "fmt": "31.9M",
+                    "longFmt": "31,904,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 4998000,
+                    "fmt": "5M",
+                    "longFmt": "4,998,000"
+                  },
+                  "otherAssets": {
+                    "raw": 4059000,
+                    "fmt": "4.06M",
+                    "longFmt": "4,059,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 2001000,
+                    "fmt": "2M",
+                    "longFmt": "2,001,000"
+                  },
+                  "totalAssets": {
+                    "raw": 122369000,
+                    "fmt": "122.37M",
+                    "longFmt": "122,369,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1657000,
+                    "fmt": "1.66M",
+                    "longFmt": "1,657,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 101971000,
+                    "fmt": "101.97M",
+                    "longFmt": "101,971,000"
+                  },
+                  "otherLiab": {
+                    "raw": 16650000,
+                    "fmt": "16.65M",
+                    "longFmt": "16,650,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -15004000,
+                    "fmt": "-15M",
+                    "longFmt": "-15,004,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 20605000,
+                    "fmt": "20.61M",
+                    "longFmt": "20,605,000"
+                  },
+                  "totalLiab": {
+                    "raw": 139226000,
+                    "fmt": "139.23M",
+                    "longFmt": "139,226,000"
+                  },
+                  "commonStock": {
+                    "raw": 58000,
+                    "fmt": "58k",
+                    "longFmt": "58,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -5254000,
+                    "fmt": "-5.25M",
+                    "longFmt": "-5,254,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 33000,
+                    "fmt": "33k",
+                    "longFmt": "33,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 3310000,
+                    "fmt": "3.31M",
+                    "longFmt": "3,310,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 33000,
+                    "fmt": "33k",
+                    "longFmt": "33,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -1853000,
+                    "fmt": "-1.85M",
+                    "longFmt": "-1,853,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -1853000,
+                    "fmt": "-1.85M",
+                    "longFmt": "-1,853,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistory-SI.json
+++ b/tests/http/quoteSummary-balanceSheetHistory-SI.json
@@ -1,0 +1,529 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=balanceSheetHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "2qfofspg2vsdv"
+      ],
+      "x-yahoo-request-id": [
+        "2qfofspg2vsdv"
+      ],
+      "x-request-id": [
+        "bb6d6a18-084d-44b3-bec9-c712804fe80d"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1525"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:35 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistory": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "cash": {
+                    "raw": 2962087000,
+                    "fmt": "2.96B",
+                    "longFmt": "2,962,087,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 874659000,
+                    "fmt": "874.66M",
+                    "longFmt": "874,659,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 3867850000,
+                    "fmt": "3.87B",
+                    "longFmt": "3,867,850,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 953866000,
+                    "fmt": "953.87M",
+                    "longFmt": "953,866,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 2072000,
+                    "fmt": "2.07M",
+                    "longFmt": "2,072,000"
+                  },
+                  "otherAssets": {
+                    "raw": 762447000,
+                    "fmt": "762.45M",
+                    "longFmt": "762,447,000"
+                  },
+                  "totalAssets": {
+                    "raw": 5586235000,
+                    "fmt": "5.59B",
+                    "longFmt": "5,586,235,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 5248026000,
+                    "fmt": "5.25B",
+                    "longFmt": "5,248,026,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 15831000,
+                    "fmt": "15.83M",
+                    "longFmt": "15,831,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 5276105000,
+                    "fmt": "5.28B",
+                    "longFmt": "5,276,105,000"
+                  },
+                  "totalLiab": {
+                    "raw": 5291936000,
+                    "fmt": "5.29B",
+                    "longFmt": "5,291,936,000"
+                  },
+                  "commonStock": {
+                    "raw": 189000,
+                    "fmt": "189k",
+                    "longFmt": "189,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 118348000,
+                    "fmt": "118.35M",
+                    "longFmt": "118,348,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 46036000,
+                    "fmt": "46.04M",
+                    "longFmt": "46,036,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 129726000,
+                    "fmt": "129.73M",
+                    "longFmt": "129,726,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 46036000,
+                    "fmt": "46.04M",
+                    "longFmt": "46,036,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 294299000,
+                    "fmt": "294.3M",
+                    "longFmt": "294,299,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 294299000,
+                    "fmt": "294.3M",
+                    "longFmt": "294,299,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 133604000,
+                    "fmt": "133.6M",
+                    "longFmt": "133,604,000"
+                  },
+                  "inventory": {
+                    "raw": 128000,
+                    "fmt": "128k",
+                    "longFmt": "128,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 381872000,
+                    "fmt": "381.87M",
+                    "longFmt": "381,872,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 539044000,
+                    "fmt": "539.04M",
+                    "longFmt": "539,044,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 908984000,
+                    "fmt": "908.98M",
+                    "longFmt": "908,984,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 7830000,
+                    "fmt": "7.83M",
+                    "longFmt": "7,830,000"
+                  },
+                  "otherAssets": {
+                    "raw": 672269000,
+                    "fmt": "672.27M",
+                    "longFmt": "672,269,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2128127000,
+                    "fmt": "2.13B",
+                    "longFmt": "2,128,127,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1814654000,
+                    "fmt": "1.81B",
+                    "longFmt": "1,814,654,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 1143000,
+                    "fmt": "1.14M",
+                    "longFmt": "1,143,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 18387000,
+                    "fmt": "18.39M",
+                    "longFmt": "18,387,000"
+                  },
+                  "otherLiab": {
+                    "raw": 524000,
+                    "fmt": "524k",
+                    "longFmt": "524,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 1874975000,
+                    "fmt": "1.87B",
+                    "longFmt": "1,874,975,000"
+                  },
+                  "totalLiab": {
+                    "raw": 1897091000,
+                    "fmt": "1.9B",
+                    "longFmt": "1,897,091,000"
+                  },
+                  "commonStock": {
+                    "raw": 187000,
+                    "fmt": "187k",
+                    "longFmt": "187,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 92310000,
+                    "fmt": "92.31M",
+                    "longFmt": "92,310,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 6401000,
+                    "fmt": "6.4M",
+                    "longFmt": "6,401,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 132138000,
+                    "fmt": "132.14M",
+                    "longFmt": "132,138,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 6401000,
+                    "fmt": "6.4M",
+                    "longFmt": "6,401,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 231036000,
+                    "fmt": "231.04M",
+                    "longFmt": "231,036,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 231036000,
+                    "fmt": "231.04M",
+                    "longFmt": "231,036,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "cash": {
+                    "raw": 674420000,
+                    "fmt": "674.42M",
+                    "longFmt": "674,420,000"
+                  },
+                  "inventory": {
+                    "raw": 31000,
+                    "fmt": "31k",
+                    "longFmt": "31,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 356406000,
+                    "fmt": "356.41M",
+                    "longFmt": "356,406,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 1031856000,
+                    "fmt": "1.03B",
+                    "longFmt": "1,031,856,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 367955000,
+                    "fmt": "367.95M",
+                    "longFmt": "367,955,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 3656000,
+                    "fmt": "3.66M",
+                    "longFmt": "3,656,000"
+                  },
+                  "otherAssets": {
+                    "raw": 600851000,
+                    "fmt": "600.85M",
+                    "longFmt": "600,851,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 3329000,
+                    "fmt": "3.33M",
+                    "longFmt": "3,329,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2004318000,
+                    "fmt": "2B",
+                    "longFmt": "2,004,318,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1783005000,
+                    "fmt": "1.78B",
+                    "longFmt": "1,783,005,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 20659000,
+                    "fmt": "20.66M",
+                    "longFmt": "20,659,000"
+                  },
+                  "otherLiab": {
+                    "raw": 100000,
+                    "fmt": "100k",
+                    "longFmt": "100,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 1500000,
+                    "fmt": "1.5M",
+                    "longFmt": "1,500,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 1792313000,
+                    "fmt": "1.79B",
+                    "longFmt": "1,792,313,000"
+                  },
+                  "totalLiab": {
+                    "raw": 1813072000,
+                    "fmt": "1.81B",
+                    "longFmt": "1,813,072,000"
+                  },
+                  "commonStock": {
+                    "raw": 178000,
+                    "fmt": "178k",
+                    "longFmt": "178,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 67464000,
+                    "fmt": "67.46M",
+                    "longFmt": "67,464,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -2061000,
+                    "fmt": "-2.06M",
+                    "longFmt": "-2,061,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 125665000,
+                    "fmt": "125.67M",
+                    "longFmt": "125,665,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -2061000,
+                    "fmt": "-2.06M",
+                    "longFmt": "-2,061,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 191246000,
+                    "fmt": "191.25M",
+                    "longFmt": "191,246,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 191246000,
+                    "fmt": "191.25M",
+                    "longFmt": "191,246,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "cash": {
+                    "raw": 797668000,
+                    "fmt": "797.67M",
+                    "longFmt": "797,668,000"
+                  },
+                  "inventory": {
+                    "raw": 2308000,
+                    "fmt": "2.31M",
+                    "longFmt": "2,308,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 194302000,
+                    "fmt": "194.3M",
+                    "longFmt": "194,302,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 995369000,
+                    "fmt": "995.37M",
+                    "longFmt": "995,369,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 200410000,
+                    "fmt": "200.41M",
+                    "longFmt": "200,410,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 1753000,
+                    "fmt": "1.75M",
+                    "longFmt": "1,753,000"
+                  },
+                  "otherAssets": {
+                    "raw": 694416000,
+                    "fmt": "694.42M",
+                    "longFmt": "694,416,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 2840000,
+                    "fmt": "2.84M",
+                    "longFmt": "2,840,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1891948000,
+                    "fmt": "1.89B",
+                    "longFmt": "1,891,948,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1775146000,
+                    "fmt": "1.78B",
+                    "longFmt": "1,775,146,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 15000000,
+                    "fmt": "15M",
+                    "longFmt": "15,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 21788000,
+                    "fmt": "21.79M",
+                    "longFmt": "21,788,000"
+                  },
+                  "otherLiab": {
+                    "raw": 100000,
+                    "fmt": "100k",
+                    "longFmt": "100,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 1796260000,
+                    "fmt": "1.8B",
+                    "longFmt": "1,796,260,000"
+                  },
+                  "totalLiab": {
+                    "raw": 1818148000,
+                    "fmt": "1.82B",
+                    "longFmt": "1,818,148,000"
+                  },
+                  "commonStock": {
+                    "raw": 92000,
+                    "fmt": "92k",
+                    "longFmt": "92,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 45131000,
+                    "fmt": "45.13M",
+                    "longFmt": "45,131,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -1217000,
+                    "fmt": "-1.22M",
+                    "longFmt": "-1,217,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 29794000,
+                    "fmt": "29.79M",
+                    "longFmt": "29,794,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -1217000,
+                    "fmt": "-1.22M",
+                    "longFmt": "-1,217,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 73800000,
+                    "fmt": "73.8M",
+                    "longFmt": "73,800,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 73800000,
+                    "fmt": "73.8M",
+                    "longFmt": "73,800,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistoryQuarterly-ABBV.json
+++ b/tests/http/quoteSummary-balanceSheetHistoryQuarterly-ABBV.json
@@ -1,0 +1,519 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=balanceSheetHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "722e4odg2vse1"
+      ],
+      "x-yahoo-request-id": [
+        "722e4odg2vse1"
+      ],
+      "x-request-id": [
+        "586a47a0-418f-4d24-9723-f84280dbd657"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1504"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:37 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 15270000000,
+                    "fmt": "15.27B",
+                    "longFmt": "15,270,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -102174000000,
+                    "fmt": "-102.17B",
+                    "longFmt": "-102,174,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 7890000000,
+                    "fmt": "7.89B",
+                    "longFmt": "7,890,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 60000000,
+                    "fmt": "60M",
+                    "longFmt": "60,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 8416000000,
+                    "fmt": "8.42B",
+                    "longFmt": "8,416,000,000"
+                  },
+                  "inventory": {
+                    "raw": 3474000000,
+                    "fmt": "3.47B",
+                    "longFmt": "3,474,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 49000000,
+                    "fmt": "49M",
+                    "longFmt": "49,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 23009000000,
+                    "fmt": "23.01B",
+                    "longFmt": "23,009,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 403000000,
+                    "fmt": "403M",
+                    "longFmt": "403,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 4986000000,
+                    "fmt": "4.99B",
+                    "longFmt": "4,986,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 42801000000,
+                    "fmt": "42.8B",
+                    "longFmt": "42,801,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 74643000000,
+                    "fmt": "74.64B",
+                    "longFmt": "74,643,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 3779000000,
+                    "fmt": "3.78B",
+                    "longFmt": "3,779,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 149621000000,
+                    "fmt": "149.62B",
+                    "longFmt": "149,621,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 18859000000,
+                    "fmt": "18.86B",
+                    "longFmt": "18,859,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 4730000000,
+                    "fmt": "4.73B",
+                    "longFmt": "4,730,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 538000000,
+                    "fmt": "538M",
+                    "longFmt": "538,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 82315000000,
+                    "fmt": "82.31B",
+                    "longFmt": "82,315,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 27836000000,
+                    "fmt": "27.84B",
+                    "longFmt": "27,836,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 19000000,
+                    "fmt": "19M",
+                    "longFmt": "19,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 24181000000,
+                    "fmt": "24.18B",
+                    "longFmt": "24,181,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 134332000000,
+                    "fmt": "134.33B",
+                    "longFmt": "134,332,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 18000000,
+                    "fmt": "18M",
+                    "longFmt": "18,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 3335000000,
+                    "fmt": "3.33B",
+                    "longFmt": "3,335,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -5231000000,
+                    "fmt": "-5.23B",
+                    "longFmt": "-5,231,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 17148000000,
+                    "fmt": "17.15B",
+                    "longFmt": "17,148,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -3259000000,
+                    "fmt": "-3.26B",
+                    "longFmt": "-3,259,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 15270000000,
+                    "fmt": "15.27B",
+                    "longFmt": "15,270,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -102174000000,
+                    "fmt": "-102.17B",
+                    "longFmt": "-102,174,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "cash": {
+                    "raw": 6017000000,
+                    "fmt": "6.02B",
+                    "longFmt": "6,017,000,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 23000000,
+                    "fmt": "23M",
+                    "longFmt": "23,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 8354000000,
+                    "fmt": "8.35B",
+                    "longFmt": "8,354,000,000"
+                  },
+                  "inventory": {
+                    "raw": 4059000000,
+                    "fmt": "4.06B",
+                    "longFmt": "4,059,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 51000000,
+                    "fmt": "51M",
+                    "longFmt": "51,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 21256000000,
+                    "fmt": "21.26B",
+                    "longFmt": "21,256,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 381000000,
+                    "fmt": "381M",
+                    "longFmt": "381,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 4908000000,
+                    "fmt": "4.91B",
+                    "longFmt": "4,908,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 42669000000,
+                    "fmt": "42.67B",
+                    "longFmt": "42,669,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 76463000000,
+                    "fmt": "76.46B",
+                    "longFmt": "76,463,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 3853000000,
+                    "fmt": "3.85B",
+                    "longFmt": "3,853,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 149530000000,
+                    "fmt": "149.53B",
+                    "longFmt": "149,530,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 18754000000,
+                    "fmt": "18.75B",
+                    "longFmt": "18,754,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 5316000000,
+                    "fmt": "5.32B",
+                    "longFmt": "5,316,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 512000000,
+                    "fmt": "512M",
+                    "longFmt": "512,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 82099000000,
+                    "fmt": "82.1B",
+                    "longFmt": "82,099,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 28053000000,
+                    "fmt": "28.05B",
+                    "longFmt": "28,053,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 24000000,
+                    "fmt": "24M",
+                    "longFmt": "24,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 24646000000,
+                    "fmt": "24.65B",
+                    "longFmt": "24,646,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 134798000000,
+                    "fmt": "134.8B",
+                    "longFmt": "134,798,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 18000000,
+                    "fmt": "18M",
+                    "longFmt": "18,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 3130000000,
+                    "fmt": "3.13B",
+                    "longFmt": "3,130,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -5393000000,
+                    "fmt": "-5.39B",
+                    "longFmt": "-5,393,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 16953000000,
+                    "fmt": "16.95B",
+                    "longFmt": "16,953,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -3435000000,
+                    "fmt": "-3.44B",
+                    "longFmt": "-3,435,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 14708000000,
+                    "fmt": "14.71B",
+                    "longFmt": "14,708,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -104424000000,
+                    "fmt": "-104.42B",
+                    "longFmt": "-104,424,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "cash": {
+                    "raw": 41142000000,
+                    "fmt": "41.14B",
+                    "longFmt": "41,142,000,000"
+                  },
+                  "netReceivables": {
+                    "raw": 6362000000,
+                    "fmt": "6.36B",
+                    "longFmt": "6,362,000,000"
+                  },
+                  "inventory": {
+                    "raw": 1844000000,
+                    "fmt": "1.84B",
+                    "longFmt": "1,844,000,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 100000000,
+                    "fmt": "100M",
+                    "longFmt": "100,000,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 51758000000,
+                    "fmt": "51.76B",
+                    "longFmt": "51,758,000,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 211000000,
+                    "fmt": "211M",
+                    "longFmt": "211,000,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 2961000000,
+                    "fmt": "2.96B",
+                    "longFmt": "2,961,000,000"
+                  },
+                  "goodWill": {
+                    "raw": 15561000000,
+                    "fmt": "15.56B",
+                    "longFmt": "15,561,000,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 18203000000,
+                    "fmt": "18.2B",
+                    "longFmt": "18,203,000,000"
+                  },
+                  "otherAssets": {
+                    "raw": 2505000000,
+                    "fmt": "2.5B",
+                    "longFmt": "2,505,000,000"
+                  },
+                  "totalAssets": {
+                    "raw": 91199000000,
+                    "fmt": "91.2B",
+                    "longFmt": "91,199,000,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 12251000000,
+                    "fmt": "12.25B",
+                    "longFmt": "12,251,000,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 3756000000,
+                    "fmt": "3.76B",
+                    "longFmt": "3,756,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 458000000,
+                    "fmt": "458M",
+                    "longFmt": "458,000,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 63328000000,
+                    "fmt": "63.33B",
+                    "longFmt": "63,328,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 18815000000,
+                    "fmt": "18.82B",
+                    "longFmt": "18,815,000,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 16471000000,
+                    "fmt": "16.47B",
+                    "longFmt": "16,471,000,000"
+                  },
+                  "totalLiab": {
+                    "raw": 98614000000,
+                    "fmt": "98.61B",
+                    "longFmt": "98,614,000,000"
+                  },
+                  "commonStock": {
+                    "raw": 18000000,
+                    "fmt": "18M",
+                    "longFmt": "18,000,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 5973000000,
+                    "fmt": "5.97B",
+                    "longFmt": "5,973,000,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -28807000000,
+                    "fmt": "-28.81B",
+                    "longFmt": "-28,807,000,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 15401000000,
+                    "fmt": "15.4B",
+                    "longFmt": "15,401,000,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -3697000000,
+                    "fmt": "-3.7B",
+                    "longFmt": "-3,697,000,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -7415000000,
+                    "fmt": "-7.42B",
+                    "longFmt": "-7,415,000,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -41179000000,
+                    "fmt": "-41.18B",
+                    "longFmt": "-41,179,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistoryQuarterly-BRKS.json
+++ b/tests/http/quoteSummary-balanceSheetHistoryQuarterly-BRKS.json
@@ -1,0 +1,674 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=balanceSheetHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "d1f65vdg2vse1"
+      ],
+      "x-yahoo-request-id": [
+        "d1f65vdg2vse1"
+      ],
+      "x-request-id": [
+        "dda69984-5f35-40fe-8ab7-6415a569fc7a"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:37 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "cash": {
+                    "raw": 308517000,
+                    "fmt": "308.52M",
+                    "longFmt": "308,517,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 55000,
+                    "fmt": "55k",
+                    "longFmt": "55,000"
+                  },
+                  "netReceivables": {
+                    "raw": 209579000,
+                    "fmt": "209.58M",
+                    "longFmt": "209,579,000"
+                  },
+                  "inventory": {
+                    "raw": 123917000,
+                    "fmt": "123.92M",
+                    "longFmt": "123,917,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 3571000,
+                    "fmt": "3.57M",
+                    "longFmt": "3,571,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 675156000,
+                    "fmt": "675.16M",
+                    "longFmt": "675,156,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 3410000,
+                    "fmt": "3.41M",
+                    "longFmt": "3,410,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 164276000,
+                    "fmt": "164.28M",
+                    "longFmt": "164,276,000"
+                  },
+                  "goodWill": {
+                    "raw": 512989000,
+                    "fmt": "512.99M",
+                    "longFmt": "512,989,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 224666000,
+                    "fmt": "224.67M",
+                    "longFmt": "224,666,000"
+                  },
+                  "otherAssets": {
+                    "raw": 34235000,
+                    "fmt": "34.23M",
+                    "longFmt": "34,235,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 4765000,
+                    "fmt": "4.76M",
+                    "longFmt": "4,765,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1614732000,
+                    "fmt": "1.61B",
+                    "longFmt": "1,614,732,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 67811000,
+                    "fmt": "67.81M",
+                    "longFmt": "67,811,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 414000,
+                    "fmt": "414k",
+                    "longFmt": "414,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 59967000,
+                    "fmt": "59.97M",
+                    "longFmt": "59,967,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 49629000,
+                    "fmt": "49.63M",
+                    "longFmt": "49,629,000"
+                  },
+                  "otherLiab": {
+                    "raw": 52848000,
+                    "fmt": "52.85M",
+                    "longFmt": "52,848,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 400000,
+                    "fmt": "400k",
+                    "longFmt": "400,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 225770000,
+                    "fmt": "225.77M",
+                    "longFmt": "225,770,000"
+                  },
+                  "totalLiab": {
+                    "raw": 362578000,
+                    "fmt": "362.58M",
+                    "longFmt": "362,578,000"
+                  },
+                  "commonStock": {
+                    "raw": 877000,
+                    "fmt": "877k",
+                    "longFmt": "877,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -532468000,
+                    "fmt": "-532.47M",
+                    "longFmt": "-532,468,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -165811000,
+                    "fmt": "-165.81M",
+                    "longFmt": "-165,811,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1949556000,
+                    "fmt": "1.95B",
+                    "longFmt": "1,949,556,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 35145000,
+                    "fmt": "35.15M",
+                    "longFmt": "35,145,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1252154000,
+                    "fmt": "1.25B",
+                    "longFmt": "1,252,154,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 514499000,
+                    "fmt": "514.5M",
+                    "longFmt": "514,499,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 295649000,
+                    "fmt": "295.65M",
+                    "longFmt": "295,649,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 67000,
+                    "fmt": "67k",
+                    "longFmt": "67,000"
+                  },
+                  "netReceivables": {
+                    "raw": 205091000,
+                    "fmt": "205.09M",
+                    "longFmt": "205,091,000"
+                  },
+                  "inventory": {
+                    "raw": 114834000,
+                    "fmt": "114.83M",
+                    "longFmt": "114,834,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 3937000,
+                    "fmt": "3.94M",
+                    "longFmt": "3,937,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 649453000,
+                    "fmt": "649.45M",
+                    "longFmt": "649,453,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 3101000,
+                    "fmt": "3.1M",
+                    "longFmt": "3,101,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 156736000,
+                    "fmt": "156.74M",
+                    "longFmt": "156,736,000"
+                  },
+                  "goodWill": {
+                    "raw": 501536000,
+                    "fmt": "501.54M",
+                    "longFmt": "501,536,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 218325000,
+                    "fmt": "218.32M",
+                    "longFmt": "218,325,000"
+                  },
+                  "otherAssets": {
+                    "raw": 29974000,
+                    "fmt": "29.97M",
+                    "longFmt": "29,974,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 4979000,
+                    "fmt": "4.98M",
+                    "longFmt": "4,979,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1559125000,
+                    "fmt": "1.56B",
+                    "longFmt": "1,559,125,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 61758000,
+                    "fmt": "61.76M",
+                    "longFmt": "61,758,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 827000,
+                    "fmt": "827k",
+                    "longFmt": "827,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 50071000,
+                    "fmt": "50.07M",
+                    "longFmt": "50,071,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 49588000,
+                    "fmt": "49.59M",
+                    "longFmt": "49,588,000"
+                  },
+                  "otherLiab": {
+                    "raw": 52602000,
+                    "fmt": "52.6M",
+                    "longFmt": "52,602,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 400000,
+                    "fmt": "400k",
+                    "longFmt": "400,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 211118000,
+                    "fmt": "211.12M",
+                    "longFmt": "211,118,000"
+                  },
+                  "totalLiab": {
+                    "raw": 345511000,
+                    "fmt": "345.51M",
+                    "longFmt": "345,511,000"
+                  },
+                  "commonStock": {
+                    "raw": 873000,
+                    "fmt": "873k",
+                    "longFmt": "873,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -551072000,
+                    "fmt": "-551.07M",
+                    "longFmt": "-551,072,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -179037000,
+                    "fmt": "-179.04M",
+                    "longFmt": "-179,037,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1942850000,
+                    "fmt": "1.94B",
+                    "longFmt": "1,942,850,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 21919000,
+                    "fmt": "21.92M",
+                    "longFmt": "21,919,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1213614000,
+                    "fmt": "1.21B",
+                    "longFmt": "1,213,614,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 493753000,
+                    "fmt": "493.75M",
+                    "longFmt": "493,753,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "cash": {
+                    "raw": 256633000,
+                    "fmt": "256.63M",
+                    "longFmt": "256,633,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 136000,
+                    "fmt": "136k",
+                    "longFmt": "136,000"
+                  },
+                  "netReceivables": {
+                    "raw": 198667000,
+                    "fmt": "198.67M",
+                    "longFmt": "198,667,000"
+                  },
+                  "inventory": {
+                    "raw": 117686000,
+                    "fmt": "117.69M",
+                    "longFmt": "117,686,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 3567000,
+                    "fmt": "3.57M",
+                    "longFmt": "3,567,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 602011000,
+                    "fmt": "602.01M",
+                    "longFmt": "602,011,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2939000,
+                    "fmt": "2.94M",
+                    "longFmt": "2,939,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 147640000,
+                    "fmt": "147.64M",
+                    "longFmt": "147,640,000"
+                  },
+                  "goodWill": {
+                    "raw": 500062000,
+                    "fmt": "500.06M",
+                    "longFmt": "500,062,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 226623000,
+                    "fmt": "226.62M",
+                    "longFmt": "226,623,000"
+                  },
+                  "otherAssets": {
+                    "raw": 24642000,
+                    "fmt": "24.64M",
+                    "longFmt": "24,642,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 3489000,
+                    "fmt": "3.49M",
+                    "longFmt": "3,489,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1503917000,
+                    "fmt": "1.5B",
+                    "longFmt": "1,503,917,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 70344000,
+                    "fmt": "70.34M",
+                    "longFmt": "70,344,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 828000,
+                    "fmt": "828k",
+                    "longFmt": "828,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 56696000,
+                    "fmt": "56.7M",
+                    "longFmt": "56,696,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 49563000,
+                    "fmt": "49.56M",
+                    "longFmt": "49,563,000"
+                  },
+                  "otherLiab": {
+                    "raw": 43817000,
+                    "fmt": "43.82M",
+                    "longFmt": "43,817,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 800000,
+                    "fmt": "800k",
+                    "longFmt": "800,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 205805000,
+                    "fmt": "205.81M",
+                    "longFmt": "205,805,000"
+                  },
+                  "totalLiab": {
+                    "raw": 329064000,
+                    "fmt": "329.06M",
+                    "longFmt": "329,064,000"
+                  },
+                  "commonStock": {
+                    "raw": 872000,
+                    "fmt": "872k",
+                    "longFmt": "872,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -572659000,
+                    "fmt": "-572.66M",
+                    "longFmt": "-572,659,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -189979000,
+                    "fmt": "-189.98M",
+                    "longFmt": "-189,979,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1936619000,
+                    "fmt": "1.94B",
+                    "longFmt": "1,936,619,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 10977000,
+                    "fmt": "10.98M",
+                    "longFmt": "10,977,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1174853000,
+                    "fmt": "1.17B",
+                    "longFmt": "1,174,853,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 448168000,
+                    "fmt": "448.17M",
+                    "longFmt": "448,168,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "cash": {
+                    "raw": 242274000,
+                    "fmt": "242.27M",
+                    "longFmt": "242,274,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 162000,
+                    "fmt": "162k",
+                    "longFmt": "162,000"
+                  },
+                  "netReceivables": {
+                    "raw": 179014000,
+                    "fmt": "179.01M",
+                    "longFmt": "179,014,000"
+                  },
+                  "inventory": {
+                    "raw": 107699000,
+                    "fmt": "107.7M",
+                    "longFmt": "107,699,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 3529000,
+                    "fmt": "3.53M",
+                    "longFmt": "3,529,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 572528000,
+                    "fmt": "572.53M",
+                    "longFmt": "572,528,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 2555000,
+                    "fmt": "2.56M",
+                    "longFmt": "2,555,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 108744000,
+                    "fmt": "108.74M",
+                    "longFmt": "108,744,000"
+                  },
+                  "goodWill": {
+                    "raw": 498502000,
+                    "fmt": "498.5M",
+                    "longFmt": "498,502,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 236095000,
+                    "fmt": "236.09M",
+                    "longFmt": "236,095,000"
+                  },
+                  "otherAssets": {
+                    "raw": 60907000,
+                    "fmt": "60.91M",
+                    "longFmt": "60,907,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 5080000,
+                    "fmt": "5.08M",
+                    "longFmt": "5,080,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1479331000,
+                    "fmt": "1.48B",
+                    "longFmt": "1,479,331,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 63958000,
+                    "fmt": "63.96M",
+                    "longFmt": "63,958,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 828000,
+                    "fmt": "828k",
+                    "longFmt": "828,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 47069000,
+                    "fmt": "47.07M",
+                    "longFmt": "47,069,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 49951000,
+                    "fmt": "49.95M",
+                    "longFmt": "49,951,000"
+                  },
+                  "otherLiab": {
+                    "raw": 43979000,
+                    "fmt": "43.98M",
+                    "longFmt": "43,979,000"
+                  },
+                  "deferredLongTermLiab": {
+                    "raw": 900000,
+                    "fmt": "900k",
+                    "longFmt": "900,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 197035000,
+                    "fmt": "197.03M",
+                    "longFmt": "197,035,000"
+                  },
+                  "totalLiab": {
+                    "raw": 318198000,
+                    "fmt": "318.2M",
+                    "longFmt": "318,198,000"
+                  },
+                  "commonStock": {
+                    "raw": 872000,
+                    "fmt": "872k",
+                    "longFmt": "872,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -578975000,
+                    "fmt": "-578.98M",
+                    "longFmt": "-578,975,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -193657000,
+                    "fmt": "-193.66M",
+                    "longFmt": "-193,657,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 1932893000,
+                    "fmt": "1.93B",
+                    "longFmt": "1,932,893,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 7299000,
+                    "fmt": "7.3M",
+                    "longFmt": "7,299,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1161133000,
+                    "fmt": "1.16B",
+                    "longFmt": "1,161,133,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 426536000,
+                    "fmt": "426.54M",
+                    "longFmt": "426,536,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistoryQuarterly-CRON.json
+++ b/tests/http/quoteSummary-balanceSheetHistoryQuarterly-CRON.json
@@ -1,0 +1,599 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=balanceSheetHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "0f6s5o9g2vse2"
+      ],
+      "x-yahoo-request-id": [
+        "0f6s5o9g2vse2"
+      ],
+      "x-request-id": [
+        "92867323-7c11-445a-a645-b4dbce8c25cf"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1814"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:37 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 1097846000,
+                    "fmt": "1.1B",
+                    "longFmt": "1,097,846,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 202883000,
+                    "fmt": "202.88M",
+                    "longFmt": "202,883,000"
+                  },
+                  "netReceivables": {
+                    "raw": 24268000,
+                    "fmt": "24.27M",
+                    "longFmt": "24,268,000"
+                  },
+                  "inventory": {
+                    "raw": 56359000,
+                    "fmt": "56.36M",
+                    "longFmt": "56,359,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 2066000,
+                    "fmt": "2.07M",
+                    "longFmt": "2,066,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 1393954000,
+                    "fmt": "1.39B",
+                    "longFmt": "1,393,954,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 19059000,
+                    "fmt": "19.06M",
+                    "longFmt": "19,059,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 181244000,
+                    "fmt": "181.24M",
+                    "longFmt": "181,244,000"
+                  },
+                  "goodWill": {
+                    "raw": 179459000,
+                    "fmt": "179.46M",
+                    "longFmt": "179,459,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 68604000,
+                    "fmt": "68.6M",
+                    "longFmt": "68,604,000"
+                  },
+                  "otherAssets": {
+                    "raw": 76609000,
+                    "fmt": "76.61M",
+                    "longFmt": "76,609,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1918929000,
+                    "fmt": "1.92B",
+                    "longFmt": "1,918,929,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 39012000,
+                    "fmt": "39.01M",
+                    "longFmt": "39,012,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 102655000,
+                    "fmt": "102.66M",
+                    "longFmt": "102,655,000"
+                  },
+                  "otherLiab": {
+                    "raw": 2889000,
+                    "fmt": "2.89M",
+                    "longFmt": "2,889,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -2503000,
+                    "fmt": "-2.5M",
+                    "longFmt": "-2,503,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 142941000,
+                    "fmt": "142.94M",
+                    "longFmt": "142,941,000"
+                  },
+                  "totalLiab": {
+                    "raw": 154442000,
+                    "fmt": "154.44M",
+                    "longFmt": "154,442,000"
+                  },
+                  "commonStock": {
+                    "raw": 566577000,
+                    "fmt": "566.58M",
+                    "longFmt": "566,577,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 1175742000,
+                    "fmt": "1.18B",
+                    "longFmt": "1,175,742,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -7820000,
+                    "fmt": "-7.82M",
+                    "longFmt": "-7,820,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 32491000,
+                    "fmt": "32.49M",
+                    "longFmt": "32,491,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -7820000,
+                    "fmt": "-7.82M",
+                    "longFmt": "-7,820,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1766990000,
+                    "fmt": "1.77B",
+                    "longFmt": "1,766,990,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 1518927000,
+                    "fmt": "1.52B",
+                    "longFmt": "1,518,927,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "cash": {
+                    "raw": 1109700000,
+                    "fmt": "1.11B",
+                    "longFmt": "1,109,700,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 213614000,
+                    "fmt": "213.61M",
+                    "longFmt": "213,614,000"
+                  },
+                  "netReceivables": {
+                    "raw": 17503000,
+                    "fmt": "17.5M",
+                    "longFmt": "17,503,000"
+                  },
+                  "inventory": {
+                    "raw": 53216000,
+                    "fmt": "53.22M",
+                    "longFmt": "53,216,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 1401860000,
+                    "fmt": "1.4B",
+                    "longFmt": "1,401,860,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 933000,
+                    "fmt": "933k",
+                    "longFmt": "933,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 174390000,
+                    "fmt": "174.39M",
+                    "longFmt": "174,390,000"
+                  },
+                  "goodWill": {
+                    "raw": 179736000,
+                    "fmt": "179.74M",
+                    "longFmt": "179,736,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 69399000,
+                    "fmt": "69.4M",
+                    "longFmt": "69,399,000"
+                  },
+                  "otherAssets": {
+                    "raw": 83969000,
+                    "fmt": "83.97M",
+                    "longFmt": "83,969,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1910287000,
+                    "fmt": "1.91B",
+                    "longFmt": "1,910,287,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 28316000,
+                    "fmt": "28.32M",
+                    "longFmt": "28,316,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 205714000,
+                    "fmt": "205.71M",
+                    "longFmt": "205,714,000"
+                  },
+                  "otherLiab": {
+                    "raw": 3048000,
+                    "fmt": "3.05M",
+                    "longFmt": "3,048,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -1951000,
+                    "fmt": "-1.95M",
+                    "longFmt": "-1,951,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 235236000,
+                    "fmt": "235.24M",
+                    "longFmt": "235,236,000"
+                  },
+                  "totalLiab": {
+                    "raw": 247242000,
+                    "fmt": "247.24M",
+                    "longFmt": "247,242,000"
+                  },
+                  "commonStock": {
+                    "raw": 565211000,
+                    "fmt": "565.21M",
+                    "longFmt": "565,211,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 1106709000,
+                    "fmt": "1.11B",
+                    "longFmt": "1,106,709,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -33970000,
+                    "fmt": "-33.97M",
+                    "longFmt": "-33,970,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 27046000,
+                    "fmt": "27.05M",
+                    "longFmt": "27,046,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -33970000,
+                    "fmt": "-33.97M",
+                    "longFmt": "-33,970,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1664996000,
+                    "fmt": "1.66B",
+                    "longFmt": "1,664,996,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 1415861000,
+                    "fmt": "1.42B",
+                    "longFmt": "1,415,861,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "cash": {
+                    "raw": 1128396000,
+                    "fmt": "1.13B",
+                    "longFmt": "1,128,396,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 206230000,
+                    "fmt": "206.23M",
+                    "longFmt": "206,230,000"
+                  },
+                  "netReceivables": {
+                    "raw": 14957000,
+                    "fmt": "14.96M",
+                    "longFmt": "14,957,000"
+                  },
+                  "inventory": {
+                    "raw": 43118000,
+                    "fmt": "43.12M",
+                    "longFmt": "43,118,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 1403780000,
+                    "fmt": "1.4B",
+                    "longFmt": "1,403,780,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 1089000,
+                    "fmt": "1.09M",
+                    "longFmt": "1,089,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 164543000,
+                    "fmt": "164.54M",
+                    "longFmt": "164,543,000"
+                  },
+                  "goodWill": {
+                    "raw": 214689000,
+                    "fmt": "214.69M",
+                    "longFmt": "214,689,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 72599000,
+                    "fmt": "72.6M",
+                    "longFmt": "72,599,000"
+                  },
+                  "otherAssets": {
+                    "raw": 71226000,
+                    "fmt": "71.23M",
+                    "longFmt": "71,226,000"
+                  },
+                  "totalAssets": {
+                    "raw": 1927926000,
+                    "fmt": "1.93B",
+                    "longFmt": "1,927,926,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 34290000,
+                    "fmt": "34.29M",
+                    "longFmt": "34,290,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 166176000,
+                    "fmt": "166.18M",
+                    "longFmt": "166,176,000"
+                  },
+                  "otherLiab": {
+                    "raw": 1681000,
+                    "fmt": "1.68M",
+                    "longFmt": "1,681,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -1189000,
+                    "fmt": "-1.19M",
+                    "longFmt": "-1,189,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 201523000,
+                    "fmt": "201.52M",
+                    "longFmt": "201,523,000"
+                  },
+                  "totalLiab": {
+                    "raw": 212658000,
+                    "fmt": "212.66M",
+                    "longFmt": "212,658,000"
+                  },
+                  "commonStock": {
+                    "raw": 563165000,
+                    "fmt": "563.16M",
+                    "longFmt": "563,165,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 1213686000,
+                    "fmt": "1.21B",
+                    "longFmt": "1,213,686,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -85877000,
+                    "fmt": "-85.88M",
+                    "longFmt": "-85,877,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 25483000,
+                    "fmt": "25.48M",
+                    "longFmt": "25,483,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -85877000,
+                    "fmt": "-85.88M",
+                    "longFmt": "-85,877,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1716457000,
+                    "fmt": "1.72B",
+                    "longFmt": "1,716,457,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 1429169000,
+                    "fmt": "1.43B",
+                    "longFmt": "1,429,169,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 1199693000,
+                    "fmt": "1.2B",
+                    "longFmt": "1,199,693,000"
+                  },
+                  "shortTermInvestments": {
+                    "raw": 306347000,
+                    "fmt": "306.35M",
+                    "longFmt": "306,347,000"
+                  },
+                  "netReceivables": {
+                    "raw": 16534000,
+                    "fmt": "16.53M",
+                    "longFmt": "16,534,000"
+                  },
+                  "inventory": {
+                    "raw": 38043000,
+                    "fmt": "38.04M",
+                    "longFmt": "38,043,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 1570012000,
+                    "fmt": "1.57B",
+                    "longFmt": "1,570,012,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 557000,
+                    "fmt": "557k",
+                    "longFmt": "557,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 168355000,
+                    "fmt": "168.35M",
+                    "longFmt": "168,355,000"
+                  },
+                  "goodWill": {
+                    "raw": 214794000,
+                    "fmt": "214.79M",
+                    "longFmt": "214,794,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 72320000,
+                    "fmt": "72.32M",
+                    "longFmt": "72,320,000"
+                  },
+                  "otherAssets": {
+                    "raw": 64404000,
+                    "fmt": "64.4M",
+                    "longFmt": "64,404,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2090442000,
+                    "fmt": "2.09B",
+                    "longFmt": "2,090,442,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 9194000,
+                    "fmt": "9.19M",
+                    "longFmt": "9,194,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 323267000,
+                    "fmt": "323.27M",
+                    "longFmt": "323,267,000"
+                  },
+                  "otherLiab": {
+                    "raw": 1844000,
+                    "fmt": "1.84M",
+                    "longFmt": "1,844,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -853000,
+                    "fmt": "-853k",
+                    "longFmt": "-853,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 332888000,
+                    "fmt": "332.89M",
+                    "longFmt": "332,888,000"
+                  },
+                  "totalLiab": {
+                    "raw": 341412000,
+                    "fmt": "341.41M",
+                    "longFmt": "341,412,000"
+                  },
+                  "commonStock": {
+                    "raw": 561165000,
+                    "fmt": "561.16M",
+                    "longFmt": "561,165,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 1137646000,
+                    "fmt": "1.14B",
+                    "longFmt": "1,137,646,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 27838000,
+                    "fmt": "27.84M",
+                    "longFmt": "27,838,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 23234000,
+                    "fmt": "23.23M",
+                    "longFmt": "23,234,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 27838000,
+                    "fmt": "27.84M",
+                    "longFmt": "27,838,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 1749883000,
+                    "fmt": "1.75B",
+                    "longFmt": "1,749,883,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 1462769000,
+                    "fmt": "1.46B",
+                    "longFmt": "1,462,769,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistoryQuarterly-EPAC.json
+++ b/tests/http/quoteSummary-balanceSheetHistoryQuarterly-EPAC.json
@@ -1,0 +1,579 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=balanceSheetHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "4sjk8epg2vse2"
+      ],
+      "x-yahoo-request-id": [
+        "4sjk8epg2vse2"
+      ],
+      "x-request-id": [
+        "dcad3b78-6ef4-4280-811e-b4171cb34ebf"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1779"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:38 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1606694400,
+                    "fmt": "2020-11-30"
+                  },
+                  "cash": {
+                    "raw": 158568000,
+                    "fmt": "158.57M",
+                    "longFmt": "158,568,000"
+                  },
+                  "netReceivables": {
+                    "raw": 95639000,
+                    "fmt": "95.64M",
+                    "longFmt": "95,639,000"
+                  },
+                  "inventory": {
+                    "raw": 70701000,
+                    "fmt": "70.7M",
+                    "longFmt": "70,701,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 32907000,
+                    "fmt": "32.91M",
+                    "longFmt": "32,907,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 357815000,
+                    "fmt": "357.81M",
+                    "longFmt": "357,815,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 60219000,
+                    "fmt": "60.22M",
+                    "longFmt": "60,219,000"
+                  },
+                  "goodWill": {
+                    "raw": 280977000,
+                    "fmt": "280.98M",
+                    "longFmt": "280,977,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 60097000,
+                    "fmt": "60.1M",
+                    "longFmt": "60,097,000"
+                  },
+                  "otherAssets": {
+                    "raw": 79467000,
+                    "fmt": "79.47M",
+                    "longFmt": "79,467,000"
+                  },
+                  "totalAssets": {
+                    "raw": 838575000,
+                    "fmt": "838.58M",
+                    "longFmt": "838,575,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 46954000,
+                    "fmt": "46.95M",
+                    "longFmt": "46,954,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 44528000,
+                    "fmt": "44.53M",
+                    "longFmt": "44,528,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 255000000,
+                    "fmt": "255M",
+                    "longFmt": "255,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 105925000,
+                    "fmt": "105.92M",
+                    "longFmt": "105,925,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 109704000,
+                    "fmt": "109.7M",
+                    "longFmt": "109,704,000"
+                  },
+                  "totalLiab": {
+                    "raw": 470629000,
+                    "fmt": "470.63M",
+                    "longFmt": "470,629,000"
+                  },
+                  "commonStock": {
+                    "raw": 16525000,
+                    "fmt": "16.52M",
+                    "longFmt": "16,525,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 922269000,
+                    "fmt": "922.27M",
+                    "longFmt": "922,269,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -766827000,
+                    "fmt": "-766.83M",
+                    "longFmt": "-766,827,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 195979000,
+                    "fmt": "195.98M",
+                    "longFmt": "195,979,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -99095000,
+                    "fmt": "-99.09M",
+                    "longFmt": "-99,095,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 367946000,
+                    "fmt": "367.95M",
+                    "longFmt": "367,946,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 26872000,
+                    "fmt": "26.87M",
+                    "longFmt": "26,872,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1598832000,
+                    "fmt": "2020-08-31"
+                  },
+                  "cash": {
+                    "raw": 152170000,
+                    "fmt": "152.17M",
+                    "longFmt": "152,170,000"
+                  },
+                  "netReceivables": {
+                    "raw": 90315000,
+                    "fmt": "90.31M",
+                    "longFmt": "90,315,000"
+                  },
+                  "inventory": {
+                    "raw": 69171000,
+                    "fmt": "69.17M",
+                    "longFmt": "69,171,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 29476000,
+                    "fmt": "29.48M",
+                    "longFmt": "29,476,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 341132000,
+                    "fmt": "341.13M",
+                    "longFmt": "341,132,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 110138000,
+                    "fmt": "110.14M",
+                    "longFmt": "110,138,000"
+                  },
+                  "goodWill": {
+                    "raw": 281154000,
+                    "fmt": "281.15M",
+                    "longFmt": "281,154,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 62382000,
+                    "fmt": "62.38M",
+                    "longFmt": "62,382,000"
+                  },
+                  "otherAssets": {
+                    "raw": 29488000,
+                    "fmt": "29.49M",
+                    "longFmt": "29,488,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 22600000,
+                    "fmt": "22.6M",
+                    "longFmt": "22,600,000"
+                  },
+                  "totalAssets": {
+                    "raw": 824294000,
+                    "fmt": "824.29M",
+                    "longFmt": "824,294,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 45069000,
+                    "fmt": "45.07M",
+                    "longFmt": "45,069,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 30790000,
+                    "fmt": "30.79M",
+                    "longFmt": "30,790,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 255000000,
+                    "fmt": "255M",
+                    "longFmt": "255,000,000"
+                  },
+                  "otherLiab": {
+                    "raw": 66467000,
+                    "fmt": "66.47M",
+                    "longFmt": "66,467,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 105522000,
+                    "fmt": "105.52M",
+                    "longFmt": "105,522,000"
+                  },
+                  "totalLiab": {
+                    "raw": 465068000,
+                    "fmt": "465.07M",
+                    "longFmt": "465,068,000"
+                  },
+                  "commonStock": {
+                    "raw": 16519000,
+                    "fmt": "16.52M",
+                    "longFmt": "16,519,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 917671000,
+                    "fmt": "917.67M",
+                    "longFmt": "917,671,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -768456000,
+                    "fmt": "-768.46M",
+                    "longFmt": "-768,456,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 193492000,
+                    "fmt": "193.49M",
+                    "longFmt": "193,492,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -100724000,
+                    "fmt": "-100.72M",
+                    "longFmt": "-100,724,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 359226000,
+                    "fmt": "359.23M",
+                    "longFmt": "359,226,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 15690000,
+                    "fmt": "15.69M",
+                    "longFmt": "15,690,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1590883200,
+                    "fmt": "2020-05-31"
+                  },
+                  "cash": {
+                    "raw": 163603000,
+                    "fmt": "163.6M",
+                    "longFmt": "163,603,000"
+                  },
+                  "netReceivables": {
+                    "raw": 98359000,
+                    "fmt": "98.36M",
+                    "longFmt": "98,359,000"
+                  },
+                  "inventory": {
+                    "raw": 78914000,
+                    "fmt": "78.91M",
+                    "longFmt": "78,914,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 38952000,
+                    "fmt": "38.95M",
+                    "longFmt": "38,952,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 379828000,
+                    "fmt": "379.83M",
+                    "longFmt": "379,828,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 111582000,
+                    "fmt": "111.58M",
+                    "longFmt": "111,582,000"
+                  },
+                  "goodWill": {
+                    "raw": 271169000,
+                    "fmt": "271.17M",
+                    "longFmt": "271,169,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 62833000,
+                    "fmt": "62.83M",
+                    "longFmt": "62,833,000"
+                  },
+                  "otherAssets": {
+                    "raw": 26123000,
+                    "fmt": "26.12M",
+                    "longFmt": "26,123,000"
+                  },
+                  "totalAssets": {
+                    "raw": 851535000,
+                    "fmt": "851.53M",
+                    "longFmt": "851,535,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 52091000,
+                    "fmt": "52.09M",
+                    "longFmt": "52,091,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 43349000,
+                    "fmt": "43.35M",
+                    "longFmt": "43,349,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 286497000,
+                    "fmt": "286.5M",
+                    "longFmt": "286,497,000"
+                  },
+                  "otherLiab": {
+                    "raw": 66278000,
+                    "fmt": "66.28M",
+                    "longFmt": "66,278,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 122539000,
+                    "fmt": "122.54M",
+                    "longFmt": "122,539,000"
+                  },
+                  "totalLiab": {
+                    "raw": 515253000,
+                    "fmt": "515.25M",
+                    "longFmt": "515,253,000"
+                  },
+                  "commonStock": {
+                    "raw": 16513000,
+                    "fmt": "16.51M",
+                    "longFmt": "16,513,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 918623000,
+                    "fmt": "918.62M",
+                    "longFmt": "918,623,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -791782000,
+                    "fmt": "-791.78M",
+                    "longFmt": "-791,782,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 192928000,
+                    "fmt": "192.93M",
+                    "longFmt": "192,928,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -124050000,
+                    "fmt": "-124.05M",
+                    "longFmt": "-124,050,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 336282000,
+                    "fmt": "336.28M",
+                    "longFmt": "336,282,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 2280000,
+                    "fmt": "2.28M",
+                    "longFmt": "2,280,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1582934400,
+                    "fmt": "2020-02-29"
+                  },
+                  "cash": {
+                    "raw": 163437000,
+                    "fmt": "163.44M",
+                    "longFmt": "163,437,000"
+                  },
+                  "netReceivables": {
+                    "raw": 118471000,
+                    "fmt": "118.47M",
+                    "longFmt": "118,471,000"
+                  },
+                  "inventory": {
+                    "raw": 78046000,
+                    "fmt": "78.05M",
+                    "longFmt": "78,046,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 38209000,
+                    "fmt": "38.21M",
+                    "longFmt": "38,209,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 398163000,
+                    "fmt": "398.16M",
+                    "longFmt": "398,163,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 116620000,
+                    "fmt": "116.62M",
+                    "longFmt": "116,620,000"
+                  },
+                  "goodWill": {
+                    "raw": 271828000,
+                    "fmt": "271.83M",
+                    "longFmt": "271,828,000"
+                  },
+                  "intangibleAssets": {
+                    "raw": 66501000,
+                    "fmt": "66.5M",
+                    "longFmt": "66,501,000"
+                  },
+                  "otherAssets": {
+                    "raw": 26230000,
+                    "fmt": "26.23M",
+                    "longFmt": "26,230,000"
+                  },
+                  "totalAssets": {
+                    "raw": 879342000,
+                    "fmt": "879.34M",
+                    "longFmt": "879,342,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 62291000,
+                    "fmt": "62.29M",
+                    "longFmt": "62,291,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 34806000,
+                    "fmt": "34.81M",
+                    "longFmt": "34,806,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 286367000,
+                    "fmt": "286.37M",
+                    "longFmt": "286,367,000"
+                  },
+                  "otherLiab": {
+                    "raw": 66944000,
+                    "fmt": "66.94M",
+                    "longFmt": "66,944,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 129561000,
+                    "fmt": "129.56M",
+                    "longFmt": "129,561,000"
+                  },
+                  "totalLiab": {
+                    "raw": 524977000,
+                    "fmt": "524.98M",
+                    "longFmt": "524,977,000"
+                  },
+                  "commonStock": {
+                    "raw": 16508000,
+                    "fmt": "16.51M",
+                    "longFmt": "16,508,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 923622000,
+                    "fmt": "923.62M",
+                    "longFmt": "923,622,000"
+                  },
+                  "treasuryStock": {
+                    "raw": -775481000,
+                    "fmt": "-775.48M",
+                    "longFmt": "-775,481,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 189716000,
+                    "fmt": "189.72M",
+                    "longFmt": "189,716,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": -117464000,
+                    "fmt": "-117.46M",
+                    "longFmt": "-117,464,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 354365000,
+                    "fmt": "354.37M",
+                    "longFmt": "354,365,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 16036000,
+                    "fmt": "16.04M",
+                    "longFmt": "16,036,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistoryQuarterly-MDLY.json
+++ b/tests/http/quoteSummary-balanceSheetHistoryQuarterly-MDLY.json
@@ -1,0 +1,554 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=balanceSheetHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "cqc3vu9g2vse1"
+      ],
+      "x-yahoo-request-id": [
+        "cqc3vu9g2vse1"
+      ],
+      "x-request-id": [
+        "e33d1254-56cf-4ee3-a200-1ae01d33ad2e"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1473"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:37 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 6048000,
+                    "fmt": "6.05M",
+                    "longFmt": "6,048,000"
+                  },
+                  "netReceivables": {
+                    "raw": 7449000,
+                    "fmt": "7.45M",
+                    "longFmt": "7,449,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 1975000,
+                    "fmt": "1.98M",
+                    "longFmt": "1,975,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 21257000,
+                    "fmt": "21.26M",
+                    "longFmt": "21,257,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 9637000,
+                    "fmt": "9.64M",
+                    "longFmt": "9,637,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 7247000,
+                    "fmt": "7.25M",
+                    "longFmt": "7,247,000"
+                  },
+                  "otherAssets": {
+                    "raw": 570000,
+                    "fmt": "570k",
+                    "longFmt": "570,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 268000,
+                    "fmt": "268k",
+                    "longFmt": "268,000"
+                  },
+                  "totalAssets": {
+                    "raw": 38711000,
+                    "fmt": "38.71M",
+                    "longFmt": "38,711,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 2593000,
+                    "fmt": "2.59M",
+                    "longFmt": "2,593,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 10000000,
+                    "fmt": "10M",
+                    "longFmt": "10,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 781000,
+                    "fmt": "781k",
+                    "longFmt": "781,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 118958000,
+                    "fmt": "118.96M",
+                    "longFmt": "118,958,000"
+                  },
+                  "otherLiab": {
+                    "raw": 21781000,
+                    "fmt": "21.78M",
+                    "longFmt": "21,781,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -123848000,
+                    "fmt": "-123.85M",
+                    "longFmt": "-123,848,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 23260000,
+                    "fmt": "23.26M",
+                    "longFmt": "23,260,000"
+                  },
+                  "totalLiab": {
+                    "raw": 170691000,
+                    "fmt": "170.69M",
+                    "longFmt": "170,691,000"
+                  },
+                  "commonStock": {
+                    "raw": 7000,
+                    "fmt": "7k",
+                    "longFmt": "7,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -24796000,
+                    "fmt": "-24.8M",
+                    "longFmt": "-24,796,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 16657000,
+                    "fmt": "16.66M",
+                    "longFmt": "16,657,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -8132000,
+                    "fmt": "-8.13M",
+                    "longFmt": "-8,132,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -8132000,
+                    "fmt": "-8.13M",
+                    "longFmt": "-8,132,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "cash": {
+                    "raw": 7653000,
+                    "fmt": "7.65M",
+                    "longFmt": "7,653,000"
+                  },
+                  "netReceivables": {
+                    "raw": 7802000,
+                    "fmt": "7.8M",
+                    "longFmt": "7,802,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 1975000,
+                    "fmt": "1.98M",
+                    "longFmt": "1,975,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 21674000,
+                    "fmt": "21.67M",
+                    "longFmt": "21,674,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 9479000,
+                    "fmt": "9.48M",
+                    "longFmt": "9,479,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 7883000,
+                    "fmt": "7.88M",
+                    "longFmt": "7,883,000"
+                  },
+                  "otherAssets": {
+                    "raw": 679000,
+                    "fmt": "679k",
+                    "longFmt": "679,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 230000,
+                    "fmt": "230k",
+                    "longFmt": "230,000"
+                  },
+                  "totalAssets": {
+                    "raw": 39715000,
+                    "fmt": "39.72M",
+                    "longFmt": "39,715,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1699000,
+                    "fmt": "1.7M",
+                    "longFmt": "1,699,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 10000000,
+                    "fmt": "10M",
+                    "longFmt": "10,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 631000,
+                    "fmt": "631k",
+                    "longFmt": "631,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 118766000,
+                    "fmt": "118.77M",
+                    "longFmt": "118,766,000"
+                  },
+                  "otherLiab": {
+                    "raw": 22403000,
+                    "fmt": "22.4M",
+                    "longFmt": "22,403,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -122161000,
+                    "fmt": "-122.16M",
+                    "longFmt": "-122,161,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 23354000,
+                    "fmt": "23.35M",
+                    "longFmt": "23,354,000"
+                  },
+                  "totalLiab": {
+                    "raw": 171071000,
+                    "fmt": "171.07M",
+                    "longFmt": "171,071,000"
+                  },
+                  "commonStock": {
+                    "raw": 64000,
+                    "fmt": "64k",
+                    "longFmt": "64,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -24674000,
+                    "fmt": "-24.67M",
+                    "longFmt": "-24,674,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 15415000,
+                    "fmt": "15.41M",
+                    "longFmt": "15,415,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -9195000,
+                    "fmt": "-9.2M",
+                    "longFmt": "-9,195,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -9195000,
+                    "fmt": "-9.2M",
+                    "longFmt": "-9,195,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "cash": {
+                    "raw": 6599000,
+                    "fmt": "6.6M",
+                    "longFmt": "6,599,000"
+                  },
+                  "netReceivables": {
+                    "raw": 11117000,
+                    "fmt": "11.12M",
+                    "longFmt": "11,117,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 1975000,
+                    "fmt": "1.98M",
+                    "longFmt": "1,975,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 21476000,
+                    "fmt": "21.48M",
+                    "longFmt": "21,476,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 10605000,
+                    "fmt": "10.61M",
+                    "longFmt": "10,605,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 8508000,
+                    "fmt": "8.51M",
+                    "longFmt": "8,508,000"
+                  },
+                  "otherAssets": {
+                    "raw": 562000,
+                    "fmt": "562k",
+                    "longFmt": "562,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 210000,
+                    "fmt": "210k",
+                    "longFmt": "210,000"
+                  },
+                  "totalAssets": {
+                    "raw": 41151000,
+                    "fmt": "41.15M",
+                    "longFmt": "41,151,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 2230000,
+                    "fmt": "2.23M",
+                    "longFmt": "2,230,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 10000000,
+                    "fmt": "10M",
+                    "longFmt": "10,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 2682000,
+                    "fmt": "2.68M",
+                    "longFmt": "2,682,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 118573000,
+                    "fmt": "118.57M",
+                    "longFmt": "118,573,000"
+                  },
+                  "otherLiab": {
+                    "raw": 16347000,
+                    "fmt": "16.35M",
+                    "longFmt": "16,347,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -114679000,
+                    "fmt": "-114.68M",
+                    "longFmt": "-114,679,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 24358000,
+                    "fmt": "24.36M",
+                    "longFmt": "24,358,000"
+                  },
+                  "totalLiab": {
+                    "raw": 164865000,
+                    "fmt": "164.87M",
+                    "longFmt": "164,865,000"
+                  },
+                  "commonStock": {
+                    "raw": 63000,
+                    "fmt": "63k",
+                    "longFmt": "63,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -24235000,
+                    "fmt": "-24.23M",
+                    "longFmt": "-24,235,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 15137000,
+                    "fmt": "15.14M",
+                    "longFmt": "15,137,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -9035000,
+                    "fmt": "-9.04M",
+                    "longFmt": "-9,035,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -9035000,
+                    "fmt": "-9.04M",
+                    "longFmt": "-9,035,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "cash": {
+                    "raw": 10558000,
+                    "fmt": "10.56M",
+                    "longFmt": "10,558,000"
+                  },
+                  "netReceivables": {
+                    "raw": 10964000,
+                    "fmt": "10.96M",
+                    "longFmt": "10,964,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 1975000,
+                    "fmt": "1.98M",
+                    "longFmt": "1,975,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 25519000,
+                    "fmt": "25.52M",
+                    "longFmt": "25,519,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 13287000,
+                    "fmt": "13.29M",
+                    "longFmt": "13,287,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 9128000,
+                    "fmt": "9.13M",
+                    "longFmt": "9,128,000"
+                  },
+                  "otherAssets": {
+                    "raw": 862000,
+                    "fmt": "862k",
+                    "longFmt": "862,000"
+                  },
+                  "deferredLongTermAssetCharges": {
+                    "raw": 185000,
+                    "fmt": "185k",
+                    "longFmt": "185,000"
+                  },
+                  "totalAssets": {
+                    "raw": 48796000,
+                    "fmt": "48.8M",
+                    "longFmt": "48,796,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1829000,
+                    "fmt": "1.83M",
+                    "longFmt": "1,829,000"
+                  },
+                  "shortLongTermDebt": {
+                    "raw": 10000000,
+                    "fmt": "10M",
+                    "longFmt": "10,000,000"
+                  },
+                  "otherCurrentLiab": {
+                    "raw": 2927000,
+                    "fmt": "2.93M",
+                    "longFmt": "2,927,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 118382000,
+                    "fmt": "118.38M",
+                    "longFmt": "118,382,000"
+                  },
+                  "otherLiab": {
+                    "raw": 17119000,
+                    "fmt": "17.12M",
+                    "longFmt": "17,119,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -109714000,
+                    "fmt": "-109.71M",
+                    "longFmt": "-109,714,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 26707000,
+                    "fmt": "26.71M",
+                    "longFmt": "26,707,000"
+                  },
+                  "totalLiab": {
+                    "raw": 167629000,
+                    "fmt": "167.63M",
+                    "longFmt": "167,629,000"
+                  },
+                  "commonStock": {
+                    "raw": 62000,
+                    "fmt": "62k",
+                    "longFmt": "62,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": -22960000,
+                    "fmt": "-22.96M",
+                    "longFmt": "-22,960,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 13779000,
+                    "fmt": "13.78M",
+                    "longFmt": "13,779,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": -9119000,
+                    "fmt": "-9.12M",
+                    "longFmt": "-9,119,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": -9119000,
+                    "fmt": "-9.12M",
+                    "longFmt": "-9,119,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-balanceSheetHistoryQuarterly-SI.json
+++ b/tests/http/quoteSummary-balanceSheetHistoryQuarterly-SI.json
@@ -1,0 +1,499 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=balanceSheetHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "2v3ack1g2vse1"
+      ],
+      "x-yahoo-request-id": [
+        "2v3ack1g2vse1"
+      ],
+      "x-request-id": [
+        "f87ca7bd-9f21-483b-9126-f49533bf43a0"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1393"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:36 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "balanceSheetHistoryQuarterly": {
+              "balanceSheetStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "cash": {
+                    "raw": 2962087000,
+                    "fmt": "2.96B",
+                    "longFmt": "2,962,087,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 874659000,
+                    "fmt": "874.66M",
+                    "longFmt": "874,659,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 3867850000,
+                    "fmt": "3.87B",
+                    "longFmt": "3,867,850,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 953866000,
+                    "fmt": "953.87M",
+                    "longFmt": "953,866,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 2072000,
+                    "fmt": "2.07M",
+                    "longFmt": "2,072,000"
+                  },
+                  "otherAssets": {
+                    "raw": 762447000,
+                    "fmt": "762.45M",
+                    "longFmt": "762,447,000"
+                  },
+                  "totalAssets": {
+                    "raw": 5586235000,
+                    "fmt": "5.59B",
+                    "longFmt": "5,586,235,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 5248026000,
+                    "fmt": "5.25B",
+                    "longFmt": "5,248,026,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 15831000,
+                    "fmt": "15.83M",
+                    "longFmt": "15,831,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 5276105000,
+                    "fmt": "5.28B",
+                    "longFmt": "5,276,105,000"
+                  },
+                  "totalLiab": {
+                    "raw": 5291936000,
+                    "fmt": "5.29B",
+                    "longFmt": "5,291,936,000"
+                  },
+                  "commonStock": {
+                    "raw": 189000,
+                    "fmt": "189k",
+                    "longFmt": "189,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 118348000,
+                    "fmt": "118.35M",
+                    "longFmt": "118,348,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 46036000,
+                    "fmt": "46.04M",
+                    "longFmt": "46,036,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 129726000,
+                    "fmt": "129.73M",
+                    "longFmt": "129,726,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 46036000,
+                    "fmt": "46.04M",
+                    "longFmt": "46,036,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 294299000,
+                    "fmt": "294.3M",
+                    "longFmt": "294,299,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 294299000,
+                    "fmt": "294.3M",
+                    "longFmt": "294,299,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "cash": {
+                    "raw": 197482000,
+                    "fmt": "197.48M",
+                    "longFmt": "197,482,000"
+                  },
+                  "inventory": {
+                    "raw": 27000,
+                    "fmt": "27k",
+                    "longFmt": "27,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 673227000,
+                    "fmt": "673.23M",
+                    "longFmt": "673,227,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 904874000,
+                    "fmt": "904.87M",
+                    "longFmt": "904,874,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 959890000,
+                    "fmt": "959.89M",
+                    "longFmt": "959,890,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 6600000,
+                    "fmt": "6.6M",
+                    "longFmt": "6,600,000"
+                  },
+                  "otherAssets": {
+                    "raw": 749209000,
+                    "fmt": "749.21M",
+                    "longFmt": "749,209,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2620573000,
+                    "fmt": "2.62B",
+                    "longFmt": "2,620,573,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 2281108000,
+                    "fmt": "2.28B",
+                    "longFmt": "2,281,108,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 15827000,
+                    "fmt": "15.83M",
+                    "longFmt": "15,827,000"
+                  },
+                  "otherLiab": {
+                    "raw": 100000,
+                    "fmt": "100k",
+                    "longFmt": "100,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 2317115000,
+                    "fmt": "2.32B",
+                    "longFmt": "2,317,115,000"
+                  },
+                  "totalLiab": {
+                    "raw": 2336812000,
+                    "fmt": "2.34B",
+                    "longFmt": "2,336,812,000"
+                  },
+                  "commonStock": {
+                    "raw": 187000,
+                    "fmt": "187k",
+                    "longFmt": "187,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 109229000,
+                    "fmt": "109.23M",
+                    "longFmt": "109,229,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 41698000,
+                    "fmt": "41.7M",
+                    "longFmt": "41,698,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 132647000,
+                    "fmt": "132.65M",
+                    "longFmt": "132,647,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 41698000,
+                    "fmt": "41.7M",
+                    "longFmt": "41,698,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 283761000,
+                    "fmt": "283.76M",
+                    "longFmt": "283,761,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 283761000,
+                    "fmt": "283.76M",
+                    "longFmt": "283,761,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "cash": {
+                    "raw": 199444000,
+                    "fmt": "199.44M",
+                    "longFmt": "199,444,000"
+                  },
+                  "inventory": {
+                    "raw": 51000,
+                    "fmt": "51k",
+                    "longFmt": "51,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 329535000,
+                    "fmt": "329.54M",
+                    "longFmt": "329,535,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 564800000,
+                    "fmt": "564.8M",
+                    "longFmt": "564,800,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 965510000,
+                    "fmt": "965.51M",
+                    "longFmt": "965,510,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 7172000,
+                    "fmt": "7.17M",
+                    "longFmt": "7,172,000"
+                  },
+                  "otherAssets": {
+                    "raw": 803231000,
+                    "fmt": "803.23M",
+                    "longFmt": "803,231,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2340713000,
+                    "fmt": "2.34B",
+                    "longFmt": "2,340,713,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 1670909000,
+                    "fmt": "1.67B",
+                    "longFmt": "1,670,909,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 15823000,
+                    "fmt": "15.82M",
+                    "longFmt": "15,823,000"
+                  },
+                  "otherLiab": {
+                    "raw": 100000,
+                    "fmt": "100k",
+                    "longFmt": "100,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 2052539000,
+                    "fmt": "2.05B",
+                    "longFmt": "2,052,539,000"
+                  },
+                  "totalLiab": {
+                    "raw": 2072608000,
+                    "fmt": "2.07B",
+                    "longFmt": "2,072,608,000"
+                  },
+                  "commonStock": {
+                    "raw": 187000,
+                    "fmt": "187k",
+                    "longFmt": "187,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 102169000,
+                    "fmt": "102.17M",
+                    "longFmt": "102,169,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 33270000,
+                    "fmt": "33.27M",
+                    "longFmt": "33,270,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 132479000,
+                    "fmt": "132.48M",
+                    "longFmt": "132,479,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 33270000,
+                    "fmt": "33.27M",
+                    "longFmt": "33,270,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 268105000,
+                    "fmt": "268.11M",
+                    "longFmt": "268,105,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 268105000,
+                    "fmt": "268.11M",
+                    "longFmt": "268,105,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "cash": {
+                    "raw": 166200000,
+                    "fmt": "166.2M",
+                    "longFmt": "166,200,000"
+                  },
+                  "otherCurrentAssets": {
+                    "raw": 441367000,
+                    "fmt": "441.37M",
+                    "longFmt": "441,367,000"
+                  },
+                  "totalCurrentAssets": {
+                    "raw": 641073000,
+                    "fmt": "641.07M",
+                    "longFmt": "641,073,000"
+                  },
+                  "longTermInvestments": {
+                    "raw": 975513000,
+                    "fmt": "975.51M",
+                    "longFmt": "975,513,000"
+                  },
+                  "propertyPlantEquipment": {
+                    "raw": 7616000,
+                    "fmt": "7.62M",
+                    "longFmt": "7,616,000"
+                  },
+                  "otherAssets": {
+                    "raw": 686506000,
+                    "fmt": "686.51M",
+                    "longFmt": "686,506,000"
+                  },
+                  "totalAssets": {
+                    "raw": 2310708000,
+                    "fmt": "2.31B",
+                    "longFmt": "2,310,708,000"
+                  },
+                  "accountsPayable": {
+                    "raw": 2002957000,
+                    "fmt": "2B",
+                    "longFmt": "2,002,957,000"
+                  },
+                  "longTermDebt": {
+                    "raw": 15820000,
+                    "fmt": "15.82M",
+                    "longFmt": "15,820,000"
+                  },
+                  "otherLiab": {
+                    "raw": 200000,
+                    "fmt": "200k",
+                    "longFmt": "200,000"
+                  },
+                  "totalCurrentLiabilities": {
+                    "raw": 2045421000,
+                    "fmt": "2.05B",
+                    "longFmt": "2,045,421,000"
+                  },
+                  "totalLiab": {
+                    "raw": 2065956000,
+                    "fmt": "2.07B",
+                    "longFmt": "2,065,956,000"
+                  },
+                  "commonStock": {
+                    "raw": 187000,
+                    "fmt": "187k",
+                    "longFmt": "187,000"
+                  },
+                  "retainedEarnings": {
+                    "raw": 96703000,
+                    "fmt": "96.7M",
+                    "longFmt": "96,703,000"
+                  },
+                  "treasuryStock": {
+                    "raw": 15526000,
+                    "fmt": "15.53M",
+                    "longFmt": "15,526,000"
+                  },
+                  "capitalSurplus": {
+                    "raw": 132336000,
+                    "fmt": "132.34M",
+                    "longFmt": "132,336,000"
+                  },
+                  "otherStockholderEquity": {
+                    "raw": 15526000,
+                    "fmt": "15.53M",
+                    "longFmt": "15,526,000"
+                  },
+                  "totalStockholderEquity": {
+                    "raw": 244752000,
+                    "fmt": "244.75M",
+                    "longFmt": "244,752,000"
+                  },
+                  "netTangibleAssets": {
+                    "raw": 244752000,
+                    "fmt": "244.75M",
+                    "longFmt": "244,752,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-calendarEvents-ABBV.json
+++ b/tests/http/quoteSummary-calendarEvents-ABBV.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=calendarEvents"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "9bog9p9g2vse3"
+      ],
+      "x-yahoo-request-id": [
+        "9bog9p9g2vse3"
+      ],
+      "x-request-id": [
+        "f2e32557-f1c3-42bd-8c78-a02f95a0b4d2"
+      ],
+      "content-length": [
+        "322"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:38 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": [
+                  1619654400,
+                  1620000000
+                ],
+                "earningsAverage": 2.79,
+                "earningsLow": 2.14,
+                "earningsHigh": 3.01,
+                "revenueAverage": 12819100000,
+                "revenueLow": 12663000000,
+                "revenueHigh": 13478000000
+              },
+              "exDividendDate": 1610582400,
+              "dividendDate": 1613433600
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-calendarEvents-BRKS.json
+++ b/tests/http/quoteSummary-calendarEvents-BRKS.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=calendarEvents"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "56gg8c1g2vse3"
+      ],
+      "x-yahoo-request-id": [
+        "56gg8c1g2vse3"
+      ],
+      "x-request-id": [
+        "10860ce8-c6e8-47bc-9a3e-1506dbc8d41c"
+      ],
+      "content-length": [
+        "315"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:38 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": [
+                  1619568000,
+                  1620000000
+                ],
+                "earningsAverage": 0.5,
+                "earningsLow": 0.47,
+                "earningsHigh": 0.52,
+                "revenueAverage": 272280000,
+                "revenueLow": 267000000,
+                "revenueHigh": 275000000
+              },
+              "exDividendDate": 1614816000,
+              "dividendDate": 1616716800
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-calendarEvents-CRON.json
+++ b/tests/http/quoteSummary-calendarEvents-CRON.json
@@ -1,0 +1,84 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=calendarEvents"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "7h7i8epg2vse3"
+      ],
+      "x-yahoo-request-id": [
+        "7h7i8epg2vse3"
+      ],
+      "x-request-id": [
+        "5579a018-306b-42f8-acbb-dfcc5ff78cf6"
+      ],
+      "content-length": [
+        "105"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:39 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": []
+              }
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-calendarEvents-EPAC.json
+++ b/tests/http/quoteSummary-calendarEvents-EPAC.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=calendarEvents"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "79njs11g2vse3"
+      ],
+      "x-yahoo-request-id": [
+        "79njs11g2vse3"
+      ],
+      "x-request-id": [
+        "061ee7cd-e68e-489d-9faf-109961c659cf"
+      ],
+      "content-length": [
+        "315"
+      ],
+      "x-envoy-upstream-service-time": [
+        "1"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:39 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": [
+                  1615939200,
+                  1616371200
+                ],
+                "earningsAverage": 0.12,
+                "earningsLow": 0.1,
+                "earningsHigh": 0.15,
+                "revenueAverage": 126060000,
+                "revenueLow": 119800000,
+                "revenueHigh": 130900000
+              },
+              "exDividendDate": 1601510400,
+              "dividendDate": 1603065600
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-calendarEvents-MDLY.json
+++ b/tests/http/quoteSummary-calendarEvents-MDLY.json
@@ -1,0 +1,91 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=calendarEvents"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "8ivuamtg2vse2"
+      ],
+      "x-yahoo-request-id": [
+        "8ivuamtg2vse2"
+      ],
+      "x-request-id": [
+        "9659451f-3fd0-49a5-bf6b-34407c8dfd62"
+      ],
+      "content-length": [
+        "237"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:38 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": [
+                  1605484800
+                ],
+                "revenueAverage": 8326000,
+                "revenueLow": 8310000,
+                "revenueHigh": 8310000
+              },
+              "exDividendDate": 1585267200,
+              "dividendDate": 1556841600
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-calendarEvents-SI.json
+++ b/tests/http/quoteSummary-calendarEvents-SI.json
@@ -1,0 +1,92 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=calendarEvents"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "18b2uvpg2vse2"
+      ],
+      "x-yahoo-request-id": [
+        "18b2uvpg2vse2"
+      ],
+      "x-request-id": [
+        "de1c92d9-6757-4b6d-aa29-c7483faa0722"
+      ],
+      "content-length": [
+        "247"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:38 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "calendarEvents": {
+              "maxAge": 1,
+              "earnings": {
+                "earningsDate": [
+                  1611187200
+                ],
+                "earningsAverage": 0.45,
+                "earningsLow": 0.33,
+                "earningsHigh": 0.5,
+                "revenueAverage": 29700000,
+                "revenueLow": 27310000,
+                "revenueHigh": 31800000
+              }
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistory-ABBV.json
+++ b/tests/http/quoteSummary-cashflowStatementHistory-ABBV.json
@@ -1,0 +1,424 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=cashflowStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "84g4qotg2vse4"
+      ],
+      "x-yahoo-request-id": [
+        "84g4qotg2vse4"
+      ],
+      "x-request-id": [
+        "de6c7237-0fab-46ff-afcc-7f11e016b951"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1149"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:40 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 4616000000,
+                    "fmt": "4.62B",
+                    "longFmt": "4,616,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 7882000000,
+                    "fmt": "7.88B",
+                    "longFmt": "7,882,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 2017000000,
+                    "fmt": "2.02B",
+                    "longFmt": "2,017,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 4754000000,
+                    "fmt": "4.75B",
+                    "longFmt": "4,754,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -74000000,
+                    "fmt": "-74M",
+                    "longFmt": "-74,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -1121000000,
+                    "fmt": "-1.12B",
+                    "longFmt": "-1,121,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -231000000,
+                    "fmt": "-231M",
+                    "longFmt": "-231,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 97000000,
+                    "fmt": "97M",
+                    "longFmt": "97,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 13324000000,
+                    "fmt": "13.32B",
+                    "longFmt": "13,324,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -552000000,
+                    "fmt": "-552M",
+                    "longFmt": "-552,000,000"
+                  },
+                  "investments": {
+                    "raw": 2116000000,
+                    "fmt": "2.12B",
+                    "longFmt": "2,116,000,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 167000000,
+                    "fmt": "167M",
+                    "longFmt": "167,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 596000000,
+                    "fmt": "596M",
+                    "longFmt": "596,000,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -6366000000,
+                    "fmt": "-6.37B",
+                    "longFmt": "-6,366,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 26247000000,
+                    "fmt": "26.25B",
+                    "longFmt": "26,247,000,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -552000000,
+                    "fmt": "-552M",
+                    "longFmt": "-552,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 18708000000,
+                    "fmt": "18.71B",
+                    "longFmt": "18,708,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 7000000,
+                    "fmt": "7M",
+                    "longFmt": "7,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 32635000000,
+                    "fmt": "32.63B",
+                    "longFmt": "32,635,000,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -629000000,
+                    "fmt": "-629M",
+                    "longFmt": "-629,000,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 8000000,
+                    "fmt": "8M",
+                    "longFmt": "8,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 5687000000,
+                    "fmt": "5.69B",
+                    "longFmt": "5,687,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 1765000000,
+                    "fmt": "1.76B",
+                    "longFmt": "1,765,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 7101000000,
+                    "fmt": "7.1B",
+                    "longFmt": "7,101,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -591000000,
+                    "fmt": "-591M",
+                    "longFmt": "-591,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 190000000,
+                    "fmt": "190M",
+                    "longFmt": "190,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -226000000,
+                    "fmt": "-226M",
+                    "longFmt": "-226,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -499000000,
+                    "fmt": "-499M",
+                    "longFmt": "-499,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 13427000000,
+                    "fmt": "13.43B",
+                    "longFmt": "13,427,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -638000000,
+                    "fmt": "-638M",
+                    "longFmt": "-638,000,000"
+                  },
+                  "investments": {
+                    "raw": 368000000,
+                    "fmt": "368M",
+                    "longFmt": "368,000,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 167000000,
+                    "fmt": "167M",
+                    "longFmt": "167,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -1006000000,
+                    "fmt": "-1.01B",
+                    "longFmt": "-1,006,000,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -5580000000,
+                    "fmt": "-5.58B",
+                    "longFmt": "-5,580,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 3229000000,
+                    "fmt": "3.23B",
+                    "longFmt": "3,229,000,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -104000000,
+                    "fmt": "-104M",
+                    "longFmt": "-104,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -14396000000,
+                    "fmt": "-14.4B",
+                    "longFmt": "-14,396,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -39000000,
+                    "fmt": "-39M",
+                    "longFmt": "-39,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": -2014000000,
+                    "fmt": "-2.01B",
+                    "longFmt": "-2,014,000,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -12014000000,
+                    "fmt": "-12.01B",
+                    "longFmt": "-12,014,000,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 73000000,
+                    "fmt": "73M",
+                    "longFmt": "73,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 5309000000,
+                    "fmt": "5.31B",
+                    "longFmt": "5,309,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 1501000000,
+                    "fmt": "1.5B",
+                    "longFmt": "1,501,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 3141000000,
+                    "fmt": "3.14B",
+                    "longFmt": "3,141,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -391000000,
+                    "fmt": "-391M",
+                    "longFmt": "-391,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 425000000,
+                    "fmt": "425M",
+                    "longFmt": "425,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 93000000,
+                    "fmt": "93M",
+                    "longFmt": "93,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -118000000,
+                    "fmt": "-118M",
+                    "longFmt": "-118,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 9960000000,
+                    "fmt": "9.96B",
+                    "longFmt": "9,960,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -529000000,
+                    "fmt": "-529M",
+                    "longFmt": "-529,000,000"
+                  },
+                  "investments": {
+                    "raw": 563000000,
+                    "fmt": "563M",
+                    "longFmt": "563,000,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 167000000,
+                    "fmt": "167M",
+                    "longFmt": "167,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -274000000,
+                    "fmt": "-274M",
+                    "longFmt": "-274,000,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -4107000000,
+                    "fmt": "-4.11B",
+                    "longFmt": "-4,107,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -2000000,
+                    "fmt": "-2M",
+                    "longFmt": "-2,000,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -247000000,
+                    "fmt": "-247M",
+                    "longFmt": "-247,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -5512000000,
+                    "fmt": "-5.51B",
+                    "longFmt": "-5,512,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 29000000,
+                    "fmt": "29M",
+                    "longFmt": "29,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 4203000000,
+                    "fmt": "4.2B",
+                    "longFmt": "4,203,000,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -1410000000,
+                    "fmt": "-1.41B",
+                    "longFmt": "-1,410,000,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 254000000,
+                    "fmt": "254M",
+                    "longFmt": "254,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistory-BRKS.json
+++ b/tests/http/quoteSummary-cashflowStatementHistory-BRKS.json
@@ -1,0 +1,489 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=cashflowStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "0er3cplg2vse4"
+      ],
+      "x-yahoo-request-id": [
+        "0er3cplg2vse4"
+      ],
+      "x-request-id": [
+        "15b390d4-a20c-48f9-99c5-569ec05c29cc"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1421"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:40 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "2"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 64853000,
+                    "fmt": "64.85M",
+                    "longFmt": "64,853,000"
+                  },
+                  "depreciation": {
+                    "raw": 65496000,
+                    "fmt": "65.5M",
+                    "longFmt": "65,496,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -79812000,
+                    "fmt": "-79.81M",
+                    "longFmt": "-79,812,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -18755000,
+                    "fmt": "-18.75M",
+                    "longFmt": "-18,755,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 653000,
+                    "fmt": "653k",
+                    "longFmt": "653,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -13144000,
+                    "fmt": "-13.14M",
+                    "longFmt": "-13,144,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 18575000,
+                    "fmt": "18.57M",
+                    "longFmt": "18,575,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 37866000,
+                    "fmt": "37.87M",
+                    "longFmt": "37,866,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -39924000,
+                    "fmt": "-39.92M",
+                    "longFmt": "-39,924,000"
+                  },
+                  "investments": {
+                    "raw": 33926000,
+                    "fmt": "33.93M",
+                    "longFmt": "33,926,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -1000000,
+                    "fmt": "-1M",
+                    "longFmt": "-1,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -22742000,
+                    "fmt": "-22.74M",
+                    "longFmt": "-22,742,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -29513000,
+                    "fmt": "-29.51M",
+                    "longFmt": "-29,513,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -2105000,
+                    "fmt": "-2.1M",
+                    "longFmt": "-2,105,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -27023000,
+                    "fmt": "-27.02M",
+                    "longFmt": "-27,023,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 9254000,
+                    "fmt": "9.25M",
+                    "longFmt": "9,254,000"
+                  },
+                  "changeInCash": {
+                    "raw": -2645000,
+                    "fmt": "-2.65M",
+                    "longFmt": "-2,645,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 4595000,
+                    "fmt": "4.59M",
+                    "longFmt": "4,595,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1569801600,
+                    "fmt": "2019-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 437416000,
+                    "fmt": "437.42M",
+                    "longFmt": "437,416,000"
+                  },
+                  "depreciation": {
+                    "raw": 54450000,
+                    "fmt": "54.45M",
+                    "longFmt": "54,450,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -407241000,
+                    "fmt": "-407.24M",
+                    "longFmt": "-407,241,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -11445000,
+                    "fmt": "-11.45M",
+                    "longFmt": "-11,445,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 8908000,
+                    "fmt": "8.91M",
+                    "longFmt": "8,908,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -2933000,
+                    "fmt": "-2.93M",
+                    "longFmt": "-2,933,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 11743000,
+                    "fmt": "11.74M",
+                    "longFmt": "11,743,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 90898000,
+                    "fmt": "90.9M",
+                    "longFmt": "90,898,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -23861000,
+                    "fmt": "-23.86M",
+                    "longFmt": "-23,861,000"
+                  },
+                  "investments": {
+                    "raw": 16235000,
+                    "fmt": "16.23M",
+                    "longFmt": "16,235,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -1000000,
+                    "fmt": "-1M",
+                    "longFmt": "-1,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 211312000,
+                    "fmt": "211.31M",
+                    "longFmt": "211,312,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -28895000,
+                    "fmt": "-28.89M",
+                    "longFmt": "-28,895,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -165001000,
+                    "fmt": "-165M",
+                    "longFmt": "-165,001,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -687000,
+                    "fmt": "-687k",
+                    "longFmt": "-687,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -191161000,
+                    "fmt": "-191.16M",
+                    "longFmt": "-191,161,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -3586000,
+                    "fmt": "-3.59M",
+                    "longFmt": "-3,586,000"
+                  },
+                  "changeInCash": {
+                    "raw": 107463000,
+                    "fmt": "107.46M",
+                    "longFmt": "107,463,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 3422000,
+                    "fmt": "3.42M",
+                    "longFmt": "3,422,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1538265600,
+                    "fmt": "2018-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 116575000,
+                    "fmt": "116.58M",
+                    "longFmt": "116,575,000"
+                  },
+                  "depreciation": {
+                    "raw": 36686000,
+                    "fmt": "36.69M",
+                    "longFmt": "36,686,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -32702000,
+                    "fmt": "-32.7M",
+                    "longFmt": "-32,702,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -28463000,
+                    "fmt": "-28.46M",
+                    "longFmt": "-28,463,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 8248000,
+                    "fmt": "8.25M",
+                    "longFmt": "8,248,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -24365000,
+                    "fmt": "-24.36M",
+                    "longFmt": "-24,365,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -2015000,
+                    "fmt": "-2.02M",
+                    "longFmt": "-2,015,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 73964000,
+                    "fmt": "73.96M",
+                    "longFmt": "73,964,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -12787000,
+                    "fmt": "-12.79M",
+                    "longFmt": "-12,787,000"
+                  },
+                  "investments": {
+                    "raw": -50126000,
+                    "fmt": "-50.13M",
+                    "longFmt": "-50,126,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -1000000,
+                    "fmt": "-1M",
+                    "longFmt": "-1,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -148468000,
+                    "fmt": "-148.47M",
+                    "longFmt": "-148,468,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -28285000,
+                    "fmt": "-28.29M",
+                    "longFmt": "-28,285,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 196054000,
+                    "fmt": "196.05M",
+                    "longFmt": "196,054,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -318000,
+                    "fmt": "-318k",
+                    "longFmt": "-318,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 170277000,
+                    "fmt": "170.28M",
+                    "longFmt": "170,277,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 313000,
+                    "fmt": "313k",
+                    "longFmt": "313,000"
+                  },
+                  "changeInCash": {
+                    "raw": 96086000,
+                    "fmt": "96.09M",
+                    "longFmt": "96,086,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 2826000,
+                    "fmt": "2.83M",
+                    "longFmt": "2,826,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1506729600,
+                    "fmt": "2017-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 62612000,
+                    "fmt": "62.61M",
+                    "longFmt": "62,612,000"
+                  },
+                  "depreciation": {
+                    "raw": 27230000,
+                    "fmt": "27.23M",
+                    "longFmt": "27,230,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 7073000,
+                    "fmt": "7.07M",
+                    "longFmt": "7,073,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -11178000,
+                    "fmt": "-11.18M",
+                    "longFmt": "-11,178,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 15895000,
+                    "fmt": "15.89M",
+                    "longFmt": "15,895,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -12792000,
+                    "fmt": "-12.79M",
+                    "longFmt": "-12,792,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 7384000,
+                    "fmt": "7.38M",
+                    "longFmt": "7,384,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 96224000,
+                    "fmt": "96.22M",
+                    "longFmt": "96,224,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -12677000,
+                    "fmt": "-12.68M",
+                    "longFmt": "-12,677,000"
+                  },
+                  "investments": {
+                    "raw": 3420000,
+                    "fmt": "3.42M",
+                    "longFmt": "3,420,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -1000000,
+                    "fmt": "-1M",
+                    "longFmt": "-1,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -54188000,
+                    "fmt": "-54.19M",
+                    "longFmt": "-54,188,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -27932000,
+                    "fmt": "-27.93M",
+                    "longFmt": "-27,932,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 196054000,
+                    "fmt": "196.05M",
+                    "longFmt": "196,054,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -28000,
+                    "fmt": "-28k",
+                    "longFmt": "-28,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -25920000,
+                    "fmt": "-25.92M",
+                    "longFmt": "-25,920,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 420000,
+                    "fmt": "420k",
+                    "longFmt": "420,000"
+                  },
+                  "changeInCash": {
+                    "raw": 16536000,
+                    "fmt": "16.54M",
+                    "longFmt": "16,536,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 2040000,
+                    "fmt": "2.04M",
+                    "longFmt": "2,040,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistory-CRON.json
+++ b/tests/http/quoteSummary-cashflowStatementHistory-CRON.json
@@ -1,0 +1,494 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=cashflowStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "a0di7uhg2vse5"
+      ],
+      "x-yahoo-request-id": [
+        "a0di7uhg2vse5"
+      ],
+      "x-request-id": [
+        "a575392f-ce46-4aff-8282-4de4f36b1f25"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1404"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:41 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 1166506000,
+                    "fmt": "1.17B",
+                    "longFmt": "1,166,506,000"
+                  },
+                  "depreciation": {
+                    "raw": 3913000,
+                    "fmt": "3.91M",
+                    "longFmt": "3,913,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -1246218000,
+                    "fmt": "-1.25B",
+                    "longFmt": "-1,246,218,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -702000,
+                    "fmt": "-702k",
+                    "longFmt": "-702,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 13317000,
+                    "fmt": "13.32M",
+                    "longFmt": "13,317,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -51888000,
+                    "fmt": "-51.89M",
+                    "longFmt": "-51,888,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -14935000,
+                    "fmt": "-14.94M",
+                    "longFmt": "-14,935,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -130007000,
+                    "fmt": "-130.01M",
+                    "longFmt": "-130,007,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -38664000,
+                    "fmt": "-38.66M",
+                    "longFmt": "-38,664,000"
+                  },
+                  "investments": {
+                    "raw": -297102000,
+                    "fmt": "-297.1M",
+                    "longFmt": "-297,102,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -89000,
+                    "fmt": "-89k",
+                    "longFmt": "-89,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -603539000,
+                    "fmt": "-603.54M",
+                    "longFmt": "-603,539,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -16484000,
+                    "fmt": "-16.48M",
+                    "longFmt": "-16,484,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -3722000,
+                    "fmt": "-3.72M",
+                    "longFmt": "-3,722,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 1856941000,
+                    "fmt": "1.86B",
+                    "longFmt": "1,856,941,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 52371000,
+                    "fmt": "52.37M",
+                    "longFmt": "52,371,000"
+                  },
+                  "changeInCash": {
+                    "raw": 1175766000,
+                    "fmt": "1.18B",
+                    "longFmt": "1,175,766,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -915000,
+                    "fmt": "-915k",
+                    "longFmt": "-915,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 1878062000,
+                    "fmt": "1.88B",
+                    "longFmt": "1,878,062,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -21636000,
+                    "fmt": "-21.64M",
+                    "longFmt": "-21,636,000"
+                  },
+                  "depreciation": {
+                    "raw": 1848000,
+                    "fmt": "1.85M",
+                    "longFmt": "1,848,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 8609000,
+                    "fmt": "8.61M",
+                    "longFmt": "8,609,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -2569000,
+                    "fmt": "-2.57M",
+                    "longFmt": "-2,569,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 12705000,
+                    "fmt": "12.71M",
+                    "longFmt": "12,705,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -4092000,
+                    "fmt": "-4.09M",
+                    "longFmt": "-4,092,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -2382000,
+                    "fmt": "-2.38M",
+                    "longFmt": "-2,382,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -7517000,
+                    "fmt": "-7.52M",
+                    "longFmt": "-7,517,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -88308000,
+                    "fmt": "-88.31M",
+                    "longFmt": "-88,308,000"
+                  },
+                  "investments": {
+                    "raw": -5179000,
+                    "fmt": "-5.18M",
+                    "longFmt": "-5,179,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -143000,
+                    "fmt": "-143k",
+                    "longFmt": "-143,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -93908000,
+                    "fmt": "-93.91M",
+                    "longFmt": "-93,908,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 11583000,
+                    "fmt": "11.58M",
+                    "longFmt": "11,583,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -7577000,
+                    "fmt": "-7.58M",
+                    "longFmt": "-7,577,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 122112000,
+                    "fmt": "122.11M",
+                    "longFmt": "122,112,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -4085000,
+                    "fmt": "-4.08M",
+                    "longFmt": "-4,085,000"
+                  },
+                  "changeInCash": {
+                    "raw": 16602000,
+                    "fmt": "16.6M",
+                    "longFmt": "16,602,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -16000,
+                    "fmt": "-16k",
+                    "longFmt": "-16,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 118122000,
+                    "fmt": "118.12M",
+                    "longFmt": "118,122,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -1483000,
+                    "fmt": "-1.48M",
+                    "longFmt": "-1,483,000"
+                  },
+                  "depreciation": {
+                    "raw": 768000,
+                    "fmt": "768k",
+                    "longFmt": "768,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -2804000,
+                    "fmt": "-2.8M",
+                    "longFmt": "-2,804,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -3198000,
+                    "fmt": "-3.2M",
+                    "longFmt": "-3,198,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 5164000,
+                    "fmt": "5.16M",
+                    "longFmt": "5,164,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -2504000,
+                    "fmt": "-2.5M",
+                    "longFmt": "-2,504,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -221000,
+                    "fmt": "-221k",
+                    "longFmt": "-221,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -4278000,
+                    "fmt": "-4.28M",
+                    "longFmt": "-4,278,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -32926000,
+                    "fmt": "-32.93M",
+                    "longFmt": "-32,926,000"
+                  },
+                  "investments": {
+                    "raw": 5026000,
+                    "fmt": "5.03M",
+                    "longFmt": "5,026,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -143000,
+                    "fmt": "-143k",
+                    "longFmt": "-143,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -29897000,
+                    "fmt": "-29.9M",
+                    "longFmt": "-29,897,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 1938000,
+                    "fmt": "1.94M",
+                    "longFmt": "1,938,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -3103000,
+                    "fmt": "-3.1M",
+                    "longFmt": "-3,103,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 39074000,
+                    "fmt": "39.07M",
+                    "longFmt": "39,074,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -152000,
+                    "fmt": "-152k",
+                    "longFmt": "-152,000"
+                  },
+                  "changeInCash": {
+                    "raw": 4747000,
+                    "fmt": "4.75M",
+                    "longFmt": "4,747,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -16000,
+                    "fmt": "-16k",
+                    "longFmt": "-16,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 40239000,
+                    "fmt": "40.24M",
+                    "longFmt": "40,239,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -1190000,
+                    "fmt": "-1.19M",
+                    "longFmt": "-1,190,000"
+                  },
+                  "depreciation": {
+                    "raw": 382000,
+                    "fmt": "382k",
+                    "longFmt": "382,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -839000,
+                    "fmt": "-839k",
+                    "longFmt": "-839,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -57000,
+                    "fmt": "-57k",
+                    "longFmt": "-57,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -2746000,
+                    "fmt": "-2.75M",
+                    "longFmt": "-2,746,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -1643000,
+                    "fmt": "-1.64M",
+                    "longFmt": "-1,643,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -383000,
+                    "fmt": "-383k",
+                    "longFmt": "-383,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -6476000,
+                    "fmt": "-6.48M",
+                    "longFmt": "-6,476,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -900000,
+                    "fmt": "-900k",
+                    "longFmt": "-900,000"
+                  },
+                  "investments": {
+                    "raw": 2000,
+                    "fmt": "2k",
+                    "longFmt": "2,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -348000,
+                    "fmt": "-348k",
+                    "longFmt": "-348,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -8008000,
+                    "fmt": "-8.01M",
+                    "longFmt": "-8,008,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -4139000,
+                    "fmt": "-4.14M",
+                    "longFmt": "-4,139,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 2470000,
+                    "fmt": "2.47M",
+                    "longFmt": "2,470,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 16821000,
+                    "fmt": "16.82M",
+                    "longFmt": "16,821,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -152000,
+                    "fmt": "-152k",
+                    "longFmt": "-152,000"
+                  },
+                  "changeInCash": {
+                    "raw": 2337000,
+                    "fmt": "2.34M",
+                    "longFmt": "2,337,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -16000,
+                    "fmt": "-16k",
+                    "longFmt": "-16,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 18490000,
+                    "fmt": "18.49M",
+                    "longFmt": "18,490,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistory-EPAC.json
+++ b/tests/http/quoteSummary-cashflowStatementHistory-EPAC.json
@@ -1,0 +1,494 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=cashflowStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "4gj2ok9g2vse5"
+      ],
+      "x-yahoo-request-id": [
+        "4gj2ok9g2vse5"
+      ],
+      "x-request-id": [
+        "13ce69a9-a954-4d4d-98f0-af6ed6f8ebc1"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1495"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:41 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1598832000,
+                    "fmt": "2020-08-31"
+                  },
+                  "netIncome": {
+                    "raw": 723000,
+                    "fmt": "723k",
+                    "longFmt": "723,000"
+                  },
+                  "depreciation": {
+                    "raw": 20720000,
+                    "fmt": "20.72M",
+                    "longFmt": "20,720,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -15821000,
+                    "fmt": "-15.82M",
+                    "longFmt": "-15,821,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 44749000,
+                    "fmt": "44.75M",
+                    "longFmt": "44,749,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -32081000,
+                    "fmt": "-32.08M",
+                    "longFmt": "-32,081,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 8960000,
+                    "fmt": "8.96M",
+                    "longFmt": "8,960,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -25652000,
+                    "fmt": "-25.65M",
+                    "longFmt": "-25,652,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -3159000,
+                    "fmt": "-3.16M",
+                    "longFmt": "-3,159,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -12053000,
+                    "fmt": "-12.05M",
+                    "longFmt": "-12,053,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 210490000,
+                    "fmt": "210.49M",
+                    "longFmt": "210,490,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 176073000,
+                    "fmt": "176.07M",
+                    "longFmt": "176,073,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -2419000,
+                    "fmt": "-2.42M",
+                    "longFmt": "-2,419,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -207559000,
+                    "fmt": "-207.56M",
+                    "longFmt": "-207,559,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -234000,
+                    "fmt": "-234k",
+                    "longFmt": "-234,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -238926000,
+                    "fmt": "-238.93M",
+                    "longFmt": "-238,926,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 7031000,
+                    "fmt": "7.03M",
+                    "longFmt": "7,031,000"
+                  },
+                  "changeInCash": {
+                    "raw": -58981000,
+                    "fmt": "-58.98M",
+                    "longFmt": "-58,981,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -31806000,
+                    "fmt": "-31.81M",
+                    "longFmt": "-31,806,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 3092000,
+                    "fmt": "3.09M",
+                    "longFmt": "3,092,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1567209600,
+                    "fmt": "2019-08-31"
+                  },
+                  "netIncome": {
+                    "raw": -249145000,
+                    "fmt": "-249.15M",
+                    "longFmt": "-249,145,000"
+                  },
+                  "depreciation": {
+                    "raw": 20217000,
+                    "fmt": "20.22M",
+                    "longFmt": "20,217,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 306326000,
+                    "fmt": "306.33M",
+                    "longFmt": "306,326,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -4993000,
+                    "fmt": "-4.99M",
+                    "longFmt": "-4,993,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 6858000,
+                    "fmt": "6.86M",
+                    "longFmt": "6,858,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -7760000,
+                    "fmt": "-7.76M",
+                    "longFmt": "-7,760,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -17945000,
+                    "fmt": "-17.95M",
+                    "longFmt": "-17,945,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 53845000,
+                    "fmt": "53.84M",
+                    "longFmt": "53,845,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -14923000,
+                    "fmt": "-14.92M",
+                    "longFmt": "-14,923,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 24507000,
+                    "fmt": "24.51M",
+                    "longFmt": "24,507,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 11046000,
+                    "fmt": "11.05M",
+                    "longFmt": "11,046,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -2439000,
+                    "fmt": "-2.44M",
+                    "longFmt": "-2,439,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -72500000,
+                    "fmt": "-72.5M",
+                    "longFmt": "-72,500,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -2125000,
+                    "fmt": "-2.12M",
+                    "longFmt": "-2,125,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -99517000,
+                    "fmt": "-99.52M",
+                    "longFmt": "-99,517,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -4713000,
+                    "fmt": "-4.71M",
+                    "longFmt": "-4,713,000"
+                  },
+                  "changeInCash": {
+                    "raw": -39339000,
+                    "fmt": "-39.34M",
+                    "longFmt": "-39,339,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -24353000,
+                    "fmt": "-24.35M",
+                    "longFmt": "-24,353,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 1900000,
+                    "fmt": "1.9M",
+                    "longFmt": "1,900,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1535673600,
+                    "fmt": "2018-08-31"
+                  },
+                  "netIncome": {
+                    "raw": -21648000,
+                    "fmt": "-21.65M",
+                    "longFmt": "-21,648,000"
+                  },
+                  "depreciation": {
+                    "raw": 20405000,
+                    "fmt": "20.41M",
+                    "longFmt": "20,405,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 90162000,
+                    "fmt": "90.16M",
+                    "longFmt": "90,162,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -7462000,
+                    "fmt": "-7.46M",
+                    "longFmt": "-7,462,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -1872000,
+                    "fmt": "-1.87M",
+                    "longFmt": "-1,872,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -1142000,
+                    "fmt": "-1.14M",
+                    "longFmt": "-1,142,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 7897000,
+                    "fmt": "7.9M",
+                    "longFmt": "7,897,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 106093000,
+                    "fmt": "106.09M",
+                    "longFmt": "106,093,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -11021000,
+                    "fmt": "-11.02M",
+                    "longFmt": "-11,021,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -37518000,
+                    "fmt": "-37.52M",
+                    "longFmt": "-37,518,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -62751000,
+                    "fmt": "-62.75M",
+                    "longFmt": "-62,751,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -2390000,
+                    "fmt": "-2.39M",
+                    "longFmt": "-2,390,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -30000000,
+                    "fmt": "-30M",
+                    "longFmt": "-30,000,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -2125000,
+                    "fmt": "-2.12M",
+                    "longFmt": "-2,125,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -17993000,
+                    "fmt": "-17.99M",
+                    "longFmt": "-17,993,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -4430000,
+                    "fmt": "-4.43M",
+                    "longFmt": "-4,430,000"
+                  },
+                  "changeInCash": {
+                    "raw": 20919000,
+                    "fmt": "20.92M",
+                    "longFmt": "20,919,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -1284000,
+                    "fmt": "-1.28M",
+                    "longFmt": "-1,284,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 15681000,
+                    "fmt": "15.68M",
+                    "longFmt": "15,681,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1504137600,
+                    "fmt": "2017-08-31"
+                  },
+                  "netIncome": {
+                    "raw": -66213000,
+                    "fmt": "-66.21M",
+                    "longFmt": "-66,213,000"
+                  },
+                  "depreciation": {
+                    "raw": 22925000,
+                    "fmt": "22.93M",
+                    "longFmt": "22,925,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 126943000,
+                    "fmt": "126.94M",
+                    "longFmt": "126,943,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 11230000,
+                    "fmt": "11.23M",
+                    "longFmt": "11,230,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 3128000,
+                    "fmt": "3.13M",
+                    "longFmt": "3,128,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -4502000,
+                    "fmt": "-4.5M",
+                    "longFmt": "-4,502,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -1584000,
+                    "fmt": "-1.58M",
+                    "longFmt": "-1,584,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 88499000,
+                    "fmt": "88.5M",
+                    "longFmt": "88,499,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -17238000,
+                    "fmt": "-17.24M",
+                    "longFmt": "-17,238,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -10835000,
+                    "fmt": "-10.84M",
+                    "longFmt": "-10,835,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -27625000,
+                    "fmt": "-27.62M",
+                    "longFmt": "-27,625,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -2358000,
+                    "fmt": "-2.36M",
+                    "longFmt": "-2,358,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -19250000,
+                    "fmt": "-19.25M",
+                    "longFmt": "-19,250,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -742000,
+                    "fmt": "-742k",
+                    "longFmt": "-742,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -15150000,
+                    "fmt": "-15.15M",
+                    "longFmt": "-15,150,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 4243000,
+                    "fmt": "4.24M",
+                    "longFmt": "4,243,000"
+                  },
+                  "changeInCash": {
+                    "raw": 49967000,
+                    "fmt": "49.97M",
+                    "longFmt": "49,967,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -1065000,
+                    "fmt": "-1.06M",
+                    "longFmt": "-1,065,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 8265000,
+                    "fmt": "8.27M",
+                    "longFmt": "8,265,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistory-MDLY.json
+++ b/tests/http/quoteSummary-cashflowStatementHistory-MDLY.json
@@ -1,0 +1,444 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=cashflowStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "3perjupg2vse4"
+      ],
+      "x-yahoo-request-id": [
+        "3perjupg2vse4"
+      ],
+      "x-request-id": [
+        "248be85c-ce2e-4842-a9b2-15e789dd6381"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1208"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:40 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -3379000,
+                    "fmt": "-3.38M",
+                    "longFmt": "-3,379,000"
+                  },
+                  "depreciation": {
+                    "raw": 702000,
+                    "fmt": "702k",
+                    "longFmt": "702,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 6148000,
+                    "fmt": "6.15M",
+                    "longFmt": "6,148,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 2170000,
+                    "fmt": "2.17M",
+                    "longFmt": "2,170,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -4199000,
+                    "fmt": "-4.2M",
+                    "longFmt": "-4,199,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -1348000,
+                    "fmt": "-1.35M",
+                    "longFmt": "-1,348,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 2145000,
+                    "fmt": "2.15M",
+                    "longFmt": "2,145,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -126000,
+                    "fmt": "-126k",
+                    "longFmt": "-126,000"
+                  },
+                  "investments": {
+                    "raw": -3000,
+                    "fmt": "-3k",
+                    "longFmt": "-3,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 222000,
+                    "fmt": "222k",
+                    "longFmt": "222,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 93000,
+                    "fmt": "93k",
+                    "longFmt": "93,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -238000,
+                    "fmt": "-238k",
+                    "longFmt": "-238,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -7694000,
+                    "fmt": "-7.69M",
+                    "longFmt": "-7,694,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -8899000,
+                    "fmt": "-8.9M",
+                    "longFmt": "-8,899,000"
+                  },
+                  "changeInCash": {
+                    "raw": -6661000,
+                    "fmt": "-6.66M",
+                    "longFmt": "-6,661,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -967000,
+                    "fmt": "-967k",
+                    "longFmt": "-967,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -2432000,
+                    "fmt": "-2.43M",
+                    "longFmt": "-2,432,000"
+                  },
+                  "depreciation": {
+                    "raw": 1076000,
+                    "fmt": "1.08M",
+                    "longFmt": "1,076,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 7136000,
+                    "fmt": "7.14M",
+                    "longFmt": "7,136,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 4440000,
+                    "fmt": "4.44M",
+                    "longFmt": "4,440,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 1686000,
+                    "fmt": "1.69M",
+                    "longFmt": "1,686,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 2903000,
+                    "fmt": "2.9M",
+                    "longFmt": "2,903,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 16217000,
+                    "fmt": "16.22M",
+                    "longFmt": "16,217,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -56000,
+                    "fmt": "-56k",
+                    "longFmt": "-56,000"
+                  },
+                  "investments": {
+                    "raw": -1538000,
+                    "fmt": "-1.54M",
+                    "longFmt": "-1,538,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 222000,
+                    "fmt": "222k",
+                    "longFmt": "222,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -1594000,
+                    "fmt": "-1.59M",
+                    "longFmt": "-1,594,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -5750000,
+                    "fmt": "-5.75M",
+                    "longFmt": "-5,750,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -27288000,
+                    "fmt": "-27.29M",
+                    "longFmt": "-27,288,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -33731000,
+                    "fmt": "-33.73M",
+                    "longFmt": "-33,731,000"
+                  },
+                  "changeInCash": {
+                    "raw": -19108000,
+                    "fmt": "-19.11M",
+                    "longFmt": "-19,108,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -693000,
+                    "fmt": "-693k",
+                    "longFmt": "-693,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 927000,
+                    "fmt": "927k",
+                    "longFmt": "927,000"
+                  },
+                  "depreciation": {
+                    "raw": 911000,
+                    "fmt": "911k",
+                    "longFmt": "911,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 20511000,
+                    "fmt": "20.51M",
+                    "longFmt": "20,511,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -110000,
+                    "fmt": "-110k",
+                    "longFmt": "-110,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -12014000,
+                    "fmt": "-12.01M",
+                    "longFmt": "-12,014,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -367000,
+                    "fmt": "-367k",
+                    "longFmt": "-367,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 12563000,
+                    "fmt": "12.56M",
+                    "longFmt": "12,563,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -73000,
+                    "fmt": "-73k",
+                    "longFmt": "-73,000"
+                  },
+                  "investments": {
+                    "raw": -35130000,
+                    "fmt": "-35.13M",
+                    "longFmt": "-35,130,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 222000,
+                    "fmt": "222k",
+                    "longFmt": "222,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -35203000,
+                    "fmt": "-35.2M",
+                    "longFmt": "-35,203,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -5766000,
+                    "fmt": "-5.77M",
+                    "longFmt": "-5,766,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 24308000,
+                    "fmt": "24.31M",
+                    "longFmt": "24,308,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -9836000,
+                    "fmt": "-9.84M",
+                    "longFmt": "-9,836,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 4404000,
+                    "fmt": "4.4M",
+                    "longFmt": "4,404,000"
+                  },
+                  "changeInCash": {
+                    "raw": -18236000,
+                    "fmt": "-18.24M",
+                    "longFmt": "-18,236,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -4302000,
+                    "fmt": "-4.3M",
+                    "longFmt": "-4,302,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 997000,
+                    "fmt": "997k",
+                    "longFmt": "997,000"
+                  },
+                  "depreciation": {
+                    "raw": 913000,
+                    "fmt": "913k",
+                    "longFmt": "913,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 12734000,
+                    "fmt": "12.73M",
+                    "longFmt": "12,734,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 1099000,
+                    "fmt": "1.1M",
+                    "longFmt": "1,099,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -1682000,
+                    "fmt": "-1.68M",
+                    "longFmt": "-1,682,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -142000,
+                    "fmt": "-142k",
+                    "longFmt": "-142,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 15895000,
+                    "fmt": "15.89M",
+                    "longFmt": "15,895,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -1935000,
+                    "fmt": "-1.94M",
+                    "longFmt": "-1,935,000"
+                  },
+                  "investments": {
+                    "raw": -16891000,
+                    "fmt": "-16.89M",
+                    "longFmt": "-16,891,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 222000,
+                    "fmt": "222k",
+                    "longFmt": "222,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -18826000,
+                    "fmt": "-18.83M",
+                    "longFmt": "-18,826,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -5521000,
+                    "fmt": "-5.52M",
+                    "longFmt": "-5,521,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 2075000,
+                    "fmt": "2.08M",
+                    "longFmt": "2,075,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -9550000,
+                    "fmt": "-9.55M",
+                    "longFmt": "-9,550,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -14194000,
+                    "fmt": "-14.19M",
+                    "longFmt": "-14,194,000"
+                  },
+                  "changeInCash": {
+                    "raw": -17125000,
+                    "fmt": "-17.12M",
+                    "longFmt": "-17,125,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -1198000,
+                    "fmt": "-1.2M",
+                    "longFmt": "-1,198,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistory-SI.json
+++ b/tests/http/quoteSummary-cashflowStatementHistory-SI.json
@@ -1,0 +1,364 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=cashflowStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "60ac5h1g2vse4"
+      ],
+      "x-yahoo-request-id": [
+        "60ac5h1g2vse4"
+      ],
+      "x-request-id": [
+        "8b9146c4-9b7b-4b84-a9f2-1a768acafd03"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1024"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:40 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistory": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 26038000,
+                    "fmt": "26.04M",
+                    "longFmt": "26,038,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 24846000,
+                    "fmt": "24.85M",
+                    "longFmt": "24,846,000"
+                  },
+                  "depreciation": {
+                    "raw": 2673000,
+                    "fmt": "2.67M",
+                    "longFmt": "2,673,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -149830000,
+                    "fmt": "-149.83M",
+                    "longFmt": "-149,830,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -3328000,
+                    "fmt": "-3.33M",
+                    "longFmt": "-3,328,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -126862000,
+                    "fmt": "-126.86M",
+                    "longFmt": "-126,862,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -1213000,
+                    "fmt": "-1.21M",
+                    "longFmt": "-1,213,000"
+                  },
+                  "investments": {
+                    "raw": -534336000,
+                    "fmt": "-534.34M",
+                    "longFmt": "-534,336,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -20764000,
+                    "fmt": "-20.76M",
+                    "longFmt": "-20,764,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -574501000,
+                    "fmt": "-574.5M",
+                    "longFmt": "-574,501,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 47857000,
+                    "fmt": "47.86M",
+                    "longFmt": "47,857,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 106385000,
+                    "fmt": "106.39M",
+                    "longFmt": "106,385,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 160547000,
+                    "fmt": "160.55M",
+                    "longFmt": "160,547,000"
+                  },
+                  "changeInCash": {
+                    "raw": -540816000,
+                    "fmt": "-540.82M",
+                    "longFmt": "-540,816,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -157000,
+                    "fmt": "-157k",
+                    "longFmt": "-157,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 6462000,
+                    "fmt": "6.46M",
+                    "longFmt": "6,462,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 22333000,
+                    "fmt": "22.33M",
+                    "longFmt": "22,333,000"
+                  },
+                  "depreciation": {
+                    "raw": 1178000,
+                    "fmt": "1.18M",
+                    "longFmt": "1,178,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -27184000,
+                    "fmt": "-27.18M",
+                    "longFmt": "-27,184,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 2967000,
+                    "fmt": "2.97M",
+                    "longFmt": "2,967,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -3067000,
+                    "fmt": "-3.07M",
+                    "longFmt": "-3,067,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -2664000,
+                    "fmt": "-2.66M",
+                    "longFmt": "-2,664,000"
+                  },
+                  "investments": {
+                    "raw": -167763000,
+                    "fmt": "-167.76M",
+                    "longFmt": "-167,763,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -2268000,
+                    "fmt": "-2.27M",
+                    "longFmt": "-2,268,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -206633000,
+                    "fmt": "-206.63M",
+                    "longFmt": "-206,633,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -16143000,
+                    "fmt": "-16.14M",
+                    "longFmt": "-16,143,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 6750000,
+                    "fmt": "6.75M",
+                    "longFmt": "6,750,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 86452000,
+                    "fmt": "86.45M",
+                    "longFmt": "86,452,000"
+                  },
+                  "changeInCash": {
+                    "raw": -123248000,
+                    "fmt": "-123.25M",
+                    "longFmt": "-123,248,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -12158000,
+                    "fmt": "-12.16M",
+                    "longFmt": "-12,158,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 108003000,
+                    "fmt": "108M",
+                    "longFmt": "108,003,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 7643000,
+                    "fmt": "7.64M",
+                    "longFmt": "7,643,000"
+                  },
+                  "depreciation": {
+                    "raw": 1103000,
+                    "fmt": "1.1M",
+                    "longFmt": "1,103,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -22200000,
+                    "fmt": "-22.2M",
+                    "longFmt": "-22,200,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -3806000,
+                    "fmt": "-3.81M",
+                    "longFmt": "-3,806,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -18246000,
+                    "fmt": "-18.25M",
+                    "longFmt": "-18,246,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -1119000,
+                    "fmt": "-1.12M",
+                    "longFmt": "-1,119,000"
+                  },
+                  "investments": {
+                    "raw": -101576000,
+                    "fmt": "-101.58M",
+                    "longFmt": "-101,576,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -170000,
+                    "fmt": "-170k",
+                    "longFmt": "-170,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -124868000,
+                    "fmt": "-124.87M",
+                    "longFmt": "-124,868,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -101143000,
+                    "fmt": "-101.14M",
+                    "longFmt": "-101,143,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 1007284000,
+                    "fmt": "1.01B",
+                    "longFmt": "1,007,284,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 906133000,
+                    "fmt": "906.13M",
+                    "longFmt": "906,133,000"
+                  },
+                  "changeInCash": {
+                    "raw": 763019000,
+                    "fmt": "763.02M",
+                    "longFmt": "763,019,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -8000,
+                    "fmt": "-8k",
+                    "longFmt": "-8,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 108003000,
+                    "fmt": "108M",
+                    "longFmt": "108,003,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-ABBV.json
+++ b/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-ABBV.json
@@ -1,0 +1,424 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=cashflowStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "bs20endg2vse6"
+      ],
+      "x-yahoo-request-id": [
+        "bs20endg2vse6"
+      ],
+      "x-request-id": [
+        "c19adff1-0d5b-49b6-9287-afcedcc2675e"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1134"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:41 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 36000000,
+                    "fmt": "36M",
+                    "longFmt": "36,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 2308000000,
+                    "fmt": "2.31B",
+                    "longFmt": "2,308,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 2292000000,
+                    "fmt": "2.29B",
+                    "longFmt": "2,292,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 265000000,
+                    "fmt": "265M",
+                    "longFmt": "265,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -31000000,
+                    "fmt": "-31M",
+                    "longFmt": "-31,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 1437000000,
+                    "fmt": "1.44B",
+                    "longFmt": "1,437,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 111000000,
+                    "fmt": "111M",
+                    "longFmt": "111,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -50000000,
+                    "fmt": "-50M",
+                    "longFmt": "-50,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 5830000000,
+                    "fmt": "5.83B",
+                    "longFmt": "5,830,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -217000000,
+                    "fmt": "-217M",
+                    "longFmt": "-217,000,000"
+                  },
+                  "investments": {
+                    "raw": 20000000,
+                    "fmt": "20M",
+                    "longFmt": "20,000,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -72000000,
+                    "fmt": "-72M",
+                    "longFmt": "-72,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -1149000000,
+                    "fmt": "-1.15B",
+                    "longFmt": "-1,149,000,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -2100000000,
+                    "fmt": "-2.1B",
+                    "longFmt": "-2,100,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -651000000,
+                    "fmt": "-651M",
+                    "longFmt": "-651,000,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -75000000,
+                    "fmt": "-75M",
+                    "longFmt": "-75,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -2814000000,
+                    "fmt": "-2.81B",
+                    "longFmt": "-2,814,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 6000000,
+                    "fmt": "6M",
+                    "longFmt": "6,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 1873000000,
+                    "fmt": "1.87B",
+                    "longFmt": "1,873,000,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -20000000,
+                    "fmt": "-20M",
+                    "longFmt": "-20,000,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 32000000,
+                    "fmt": "32M",
+                    "longFmt": "32,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "netIncome": {
+                    "raw": -738000000,
+                    "fmt": "-738M",
+                    "longFmt": "-738,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 1555000000,
+                    "fmt": "1.55B",
+                    "longFmt": "1,555,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 2123000000,
+                    "fmt": "2.12B",
+                    "longFmt": "2,123,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 482000000,
+                    "fmt": "482M",
+                    "longFmt": "482,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -599000000,
+                    "fmt": "-599M",
+                    "longFmt": "-599,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -197000000,
+                    "fmt": "-197M",
+                    "longFmt": "-197,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 259000000,
+                    "fmt": "259M",
+                    "longFmt": "259,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 3089000000,
+                    "fmt": "3.09B",
+                    "longFmt": "3,089,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -177000000,
+                    "fmt": "-177M",
+                    "longFmt": "-177,000,000"
+                  },
+                  "investments": {
+                    "raw": 1384000000,
+                    "fmt": "1.38B",
+                    "longFmt": "1,384,000,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 1459000000,
+                    "fmt": "1.46B",
+                    "longFmt": "1,459,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -35652000000,
+                    "fmt": "-35.65B",
+                    "longFmt": "-35,652,000,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -1752000000,
+                    "fmt": "-1.75B",
+                    "longFmt": "-1,752,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -763000000,
+                    "fmt": "-763M",
+                    "longFmt": "-763,000,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -101000000,
+                    "fmt": "-101M",
+                    "longFmt": "-101,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -2570000000,
+                    "fmt": "-2.57B",
+                    "longFmt": "-2,570,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 8000000,
+                    "fmt": "8M",
+                    "longFmt": "8,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": -35125000000,
+                    "fmt": "-35.12B",
+                    "longFmt": "-35,125,000,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -19000000,
+                    "fmt": "-19M",
+                    "longFmt": "-19,000,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 65000000,
+                    "fmt": "65M",
+                    "longFmt": "65,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "netIncome": {
+                    "raw": 3010000000,
+                    "fmt": "3.01B",
+                    "longFmt": "3,010,000,000"
+                  },
+                  "depreciation": {
+                    "raw": 559000000,
+                    "fmt": "559M",
+                    "longFmt": "559,000,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 332000000,
+                    "fmt": "332M",
+                    "longFmt": "332,000,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -1025000000,
+                    "fmt": "-1.02B",
+                    "longFmt": "-1,025,000,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 1065000000,
+                    "fmt": "1.06B",
+                    "longFmt": "1,065,000,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -107000000,
+                    "fmt": "-107M",
+                    "longFmt": "-107,000,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -19000000,
+                    "fmt": "-19M",
+                    "longFmt": "-19,000,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 3815000000,
+                    "fmt": "3.81B",
+                    "longFmt": "3,815,000,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -125000000,
+                    "fmt": "-125M",
+                    "longFmt": "-125,000,000"
+                  },
+                  "investments": {
+                    "raw": 13000000,
+                    "fmt": "13M",
+                    "longFmt": "13,000,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -5000000,
+                    "fmt": "-5M",
+                    "longFmt": "-5,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -129000000,
+                    "fmt": "-129M",
+                    "longFmt": "-129,000,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -1763000000,
+                    "fmt": "-1.76B",
+                    "longFmt": "-1,763,000,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -763000000,
+                    "fmt": "-763M",
+                    "longFmt": "-763,000,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -28000000,
+                    "fmt": "-28M",
+                    "longFmt": "-28,000,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -2422000000,
+                    "fmt": "-2.42B",
+                    "longFmt": "-2,422,000,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -46000000,
+                    "fmt": "-46M",
+                    "longFmt": "-46,000,000"
+                  },
+                  "changeInCash": {
+                    "raw": 1218000000,
+                    "fmt": "1.22B",
+                    "longFmt": "1,218,000,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -643000000,
+                    "fmt": "-643M",
+                    "longFmt": "-643,000,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 12000000,
+                    "fmt": "12M",
+                    "longFmt": "12,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-BRKS.json
+++ b/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-BRKS.json
@@ -1,0 +1,464 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=cashflowStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "9k508phg2vse6"
+      ],
+      "x-yahoo-request-id": [
+        "9k508phg2vse6"
+      ],
+      "x-request-id": [
+        "e6d63e5f-3a07-4442-b5f6-078a23f9bc74"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1308"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:42 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 26028000,
+                    "fmt": "26.03M",
+                    "longFmt": "26,028,000"
+                  },
+                  "depreciation": {
+                    "raw": 15746000,
+                    "fmt": "15.75M",
+                    "longFmt": "15,746,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 2755000,
+                    "fmt": "2.75M",
+                    "longFmt": "2,755,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -4504000,
+                    "fmt": "-4.5M",
+                    "longFmt": "-4,504,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 8913000,
+                    "fmt": "8.91M",
+                    "longFmt": "8,913,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -6307000,
+                    "fmt": "-6.31M",
+                    "longFmt": "-6,307,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 1099000,
+                    "fmt": "1.1M",
+                    "longFmt": "1,099,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 43730000,
+                    "fmt": "43.73M",
+                    "longFmt": "43,730,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -15227000,
+                    "fmt": "-15.23M",
+                    "longFmt": "-15,227,000"
+                  },
+                  "investments": {
+                    "raw": -4000,
+                    "fmt": "-4k",
+                    "longFmt": "-4,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -30292000,
+                    "fmt": "-30.29M",
+                    "longFmt": "-30,292,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -7424000,
+                    "fmt": "-7.42M",
+                    "longFmt": "-7,424,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -733000,
+                    "fmt": "-733k",
+                    "longFmt": "-733,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -8157000,
+                    "fmt": "-8.16M",
+                    "longFmt": "-8,157,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 11250000,
+                    "fmt": "11.25M",
+                    "longFmt": "11,250,000"
+                  },
+                  "changeInCash": {
+                    "raw": 16531000,
+                    "fmt": "16.53M",
+                    "longFmt": "16,531,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 28973000,
+                    "fmt": "28.97M",
+                    "longFmt": "28,973,000"
+                  },
+                  "depreciation": {
+                    "raw": 15736000,
+                    "fmt": "15.74M",
+                    "longFmt": "15,736,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 7699000,
+                    "fmt": "7.7M",
+                    "longFmt": "7,699,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -3036000,
+                    "fmt": "-3.04M",
+                    "longFmt": "-3,036,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -10593000,
+                    "fmt": "-10.59M",
+                    "longFmt": "-10,593,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 4551000,
+                    "fmt": "4.55M",
+                    "longFmt": "4,551,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 8469000,
+                    "fmt": "8.47M",
+                    "longFmt": "8,469,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 51799000,
+                    "fmt": "51.8M",
+                    "longFmt": "51,799,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -10239000,
+                    "fmt": "-10.24M",
+                    "longFmt": "-10,239,000"
+                  },
+                  "investments": {
+                    "raw": -949000,
+                    "fmt": "-949k",
+                    "longFmt": "-949,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 1000000,
+                    "fmt": "1M",
+                    "longFmt": "1,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -10189000,
+                    "fmt": "-10.19M",
+                    "longFmt": "-10,189,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -7386000,
+                    "fmt": "-7.39M",
+                    "longFmt": "-7,386,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -320000,
+                    "fmt": "-320k",
+                    "longFmt": "-320,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -5443000,
+                    "fmt": "-5.44M",
+                    "longFmt": "-5,443,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 6159000,
+                    "fmt": "6.16M",
+                    "longFmt": "6,159,000"
+                  },
+                  "changeInCash": {
+                    "raw": 42326000,
+                    "fmt": "42.33M",
+                    "longFmt": "42,326,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 2263000,
+                    "fmt": "2.26M",
+                    "longFmt": "2,263,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "netIncome": {
+                    "raw": 13696000,
+                    "fmt": "13.7M",
+                    "longFmt": "13,696,000"
+                  },
+                  "depreciation": {
+                    "raw": 16681000,
+                    "fmt": "16.68M",
+                    "longFmt": "16,681,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 4304000,
+                    "fmt": "4.3M",
+                    "longFmt": "4,304,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -3049000,
+                    "fmt": "-3.05M",
+                    "longFmt": "-3,049,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 6917000,
+                    "fmt": "6.92M",
+                    "longFmt": "6,917,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -8601000,
+                    "fmt": "-8.6M",
+                    "longFmt": "-8,601,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -3824000,
+                    "fmt": "-3.82M",
+                    "longFmt": "-3,824,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 26124000,
+                    "fmt": "26.12M",
+                    "longFmt": "26,124,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -8515000,
+                    "fmt": "-8.52M",
+                    "longFmt": "-8,515,000"
+                  },
+                  "investments": {
+                    "raw": -949000,
+                    "fmt": "-949k",
+                    "longFmt": "-949,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 1000000,
+                    "fmt": "1M",
+                    "longFmt": "1,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -8515000,
+                    "fmt": "-8.52M",
+                    "longFmt": "-8,515,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -7380000,
+                    "fmt": "-7.38M",
+                    "longFmt": "-7,380,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -732000,
+                    "fmt": "-732k",
+                    "longFmt": "-732,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -8110000,
+                    "fmt": "-8.11M",
+                    "longFmt": "-8,110,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 4898000,
+                    "fmt": "4.9M",
+                    "longFmt": "4,898,000"
+                  },
+                  "changeInCash": {
+                    "raw": 14397000,
+                    "fmt": "14.4M",
+                    "longFmt": "14,397,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 2000,
+                    "fmt": "2k",
+                    "longFmt": "2,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "netIncome": {
+                    "raw": 9127000,
+                    "fmt": "9.13M",
+                    "longFmt": "9,127,000"
+                  },
+                  "depreciation": {
+                    "raw": 16602000,
+                    "fmt": "16.6M",
+                    "longFmt": "16,602,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -88554000,
+                    "fmt": "-88.55M",
+                    "longFmt": "-88,554,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -14173000,
+                    "fmt": "-14.17M",
+                    "longFmt": "-14,173,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -206000,
+                    "fmt": "-206k",
+                    "longFmt": "-206,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -4759000,
+                    "fmt": "-4.76M",
+                    "longFmt": "-4,759,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 16163000,
+                    "fmt": "16.16M",
+                    "longFmt": "16,163,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -65800000,
+                    "fmt": "-65.8M",
+                    "longFmt": "-65,800,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -11556000,
+                    "fmt": "-11.56M",
+                    "longFmt": "-11,556,000"
+                  },
+                  "investments": {
+                    "raw": 10033000,
+                    "fmt": "10.03M",
+                    "longFmt": "10,033,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -1000000,
+                    "fmt": "-1M",
+                    "longFmt": "-1,000,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -17266000,
+                    "fmt": "-17.27M",
+                    "longFmt": "-17,266,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -7378000,
+                    "fmt": "-7.38M",
+                    "longFmt": "-7,378,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -320000,
+                    "fmt": "-320k",
+                    "longFmt": "-320,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -5368000,
+                    "fmt": "-5.37M",
+                    "longFmt": "-5,368,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -4611000,
+                    "fmt": "-4.61M",
+                    "longFmt": "-4,611,000"
+                  },
+                  "changeInCash": {
+                    "raw": -93045000,
+                    "fmt": "-93.05M",
+                    "longFmt": "-93,045,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 2330000,
+                    "fmt": "2.33M",
+                    "longFmt": "2,330,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-CRON.json
+++ b/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-CRON.json
@@ -1,0 +1,464 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=cashflowStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "5dg4uc5g2vse6"
+      ],
+      "x-yahoo-request-id": [
+        "5dg4uc5g2vse6"
+      ],
+      "x-request-id": [
+        "1b5f9809-e61c-400c-8a6c-c0feb5146be4"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1410"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:42 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 69033000,
+                    "fmt": "69.03M",
+                    "longFmt": "69,033,000"
+                  },
+                  "depreciation": {
+                    "raw": 2216000,
+                    "fmt": "2.22M",
+                    "longFmt": "2,216,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -100187000,
+                    "fmt": "-100.19M",
+                    "longFmt": "-100,187,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -2609000,
+                    "fmt": "-2.61M",
+                    "longFmt": "-2,609,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 10696000,
+                    "fmt": "10.7M",
+                    "longFmt": "10,696,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 5597000,
+                    "fmt": "5.6M",
+                    "longFmt": "5,597,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -12237000,
+                    "fmt": "-12.24M",
+                    "longFmt": "-12,237,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -27491000,
+                    "fmt": "-27.49M",
+                    "longFmt": "-27,491,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -7990000,
+                    "fmt": "-7.99M",
+                    "longFmt": "-7,990,000"
+                  },
+                  "investments": {
+                    "raw": 19368000,
+                    "fmt": "19.37M",
+                    "longFmt": "19,368,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -1988000,
+                    "fmt": "-1.99M",
+                    "longFmt": "-1,988,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -862000,
+                    "fmt": "-862k",
+                    "longFmt": "-862,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -3006000,
+                    "fmt": "-3.01M",
+                    "longFmt": "-3,006,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 20631000,
+                    "fmt": "20.63M",
+                    "longFmt": "20,631,000"
+                  },
+                  "changeInCash": {
+                    "raw": -11854000,
+                    "fmt": "-11.85M",
+                    "longFmt": "-11,854,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -2148000,
+                    "fmt": "-2.15M",
+                    "longFmt": "-2,148,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 4000,
+                    "fmt": "4k",
+                    "longFmt": "4,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "netIncome": {
+                    "raw": -106977000,
+                    "fmt": "-106.98M",
+                    "longFmt": "-106,977,000"
+                  },
+                  "depreciation": {
+                    "raw": 1717000,
+                    "fmt": "1.72M",
+                    "longFmt": "1,717,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 82053000,
+                    "fmt": "82.05M",
+                    "longFmt": "82,053,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -73000,
+                    "fmt": "-73k",
+                    "longFmt": "-73,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -5974000,
+                    "fmt": "-5.97M",
+                    "longFmt": "-5,974,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -12643000,
+                    "fmt": "-12.64M",
+                    "longFmt": "-12,643,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 3602000,
+                    "fmt": "3.6M",
+                    "longFmt": "3,602,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -38295000,
+                    "fmt": "-38.3M",
+                    "longFmt": "-38,295,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -6933000,
+                    "fmt": "-6.93M",
+                    "longFmt": "-6,933,000"
+                  },
+                  "investments": {
+                    "raw": -1243000,
+                    "fmt": "-1.24M",
+                    "longFmt": "-1,243,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -19287000,
+                    "fmt": "-19.29M",
+                    "longFmt": "-19,287,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -736000,
+                    "fmt": "-736k",
+                    "longFmt": "-736,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -735000,
+                    "fmt": "-735k",
+                    "longFmt": "-735,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 39621000,
+                    "fmt": "39.62M",
+                    "longFmt": "39,621,000"
+                  },
+                  "changeInCash": {
+                    "raw": -18696000,
+                    "fmt": "-18.7M",
+                    "longFmt": "-18,696,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -2148000,
+                    "fmt": "-2.15M",
+                    "longFmt": "-2,148,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 1000,
+                    "fmt": "1k",
+                    "longFmt": "1,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "netIncome": {
+                    "raw": 76040000,
+                    "fmt": "76.04M",
+                    "longFmt": "76,040,000"
+                  },
+                  "depreciation": {
+                    "raw": 1162000,
+                    "fmt": "1.16M",
+                    "longFmt": "1,162,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -100618000,
+                    "fmt": "-100.62M",
+                    "longFmt": "-100,618,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 1234000,
+                    "fmt": "1.23M",
+                    "longFmt": "1,234,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -1011000,
+                    "fmt": "-1.01M",
+                    "longFmt": "-1,011,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -11270000,
+                    "fmt": "-11.27M",
+                    "longFmt": "-11,270,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -4435000,
+                    "fmt": "-4.43M",
+                    "longFmt": "-4,435,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -38898000,
+                    "fmt": "-38.9M",
+                    "longFmt": "-38,898,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -6411000,
+                    "fmt": "-6.41M",
+                    "longFmt": "-6,411,000"
+                  },
+                  "investments": {
+                    "raw": 81114000,
+                    "fmt": "81.11M",
+                    "longFmt": "81,114,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 59086000,
+                    "fmt": "59.09M",
+                    "longFmt": "59,086,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -448000,
+                    "fmt": "-448k",
+                    "longFmt": "-448,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -448000,
+                    "fmt": "-448k",
+                    "longFmt": "-448,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -91037000,
+                    "fmt": "-91.04M",
+                    "longFmt": "-91,037,000"
+                  },
+                  "changeInCash": {
+                    "raw": -71297000,
+                    "fmt": "-71.3M",
+                    "longFmt": "-71,297,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -2148000,
+                    "fmt": "-2.15M",
+                    "longFmt": "-2,148,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 1000,
+                    "fmt": "1k",
+                    "longFmt": "1,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 36276217,
+                    "fmt": "36.28M",
+                    "longFmt": "36,276,217"
+                  },
+                  "depreciation": {
+                    "raw": 2455831,
+                    "fmt": "2.46M",
+                    "longFmt": "2,455,831"
+                  },
+                  "changeToNetincome": {
+                    "raw": -61557165,
+                    "fmt": "-61.56M",
+                    "longFmt": "-61,557,165"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -722046,
+                    "fmt": "-722.05k",
+                    "longFmt": "-722,046"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -14758564,
+                    "fmt": "-14.76M",
+                    "longFmt": "-14,758,564"
+                  },
+                  "changeToInventory": {
+                    "raw": -17220480,
+                    "fmt": "-17.22M",
+                    "longFmt": "-17,220,480"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 4606487,
+                    "fmt": "4.61M",
+                    "longFmt": "4,606,487"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -51044620,
+                    "fmt": "-51.04M",
+                    "longFmt": "-51,044,620"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -150015,
+                    "fmt": "-150.01k",
+                    "longFmt": "-150,015"
+                  },
+                  "investments": {
+                    "raw": 99483948,
+                    "fmt": "99.48M",
+                    "longFmt": "99,483,948"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -89000,
+                    "fmt": "-89k",
+                    "longFmt": "-89,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 95005561,
+                    "fmt": "95.01M",
+                    "longFmt": "95,005,561"
+                  },
+                  "netBorrowings": {
+                    "raw": 185553,
+                    "fmt": "185.55k",
+                    "longFmt": "185,553"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 231632,
+                    "fmt": "231.63k",
+                    "longFmt": "231,632"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -32356751,
+                    "fmt": "-32.36M",
+                    "longFmt": "-32,356,751"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 51759606,
+                    "fmt": "51.76M",
+                    "longFmt": "51,759,606"
+                  },
+                  "changeInCash": {
+                    "raw": 63363796,
+                    "fmt": "63.36M",
+                    "longFmt": "63,363,796"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -32773936,
+                    "fmt": "-32.77M",
+                    "longFmt": "-32,773,936"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 1000,
+                    "fmt": "1k",
+                    "longFmt": "1,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-EPAC.json
+++ b/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-EPAC.json
@@ -1,0 +1,484 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=cashflowStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "66inl3pg2vse6"
+      ],
+      "x-yahoo-request-id": [
+        "66inl3pg2vse6"
+      ],
+      "x-request-id": [
+        "4c8b13ce-f577-4627-89e1-e90505f30195"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1277"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:42 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1606694400,
+                    "fmt": "2020-11-30"
+                  },
+                  "netIncome": {
+                    "raw": 4598000,
+                    "fmt": "4.6M",
+                    "longFmt": "4,598,000"
+                  },
+                  "depreciation": {
+                    "raw": 5458000,
+                    "fmt": "5.46M",
+                    "longFmt": "5,458,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 2681000,
+                    "fmt": "2.68M",
+                    "longFmt": "2,681,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -6268000,
+                    "fmt": "-6.27M",
+                    "longFmt": "-6,268,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 1847000,
+                    "fmt": "1.85M",
+                    "longFmt": "1,847,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -1387000,
+                    "fmt": "-1.39M",
+                    "longFmt": "-1,387,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -848000,
+                    "fmt": "-848k",
+                    "longFmt": "-848,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 8667000,
+                    "fmt": "8.67M",
+                    "longFmt": "8,667,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -1905000,
+                    "fmt": "-1.91M",
+                    "longFmt": "-1,905,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -1858000,
+                    "fmt": "-1.86M",
+                    "longFmt": "-1,858,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -2394000,
+                    "fmt": "-2.39M",
+                    "longFmt": "-2,394,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 750000,
+                    "fmt": "750k",
+                    "longFmt": "750,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -1818000,
+                    "fmt": "-1.82M",
+                    "longFmt": "-1,818,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 1407000,
+                    "fmt": "1.41M",
+                    "longFmt": "1,407,000"
+                  },
+                  "changeInCash": {
+                    "raw": 6398000,
+                    "fmt": "6.4M",
+                    "longFmt": "6,398,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -275000,
+                    "fmt": "-275k",
+                    "longFmt": "-275,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 101000,
+                    "fmt": "101k",
+                    "longFmt": "101,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1598832000,
+                    "fmt": "2020-08-31"
+                  },
+                  "netIncome": {
+                    "raw": 1439000,
+                    "fmt": "1.44M",
+                    "longFmt": "1,439,000"
+                  },
+                  "depreciation": {
+                    "raw": 5347000,
+                    "fmt": "5.35M",
+                    "longFmt": "5,347,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -9632000,
+                    "fmt": "-9.63M",
+                    "longFmt": "-9,632,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 12004000,
+                    "fmt": "12M",
+                    "longFmt": "12,004,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -7835000,
+                    "fmt": "-7.83M",
+                    "longFmt": "-7,835,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 13126000,
+                    "fmt": "13.13M",
+                    "longFmt": "13,126,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -9767000,
+                    "fmt": "-9.77M",
+                    "longFmt": "-9,767,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 12544000,
+                    "fmt": "12.54M",
+                    "longFmt": "12,544,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -2745000,
+                    "fmt": "-2.75M",
+                    "longFmt": "-2,745,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 2674000,
+                    "fmt": "2.67M",
+                    "longFmt": "2,674,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 138000,
+                    "fmt": "138k",
+                    "longFmt": "138,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -2394000,
+                    "fmt": "-2.39M",
+                    "longFmt": "-2,394,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -32559000,
+                    "fmt": "-32.56M",
+                    "longFmt": "-32,559,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 750000,
+                    "fmt": "750k",
+                    "longFmt": "750,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -32528000,
+                    "fmt": "-32.53M",
+                    "longFmt": "-32,528,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 8413000,
+                    "fmt": "8.41M",
+                    "longFmt": "8,413,000"
+                  },
+                  "changeInCash": {
+                    "raw": -11433000,
+                    "fmt": "-11.43M",
+                    "longFmt": "-11,433,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -76000,
+                    "fmt": "-76k",
+                    "longFmt": "-76,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 107000,
+                    "fmt": "107k",
+                    "longFmt": "107,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1590883200,
+                    "fmt": "2020-05-31"
+                  },
+                  "netIncome": {
+                    "raw": -4999000,
+                    "fmt": "-5M",
+                    "longFmt": "-4,999,000"
+                  },
+                  "depreciation": {
+                    "raw": 5317000,
+                    "fmt": "5.32M",
+                    "longFmt": "5,317,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 4610000,
+                    "fmt": "4.61M",
+                    "longFmt": "4,610,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 18789000,
+                    "fmt": "18.79M",
+                    "longFmt": "18,789,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -9882000,
+                    "fmt": "-9.88M",
+                    "longFmt": "-9,882,000"
+                  },
+                  "changeToInventory": {
+                    "raw": -2268000,
+                    "fmt": "-2.27M",
+                    "longFmt": "-2,268,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 5295000,
+                    "fmt": "5.29M",
+                    "longFmt": "5,295,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 13038000,
+                    "fmt": "13.04M",
+                    "longFmt": "13,038,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -2341000,
+                    "fmt": "-2.34M",
+                    "longFmt": "-2,341,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 2674000,
+                    "fmt": "2.67M",
+                    "longFmt": "2,674,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -646000,
+                    "fmt": "-646k",
+                    "longFmt": "-646,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -2394000,
+                    "fmt": "-2.39M",
+                    "longFmt": "-2,394,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -32559000,
+                    "fmt": "-32.56M",
+                    "longFmt": "-32,559,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -234000,
+                    "fmt": "-234k",
+                    "longFmt": "-234,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -9999000,
+                    "fmt": "-10M",
+                    "longFmt": "-9,999,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": -2227000,
+                    "fmt": "-2.23M",
+                    "longFmt": "-2,227,000"
+                  },
+                  "changeInCash": {
+                    "raw": 166000,
+                    "fmt": "166k",
+                    "longFmt": "166,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -9862000,
+                    "fmt": "-9.86M",
+                    "longFmt": "-9,862,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 97000,
+                    "fmt": "97k",
+                    "longFmt": "97,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1582934400,
+                    "fmt": "2020-02-29"
+                  },
+                  "netIncome": {
+                    "raw": 2162000,
+                    "fmt": "2.16M",
+                    "longFmt": "2,162,000"
+                  },
+                  "depreciation": {
+                    "raw": 5277000,
+                    "fmt": "5.28M",
+                    "longFmt": "5,277,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 2496000,
+                    "fmt": "2.5M",
+                    "longFmt": "2,496,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 10805000,
+                    "fmt": "10.8M",
+                    "longFmt": "10,805,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -8278000,
+                    "fmt": "-8.28M",
+                    "longFmt": "-8,278,000"
+                  },
+                  "changeToInventory": {
+                    "raw": 3869000,
+                    "fmt": "3.87M",
+                    "longFmt": "3,869,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -17714000,
+                    "fmt": "-17.71M",
+                    "longFmt": "-17,714,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -5814000,
+                    "fmt": "-5.81M",
+                    "longFmt": "-5,814,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -3780000,
+                    "fmt": "-3.78M",
+                    "longFmt": "-3,780,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 175000,
+                    "fmt": "175k",
+                    "longFmt": "175,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -36761000,
+                    "fmt": "-36.76M",
+                    "longFmt": "-36,761,000"
+                  },
+                  "dividendsPaid": {
+                    "raw": -2394000,
+                    "fmt": "-2.39M",
+                    "longFmt": "-2,394,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -32559000,
+                    "fmt": "-32.56M",
+                    "longFmt": "-32,559,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -234000,
+                    "fmt": "-234k",
+                    "longFmt": "-234,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -1177000,
+                    "fmt": "-1.18M",
+                    "longFmt": "-1,177,000"
+                  },
+                  "effectOfExchangeRate": {
+                    "raw": 409000,
+                    "fmt": "409k",
+                    "longFmt": "409,000"
+                  },
+                  "changeInCash": {
+                    "raw": -43343000,
+                    "fmt": "-43.34M",
+                    "longFmt": "-43,343,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -1425000,
+                    "fmt": "-1.43M",
+                    "longFmt": "-1,425,000"
+                  },
+                  "issuanceOfStock": {
+                    "raw": 248000,
+                    "fmt": "248k",
+                    "longFmt": "248,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-MDLY.json
+++ b/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-MDLY.json
@@ -1,0 +1,384 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=cashflowStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "07ihj3dg2vse5"
+      ],
+      "x-yahoo-request-id": [
+        "07ihj3dg2vse5"
+      ],
+      "x-request-id": [
+        "abad5a05-1975-43ae-803e-04e58369e8ba"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "913"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:41 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": -122000,
+                    "fmt": "-122k",
+                    "longFmt": "-122,000"
+                  },
+                  "depreciation": {
+                    "raw": 180000,
+                    "fmt": "180k",
+                    "longFmt": "180,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -178000,
+                    "fmt": "-178k",
+                    "longFmt": "-178,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": -144000,
+                    "fmt": "-144k",
+                    "longFmt": "-144,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 98000,
+                    "fmt": "98k",
+                    "longFmt": "98,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -956000,
+                    "fmt": "-956k",
+                    "longFmt": "-956,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -760000,
+                    "fmt": "-760k",
+                    "longFmt": "-760,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -8000,
+                    "fmt": "-8k",
+                    "longFmt": "-8,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -8000,
+                    "fmt": "-8k",
+                    "longFmt": "-8,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -814000,
+                    "fmt": "-814k",
+                    "longFmt": "-814,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -837000,
+                    "fmt": "-837k",
+                    "longFmt": "-837,000"
+                  },
+                  "changeInCash": {
+                    "raw": -1605000,
+                    "fmt": "-1.6M",
+                    "longFmt": "-1,605,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -23000,
+                    "fmt": "-23k",
+                    "longFmt": "-23,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "netIncome": {
+                    "raw": -814000,
+                    "fmt": "-814k",
+                    "longFmt": "-814,000"
+                  },
+                  "depreciation": {
+                    "raw": 181000,
+                    "fmt": "181k",
+                    "longFmt": "181,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -6474000,
+                    "fmt": "-6.47M",
+                    "longFmt": "-6,474,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 1953000,
+                    "fmt": "1.95M",
+                    "longFmt": "1,953,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 7370000,
+                    "fmt": "7.37M",
+                    "longFmt": "7,370,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -1072000,
+                    "fmt": "-1.07M",
+                    "longFmt": "-1,072,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 1571000,
+                    "fmt": "1.57M",
+                    "longFmt": "1,571,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -8000,
+                    "fmt": "-8k",
+                    "longFmt": "-8,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -479000,
+                    "fmt": "-479k",
+                    "longFmt": "-479,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -36000,
+                    "fmt": "-36k",
+                    "longFmt": "-36,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -38000,
+                    "fmt": "-38k",
+                    "longFmt": "-38,000"
+                  },
+                  "changeInCash": {
+                    "raw": 1054000,
+                    "fmt": "1.05M",
+                    "longFmt": "1,054,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -2000,
+                    "fmt": "-2k",
+                    "longFmt": "-2,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "netIncome": {
+                    "raw": -1130000,
+                    "fmt": "-1.13M",
+                    "longFmt": "-1,130,000"
+                  },
+                  "depreciation": {
+                    "raw": 178000,
+                    "fmt": "178k",
+                    "longFmt": "178,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 123000,
+                    "fmt": "123k",
+                    "longFmt": "123,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 496000,
+                    "fmt": "496k",
+                    "longFmt": "496,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": -2130000,
+                    "fmt": "-2.13M",
+                    "longFmt": "-2,130,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": -599000,
+                    "fmt": "-599k",
+                    "longFmt": "-599,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -2612000,
+                    "fmt": "-2.61M",
+                    "longFmt": "-2,612,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -8000,
+                    "fmt": "-8k",
+                    "longFmt": "-8,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 27000,
+                    "fmt": "27k",
+                    "longFmt": "27,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 27000,
+                    "fmt": "27k",
+                    "longFmt": "27,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -1276000,
+                    "fmt": "-1.28M",
+                    "longFmt": "-1,276,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -1374000,
+                    "fmt": "-1.37M",
+                    "longFmt": "-1,374,000"
+                  },
+                  "changeInCash": {
+                    "raw": -3959000,
+                    "fmt": "-3.96M",
+                    "longFmt": "-3,959,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -98000,
+                    "fmt": "-98k",
+                    "longFmt": "-98,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "netIncome": {
+                    "raw": -2609000,
+                    "fmt": "-2.61M",
+                    "longFmt": "-2,609,000"
+                  },
+                  "depreciation": {
+                    "raw": 174000,
+                    "fmt": "174k",
+                    "longFmt": "174,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 2124000,
+                    "fmt": "2.12M",
+                    "longFmt": "2,124,000"
+                  },
+                  "changeToAccountReceivables": {
+                    "raw": 422000,
+                    "fmt": "422k",
+                    "longFmt": "422,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 130000,
+                    "fmt": "130k",
+                    "longFmt": "130,000"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 137000,
+                    "fmt": "137k",
+                    "longFmt": "137,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 855000,
+                    "fmt": "855k",
+                    "longFmt": "855,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -89000,
+                    "fmt": "-89k",
+                    "longFmt": "-89,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 27000,
+                    "fmt": "27k",
+                    "longFmt": "27,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -89000,
+                    "fmt": "-89k",
+                    "longFmt": "-89,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -877000,
+                    "fmt": "-877k",
+                    "longFmt": "-877,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -1333000,
+                    "fmt": "-1.33M",
+                    "longFmt": "-1,333,000"
+                  },
+                  "changeInCash": {
+                    "raw": -567000,
+                    "fmt": "-567k",
+                    "longFmt": "-567,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -456000,
+                    "fmt": "-456k",
+                    "longFmt": "-456,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-SI.json
+++ b/tests/http/quoteSummary-cashflowStatementHistoryQuarterly-SI.json
@@ -1,0 +1,349 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=cashflowStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "bo0g565g2vse5"
+      ],
+      "x-yahoo-request-id": [
+        "bo0g565g2vse5"
+      ],
+      "x-request-id": [
+        "e18d388f-b666-4893-9137-00b82f3b2398"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "983"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:41 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "cashflowStatementHistoryQuarterly": {
+              "cashflowStatements": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "netIncome": {
+                    "raw": 9119000,
+                    "fmt": "9.12M",
+                    "longFmt": "9,119,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "netIncome": {
+                    "raw": 7060000,
+                    "fmt": "7.06M",
+                    "longFmt": "7,060,000"
+                  },
+                  "depreciation": {
+                    "raw": 965000,
+                    "fmt": "965k",
+                    "longFmt": "965,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -344055000,
+                    "fmt": "-344.06M",
+                    "longFmt": "-344,055,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 2250000,
+                    "fmt": "2.25M",
+                    "longFmt": "2,250,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -338620000,
+                    "fmt": "-338.62M",
+                    "longFmt": "-338,620,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -123000,
+                    "fmt": "-123k",
+                    "longFmt": "-123,000"
+                  },
+                  "investments": {
+                    "raw": 19433000,
+                    "fmt": "19.43M",
+                    "longFmt": "19,433,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -289000,
+                    "fmt": "-289k",
+                    "longFmt": "-289,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": 76540000,
+                    "fmt": "76.54M",
+                    "longFmt": "76,540,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -350000000,
+                    "fmt": "-350M",
+                    "longFmt": "-350,000,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 610209000,
+                    "fmt": "610.21M",
+                    "longFmt": "610,209,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 260118000,
+                    "fmt": "260.12M",
+                    "longFmt": "260,118,000"
+                  },
+                  "changeInCash": {
+                    "raw": -1962000,
+                    "fmt": "-1.96M",
+                    "longFmt": "-1,962,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -91000,
+                    "fmt": "-91k",
+                    "longFmt": "-91,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "netIncome": {
+                    "raw": 5466000,
+                    "fmt": "5.47M",
+                    "longFmt": "5,466,000"
+                  },
+                  "depreciation": {
+                    "raw": 740000,
+                    "fmt": "740k",
+                    "longFmt": "740,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": 111623000,
+                    "fmt": "111.62M",
+                    "longFmt": "111,623,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 297000,
+                    "fmt": "297k",
+                    "longFmt": "297,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": 116244000,
+                    "fmt": "116.24M",
+                    "longFmt": "116,244,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -274000,
+                    "fmt": "-274k",
+                    "longFmt": "-274,000"
+                  },
+                  "investments": {
+                    "raw": 36230000,
+                    "fmt": "36.23M",
+                    "longFmt": "36,230,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": -2340000,
+                    "fmt": "-2.34M",
+                    "longFmt": "-2,340,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -80927000,
+                    "fmt": "-80.93M",
+                    "longFmt": "-80,927,000"
+                  },
+                  "netBorrowings": {
+                    "raw": 330000000,
+                    "fmt": "330M",
+                    "longFmt": "330,000,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": -332015000,
+                    "fmt": "-332.01M",
+                    "longFmt": "-332,015,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": -2073000,
+                    "fmt": "-2.07M",
+                    "longFmt": "-2,073,000"
+                  },
+                  "changeInCash": {
+                    "raw": 33244000,
+                    "fmt": "33.24M",
+                    "longFmt": "33,244,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -58000,
+                    "fmt": "-58k",
+                    "longFmt": "-58,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "netIncome": {
+                    "raw": 4393000,
+                    "fmt": "4.39M",
+                    "longFmt": "4,393,000"
+                  },
+                  "depreciation": {
+                    "raw": 830000,
+                    "fmt": "830k",
+                    "longFmt": "830,000"
+                  },
+                  "changeToNetincome": {
+                    "raw": -69966000,
+                    "fmt": "-69.97M",
+                    "longFmt": "-69,966,000"
+                  },
+                  "changeToLiabilities": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "changeToOperatingActivities": {
+                    "raw": 87000,
+                    "fmt": "87k",
+                    "longFmt": "87,000"
+                  },
+                  "totalCashFromOperatingActivities": {
+                    "raw": -65176000,
+                    "fmt": "-65.18M",
+                    "longFmt": "-65,176,000"
+                  },
+                  "capitalExpenditures": {
+                    "raw": -391000,
+                    "fmt": "-391k",
+                    "longFmt": "-391,000"
+                  },
+                  "investments": {
+                    "raw": -77034000,
+                    "fmt": "-77.03M",
+                    "longFmt": "-77,034,000"
+                  },
+                  "otherCashflowsFromInvestingActivities": {
+                    "raw": 13365000,
+                    "fmt": "13.37M",
+                    "longFmt": "13,365,000"
+                  },
+                  "totalCashflowsFromInvestingActivities": {
+                    "raw": -68786000,
+                    "fmt": "-68.79M",
+                    "longFmt": "-68,786,000"
+                  },
+                  "netBorrowings": {
+                    "raw": -21789000,
+                    "fmt": "-21.79M",
+                    "longFmt": "-21,789,000"
+                  },
+                  "otherCashflowsFromFinancingActivities": {
+                    "raw": 188348000,
+                    "fmt": "188.35M",
+                    "longFmt": "188,348,000"
+                  },
+                  "totalCashFromFinancingActivities": {
+                    "raw": 166558000,
+                    "fmt": "166.56M",
+                    "longFmt": "166,558,000"
+                  },
+                  "changeInCash": {
+                    "raw": 32596000,
+                    "fmt": "32.6M",
+                    "longFmt": "32,596,000"
+                  },
+                  "repurchaseOfStock": {
+                    "raw": -1000,
+                    "fmt": "-1k",
+                    "longFmt": "-1,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-defaultKeyStatistics-ABBV.json
+++ b/tests/http/quoteSummary-defaultKeyStatistics-ABBV.json
@@ -1,0 +1,120 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=defaultKeyStatistics"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "8bqqkstg2vse7"
+      ],
+      "x-yahoo-request-id": [
+        "8bqqkstg2vse7"
+      ],
+      "x-request-id": [
+        "c214355c-06fa-4147-807b-b372b8adaf26"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "574"
+      ],
+      "x-envoy-upstream-service-time": [
+        "5"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:42 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": 266400169984,
+              "forwardPE": 7.6772,
+              "profitMargins": 0.10078,
+              "floatShares": 1737614744,
+              "sharesOutstanding": 1765469952,
+              "sharesShort": 14874548,
+              "sharesShortPriorMonth": 13334764,
+              "sharesShortPreviousMonthDate": 1609372800,
+              "dateShortInterest": 1611878400,
+              "sharesPercentSharesOut": 0.0084,
+              "heldPercentInsiders": 0.001,
+              "heldPercentInstitutions": 0.70001,
+              "shortRatio": 1.99,
+              "shortPercentOfFloat": 0.0084,
+              "beta": 0.80683,
+              "category": null,
+              "bookValue": 8.65,
+              "priceToBook": 12.203642,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1609372800,
+              "nextFiscalYearEnd": 1672444800,
+              "mostRecentQuarter": 1609372800,
+              "earningsQuarterlyGrowth": -0.987,
+              "netIncomeToCommon": 4616000000,
+              "trailingEps": 2.72,
+              "forwardEps": 13.75,
+              "pegRatio": 1.9,
+              "lastSplitFactor": null,
+              "enterpriseToRevenue": 5.816,
+              "enterpriseToEbitda": 12.375,
+              "52WeekChange": 0.116891265,
+              "SandP52WeekChange": 0.17263722,
+              "lastDividendValue": 1.3,
+              "lastDividendDate": 1610582400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-defaultKeyStatistics-BRKS.json
+++ b/tests/http/quoteSummary-defaultKeyStatistics-BRKS.json
@@ -1,0 +1,120 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=defaultKeyStatistics"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "59o3audg2vse7"
+      ],
+      "x-yahoo-request-id": [
+        "59o3audg2vse7"
+      ],
+      "x-request-id": [
+        "c2536844-371f-4c57-ac8b-bba0ab67b934"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "575"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:43 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": 5856073216,
+              "forwardPE": 38.493393,
+              "profitMargins": 0.08312,
+              "floatShares": 71729128,
+              "sharesOutstanding": 74220096,
+              "sharesShort": 2188456,
+              "sharesShortPriorMonth": 2341236,
+              "sharesShortPreviousMonthDate": 1609372800,
+              "dateShortInterest": 1611878400,
+              "sharesPercentSharesOut": 0.0295,
+              "heldPercentInsiders": 0.01582,
+              "heldPercentInstitutions": 1.00236,
+              "shortRatio": 1.55,
+              "shortPercentOfFloat": 0.0399,
+              "beta": 1.930096,
+              "category": null,
+              "bookValue": 17.118,
+              "priceToBook": 5.104568,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1601424000,
+              "nextFiscalYearEnd": 1664496000,
+              "mostRecentQuarter": 1609372800,
+              "earningsQuarterlyGrowth": 0.993,
+              "netIncomeToCommon": 78868000,
+              "trailingEps": 1.046,
+              "forwardEps": 2.27,
+              "pegRatio": 2.92,
+              "lastSplitFactor": null,
+              "enterpriseToRevenue": 6.255,
+              "enterpriseToEbitda": 34.865,
+              "52WeekChange": 1.1730819,
+              "SandP52WeekChange": 0.17263722,
+              "lastDividendValue": 0.1,
+              "lastDividendDate": 1606953600
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-defaultKeyStatistics-CRON.json
+++ b/tests/http/quoteSummary-defaultKeyStatistics-CRON.json
@@ -1,0 +1,115 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=defaultKeyStatistics"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "9dt6mjhg2vse7"
+      ],
+      "x-yahoo-request-id": [
+        "9dt6mjhg2vse7"
+      ],
+      "x-request-id": [
+        "450d8b2c-8887-4ce5-9e99-207b4e258ee8"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "546"
+      ],
+      "x-envoy-upstream-service-time": [
+        "5"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:43 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": 2875855360,
+              "profitMargins": 2.70682,
+              "floatShares": 189769814,
+              "sharesOutstanding": 356187008,
+              "sharesShort": 26086914,
+              "sharesShortPriorMonth": 28728929,
+              "sharesShortPreviousMonthDate": 1609372800,
+              "dateShortInterest": 1611878400,
+              "sharesPercentSharesOut": 0.0732,
+              "heldPercentInsiders": 0.49218,
+              "heldPercentInstitutions": 0.14603,
+              "shortRatio": 4.34,
+              "shortPercentOfFloat": 0.13949999,
+              "beta": 1.990234,
+              "category": null,
+              "bookValue": 4.967,
+              "priceToBook": 2.4461446,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1577750400,
+              "nextFiscalYearEnd": 1640908800,
+              "mostRecentQuarter": 1601424000,
+              "earningsQuarterlyGrowth": -0.886,
+              "netIncomeToCommon": 100557000,
+              "trailingEps": 0.287,
+              "lastSplitFactor": null,
+              "enterpriseToRevenue": 77.766,
+              "enterpriseToEbitda": -16.254,
+              "52WeekChange": 0.6391609,
+              "SandP52WeekChange": 0.17263722
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-defaultKeyStatistics-EPAC.json
+++ b/tests/http/quoteSummary-defaultKeyStatistics-EPAC.json
@@ -1,0 +1,117 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=defaultKeyStatistics"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "fdj16klg2vse8"
+      ],
+      "x-yahoo-request-id": [
+        "fdj16klg2vse8"
+      ],
+      "x-request-id": [
+        "ce9e7ffd-6215-432e-be92-2e769d11d415"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "566"
+      ],
+      "x-envoy-upstream-service-time": [
+        "5"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:44 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": 1456103936,
+              "forwardPE": 30.657894,
+              "profitMargins": 0.0068699997,
+              "floatShares": 59256192,
+              "sharesOutstanding": 59871100,
+              "sharesShort": 1583647,
+              "sharesShortPriorMonth": 2103413,
+              "sharesShortPreviousMonthDate": 1609372800,
+              "dateShortInterest": 1611878400,
+              "sharesPercentSharesOut": 0.026500002,
+              "heldPercentInsiders": 0.00569,
+              "heldPercentInstitutions": 1.04787,
+              "shortRatio": 5.81,
+              "shortPercentOfFloat": 0.040799998,
+              "beta": 1.450373,
+              "category": null,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1598832000,
+              "nextFiscalYearEnd": 1661904000,
+              "mostRecentQuarter": 1606694400,
+              "earningsQuarterlyGrowth": 1.168,
+              "netIncomeToCommon": 4007000,
+              "pegRatio": 3.8,
+              "lastSplitFactor": "2:1",
+              "lastSplitDate": 1194566400,
+              "enterpriseToRevenue": 3.124,
+              "enterpriseToEbitda": 33.177,
+              "52WeekChange": -0.11032587,
+              "SandP52WeekChange": 0.17263722,
+              "lastDividendValue": 0.04,
+              "lastDividendDate": 1601510400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-defaultKeyStatistics-MDLY.json
+++ b/tests/http/quoteSummary-defaultKeyStatistics-MDLY.json
@@ -1,0 +1,118 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=defaultKeyStatistics"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "5aq4ogdg2vse7"
+      ],
+      "x-yahoo-request-id": [
+        "5aq4ogdg2vse7"
+      ],
+      "x-request-id": [
+        "f5d9468c-ef58-4e91-bd2f-d24918d6a0e8"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "564"
+      ],
+      "x-envoy-upstream-service-time": [
+        "7"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:42 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": 13253203,
+              "profitMargins": -0.13196,
+              "floatShares": 219759,
+              "sharesOutstanding": 3045180,
+              "sharesShort": 77266,
+              "sharesShortPriorMonth": 37908,
+              "sharesShortPreviousMonthDate": 1609372800,
+              "dateShortInterest": 1611878400,
+              "sharesPercentSharesOut": 0.0135,
+              "heldPercentInsiders": 0.12206,
+              "heldPercentInstitutions": 0.17618999,
+              "shortRatio": 0.25,
+              "shortPercentOfFloat": 0.0257,
+              "beta": 1.89381,
+              "impliedSharesOutstanding": 5718700,
+              "category": null,
+              "bookValue": -12.142,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1577750400,
+              "nextFiscalYearEnd": 1640908800,
+              "mostRecentQuarter": 1601424000,
+              "netIncomeToCommon": -4901000,
+              "trailingEps": -7.855,
+              "forwardEps": 0.25,
+              "lastSplitFactor": "1:10",
+              "lastSplitDate": 1604275200,
+              "enterpriseToRevenue": 0.374,
+              "enterpriseToEbitda": 4.634,
+              "52WeekChange": -0.6452632,
+              "SandP52WeekChange": 0.17263722,
+              "lastDividendValue": 0.035,
+              "lastDividendDate": 1585267200
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-defaultKeyStatistics-SI.json
+++ b/tests/http/quoteSummary-defaultKeyStatistics-SI.json
@@ -1,0 +1,116 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=defaultKeyStatistics"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "1v251dtg2vse6"
+      ],
+      "x-yahoo-request-id": [
+        "1v251dtg2vse6"
+      ],
+      "x-request-id": [
+        "bea2976f-7248-4648-b7b1-8067940882d7"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "543"
+      ],
+      "x-envoy-upstream-service-time": [
+        "6"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:42 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "defaultKeyStatistics": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "enterpriseValue": -95470000,
+              "forwardPE": 68.48207,
+              "profitMargins": 0.28972,
+              "floatShares": 15552272,
+              "sharesOutstanding": 22754500,
+              "sharesShort": 1076061,
+              "sharesShortPriorMonth": 995808,
+              "sharesShortPreviousMonthDate": 1609372800,
+              "dateShortInterest": 1611878400,
+              "sharesPercentSharesOut": 0.047199998,
+              "heldPercentInsiders": 0.05487,
+              "heldPercentInstitutions": 0.65436995,
+              "shortRatio": 0.76,
+              "shortPercentOfFloat": 0.053400002,
+              "impliedSharesOutstanding": 22818700,
+              "category": null,
+              "bookValue": 15.701,
+              "priceToBook": 10.94771,
+              "fundFamily": null,
+              "legalType": null,
+              "lastFiscalYearEnd": 1609372800,
+              "nextFiscalYearEnd": 1672444800,
+              "mostRecentQuarter": 1609372800,
+              "earningsQuarterlyGrowth": 1.534,
+              "netIncomeToCommon": 26038000,
+              "trailingEps": 1.36,
+              "forwardEps": 2.51,
+              "lastSplitFactor": null,
+              "enterpriseToRevenue": -1.062,
+              "52WeekChange": 8.262048,
+              "SandP52WeekChange": 0.17263722
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earnings-ABBV.json
+++ b/tests/http/quoteSummary-earnings-ABBV.json
@@ -1,0 +1,162 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=earnings"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "64qn11pg2vse8"
+      ],
+      "x-yahoo-request-id": [
+        "64qn11pg2vse8"
+      ],
+      "x-request-id": [
+        "75f6b9f0-7355-4648-a4f1-08efd32df29d"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "360"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:44 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [
+                  {
+                    "date": "1Q2020",
+                    "actual": 2.42,
+                    "estimate": 2.25
+                  },
+                  {
+                    "date": "2Q2020",
+                    "actual": 2.34,
+                    "estimate": 2.19
+                  },
+                  {
+                    "date": "3Q2020",
+                    "actual": 2.83,
+                    "estimate": 2.76
+                  },
+                  {
+                    "date": "4Q2020",
+                    "actual": 2.92,
+                    "estimate": 2.85
+                  }
+                ],
+                "currentQuarterEstimate": 2.79,
+                "currentQuarterEstimateDate": "1Q",
+                "currentQuarterEstimateYear": 2021,
+                "earningsDate": [
+                  1619654400,
+                  1620000000
+                ]
+              },
+              "financialsChart": {
+                "yearly": [
+                  {
+                    "date": 2017,
+                    "revenue": 28216000000,
+                    "earnings": 5309000000
+                  },
+                  {
+                    "date": 2018,
+                    "revenue": 32753000000,
+                    "earnings": 5687000000
+                  },
+                  {
+                    "date": 2019,
+                    "revenue": 33266000000,
+                    "earnings": 7882000000
+                  },
+                  {
+                    "date": 2020,
+                    "revenue": 45804000000,
+                    "earnings": 4616000000
+                  }
+                ],
+                "quarterly": [
+                  {
+                    "date": "1Q2020",
+                    "revenue": 8619000000,
+                    "earnings": 3010000000
+                  },
+                  {
+                    "date": "2Q2020",
+                    "revenue": 10425000000,
+                    "earnings": -738000000
+                  },
+                  {
+                    "date": "3Q2020",
+                    "revenue": 12902000000,
+                    "earnings": 2308000000
+                  },
+                  {
+                    "date": "4Q2020",
+                    "revenue": 13858000000,
+                    "earnings": 36000000
+                  }
+                ]
+              },
+              "financialCurrency": "USD"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earnings-BRKS.json
+++ b/tests/http/quoteSummary-earnings-BRKS.json
@@ -1,0 +1,162 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=earnings"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "721jn2lg2vse8"
+      ],
+      "x-yahoo-request-id": [
+        "721jn2lg2vse8"
+      ],
+      "x-request-id": [
+        "ef3d0a81-1696-4c47-b58a-2e5ee18b6cf8"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "367"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:44 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [
+                  {
+                    "date": "1Q2020",
+                    "actual": 0.25,
+                    "estimate": 0.24
+                  },
+                  {
+                    "date": "2Q2020",
+                    "actual": 0.32,
+                    "estimate": 0.2
+                  },
+                  {
+                    "date": "3Q2020",
+                    "actual": 0.47,
+                    "estimate": 0.36
+                  },
+                  {
+                    "date": "4Q2020",
+                    "actual": 0.47,
+                    "estimate": 0.42
+                  }
+                ],
+                "currentQuarterEstimate": 0.5,
+                "currentQuarterEstimateDate": "1Q",
+                "currentQuarterEstimateYear": 2021,
+                "earningsDate": [
+                  1619568000,
+                  1620000000
+                ]
+              },
+              "financialsChart": {
+                "yearly": [
+                  {
+                    "date": 2017,
+                    "revenue": 527499000,
+                    "earnings": 62612000
+                  },
+                  {
+                    "date": 2018,
+                    "revenue": 631560000,
+                    "earnings": 116575000
+                  },
+                  {
+                    "date": 2019,
+                    "revenue": 780848000,
+                    "earnings": 437416000
+                  },
+                  {
+                    "date": 2020,
+                    "revenue": 897273000,
+                    "earnings": 64853000
+                  }
+                ],
+                "quarterly": [
+                  {
+                    "date": "1Q2020",
+                    "revenue": 220227000,
+                    "earnings": 9127000
+                  },
+                  {
+                    "date": "2Q2020",
+                    "revenue": 220350000,
+                    "earnings": 13696000
+                  },
+                  {
+                    "date": "3Q2020",
+                    "revenue": 246196000,
+                    "earnings": 28973000
+                  },
+                  {
+                    "date": "4Q2020",
+                    "revenue": 249503000,
+                    "earnings": 26028000
+                  }
+                ]
+              },
+              "financialCurrency": "USD"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earnings-CRON.json
+++ b/tests/http/quoteSummary-earnings-CRON.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=earnings"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "eus87q5g2vse8"
+      ],
+      "x-yahoo-request-id": [
+        "eus87q5g2vse8"
+      ],
+      "x-request-id": [
+        "5b901b0e-eebc-4e7a-bcd2-88fcd70ae0d2"
+      ],
+      "content-length": [
+        "141"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:44 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "3"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=earnings"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earnings-EPAC.json
+++ b/tests/http/quoteSummary-earnings-EPAC.json
@@ -1,0 +1,162 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=earnings"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "4arcdttg2vse9"
+      ],
+      "x-yahoo-request-id": [
+        "4arcdttg2vse9"
+      ],
+      "x-request-id": [
+        "f5c57c6a-517c-47ab-92a2-0fd5bdc501b6"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "367"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:44 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [
+                  {
+                    "date": "1Q2020",
+                    "actual": 0.09,
+                    "estimate": 0.12
+                  },
+                  {
+                    "date": "2Q2020",
+                    "actual": -0.06,
+                    "estimate": 0.11
+                  },
+                  {
+                    "date": "3Q2020",
+                    "actual": 0.02,
+                    "estimate": 0.08
+                  },
+                  {
+                    "date": "4Q2020",
+                    "actual": 0.09,
+                    "estimate": 0.1
+                  }
+                ],
+                "currentQuarterEstimate": 0.12,
+                "currentQuarterEstimateDate": "1Q",
+                "currentQuarterEstimateYear": 2021,
+                "earningsDate": [
+                  1615939200,
+                  1616371200
+                ]
+              },
+              "financialsChart": {
+                "yearly": [
+                  {
+                    "date": 2017,
+                    "revenue": 616591000,
+                    "earnings": -66213000
+                  },
+                  {
+                    "date": 2018,
+                    "revenue": 641303000,
+                    "earnings": -21648000
+                  },
+                  {
+                    "date": 2019,
+                    "revenue": 654758000,
+                    "earnings": -249145000
+                  },
+                  {
+                    "date": 2020,
+                    "revenue": 493292000,
+                    "earnings": 723000
+                  }
+                ],
+                "quarterly": [
+                  {
+                    "date": "1Q2020",
+                    "revenue": 133386000,
+                    "earnings": 2162000
+                  },
+                  {
+                    "date": "2Q2020",
+                    "revenue": 101879000,
+                    "earnings": -4999000
+                  },
+                  {
+                    "date": "3Q2020",
+                    "revenue": 111353000,
+                    "earnings": 1439000
+                  },
+                  {
+                    "date": "4Q2020",
+                    "revenue": 119430000,
+                    "earnings": 4598000
+                  }
+                ]
+              },
+              "financialCurrency": "USD"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earnings-MDLY.json
+++ b/tests/http/quoteSummary-earnings-MDLY.json
@@ -1,0 +1,160 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=earnings"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "9ugauvdg2vse8"
+      ],
+      "x-yahoo-request-id": [
+        "9ugauvdg2vse8"
+      ],
+      "x-request-id": [
+        "ef55fabc-6519-4432-8735-5167425a0d03"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "353"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:44 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [
+                  {
+                    "date": "3Q2019",
+                    "actual": -0.23,
+                    "estimate": -0.01
+                  },
+                  {
+                    "date": "4Q2019",
+                    "actual": -0.4,
+                    "estimate": -0.02
+                  },
+                  {
+                    "date": "1Q2020",
+                    "actual": -0.7,
+                    "estimate": -0.04
+                  },
+                  {
+                    "date": "2Q2020",
+                    "actual": -1.1,
+                    "estimate": -0.05
+                  }
+                ],
+                "currentQuarterEstimateDate": "3Q",
+                "currentQuarterEstimateYear": 2020,
+                "earningsDate": [
+                  1605484800
+                ]
+              },
+              "financialsChart": {
+                "yearly": [
+                  {
+                    "date": 2016,
+                    "revenue": 75941000,
+                    "earnings": 997000
+                  },
+                  {
+                    "date": 2017,
+                    "revenue": 65033000,
+                    "earnings": 927000
+                  },
+                  {
+                    "date": 2018,
+                    "revenue": 56509000,
+                    "earnings": -2432000
+                  },
+                  {
+                    "date": 2019,
+                    "revenue": 48841000,
+                    "earnings": -3379000
+                  }
+                ],
+                "quarterly": [
+                  {
+                    "date": "4Q2019",
+                    "revenue": 10653000,
+                    "earnings": -2609000
+                  },
+                  {
+                    "date": "1Q2020",
+                    "revenue": 7872000,
+                    "earnings": -1130000
+                  },
+                  {
+                    "date": "2Q2020",
+                    "revenue": 8577000,
+                    "earnings": -814000
+                  },
+                  {
+                    "date": "3Q2020",
+                    "revenue": 8326000,
+                    "earnings": -122000
+                  }
+                ]
+              },
+              "financialCurrency": "USD"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earnings-SI.json
+++ b/tests/http/quoteSummary-earnings-SI.json
@@ -1,0 +1,161 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=earnings"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "dkn5u3tg2vse8"
+      ],
+      "x-yahoo-request-id": [
+        "dkn5u3tg2vse8"
+      ],
+      "x-request-id": [
+        "4c972aea-2d2f-4426-b0b5-c98c9012f28b"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "357"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:43 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earnings": {
+              "maxAge": 86400,
+              "earningsChart": {
+                "quarterly": [
+                  {
+                    "date": "1Q2020",
+                    "actual": 0.23,
+                    "estimate": 0.18
+                  },
+                  {
+                    "date": "2Q2020",
+                    "actual": 0.29,
+                    "estimate": 0.19
+                  },
+                  {
+                    "date": "3Q2020",
+                    "actual": 0.37,
+                    "estimate": 0.22
+                  },
+                  {
+                    "date": "4Q2020",
+                    "actual": 0.47,
+                    "estimate": 0.38
+                  }
+                ],
+                "currentQuarterEstimate": 0.45,
+                "currentQuarterEstimateDate": "1Q",
+                "currentQuarterEstimateYear": 2021,
+                "earningsDate": [
+                  1611187200
+                ]
+              },
+              "financialsChart": {
+                "yearly": [
+                  {
+                    "date": 2017,
+                    "revenue": 45137000,
+                    "earnings": 7643000
+                  },
+                  {
+                    "date": 2018,
+                    "revenue": 78713000,
+                    "earnings": 22333000
+                  },
+                  {
+                    "date": 2019,
+                    "revenue": 87150000,
+                    "earnings": 24846000
+                  },
+                  {
+                    "date": 2020,
+                    "revenue": 89874000,
+                    "earnings": 26038000
+                  }
+                ],
+                "quarterly": [
+                  {
+                    "date": "1Q2020",
+                    "revenue": 19117000,
+                    "earnings": 4393000
+                  },
+                  {
+                    "date": "2Q2020",
+                    "revenue": 21264000,
+                    "earnings": 5466000
+                  },
+                  {
+                    "date": "3Q2020",
+                    "revenue": 22890000,
+                    "earnings": 7060000
+                  },
+                  {
+                    "date": "4Q2020",
+                    "revenue": 26603000,
+                    "earnings": 9119000
+                  }
+                ]
+              },
+              "financialCurrency": "USD"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsHistory-ABBV.json
+++ b/tests/http/quoteSummary-earningsHistory-ABBV.json
@@ -1,0 +1,182 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=earningsHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "burjsk1g2vse9"
+      ],
+      "x-yahoo-request-id": [
+        "burjsk1g2vse9"
+      ],
+      "x-request-id": [
+        "89af2e5c-5dae-4d38-aa18-d47d48ae22b8"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "335"
+      ],
+      "x-envoy-upstream-service-time": [
+        "77"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:45 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 2.42,
+                    "fmt": "2.42"
+                  },
+                  "epsEstimate": {
+                    "raw": 2.25,
+                    "fmt": "2.25"
+                  },
+                  "epsDifference": {
+                    "raw": 0.17,
+                    "fmt": "0.17"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.076,
+                    "fmt": "7.60%"
+                  },
+                  "quarter": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 2.34,
+                    "fmt": "2.34"
+                  },
+                  "epsEstimate": {
+                    "raw": 2.19,
+                    "fmt": "2.19"
+                  },
+                  "epsDifference": {
+                    "raw": 0.15,
+                    "fmt": "0.15"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.068,
+                    "fmt": "6.80%"
+                  },
+                  "quarter": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 2.83,
+                    "fmt": "2.83"
+                  },
+                  "epsEstimate": {
+                    "raw": 2.76,
+                    "fmt": "2.76"
+                  },
+                  "epsDifference": {
+                    "raw": 0.07,
+                    "fmt": "0.07"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.025,
+                    "fmt": "2.50%"
+                  },
+                  "quarter": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 2.92,
+                    "fmt": "2.92"
+                  },
+                  "epsEstimate": {
+                    "raw": 2.85,
+                    "fmt": "2.85"
+                  },
+                  "epsDifference": {
+                    "raw": 0.07,
+                    "fmt": "0.07"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.025,
+                    "fmt": "2.50%"
+                  },
+                  "quarter": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsHistory-BRKS.json
+++ b/tests/http/quoteSummary-earningsHistory-BRKS.json
@@ -1,0 +1,182 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=earningsHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "cfp5v1hg2vse9"
+      ],
+      "x-yahoo-request-id": [
+        "cfp5v1hg2vse9"
+      ],
+      "x-request-id": [
+        "02ce54d5-2d5a-4d84-8850-597618cca0f7"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "342"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:45 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.25,
+                    "fmt": "0.25"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.24,
+                    "fmt": "0.24"
+                  },
+                  "epsDifference": {
+                    "raw": 0.01,
+                    "fmt": "0.01"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.042,
+                    "fmt": "4.20%"
+                  },
+                  "quarter": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.32,
+                    "fmt": "0.32"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.2,
+                    "fmt": "0.2"
+                  },
+                  "epsDifference": {
+                    "raw": 0.12,
+                    "fmt": "0.12"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.6,
+                    "fmt": "60.00%"
+                  },
+                  "quarter": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.47,
+                    "fmt": "0.47"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.36,
+                    "fmt": "0.36"
+                  },
+                  "epsDifference": {
+                    "raw": 0.11,
+                    "fmt": "0.11"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.306,
+                    "fmt": "30.60%"
+                  },
+                  "quarter": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.47,
+                    "fmt": "0.47"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.42,
+                    "fmt": "0.42"
+                  },
+                  "epsDifference": {
+                    "raw": 0.05,
+                    "fmt": "0.05"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.118999995,
+                    "fmt": "11.90%"
+                  },
+                  "quarter": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsHistory-CRON.json
+++ b/tests/http/quoteSummary-earningsHistory-CRON.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=earningsHistory"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "bknfma9g2vsea"
+      ],
+      "x-yahoo-request-id": [
+        "bknfma9g2vsea"
+      ],
+      "x-request-id": [
+        "65d97dcd-b520-429b-9cef-6bfcd1a2940e"
+      ],
+      "content-length": [
+        "148"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:45 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=earningsHistory"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsHistory-EPAC.json
+++ b/tests/http/quoteSummary-earningsHistory-EPAC.json
@@ -1,0 +1,182 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=earningsHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "dg7aom1g2vsea"
+      ],
+      "x-yahoo-request-id": [
+        "dg7aom1g2vsea"
+      ],
+      "x-request-id": [
+        "80c47440-dfd7-43f4-8910-900ad0521364"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "342"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:46 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.09,
+                    "fmt": "0.09"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.12,
+                    "fmt": "0.12"
+                  },
+                  "epsDifference": {
+                    "raw": -0.03,
+                    "fmt": "-0.03"
+                  },
+                  "surprisePercent": {
+                    "raw": -0.25,
+                    "fmt": "-25.00%"
+                  },
+                  "quarter": {
+                    "raw": 1582934400,
+                    "fmt": "2020-02-29"
+                  },
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": -0.06,
+                    "fmt": "-0.06"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.11,
+                    "fmt": "0.11"
+                  },
+                  "epsDifference": {
+                    "raw": -0.17,
+                    "fmt": "-0.17"
+                  },
+                  "surprisePercent": {
+                    "raw": -1.545,
+                    "fmt": "-154.50%"
+                  },
+                  "quarter": {
+                    "raw": 1590883200,
+                    "fmt": "2020-05-31"
+                  },
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.02,
+                    "fmt": "0.02"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.08,
+                    "fmt": "0.08"
+                  },
+                  "epsDifference": {
+                    "raw": -0.06,
+                    "fmt": "-0.06"
+                  },
+                  "surprisePercent": {
+                    "raw": -0.75,
+                    "fmt": "-75.00%"
+                  },
+                  "quarter": {
+                    "raw": 1598832000,
+                    "fmt": "2020-08-31"
+                  },
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.09,
+                    "fmt": "0.09"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.1,
+                    "fmt": "0.1"
+                  },
+                  "epsDifference": {
+                    "raw": -0.01,
+                    "fmt": "-0.01"
+                  },
+                  "surprisePercent": {
+                    "raw": -0.1,
+                    "fmt": "-10.00%"
+                  },
+                  "quarter": {
+                    "raw": 1606694400,
+                    "fmt": "2020-11-30"
+                  },
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsHistory-MDLY.json
+++ b/tests/http/quoteSummary-earningsHistory-MDLY.json
@@ -1,0 +1,182 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=earningsHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "64j9mcdg2vse9"
+      ],
+      "x-yahoo-request-id": [
+        "64j9mcdg2vse9"
+      ],
+      "x-request-id": [
+        "a84b1aa9-ced0-45a7-8587-9ca100851e3f"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "348"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:45 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": -0.23,
+                    "fmt": "-0.23"
+                  },
+                  "epsEstimate": {
+                    "raw": -0.01,
+                    "fmt": "-0.01"
+                  },
+                  "epsDifference": {
+                    "raw": -0.22,
+                    "fmt": "-0.22"
+                  },
+                  "surprisePercent": {
+                    "raw": -22,
+                    "fmt": "-2,200.00%"
+                  },
+                  "quarter": {
+                    "raw": 1569801600,
+                    "fmt": "2019-09-30"
+                  },
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": -0.4,
+                    "fmt": "-0.4"
+                  },
+                  "epsEstimate": {
+                    "raw": -0.02,
+                    "fmt": "-0.02"
+                  },
+                  "epsDifference": {
+                    "raw": -0.38,
+                    "fmt": "-0.38"
+                  },
+                  "surprisePercent": {
+                    "raw": -19,
+                    "fmt": "-1,900.00%"
+                  },
+                  "quarter": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": -0.7,
+                    "fmt": "-0.7"
+                  },
+                  "epsEstimate": {
+                    "raw": -0.04,
+                    "fmt": "-0.04"
+                  },
+                  "epsDifference": {
+                    "raw": -0.66,
+                    "fmt": "-0.66"
+                  },
+                  "surprisePercent": {
+                    "raw": -16.5,
+                    "fmt": "-1,650.00%"
+                  },
+                  "quarter": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": -1.1,
+                    "fmt": "-1.1"
+                  },
+                  "epsEstimate": {
+                    "raw": -0.05,
+                    "fmt": "-0.05"
+                  },
+                  "epsDifference": {
+                    "raw": -1.05,
+                    "fmt": "-1.05"
+                  },
+                  "surprisePercent": {
+                    "raw": -21,
+                    "fmt": "-2,100.00%"
+                  },
+                  "quarter": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsHistory-SI.json
+++ b/tests/http/quoteSummary-earningsHistory-SI.json
@@ -1,0 +1,182 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=earningsHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "aqfmc6tg2vse9"
+      ],
+      "x-yahoo-request-id": [
+        "aqfmc6tg2vse9"
+      ],
+      "x-request-id": [
+        "8aab980e-2f1b-4a40-bed9-036a4830f6d5"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "346"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:44 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsHistory": {
+              "history": [
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.23,
+                    "fmt": "0.23"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.18,
+                    "fmt": "0.18"
+                  },
+                  "epsDifference": {
+                    "raw": 0.05,
+                    "fmt": "0.05"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.278,
+                    "fmt": "27.80%"
+                  },
+                  "quarter": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "period": "-4q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.29,
+                    "fmt": "0.29"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.19,
+                    "fmt": "0.19"
+                  },
+                  "epsDifference": {
+                    "raw": 0.1,
+                    "fmt": "0.1"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.52599996,
+                    "fmt": "52.60%"
+                  },
+                  "quarter": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "period": "-3q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.37,
+                    "fmt": "0.37"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.22,
+                    "fmt": "0.22"
+                  },
+                  "epsDifference": {
+                    "raw": 0.15,
+                    "fmt": "0.15"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.682,
+                    "fmt": "68.20%"
+                  },
+                  "quarter": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "period": "-2q"
+                },
+                {
+                  "maxAge": 1,
+                  "epsActual": {
+                    "raw": 0.47,
+                    "fmt": "0.47"
+                  },
+                  "epsEstimate": {
+                    "raw": 0.38,
+                    "fmt": "0.38"
+                  },
+                  "epsDifference": {
+                    "raw": 0.09,
+                    "fmt": "0.09"
+                  },
+                  "surprisePercent": {
+                    "raw": 0.237,
+                    "fmt": "23.70%"
+                  },
+                  "quarter": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "period": "-1q"
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsTrend-ABBV.json
+++ b/tests/http/quoteSummary-earningsTrend-ABBV.json
@@ -1,0 +1,590 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=earningsTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "3dbg6npg2vsea"
+      ],
+      "x-yahoo-request-id": [
+        "3dbg6npg2vsea"
+      ],
+      "x-request-id": [
+        "189c0a13-5462-412c-ad08-666d5e75dcc0"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1037"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:46 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": "2021-03-31",
+                  "growth": {
+                    "raw": 0.153,
+                    "fmt": "15.30%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 2.79,
+                      "fmt": "2.79"
+                    },
+                    "low": {
+                      "raw": 2.14,
+                      "fmt": "2.14"
+                    },
+                    "high": {
+                      "raw": 3.01,
+                      "fmt": "3.01"
+                    },
+                    "yearAgoEps": {
+                      "raw": 2.42,
+                      "fmt": "2.42"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 13,
+                      "fmt": "13",
+                      "longFmt": "13"
+                    },
+                    "growth": {
+                      "raw": 0.153,
+                      "fmt": "15.30%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 12819100000,
+                      "fmt": "12.82B",
+                      "longFmt": "12,819,100,000"
+                    },
+                    "low": {
+                      "raw": 12663000000,
+                      "fmt": "12.66B",
+                      "longFmt": "12,663,000,000"
+                    },
+                    "high": {
+                      "raw": 13478000000,
+                      "fmt": "13.48B",
+                      "longFmt": "13,478,000,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 12,
+                      "fmt": "12",
+                      "longFmt": "12"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 8619000000,
+                      "fmt": "8.62B",
+                      "longFmt": "8,619,000,000"
+                    },
+                    "growth": {
+                      "raw": 0.48700002,
+                      "fmt": "48.70%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 2.79,
+                      "fmt": "2.79"
+                    },
+                    "7daysAgo": {
+                      "raw": 2.79,
+                      "fmt": "2.79"
+                    },
+                    "30daysAgo": {
+                      "raw": 2.85,
+                      "fmt": "2.85"
+                    },
+                    "60daysAgo": {
+                      "raw": 2.86,
+                      "fmt": "2.86"
+                    },
+                    "90daysAgo": {
+                      "raw": 2.81,
+                      "fmt": "2.81"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 3,
+                      "fmt": "3",
+                      "longFmt": "3"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": "2021-06-30",
+                  "growth": {
+                    "raw": 0.269,
+                    "fmt": "26.90%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 2.97,
+                      "fmt": "2.97"
+                    },
+                    "low": {
+                      "raw": 1.93,
+                      "fmt": "1.93"
+                    },
+                    "high": {
+                      "raw": 3.13,
+                      "fmt": "3.13"
+                    },
+                    "yearAgoEps": {
+                      "raw": 2.34,
+                      "fmt": "2.34"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 13,
+                      "fmt": "13",
+                      "longFmt": "13"
+                    },
+                    "growth": {
+                      "raw": 0.269,
+                      "fmt": "26.90%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 13554000000,
+                      "fmt": "13.55B",
+                      "longFmt": "13,554,000,000"
+                    },
+                    "low": {
+                      "raw": 13083000000,
+                      "fmt": "13.08B",
+                      "longFmt": "13,083,000,000"
+                    },
+                    "high": {
+                      "raw": 13757000000,
+                      "fmt": "13.76B",
+                      "longFmt": "13,757,000,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 12,
+                      "fmt": "12",
+                      "longFmt": "12"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 10082100000,
+                      "fmt": "10.08B",
+                      "longFmt": "10,082,100,000"
+                    },
+                    "growth": {
+                      "raw": 0.344,
+                      "fmt": "34.40%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 2.97,
+                      "fmt": "2.97"
+                    },
+                    "7daysAgo": {
+                      "raw": 2.97,
+                      "fmt": "2.97"
+                    },
+                    "30daysAgo": {
+                      "raw": 2.96,
+                      "fmt": "2.96"
+                    },
+                    "60daysAgo": {
+                      "raw": 2.94,
+                      "fmt": "2.94"
+                    },
+                    "90daysAgo": {
+                      "raw": 2.91,
+                      "fmt": "2.91"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": "2021-12-31",
+                  "growth": {
+                    "raw": 0.177,
+                    "fmt": "17.70%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 12.43,
+                      "fmt": "12.43"
+                    },
+                    "low": {
+                      "raw": 11.94,
+                      "fmt": "11.94"
+                    },
+                    "high": {
+                      "raw": 12.75,
+                      "fmt": "12.75"
+                    },
+                    "yearAgoEps": {
+                      "raw": 10.56,
+                      "fmt": "10.56"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 16,
+                      "fmt": "16",
+                      "longFmt": "16"
+                    },
+                    "growth": {
+                      "raw": 0.177,
+                      "fmt": "17.70%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 55351600000,
+                      "fmt": "55.35B",
+                      "longFmt": "55,351,600,000"
+                    },
+                    "low": {
+                      "raw": 53395000000,
+                      "fmt": "53.4B",
+                      "longFmt": "53,395,000,000"
+                    },
+                    "high": {
+                      "raw": 56349000000,
+                      "fmt": "56.35B",
+                      "longFmt": "56,349,000,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 15,
+                      "fmt": "15",
+                      "longFmt": "15"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 45784000000,
+                      "fmt": "45.78B",
+                      "longFmt": "45,784,000,000"
+                    },
+                    "growth": {
+                      "raw": 0.20899999,
+                      "fmt": "20.90%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 12.43,
+                      "fmt": "12.43"
+                    },
+                    "7daysAgo": {
+                      "raw": 12.43,
+                      "fmt": "12.43"
+                    },
+                    "30daysAgo": {
+                      "raw": 12.19,
+                      "fmt": "12.19"
+                    },
+                    "60daysAgo": {
+                      "raw": 12.19,
+                      "fmt": "12.19"
+                    },
+                    "90daysAgo": {
+                      "raw": 12.19,
+                      "fmt": "12.19"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 12,
+                      "fmt": "12",
+                      "longFmt": "12"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": "2022-12-31",
+                  "growth": {
+                    "raw": 0.106000006,
+                    "fmt": "10.60%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 13.75,
+                      "fmt": "13.75"
+                    },
+                    "low": {
+                      "raw": 12.63,
+                      "fmt": "12.63"
+                    },
+                    "high": {
+                      "raw": 14.5,
+                      "fmt": "14.5"
+                    },
+                    "yearAgoEps": {
+                      "raw": 12.43,
+                      "fmt": "12.43"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 15,
+                      "fmt": "15",
+                      "longFmt": "15"
+                    },
+                    "growth": {
+                      "raw": 0.106000006,
+                      "fmt": "10.60%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 58865800000,
+                      "fmt": "58.87B",
+                      "longFmt": "58,865,800,000"
+                    },
+                    "low": {
+                      "raw": 55134000000,
+                      "fmt": "55.13B",
+                      "longFmt": "55,134,000,000"
+                    },
+                    "high": {
+                      "raw": 60787000000,
+                      "fmt": "60.79B",
+                      "longFmt": "60,787,000,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 14,
+                      "fmt": "14",
+                      "longFmt": "14"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 55351600000,
+                      "fmt": "55.35B",
+                      "longFmt": "55,351,600,000"
+                    },
+                    "growth": {
+                      "raw": 0.063,
+                      "fmt": "6.30%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 13.75,
+                      "fmt": "13.75"
+                    },
+                    "7daysAgo": {
+                      "raw": 13.75,
+                      "fmt": "13.75"
+                    },
+                    "30daysAgo": {
+                      "raw": 13.68,
+                      "fmt": "13.68"
+                    },
+                    "60daysAgo": {
+                      "raw": 13.7,
+                      "fmt": "13.7"
+                    },
+                    "90daysAgo": {
+                      "raw": 13.58,
+                      "fmt": "13.58"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 6,
+                      "fmt": "6",
+                      "longFmt": "6"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": 0.0477,
+                    "fmt": "4.77%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": 0.21909,
+                    "fmt": "21.91%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsTrend-BRKS.json
+++ b/tests/http/quoteSummary-earningsTrend-BRKS.json
@@ -1,0 +1,576 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=earningsTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "76sqab1g2vseb"
+      ],
+      "x-yahoo-request-id": [
+        "76sqab1g2vseb"
+      ],
+      "x-request-id": [
+        "b3c24d42-7c9d-4434-91f7-70c7b41d7eb0"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "901"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:47 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": "2021-03-31",
+                  "growth": {
+                    "raw": 1,
+                    "fmt": "100.00%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.5,
+                      "fmt": "0.5"
+                    },
+                    "low": {
+                      "raw": 0.47,
+                      "fmt": "0.47"
+                    },
+                    "high": {
+                      "raw": 0.52,
+                      "fmt": "0.52"
+                    },
+                    "yearAgoEps": {
+                      "raw": 0.25,
+                      "fmt": "0.25"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "growth": {
+                      "raw": 1,
+                      "fmt": "100.00%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 272280000,
+                      "fmt": "272.28M",
+                      "longFmt": "272,280,000"
+                    },
+                    "low": {
+                      "raw": 267000000,
+                      "fmt": "267M",
+                      "longFmt": "267,000,000"
+                    },
+                    "high": {
+                      "raw": 275000000,
+                      "fmt": "275M",
+                      "longFmt": "275,000,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.5,
+                      "fmt": "0.5"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.5,
+                      "fmt": "0.5"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.41,
+                      "fmt": "0.41"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.41,
+                      "fmt": "0.41"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.41,
+                      "fmt": "0.41"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": "2021-06-30",
+                  "growth": {
+                    "raw": 0.625,
+                    "fmt": "62.50%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.52,
+                      "fmt": "0.52"
+                    },
+                    "low": {
+                      "raw": 0.49,
+                      "fmt": "0.49"
+                    },
+                    "high": {
+                      "raw": 0.54,
+                      "fmt": "0.54"
+                    },
+                    "yearAgoEps": {
+                      "raw": 0.32,
+                      "fmt": "0.32"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "growth": {
+                      "raw": 0.625,
+                      "fmt": "62.50%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 273800000,
+                      "fmt": "273.8M",
+                      "longFmt": "273,800,000"
+                    },
+                    "low": {
+                      "raw": 271500000,
+                      "fmt": "271.5M",
+                      "longFmt": "271,500,000"
+                    },
+                    "high": {
+                      "raw": 277000000,
+                      "fmt": "277M",
+                      "longFmt": "277,000,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.52,
+                      "fmt": "0.52"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.52,
+                      "fmt": "0.52"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.43,
+                      "fmt": "0.43"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.43,
+                      "fmt": "0.43"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.43,
+                      "fmt": "0.43"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": "2021-09-30",
+                  "growth": {
+                    "raw": 0.579,
+                    "fmt": "57.90%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 1.99,
+                      "fmt": "1.99"
+                    },
+                    "low": {
+                      "raw": 1.94,
+                      "fmt": "1.94"
+                    },
+                    "high": {
+                      "raw": 2.06,
+                      "fmt": "2.06"
+                    },
+                    "yearAgoEps": {
+                      "raw": 1.26,
+                      "fmt": "1.26"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "growth": {
+                      "raw": 0.579,
+                      "fmt": "57.90%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 1065180000,
+                      "fmt": "1.07B",
+                      "longFmt": "1,065,180,000"
+                    },
+                    "low": {
+                      "raw": 1059000000,
+                      "fmt": "1.06B",
+                      "longFmt": "1,059,000,000"
+                    },
+                    "high": {
+                      "raw": 1073600000,
+                      "fmt": "1.07B",
+                      "longFmt": "1,073,600,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 897273000,
+                      "fmt": "897.27M",
+                      "longFmt": "897,273,000"
+                    },
+                    "growth": {
+                      "raw": 0.187,
+                      "fmt": "18.70%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 1.99,
+                      "fmt": "1.99"
+                    },
+                    "7daysAgo": {
+                      "raw": 1.99,
+                      "fmt": "1.99"
+                    },
+                    "30daysAgo": {
+                      "raw": 1.73,
+                      "fmt": "1.73"
+                    },
+                    "60daysAgo": {
+                      "raw": 1.72,
+                      "fmt": "1.72"
+                    },
+                    "90daysAgo": {
+                      "raw": 1.72,
+                      "fmt": "1.72"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 6,
+                      "fmt": "6",
+                      "longFmt": "6"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": "2022-09-30",
+                  "growth": {
+                    "raw": 0.141,
+                    "fmt": "14.10%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 2.27,
+                      "fmt": "2.27"
+                    },
+                    "low": {
+                      "raw": 2.12,
+                      "fmt": "2.12"
+                    },
+                    "high": {
+                      "raw": 2.4,
+                      "fmt": "2.4"
+                    },
+                    "yearAgoEps": {
+                      "raw": 1.99,
+                      "fmt": "1.99"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 4,
+                      "fmt": "4",
+                      "longFmt": "4"
+                    },
+                    "growth": {
+                      "raw": 0.141,
+                      "fmt": "14.10%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 1161180000,
+                      "fmt": "1.16B",
+                      "longFmt": "1,161,180,000"
+                    },
+                    "low": {
+                      "raw": 1151900000,
+                      "fmt": "1.15B",
+                      "longFmt": "1,151,900,000"
+                    },
+                    "high": {
+                      "raw": 1172800000,
+                      "fmt": "1.17B",
+                      "longFmt": "1,172,800,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 4,
+                      "fmt": "4",
+                      "longFmt": "4"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 1065180000,
+                      "fmt": "1.07B",
+                      "longFmt": "1,065,180,000"
+                    },
+                    "growth": {
+                      "raw": 0.09,
+                      "fmt": "9.00%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 2.27,
+                      "fmt": "2.27"
+                    },
+                    "7daysAgo": {
+                      "raw": 2.27,
+                      "fmt": "2.27"
+                    },
+                    "30daysAgo": {
+                      "raw": 2.13,
+                      "fmt": "2.13"
+                    },
+                    "60daysAgo": {
+                      "raw": 2.11,
+                      "fmt": "2.11"
+                    },
+                    "90daysAgo": {
+                      "raw": 2.11,
+                      "fmt": "2.11"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 4,
+                      "fmt": "4",
+                      "longFmt": "4"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": 0.12,
+                    "fmt": "12.00%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": 0.39747003,
+                    "fmt": "39.75%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsTrend-CRON.json
+++ b/tests/http/quoteSummary-earningsTrend-CRON.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=earningsTrend"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "06n2iglg2vseb"
+      ],
+      "x-yahoo-request-id": [
+        "06n2iglg2vseb"
+      ],
+      "x-request-id": [
+        "2353096a-e662-4fff-a73a-06a8d3473c02"
+      ],
+      "content-length": [
+        "146"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:47 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=earningsTrend"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsTrend-EPAC.json
+++ b/tests/http/quoteSummary-earningsTrend-EPAC.json
@@ -1,0 +1,583 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=earningsTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "0t1vjptg2vseb"
+      ],
+      "x-yahoo-request-id": [
+        "0t1vjptg2vseb"
+      ],
+      "x-request-id": [
+        "6e05e0b4-7858-4758-8778-2daa987fc139"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "923"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:47 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": "2021-02-28",
+                  "growth": {
+                    "raw": 0.333,
+                    "fmt": "33.30%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "low": {
+                      "raw": 0.1,
+                      "fmt": "0.1"
+                    },
+                    "high": {
+                      "raw": 0.15,
+                      "fmt": "0.15"
+                    },
+                    "yearAgoEps": {
+                      "raw": 0.09,
+                      "fmt": "0.09"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "growth": {
+                      "raw": 0.333,
+                      "fmt": "33.30%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 126060000,
+                      "fmt": "126.06M",
+                      "longFmt": "126,060,000"
+                    },
+                    "low": {
+                      "raw": 119800000,
+                      "fmt": "119.8M",
+                      "longFmt": "119,800,000"
+                    },
+                    "high": {
+                      "raw": 130900000,
+                      "fmt": "130.9M",
+                      "longFmt": "130,900,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.12,
+                      "fmt": "0.12"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.11,
+                      "fmt": "0.11"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.11,
+                      "fmt": "0.11"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": "2021-05-31",
+                  "growth": {
+                    "raw": 3.667,
+                    "fmt": "366.70%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.16,
+                      "fmt": "0.16"
+                    },
+                    "low": {
+                      "raw": 0.14,
+                      "fmt": "0.14"
+                    },
+                    "high": {
+                      "raw": 0.2,
+                      "fmt": "0.2"
+                    },
+                    "yearAgoEps": {
+                      "raw": -0.06,
+                      "fmt": "-0.06"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "growth": {
+                      "raw": 3.667,
+                      "fmt": "366.70%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 135460000,
+                      "fmt": "135.46M",
+                      "longFmt": "135,460,000"
+                    },
+                    "low": {
+                      "raw": 128300000,
+                      "fmt": "128.3M",
+                      "longFmt": "128,300,000"
+                    },
+                    "high": {
+                      "raw": 145000000,
+                      "fmt": "145M",
+                      "longFmt": "145,000,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 125850000,
+                      "fmt": "125.85M",
+                      "longFmt": "125,850,000"
+                    },
+                    "growth": {
+                      "raw": 0.076,
+                      "fmt": "7.60%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.16,
+                      "fmt": "0.16"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.16,
+                      "fmt": "0.16"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.16,
+                      "fmt": "0.16"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.16,
+                      "fmt": "0.16"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.16,
+                      "fmt": "0.16"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": "2021-08-31",
+                  "growth": {
+                    "raw": 1.9439999,
+                    "fmt": "194.40%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.53,
+                      "fmt": "0.53"
+                    },
+                    "low": {
+                      "raw": 0.47,
+                      "fmt": "0.47"
+                    },
+                    "high": {
+                      "raw": 0.63,
+                      "fmt": "0.63"
+                    },
+                    "yearAgoEps": {
+                      "raw": 0.18,
+                      "fmt": "0.18"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 6,
+                      "fmt": "6",
+                      "longFmt": "6"
+                    },
+                    "growth": {
+                      "raw": 1.9439999,
+                      "fmt": "194.40%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 515080000,
+                      "fmt": "515.08M",
+                      "longFmt": "515,080,000"
+                    },
+                    "low": {
+                      "raw": 503400000,
+                      "fmt": "503.4M",
+                      "longFmt": "503,400,000"
+                    },
+                    "high": {
+                      "raw": 538000000,
+                      "fmt": "538M",
+                      "longFmt": "538,000,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 6,
+                      "fmt": "6",
+                      "longFmt": "6"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 493292000,
+                      "fmt": "493.29M",
+                      "longFmt": "493,292,000"
+                    },
+                    "growth": {
+                      "raw": 0.044,
+                      "fmt": "4.40%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.53,
+                      "fmt": "0.53"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.53,
+                      "fmt": "0.53"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.53,
+                      "fmt": "0.53"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.54,
+                      "fmt": "0.54"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.54,
+                      "fmt": "0.54"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": "2022-08-31",
+                  "growth": {
+                    "raw": 0.43400002,
+                    "fmt": "43.40%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.76,
+                      "fmt": "0.76"
+                    },
+                    "low": {
+                      "raw": 0.65,
+                      "fmt": "0.65"
+                    },
+                    "high": {
+                      "raw": 0.84,
+                      "fmt": "0.84"
+                    },
+                    "yearAgoEps": {
+                      "raw": 0.53,
+                      "fmt": "0.53"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 6,
+                      "fmt": "6",
+                      "longFmt": "6"
+                    },
+                    "growth": {
+                      "raw": 0.43400002,
+                      "fmt": "43.40%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 552830000,
+                      "fmt": "552.83M",
+                      "longFmt": "552,830,000"
+                    },
+                    "low": {
+                      "raw": 544400000,
+                      "fmt": "544.4M",
+                      "longFmt": "544,400,000"
+                    },
+                    "high": {
+                      "raw": 562000000,
+                      "fmt": "562M",
+                      "longFmt": "562,000,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 6,
+                      "fmt": "6",
+                      "longFmt": "6"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 515080000,
+                      "fmt": "515.08M",
+                      "longFmt": "515,080,000"
+                    },
+                    "growth": {
+                      "raw": 0.073,
+                      "fmt": "7.30%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.76,
+                      "fmt": "0.76"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.76,
+                      "fmt": "0.76"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.76,
+                      "fmt": "0.76"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.78,
+                      "fmt": "0.78"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.79,
+                      "fmt": "0.79"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": 0.122,
+                    "fmt": "12.20%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": -0.09474,
+                    "fmt": "-9.47%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsTrend-MDLY.json
+++ b/tests/http/quoteSummary-earningsTrend-MDLY.json
@@ -1,0 +1,557 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=earningsTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "dt7uuh9g2vsea"
+      ],
+      "x-yahoo-request-id": [
+        "dt7uuh9g2vsea"
+      ],
+      "x-request-id": [
+        "e1e31248-b955-4bfd-8e59-e8b68cddf25d"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "677"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:46 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": "2020-09-30",
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {
+                      "raw": -0.23,
+                      "fmt": "-0.23"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 8326000,
+                      "fmt": "8.33M",
+                      "longFmt": "8,326,000"
+                    },
+                    "low": {
+                      "raw": 8310000,
+                      "fmt": "8.31M",
+                      "longFmt": "8,310,000"
+                    },
+                    "high": {
+                      "raw": 8310000,
+                      "fmt": "8.31M",
+                      "longFmt": "8,310,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 11536000,
+                      "fmt": "11.54M",
+                      "longFmt": "11,536,000"
+                    },
+                    "growth": {
+                      "raw": -0.278,
+                      "fmt": "-27.80%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": -0.04,
+                      "fmt": "-0.04"
+                    },
+                    "30daysAgo": {
+                      "raw": -0.04,
+                      "fmt": "-0.04"
+                    },
+                    "60daysAgo": {
+                      "raw": -0.04,
+                      "fmt": "-0.04"
+                    },
+                    "90daysAgo": {
+                      "raw": -0.04,
+                      "fmt": "-0.04"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": "2020-12-31",
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {
+                      "raw": -0.4,
+                      "fmt": "-0.4"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 8310000,
+                      "fmt": "8.31M",
+                      "longFmt": "8,310,000"
+                    },
+                    "low": {
+                      "raw": 8310000,
+                      "fmt": "8.31M",
+                      "longFmt": "8,310,000"
+                    },
+                    "high": {
+                      "raw": 8310000,
+                      "fmt": "8.31M",
+                      "longFmt": "8,310,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 10654000,
+                      "fmt": "10.65M",
+                      "longFmt": "10,654,000"
+                    },
+                    "growth": {
+                      "raw": -0.22,
+                      "fmt": "-22.00%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": -0.02,
+                      "fmt": "-0.02"
+                    },
+                    "30daysAgo": {
+                      "raw": -0.02,
+                      "fmt": "-0.02"
+                    },
+                    "60daysAgo": {
+                      "raw": -0.02,
+                      "fmt": "-0.02"
+                    },
+                    "90daysAgo": {
+                      "raw": -0.02,
+                      "fmt": "-0.02"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": "2020-12-31",
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 34960000,
+                      "fmt": "34.96M",
+                      "longFmt": "34,960,000"
+                    },
+                    "low": {
+                      "raw": 34960000,
+                      "fmt": "34.96M",
+                      "longFmt": "34,960,000"
+                    },
+                    "high": {
+                      "raw": 34960000,
+                      "fmt": "34.96M",
+                      "longFmt": "34,960,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 1,
+                      "fmt": "1",
+                      "longFmt": "1"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 48841000,
+                      "fmt": "48.84M",
+                      "longFmt": "48,841,000"
+                    },
+                    "growth": {
+                      "raw": -0.284,
+                      "fmt": "-28.40%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": -0.14,
+                      "fmt": "-0.14"
+                    },
+                    "30daysAgo": {
+                      "raw": -0.14,
+                      "fmt": "-0.14"
+                    },
+                    "60daysAgo": {
+                      "raw": -0.14,
+                      "fmt": "-0.14"
+                    },
+                    "90daysAgo": {
+                      "raw": -0.14,
+                      "fmt": "-0.14"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": "2021-12-31",
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "low": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "high": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 34960000,
+                      "fmt": "34.96M",
+                      "longFmt": "34,960,000"
+                    },
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "7daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "30daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "60daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    },
+                    "90daysAgo": {
+                      "raw": 0,
+                      "fmt": "0"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": 0.0201,
+                    "fmt": "2.01%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {
+                    "raw": -0.33367002,
+                    "fmt": "-33.37%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-earningsTrend-SI.json
+++ b/tests/http/quoteSummary-earningsTrend-SI.json
@@ -1,0 +1,584 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=earningsTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "3bre559g2vsea"
+      ],
+      "x-yahoo-request-id": [
+        "3bre559g2vsea"
+      ],
+      "x-request-id": [
+        "3b141b26-6fe7-497d-a2c4-b72028ff9189"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "920"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:46 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "earningsTrend": {
+              "trend": [
+                {
+                  "maxAge": 1,
+                  "period": "0q",
+                  "endDate": "2021-03-31",
+                  "growth": {
+                    "raw": 0.95699996,
+                    "fmt": "95.70%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.45,
+                      "fmt": "0.45"
+                    },
+                    "low": {
+                      "raw": 0.33,
+                      "fmt": "0.33"
+                    },
+                    "high": {
+                      "raw": 0.5,
+                      "fmt": "0.5"
+                    },
+                    "yearAgoEps": {
+                      "raw": 0.23,
+                      "fmt": "0.23"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "growth": {
+                      "raw": 0.95699996,
+                      "fmt": "95.70%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 29700000,
+                      "fmt": "29.7M",
+                      "longFmt": "29,700,000"
+                    },
+                    "low": {
+                      "raw": 27310000,
+                      "fmt": "27.31M",
+                      "longFmt": "27,310,000"
+                    },
+                    "high": {
+                      "raw": 31800000,
+                      "fmt": "31.8M",
+                      "longFmt": "31,800,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 3,
+                      "fmt": "3",
+                      "longFmt": "3"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 20409000,
+                      "fmt": "20.41M",
+                      "longFmt": "20,409,000"
+                    },
+                    "growth": {
+                      "raw": 0.455,
+                      "fmt": "45.50%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.45,
+                      "fmt": "0.45"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.45,
+                      "fmt": "0.45"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.33,
+                      "fmt": "0.33"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.33,
+                      "fmt": "0.33"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.3,
+                      "fmt": "0.3"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 4,
+                      "fmt": "4",
+                      "longFmt": "4"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1q",
+                  "endDate": "2021-06-30",
+                  "growth": {
+                    "raw": 0.58599997,
+                    "fmt": "58.60%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 0.46,
+                      "fmt": "0.46"
+                    },
+                    "low": {
+                      "raw": 0.33,
+                      "fmt": "0.33"
+                    },
+                    "high": {
+                      "raw": 0.51,
+                      "fmt": "0.51"
+                    },
+                    "yearAgoEps": {
+                      "raw": 0.29,
+                      "fmt": "0.29"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "growth": {
+                      "raw": 0.58599997,
+                      "fmt": "58.60%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 30300000,
+                      "fmt": "30.3M",
+                      "longFmt": "30,300,000"
+                    },
+                    "low": {
+                      "raw": 27900000,
+                      "fmt": "27.9M",
+                      "longFmt": "27,900,000"
+                    },
+                    "high": {
+                      "raw": 32900000,
+                      "fmt": "32.9M",
+                      "longFmt": "32,900,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 3,
+                      "fmt": "3",
+                      "longFmt": "3"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 21486000,
+                      "fmt": "21.49M",
+                      "longFmt": "21,486,000"
+                    },
+                    "growth": {
+                      "raw": 0.41,
+                      "fmt": "41.00%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 0.46,
+                      "fmt": "0.46"
+                    },
+                    "7daysAgo": {
+                      "raw": 0.46,
+                      "fmt": "0.46"
+                    },
+                    "30daysAgo": {
+                      "raw": 0.34,
+                      "fmt": "0.34"
+                    },
+                    "60daysAgo": {
+                      "raw": 0.33,
+                      "fmt": "0.33"
+                    },
+                    "90daysAgo": {
+                      "raw": 0.3,
+                      "fmt": "0.3"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 4,
+                      "fmt": "4",
+                      "longFmt": "4"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "0y",
+                  "endDate": "2021-12-31",
+                  "growth": {
+                    "raw": 0.404,
+                    "fmt": "40.40%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 1.91,
+                      "fmt": "1.91"
+                    },
+                    "low": {
+                      "raw": 1.36,
+                      "fmt": "1.36"
+                    },
+                    "high": {
+                      "raw": 2.15,
+                      "fmt": "2.15"
+                    },
+                    "yearAgoEps": {
+                      "raw": 1.36,
+                      "fmt": "1.36"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "growth": {
+                      "raw": 0.404,
+                      "fmt": "40.40%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 123430000,
+                      "fmt": "123.43M",
+                      "longFmt": "123,430,000"
+                    },
+                    "low": {
+                      "raw": 114800000,
+                      "fmt": "114.8M",
+                      "longFmt": "114,800,000"
+                    },
+                    "high": {
+                      "raw": 136200000,
+                      "fmt": "136.2M",
+                      "longFmt": "136,200,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 3,
+                      "fmt": "3",
+                      "longFmt": "3"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 91541000,
+                      "fmt": "91.54M",
+                      "longFmt": "91,541,000"
+                    },
+                    "growth": {
+                      "raw": 0.348,
+                      "fmt": "34.80%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 1.91,
+                      "fmt": "1.91"
+                    },
+                    "7daysAgo": {
+                      "raw": 1.91,
+                      "fmt": "1.91"
+                    },
+                    "30daysAgo": {
+                      "raw": 1.43,
+                      "fmt": "1.43"
+                    },
+                    "60daysAgo": {
+                      "raw": 1.39,
+                      "fmt": "1.39"
+                    },
+                    "90daysAgo": {
+                      "raw": 1.27,
+                      "fmt": "1.27"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+1y",
+                  "endDate": "2022-12-31",
+                  "growth": {
+                    "raw": 0.314,
+                    "fmt": "31.40%"
+                  },
+                  "earningsEstimate": {
+                    "avg": {
+                      "raw": 2.51,
+                      "fmt": "2.51"
+                    },
+                    "low": {
+                      "raw": 1.54,
+                      "fmt": "1.54"
+                    },
+                    "high": {
+                      "raw": 3.1,
+                      "fmt": "3.1"
+                    },
+                    "yearAgoEps": {
+                      "raw": 1.91,
+                      "fmt": "1.91"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "growth": {
+                      "raw": 0.314,
+                      "fmt": "31.40%"
+                    }
+                  },
+                  "revenueEstimate": {
+                    "avg": {
+                      "raw": 147430000,
+                      "fmt": "147.43M",
+                      "longFmt": "147,430,000"
+                    },
+                    "low": {
+                      "raw": 129410000,
+                      "fmt": "129.41M",
+                      "longFmt": "129,410,000"
+                    },
+                    "high": {
+                      "raw": 170600000,
+                      "fmt": "170.6M",
+                      "longFmt": "170,600,000"
+                    },
+                    "numberOfAnalysts": {
+                      "raw": 3,
+                      "fmt": "3",
+                      "longFmt": "3"
+                    },
+                    "yearAgoRevenue": {
+                      "raw": 123430000,
+                      "fmt": "123.43M",
+                      "longFmt": "123,430,000"
+                    },
+                    "growth": {
+                      "raw": 0.19399999,
+                      "fmt": "19.40%"
+                    }
+                  },
+                  "epsTrend": {
+                    "current": {
+                      "raw": 2.51,
+                      "fmt": "2.51"
+                    },
+                    "7daysAgo": {
+                      "raw": 2.51,
+                      "fmt": "2.51"
+                    },
+                    "30daysAgo": {
+                      "raw": 1.81,
+                      "fmt": "1.81"
+                    },
+                    "60daysAgo": {
+                      "raw": 1.75,
+                      "fmt": "1.75"
+                    },
+                    "90daysAgo": {
+                      "raw": 1.49,
+                      "fmt": "1.49"
+                    }
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "upLast30days": {
+                      "raw": 5,
+                      "fmt": "5",
+                      "longFmt": "5"
+                    },
+                    "downLast30days": {
+                      "raw": 0,
+                      "fmt": null,
+                      "longFmt": "0"
+                    },
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "+5y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "period": "-5y",
+                  "endDate": null,
+                  "growth": {},
+                  "earningsEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "yearAgoEps": {},
+                    "numberOfAnalysts": {},
+                    "growth": {}
+                  },
+                  "revenueEstimate": {
+                    "avg": {},
+                    "low": {},
+                    "high": {},
+                    "numberOfAnalysts": {},
+                    "yearAgoRevenue": {},
+                    "growth": {}
+                  },
+                  "epsTrend": {
+                    "current": {},
+                    "7daysAgo": {},
+                    "30daysAgo": {},
+                    "60daysAgo": {},
+                    "90daysAgo": {}
+                  },
+                  "epsRevisions": {
+                    "upLast7days": {},
+                    "upLast30days": {},
+                    "downLast30days": {},
+                    "downLast90days": {}
+                  }
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-financialData-ABBV.json
+++ b/tests/http/quoteSummary-financialData-ABBV.json
@@ -1,0 +1,108 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=financialData"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "ekee4f1g2vsec"
+      ],
+      "x-yahoo-request-id": [
+        "ekee4f1g2vsec"
+      ],
+      "x-request-id": [
+        "6d68808b-816e-448c-8291-33c59a00b96b"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "409"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:47 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 105.56,
+              "targetHighPrice": 140,
+              "targetLowPrice": 97,
+              "targetMeanPrice": 120.48,
+              "targetMedianPrice": 120,
+              "recommendationMean": 2,
+              "recommendationKey": "buy",
+              "numberOfAnalystOpinions": 21,
+              "totalCash": 7964000256,
+              "totalCashPerShare": 4.511,
+              "ebitda": 21527664640,
+              "totalDebt": 87098998784,
+              "totalRevenue": 45803999232,
+              "debtToEquity": 569.684,
+              "revenuePerShare": 27.378,
+              "returnOnEquity": 1.2988601,
+              "grossProfits": 31709000000,
+              "earningsGrowth": -0.995,
+              "revenueGrowth": 0.592,
+              "grossMargins": 0.69228,
+              "ebitdaMargins": 0.46999002,
+              "operatingMargins": 0.34174,
+              "profitMargins": 0.10078,
+              "financialCurrency": "USD"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-financialData-BRKS.json
+++ b/tests/http/quoteSummary-financialData-BRKS.json
@@ -1,0 +1,113 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=financialData"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "78ls8olg2vsec"
+      ],
+      "x-yahoo-request-id": [
+        "78ls8olg2vsec"
+      ],
+      "x-request-id": [
+        "84af6cd1-e519-4d6a-b91c-d88247052d2b"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "445"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:48 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 87.38,
+              "targetHighPrice": 111,
+              "targetLowPrice": 70,
+              "targetMeanPrice": 95.17,
+              "targetMedianPrice": 97.5,
+              "recommendationMean": 2,
+              "recommendationKey": "buy",
+              "numberOfAnalystOpinions": 6,
+              "totalCash": 308572000,
+              "totalCashPerShare": 4.218,
+              "ebitda": 167963008,
+              "totalDebt": 93333000,
+              "quickRatio": 2.295,
+              "currentRatio": 2.99,
+              "totalRevenue": 936275968,
+              "debtToEquity": 7.454,
+              "revenuePerShare": 12.683,
+              "returnOnAssets": 0.04064,
+              "returnOnEquity": 0.06543,
+              "grossProfits": 380325000,
+              "freeCashflow": -7406125,
+              "operatingCashflow": 55853000,
+              "earningsGrowth": 0.944,
+              "revenueGrowth": 0.185,
+              "grossMargins": 0.43627,
+              "ebitdaMargins": 0.17939,
+              "operatingMargins": 0.11022,
+              "profitMargins": 0.08312,
+              "financialCurrency": "USD"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-financialData-CRON.json
+++ b/tests/http/quoteSummary-financialData-CRON.json
@@ -1,0 +1,107 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=financialData"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "64atoatg2vsec"
+      ],
+      "x-yahoo-request-id": [
+        "64atoatg2vsec"
+      ],
+      "x-request-id": [
+        "5ef02c9e-f2bd-49c0-9be6-87d4c61804c7"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "383"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:48 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 12.15,
+              "recommendationKey": "none",
+              "totalCash": 1300728960,
+              "totalCashPerShare": 3.656,
+              "ebitda": -176930000,
+              "totalDebt": 9886000,
+              "quickRatio": 9.215,
+              "currentRatio": 9.752,
+              "totalRevenue": 36981000,
+              "debtToEquity": 0.56,
+              "revenuePerShare": 0.106,
+              "returnOnAssets": -0.057150003,
+              "returnOnEquity": 0.05816,
+              "grossProfits": -15964000,
+              "freeCashflow": -456162432,
+              "operatingCashflow": -157898000,
+              "earningsGrowth": -0.886,
+              "revenueGrowth": 0.963,
+              "grossMargins": -0.79527,
+              "ebitdaMargins": 0,
+              "operatingMargins": -4.948,
+              "profitMargins": 2.70682,
+              "financialCurrency": "USD"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-financialData-EPAC.json
+++ b/tests/http/quoteSummary-financialData-EPAC.json
@@ -1,0 +1,113 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=financialData"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "anf3fctg2vsec"
+      ],
+      "x-yahoo-request-id": [
+        "anf3fctg2vsec"
+      ],
+      "x-request-id": [
+        "b41b280c-7d72-4204-b0c1-0ea593a09549"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "452"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:48 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 23.3,
+              "targetHighPrice": 20,
+              "targetLowPrice": 16,
+              "targetMeanPrice": 18.75,
+              "targetMedianPrice": 19.5,
+              "recommendationMean": 3.2,
+              "recommendationKey": "hold",
+              "numberOfAnalystOpinions": 4,
+              "totalCash": 158568000,
+              "totalCashPerShare": 2.648,
+              "ebitda": 43889000,
+              "totalDebt": 255000000,
+              "quickRatio": 2.317,
+              "currentRatio": 3.262,
+              "totalRevenue": 466048000,
+              "debtToEquity": 69.304,
+              "revenuePerShare": 7.782,
+              "returnOnAssets": 0.01609,
+              "returnOnEquity": 0.011109999,
+              "grossProfits": 217993000,
+              "freeCashflow": 39089624,
+              "operatingCashflow": 28435000,
+              "earningsGrowth": 1.161,
+              "revenueGrowth": -0.186,
+              "grossMargins": 0.43894002,
+              "ebitdaMargins": 0.09417,
+              "operatingMargins": 0.048260003,
+              "profitMargins": 0.0068699997,
+              "financialCurrency": "USD"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-financialData-MDLY.json
+++ b/tests/http/quoteSummary-financialData-MDLY.json
@@ -1,0 +1,105 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=financialData"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "4r5b76tg2vseb"
+      ],
+      "x-yahoo-request-id": [
+        "4r5b76tg2vseb"
+      ],
+      "x-request-id": [
+        "93ee7de0-e692-4cd8-9d00-2e532d8237fb"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "356"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:47 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 10.412,
+              "recommendationMean": 3,
+              "recommendationKey": "hold",
+              "totalCash": 6048000,
+              "totalCashPerShare": 9.03,
+              "ebitda": 2860000,
+              "totalDebt": 136378000,
+              "quickRatio": 0.58,
+              "currentRatio": 0.914,
+              "totalRevenue": 35428000,
+              "revenuePerShare": 56.78,
+              "returnOnAssets": 0.023510002,
+              "grossProfits": 21474000,
+              "freeCashflow": 2893250,
+              "operatingCashflow": -946000,
+              "revenueGrowth": -0.278,
+              "grossMargins": 0.38534,
+              "ebitdaMargins": 0.08073,
+              "operatingMargins": 0.060599998,
+              "profitMargins": -0.13196,
+              "financialCurrency": "USD"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-financialData-SI.json
+++ b/tests/http/quoteSummary-financialData-SI.json
@@ -1,0 +1,107 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=financialData"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "67be539g2vseb"
+      ],
+      "x-yahoo-request-id": [
+        "67be539g2vseb"
+      ],
+      "x-request-id": [
+        "aa5b099e-e97b-4b90-849f-03653f5eee06"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "380"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:47 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "financialData": {
+              "maxAge": 86400,
+              "currentPrice": 172.1399,
+              "targetHighPrice": 150,
+              "targetLowPrice": 85,
+              "targetMeanPrice": 111.67,
+              "targetMedianPrice": 105,
+              "recommendationMean": 1.7,
+              "recommendationKey": "buy",
+              "numberOfAnalystOpinions": 6,
+              "totalCash": 2993190912,
+              "totalCashPerShare": 159.688,
+              "totalDebt": 15831000,
+              "totalRevenue": 89874000,
+              "revenuePerShare": 4.808,
+              "returnOnAssets": 0.00675,
+              "returnOnEquity": 0.099130005,
+              "grossProfits": 89874000,
+              "earningsGrowth": 1.42,
+              "revenueGrowth": 0.418,
+              "grossMargins": 0,
+              "ebitdaMargins": 0,
+              "operatingMargins": 0.34983003,
+              "profitMargins": 0.28972,
+              "financialCurrency": "USD"
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-fundOwnership-ABBV.json
+++ b/tests/http/quoteSummary-fundOwnership-ABBV.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=fundOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "64sh7bhg2vsed"
+      ],
+      "x-yahoo-request-id": [
+        "64sh7bhg2vsed"
+      ],
+      "x-request-id": [
+        "82126053-6bff-4364-a1b4-d55ec01d2538"
+      ],
+      "content-length": [
+        "92"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:48 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-fundOwnership-BRKS.json
+++ b/tests/http/quoteSummary-fundOwnership-BRKS.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=fundOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "91oana5g2vsed"
+      ],
+      "x-yahoo-request-id": [
+        "91oana5g2vsed"
+      ],
+      "x-request-id": [
+        "e67ed75e-0e6a-425e-b771-23b6fa04c8b4"
+      ],
+      "content-length": [
+        "92"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:49 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-fundOwnership-CRON.json
+++ b/tests/http/quoteSummary-fundOwnership-CRON.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=fundOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "3tvm7tdg2vsed"
+      ],
+      "x-yahoo-request-id": [
+        "3tvm7tdg2vsed"
+      ],
+      "x-request-id": [
+        "bdbd74d7-1304-90a4-9c63-af05503fdaac"
+      ],
+      "content-length": [
+        "92"
+      ],
+      "x-envoy-upstream-service-time": [
+        "1"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:49 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-fundOwnership-EPAC.json
+++ b/tests/http/quoteSummary-fundOwnership-EPAC.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=fundOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "9g8su0lg2vsed"
+      ],
+      "x-yahoo-request-id": [
+        "9g8su0lg2vsed"
+      ],
+      "x-request-id": [
+        "f21e022e-15d8-4f89-86ad-9634a4de3cf7"
+      ],
+      "content-length": [
+        "92"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:49 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-fundOwnership-MDLY.json
+++ b/tests/http/quoteSummary-fundOwnership-MDLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=fundOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "beps31tg2vsed"
+      ],
+      "x-yahoo-request-id": [
+        "beps31tg2vsed"
+      ],
+      "x-request-id": [
+        "7b403200-7690-487b-bdfc-324f30729d91"
+      ],
+      "content-length": [
+        "92"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:48 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-fundOwnership-SI.json
+++ b/tests/http/quoteSummary-fundOwnership-SI.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=fundOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "82i8eptg2vsec"
+      ],
+      "x-yahoo-request-id": [
+        "82i8eptg2vsec"
+      ],
+      "x-request-id": [
+        "1c98a2ce-c065-432e-ab69-3ba7e3796717"
+      ],
+      "content-length": [
+        "92"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:48 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "fundOwnership": {
+              "maxAge": 1,
+              "ownershipList": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistory-ABBV.json
+++ b/tests/http/quoteSummary-incomeStatementHistory-ABBV.json
@@ -1,0 +1,454 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=incomeStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "dbqvdplg2vsee"
+      ],
+      "x-yahoo-request-id": [
+        "dbqvdplg2vsee"
+      ],
+      "x-request-id": [
+        "90eeb5fa-afa5-4746-b9ec-4bcc8bb2f1c1"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1228"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:50 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 45804000000,
+                    "fmt": "45.8B",
+                    "longFmt": "45,804,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 14095000000,
+                    "fmt": "14.1B",
+                    "longFmt": "14,095,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 31709000000,
+                    "fmt": "31.71B",
+                    "longFmt": "31,709,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 6173000000,
+                    "fmt": "6.17B",
+                    "longFmt": "6,173,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 9883000000,
+                    "fmt": "9.88B",
+                    "longFmt": "9,883,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 30151000000,
+                    "fmt": "30.15B",
+                    "longFmt": "30,151,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 15653000000,
+                    "fmt": "15.65B",
+                    "longFmt": "15,653,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -12255000000,
+                    "fmt": "-12.26B",
+                    "longFmt": "-12,255,000,000"
+                  },
+                  "ebit": {
+                    "raw": 15653000000,
+                    "fmt": "15.65B",
+                    "longFmt": "15,653,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -2006000000,
+                    "fmt": "-2.01B",
+                    "longFmt": "-2,006,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 3398000000,
+                    "fmt": "3.4B",
+                    "longFmt": "3,398,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -1224000000,
+                    "fmt": "-1.22B",
+                    "longFmt": "-1,224,000,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 4622000000,
+                    "fmt": "4.62B",
+                    "longFmt": "4,622,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 4616000000,
+                    "fmt": "4.62B",
+                    "longFmt": "4,616,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 4616000000,
+                    "fmt": "4.62B",
+                    "longFmt": "4,616,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 33266000000,
+                    "fmt": "33.27B",
+                    "longFmt": "33,266,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 7439000000,
+                    "fmt": "7.44B",
+                    "longFmt": "7,439,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 25827000000,
+                    "fmt": "25.83B",
+                    "longFmt": "25,827,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 5377000000,
+                    "fmt": "5.38B",
+                    "longFmt": "5,377,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 6763000000,
+                    "fmt": "6.76B",
+                    "longFmt": "6,763,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": -10000000,
+                    "fmt": "-10M",
+                    "longFmt": "-10,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 19569000000,
+                    "fmt": "19.57B",
+                    "longFmt": "19,569,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 13697000000,
+                    "fmt": "13.7B",
+                    "longFmt": "13,697,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -5271000000,
+                    "fmt": "-5.27B",
+                    "longFmt": "-5,271,000,000"
+                  },
+                  "ebit": {
+                    "raw": 13697000000,
+                    "fmt": "13.7B",
+                    "longFmt": "13,697,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -1421000000,
+                    "fmt": "-1.42B",
+                    "longFmt": "-1,421,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 8426000000,
+                    "fmt": "8.43B",
+                    "longFmt": "8,426,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 544000000,
+                    "fmt": "544M",
+                    "longFmt": "544,000,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 7882000000,
+                    "fmt": "7.88B",
+                    "longFmt": "7,882,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 7882000000,
+                    "fmt": "7.88B",
+                    "longFmt": "7,882,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 7842000000,
+                    "fmt": "7.84B",
+                    "longFmt": "7,842,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 32753000000,
+                    "fmt": "32.75B",
+                    "longFmt": "32,753,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 7718000000,
+                    "fmt": "7.72B",
+                    "longFmt": "7,718,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 25035000000,
+                    "fmt": "25.04B",
+                    "longFmt": "25,035,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 5259000000,
+                    "fmt": "5.26B",
+                    "longFmt": "5,259,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 7003000000,
+                    "fmt": "7B",
+                    "longFmt": "7,003,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 500000000,
+                    "fmt": "500M",
+                    "longFmt": "500,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 20480000000,
+                    "fmt": "20.48B",
+                    "longFmt": "20,480,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 12273000000,
+                    "fmt": "12.27B",
+                    "longFmt": "12,273,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -7076000000,
+                    "fmt": "-7.08B",
+                    "longFmt": "-7,076,000,000"
+                  },
+                  "ebit": {
+                    "raw": 12273000000,
+                    "fmt": "12.27B",
+                    "longFmt": "12,273,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -1348000000,
+                    "fmt": "-1.35B",
+                    "longFmt": "-1,348,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 5197000000,
+                    "fmt": "5.2B",
+                    "longFmt": "5,197,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -490000000,
+                    "fmt": "-490M",
+                    "longFmt": "-490,000,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 5687000000,
+                    "fmt": "5.69B",
+                    "longFmt": "5,687,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 5687000000,
+                    "fmt": "5.69B",
+                    "longFmt": "5,687,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 5657000000,
+                    "fmt": "5.66B",
+                    "longFmt": "5,657,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 28216000000,
+                    "fmt": "28.22B",
+                    "longFmt": "28,216,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 6688000000,
+                    "fmt": "6.69B",
+                    "longFmt": "6,688,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 21528000000,
+                    "fmt": "21.53B",
+                    "longFmt": "21,528,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 5007000000,
+                    "fmt": "5.01B",
+                    "longFmt": "5,007,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 6248000000,
+                    "fmt": "6.25B",
+                    "longFmt": "6,248,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 500000000,
+                    "fmt": "500M",
+                    "longFmt": "500,000,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 17943000000,
+                    "fmt": "17.94B",
+                    "longFmt": "17,943,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 10273000000,
+                    "fmt": "10.27B",
+                    "longFmt": "10,273,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -2546000000,
+                    "fmt": "-2.55B",
+                    "longFmt": "-2,546,000,000"
+                  },
+                  "ebit": {
+                    "raw": 10273000000,
+                    "fmt": "10.27B",
+                    "longFmt": "10,273,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -1150000000,
+                    "fmt": "-1.15B",
+                    "longFmt": "-1,150,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 7727000000,
+                    "fmt": "7.73B",
+                    "longFmt": "7,727,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 2418000000,
+                    "fmt": "2.42B",
+                    "longFmt": "2,418,000,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 5309000000,
+                    "fmt": "5.31B",
+                    "longFmt": "5,309,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 5309000000,
+                    "fmt": "5.31B",
+                    "longFmt": "5,309,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 5283000000,
+                    "fmt": "5.28B",
+                    "longFmt": "5,283,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistory-BRKS.json
+++ b/tests/http/quoteSummary-incomeStatementHistory-BRKS.json
@@ -1,0 +1,458 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=incomeStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "4hrf6mhg2vsee"
+      ],
+      "x-yahoo-request-id": [
+        "4hrf6mhg2vsee"
+      ],
+      "x-request-id": [
+        "2d23aab9-993b-47a8-9b3e-1b390a9d14f9"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1348"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:50 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 897273000,
+                    "fmt": "897.27M",
+                    "longFmt": "897,273,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 516948000,
+                    "fmt": "516.95M",
+                    "longFmt": "516,948,000"
+                  },
+                  "grossProfit": {
+                    "raw": 380325000,
+                    "fmt": "380.32M",
+                    "longFmt": "380,325,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 59063000,
+                    "fmt": "59.06M",
+                    "longFmt": "59,063,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 240637000,
+                    "fmt": "240.64M",
+                    "longFmt": "240,637,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 816648000,
+                    "fmt": "816.65M",
+                    "longFmt": "816,648,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 80625000,
+                    "fmt": "80.62M",
+                    "longFmt": "80,625,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -5653000,
+                    "fmt": "-5.65M",
+                    "longFmt": "-5,653,000"
+                  },
+                  "ebit": {
+                    "raw": 80625000,
+                    "fmt": "80.62M",
+                    "longFmt": "80,625,000"
+                  },
+                  "interestExpense": {
+                    "raw": -2944000,
+                    "fmt": "-2.94M",
+                    "longFmt": "-2,944,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 74972000,
+                    "fmt": "74.97M",
+                    "longFmt": "74,972,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 9937000,
+                    "fmt": "9.94M",
+                    "longFmt": "9,937,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 65035000,
+                    "fmt": "65.03M",
+                    "longFmt": "65,035,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -182000,
+                    "fmt": "-182k",
+                    "longFmt": "-182,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 64853000,
+                    "fmt": "64.85M",
+                    "longFmt": "64,853,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 64853000,
+                    "fmt": "64.85M",
+                    "longFmt": "64,853,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1569801600,
+                    "fmt": "2019-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 780848000,
+                    "fmt": "780.85M",
+                    "longFmt": "780,848,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 464119000,
+                    "fmt": "464.12M",
+                    "longFmt": "464,119,000"
+                  },
+                  "grossProfit": {
+                    "raw": 316729000,
+                    "fmt": "316.73M",
+                    "longFmt": "316,729,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 56368000,
+                    "fmt": "56.37M",
+                    "longFmt": "56,368,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 205260000,
+                    "fmt": "205.26M",
+                    "longFmt": "205,260,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 725747000,
+                    "fmt": "725.75M",
+                    "longFmt": "725,747,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 55101000,
+                    "fmt": "55.1M",
+                    "longFmt": "55,101,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -45658000,
+                    "fmt": "-45.66M",
+                    "longFmt": "-45,658,000"
+                  },
+                  "ebit": {
+                    "raw": 55101000,
+                    "fmt": "55.1M",
+                    "longFmt": "55,101,000"
+                  },
+                  "interestExpense": {
+                    "raw": -22250000,
+                    "fmt": "-22.25M",
+                    "longFmt": "-22,250,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 9443000,
+                    "fmt": "9.44M",
+                    "longFmt": "9,443,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -111000,
+                    "fmt": "-111k",
+                    "longFmt": "-111,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 9554000,
+                    "fmt": "9.55M",
+                    "longFmt": "9,554,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": 427862000,
+                    "fmt": "427.86M",
+                    "longFmt": "427,862,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 437416000,
+                    "fmt": "437.42M",
+                    "longFmt": "437,416,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 437416000,
+                    "fmt": "437.42M",
+                    "longFmt": "437,416,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1538265600,
+                    "fmt": "2018-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 631560000,
+                    "fmt": "631.56M",
+                    "longFmt": "631,560,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 385479000,
+                    "fmt": "385.48M",
+                    "longFmt": "385,479,000"
+                  },
+                  "grossProfit": {
+                    "raw": 246081000,
+                    "fmt": "246.08M",
+                    "longFmt": "246,081,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 46936000,
+                    "fmt": "46.94M",
+                    "longFmt": "46,936,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 163222000,
+                    "fmt": "163.22M",
+                    "longFmt": "163,222,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 595637000,
+                    "fmt": "595.64M",
+                    "longFmt": "595,637,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 35923000,
+                    "fmt": "35.92M",
+                    "longFmt": "35,923,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -15457000,
+                    "fmt": "-15.46M",
+                    "longFmt": "-15,457,000"
+                  },
+                  "ebit": {
+                    "raw": 35923000,
+                    "fmt": "35.92M",
+                    "longFmt": "35,923,000"
+                  },
+                  "interestExpense": {
+                    "raw": -9520000,
+                    "fmt": "-9.52M",
+                    "longFmt": "-9,520,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 20466000,
+                    "fmt": "20.47M",
+                    "longFmt": "20,466,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -47251000,
+                    "fmt": "-47.25M",
+                    "longFmt": "-47,251,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 67717000,
+                    "fmt": "67.72M",
+                    "longFmt": "67,717,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": 48747000,
+                    "fmt": "48.75M",
+                    "longFmt": "48,747,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 116575000,
+                    "fmt": "116.58M",
+                    "longFmt": "116,575,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 116575000,
+                    "fmt": "116.58M",
+                    "longFmt": "116,575,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1506729600,
+                    "fmt": "2017-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 527499000,
+                    "fmt": "527.5M",
+                    "longFmt": "527,499,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 328089000,
+                    "fmt": "328.09M",
+                    "longFmt": "328,089,000"
+                  },
+                  "grossProfit": {
+                    "raw": 199410000,
+                    "fmt": "199.41M",
+                    "longFmt": "199,410,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 39875000,
+                    "fmt": "39.88M",
+                    "longFmt": "39,875,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 140849000,
+                    "fmt": "140.85M",
+                    "longFmt": "140,849,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 508813000,
+                    "fmt": "508.81M",
+                    "longFmt": "508,813,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 18686000,
+                    "fmt": "18.69M",
+                    "longFmt": "18,686,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -4619000,
+                    "fmt": "-4.62M",
+                    "longFmt": "-4,619,000"
+                  },
+                  "ebit": {
+                    "raw": 18686000,
+                    "fmt": "18.69M",
+                    "longFmt": "18,686,000"
+                  },
+                  "interestExpense": {
+                    "raw": -408000,
+                    "fmt": "-408k",
+                    "longFmt": "-408,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 14067000,
+                    "fmt": "14.07M",
+                    "longFmt": "14,067,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 3380000,
+                    "fmt": "3.38M",
+                    "longFmt": "3,380,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 10687000,
+                    "fmt": "10.69M",
+                    "longFmt": "10,687,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": 51925000,
+                    "fmt": "51.92M",
+                    "longFmt": "51,925,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 62612000,
+                    "fmt": "62.61M",
+                    "longFmt": "62,612,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 62612000,
+                    "fmt": "62.61M",
+                    "longFmt": "62,612,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistory-CRON.json
+++ b/tests/http/quoteSummary-incomeStatementHistory-CRON.json
@@ -1,0 +1,474 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=incomeStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "71isjvtg2vsee"
+      ],
+      "x-yahoo-request-id": [
+        "71isjvtg2vsee"
+      ],
+      "x-request-id": [
+        "2ad80a4c-5dbe-47d9-badd-8196b15755c2"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1155"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:50 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 23750000,
+                    "fmt": "23.75M",
+                    "longFmt": "23,750,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 39714000,
+                    "fmt": "39.71M",
+                    "longFmt": "39,714,000"
+                  },
+                  "grossProfit": {
+                    "raw": -15964000,
+                    "fmt": "-15.96M",
+                    "longFmt": "-15,964,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 12155000,
+                    "fmt": "12.15M",
+                    "longFmt": "12,155,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 72417000,
+                    "fmt": "72.42M",
+                    "longFmt": "72,417,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 5328000,
+                    "fmt": "5.33M",
+                    "longFmt": "5,328,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 143334000,
+                    "fmt": "143.33M",
+                    "longFmt": "143,334,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -119584000,
+                    "fmt": "-119.58M",
+                    "longFmt": "-119,584,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 1285158000,
+                    "fmt": "1.29B",
+                    "longFmt": "1,285,158,000"
+                  },
+                  "ebit": {
+                    "raw": -119584000,
+                    "fmt": "-119.58M",
+                    "longFmt": "-119,584,000"
+                  },
+                  "interestExpense": {
+                    "raw": -1244000,
+                    "fmt": "-1.24M",
+                    "longFmt": "-1,244,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 1165574000,
+                    "fmt": "1.17B",
+                    "longFmt": "1,165,574,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "minorityInterest": {
+                    "raw": -853000,
+                    "fmt": "-853k",
+                    "longFmt": "-853,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 1165574000,
+                    "fmt": "1.17B",
+                    "longFmt": "1,165,574,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 1166506000,
+                    "fmt": "1.17B",
+                    "longFmt": "1,166,506,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 1166506000,
+                    "fmt": "1.17B",
+                    "longFmt": "1,166,506,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 12121000,
+                    "fmt": "12.12M",
+                    "longFmt": "12,121,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 5908000,
+                    "fmt": "5.91M",
+                    "longFmt": "5,908,000"
+                  },
+                  "grossProfit": {
+                    "raw": 6213000,
+                    "fmt": "6.21M",
+                    "longFmt": "6,213,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 1814000,
+                    "fmt": "1.81M",
+                    "longFmt": "1,814,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 16620000,
+                    "fmt": "16.62M",
+                    "longFmt": "16,620,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 5328000,
+                    "fmt": "5.33M",
+                    "longFmt": "5,328,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 33462000,
+                    "fmt": "33.46M",
+                    "longFmt": "33,462,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -21341000,
+                    "fmt": "-21.34M",
+                    "longFmt": "-21,341,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -476000,
+                    "fmt": "-476k",
+                    "longFmt": "-476,000"
+                  },
+                  "ebit": {
+                    "raw": -21341000,
+                    "fmt": "-21.34M",
+                    "longFmt": "-21,341,000"
+                  },
+                  "interestExpense": {
+                    "raw": -139000,
+                    "fmt": "-139k",
+                    "longFmt": "-139,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -21817000,
+                    "fmt": "-21.82M",
+                    "longFmt": "-21,817,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 489000,
+                    "fmt": "489k",
+                    "longFmt": "489,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 100000,
+                    "fmt": "100k",
+                    "longFmt": "100,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -21817000,
+                    "fmt": "-21.82M",
+                    "longFmt": "-21,817,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -21636000,
+                    "fmt": "-21.64M",
+                    "longFmt": "-21,636,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -21636000,
+                    "fmt": "-21.64M",
+                    "longFmt": "-21,636,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 3147000,
+                    "fmt": "3.15M",
+                    "longFmt": "3,147,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 1573000,
+                    "fmt": "1.57M",
+                    "longFmt": "1,573,000"
+                  },
+                  "grossProfit": {
+                    "raw": 1574000,
+                    "fmt": "1.57M",
+                    "longFmt": "1,574,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 1814000,
+                    "fmt": "1.81M",
+                    "longFmt": "1,814,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 5347000,
+                    "fmt": "5.35M",
+                    "longFmt": "5,347,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 5328000,
+                    "fmt": "5.33M",
+                    "longFmt": "5,328,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 9268000,
+                    "fmt": "9.27M",
+                    "longFmt": "9,268,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -6121000,
+                    "fmt": "-6.12M",
+                    "longFmt": "-6,121,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 3776000,
+                    "fmt": "3.78M",
+                    "longFmt": "3,776,000"
+                  },
+                  "ebit": {
+                    "raw": -6121000,
+                    "fmt": "-6.12M",
+                    "longFmt": "-6,121,000"
+                  },
+                  "interestExpense": {
+                    "raw": -101000,
+                    "fmt": "-101k",
+                    "longFmt": "-101,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -2345000,
+                    "fmt": "-2.35M",
+                    "longFmt": "-2,345,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -862000,
+                    "fmt": "-862k",
+                    "longFmt": "-862,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 100000,
+                    "fmt": "100k",
+                    "longFmt": "100,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -1483000,
+                    "fmt": "-1.48M",
+                    "longFmt": "-1,483,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -1483000,
+                    "fmt": "-1.48M",
+                    "longFmt": "-1,483,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -1483000,
+                    "fmt": "-1.48M",
+                    "longFmt": "-1,483,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 554000,
+                    "fmt": "554k",
+                    "longFmt": "554,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": -1439000,
+                    "fmt": "-1.44M",
+                    "longFmt": "-1,439,000"
+                  },
+                  "grossProfit": {
+                    "raw": 1993000,
+                    "fmt": "1.99M",
+                    "longFmt": "1,993,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 1814000,
+                    "fmt": "1.81M",
+                    "longFmt": "1,814,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 3435000,
+                    "fmt": "3.44M",
+                    "longFmt": "3,435,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 5328000,
+                    "fmt": "5.33M",
+                    "longFmt": "5,328,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 2685000,
+                    "fmt": "2.69M",
+                    "longFmt": "2,685,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -2131000,
+                    "fmt": "-2.13M",
+                    "longFmt": "-2,131,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 373000,
+                    "fmt": "373k",
+                    "longFmt": "373,000"
+                  },
+                  "ebit": {
+                    "raw": -2131000,
+                    "fmt": "-2.13M",
+                    "longFmt": "-2,131,000"
+                  },
+                  "interestExpense": {
+                    "raw": -232000,
+                    "fmt": "-232k",
+                    "longFmt": "-232,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -1758000,
+                    "fmt": "-1.76M",
+                    "longFmt": "-1,758,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -568000,
+                    "fmt": "-568k",
+                    "longFmt": "-568,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 100000,
+                    "fmt": "100k",
+                    "longFmt": "100,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -1190000,
+                    "fmt": "-1.19M",
+                    "longFmt": "-1,190,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -1190000,
+                    "fmt": "-1.19M",
+                    "longFmt": "-1,190,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -1190000,
+                    "fmt": "-1.19M",
+                    "longFmt": "-1,190,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistory-EPAC.json
+++ b/tests/http/quoteSummary-incomeStatementHistory-EPAC.json
@@ -1,0 +1,442 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=incomeStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "6fh4v69g2vsef"
+      ],
+      "x-yahoo-request-id": [
+        "6fh4v69g2vsef"
+      ],
+      "x-request-id": [
+        "88b5ff3b-d0a1-4f95-ba47-1b970b1df442"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1304"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:50 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1598832000,
+                    "fmt": "2020-08-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 493292000,
+                    "fmt": "493.29M",
+                    "longFmt": "493,292,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 275299000,
+                    "fmt": "275.3M",
+                    "longFmt": "275,299,000"
+                  },
+                  "grossProfit": {
+                    "raw": 217993000,
+                    "fmt": "217.99M",
+                    "longFmt": "217,993,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 181613000,
+                    "fmt": "181.61M",
+                    "longFmt": "181,613,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 465235000,
+                    "fmt": "465.24M",
+                    "longFmt": "465,235,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 28057000,
+                    "fmt": "28.06M",
+                    "longFmt": "28,057,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -20208000,
+                    "fmt": "-20.21M",
+                    "longFmt": "-20,208,000"
+                  },
+                  "ebit": {
+                    "raw": 28057000,
+                    "fmt": "28.06M",
+                    "longFmt": "28,057,000"
+                  },
+                  "interestExpense": {
+                    "raw": -18918000,
+                    "fmt": "-18.92M",
+                    "longFmt": "-18,918,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 7849000,
+                    "fmt": "7.85M",
+                    "longFmt": "7,849,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 2292000,
+                    "fmt": "2.29M",
+                    "longFmt": "2,292,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 5557000,
+                    "fmt": "5.56M",
+                    "longFmt": "5,557,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -4834000,
+                    "fmt": "-4.83M",
+                    "longFmt": "-4,834,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 723000,
+                    "fmt": "723k",
+                    "longFmt": "723,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 723000,
+                    "fmt": "723k",
+                    "longFmt": "723,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1567209600,
+                    "fmt": "2019-08-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 654758000,
+                    "fmt": "654.76M",
+                    "longFmt": "654,758,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 362106000,
+                    "fmt": "362.11M",
+                    "longFmt": "362,106,000"
+                  },
+                  "grossProfit": {
+                    "raw": 292652000,
+                    "fmt": "292.65M",
+                    "longFmt": "292,652,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 210631000,
+                    "fmt": "210.63M",
+                    "longFmt": "210,631,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 581659000,
+                    "fmt": "581.66M",
+                    "longFmt": "581,659,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 73099000,
+                    "fmt": "73.1M",
+                    "longFmt": "73,099,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -54375000,
+                    "fmt": "-54.38M",
+                    "longFmt": "-54,375,000"
+                  },
+                  "ebit": {
+                    "raw": 73099000,
+                    "fmt": "73.1M",
+                    "longFmt": "73,099,000"
+                  },
+                  "interestExpense": {
+                    "raw": -27463000,
+                    "fmt": "-27.46M",
+                    "longFmt": "-27,463,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 18724000,
+                    "fmt": "18.72M",
+                    "longFmt": "18,724,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 10657000,
+                    "fmt": "10.66M",
+                    "longFmt": "10,657,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 8067000,
+                    "fmt": "8.07M",
+                    "longFmt": "8,067,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -257212000,
+                    "fmt": "-257.21M",
+                    "longFmt": "-257,212,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -249145000,
+                    "fmt": "-249.15M",
+                    "longFmt": "-249,145,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -249145000,
+                    "fmt": "-249.15M",
+                    "longFmt": "-249,145,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1535673600,
+                    "fmt": "2018-08-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 641303000,
+                    "fmt": "641.3M",
+                    "longFmt": "641,303,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 358019000,
+                    "fmt": "358.02M",
+                    "longFmt": "358,019,000"
+                  },
+                  "grossProfit": {
+                    "raw": 283284000,
+                    "fmt": "283.28M",
+                    "longFmt": "283,284,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 210656000,
+                    "fmt": "210.66M",
+                    "longFmt": "210,656,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 577955000,
+                    "fmt": "577.96M",
+                    "longFmt": "577,955,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 63348000,
+                    "fmt": "63.35M",
+                    "longFmt": "63,348,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -44152000,
+                    "fmt": "-44.15M",
+                    "longFmt": "-44,152,000"
+                  },
+                  "ebit": {
+                    "raw": 63348000,
+                    "fmt": "63.35M",
+                    "longFmt": "63,348,000"
+                  },
+                  "interestExpense": {
+                    "raw": -30572000,
+                    "fmt": "-30.57M",
+                    "longFmt": "-30,572,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 19196000,
+                    "fmt": "19.2M",
+                    "longFmt": "19,196,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 14450000,
+                    "fmt": "14.45M",
+                    "longFmt": "14,450,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 4746000,
+                    "fmt": "4.75M",
+                    "longFmt": "4,746,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -26394000,
+                    "fmt": "-26.39M",
+                    "longFmt": "-26,394,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -21648000,
+                    "fmt": "-21.65M",
+                    "longFmt": "-21,648,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -21648000,
+                    "fmt": "-21.65M",
+                    "longFmt": "-21,648,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1504137600,
+                    "fmt": "2017-08-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 616591000,
+                    "fmt": "616.59M",
+                    "longFmt": "616,591,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 356221000,
+                    "fmt": "356.22M",
+                    "longFmt": "356,221,000"
+                  },
+                  "grossProfit": {
+                    "raw": 260370000,
+                    "fmt": "260.37M",
+                    "longFmt": "260,370,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 209728000,
+                    "fmt": "209.73M",
+                    "longFmt": "209,728,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 575046000,
+                    "fmt": "575.05M",
+                    "longFmt": "575,046,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 41545000,
+                    "fmt": "41.55M",
+                    "longFmt": "41,545,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -159434000,
+                    "fmt": "-159.43M",
+                    "longFmt": "-159,434,000"
+                  },
+                  "ebit": {
+                    "raw": 41545000,
+                    "fmt": "41.55M",
+                    "longFmt": "41,545,000"
+                  },
+                  "interestExpense": {
+                    "raw": -28821000,
+                    "fmt": "-28.82M",
+                    "longFmt": "-28,821,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -117889000,
+                    "fmt": "-117.89M",
+                    "longFmt": "-117,889,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -22614000,
+                    "fmt": "-22.61M",
+                    "longFmt": "-22,614,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": -95275000,
+                    "fmt": "-95.28M",
+                    "longFmt": "-95,275,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": 29062000,
+                    "fmt": "29.06M",
+                    "longFmt": "29,062,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -66213000,
+                    "fmt": "-66.21M",
+                    "longFmt": "-66,213,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -66213000,
+                    "fmt": "-66.21M",
+                    "longFmt": "-66,213,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistory-MDLY.json
+++ b/tests/http/quoteSummary-incomeStatementHistory-MDLY.json
@@ -1,0 +1,442 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=incomeStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "8oojsc5g2vsee"
+      ],
+      "x-yahoo-request-id": [
+        "8oojsc5g2vsee"
+      ],
+      "x-request-id": [
+        "47795faa-ccff-45c6-b36b-4bff42c127dc"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1267"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:50 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 48841000,
+                    "fmt": "48.84M",
+                    "longFmt": "48,841,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 27367000,
+                    "fmt": "27.37M",
+                    "longFmt": "27,367,000"
+                  },
+                  "grossProfit": {
+                    "raw": 21474000,
+                    "fmt": "21.47M",
+                    "longFmt": "21,474,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 12586000,
+                    "fmt": "12.59M",
+                    "longFmt": "12,586,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 39953000,
+                    "fmt": "39.95M",
+                    "longFmt": "39,953,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 8888000,
+                    "fmt": "8.89M",
+                    "longFmt": "8,888,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -20948000,
+                    "fmt": "-20.95M",
+                    "longFmt": "-20,948,000"
+                  },
+                  "ebit": {
+                    "raw": 8888000,
+                    "fmt": "8.89M",
+                    "longFmt": "8,888,000"
+                  },
+                  "interestExpense": {
+                    "raw": -11497000,
+                    "fmt": "-11.5M",
+                    "longFmt": "-11,497,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -12060000,
+                    "fmt": "-12.06M",
+                    "longFmt": "-12,060,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 4710000,
+                    "fmt": "4.71M",
+                    "longFmt": "4,710,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -109714000,
+                    "fmt": "-109.71M",
+                    "longFmt": "-109,714,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -16770000,
+                    "fmt": "-16.77M",
+                    "longFmt": "-16,770,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -3379000,
+                    "fmt": "-3.38M",
+                    "longFmt": "-3,379,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -3529000,
+                    "fmt": "-3.53M",
+                    "longFmt": "-3,529,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 56509000,
+                    "fmt": "56.51M",
+                    "longFmt": "56,509,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 28936000,
+                    "fmt": "28.94M",
+                    "longFmt": "28,936,000"
+                  },
+                  "grossProfit": {
+                    "raw": 27573000,
+                    "fmt": "27.57M",
+                    "longFmt": "27,573,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 15566000,
+                    "fmt": "15.57M",
+                    "longFmt": "15,566,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 44502000,
+                    "fmt": "44.5M",
+                    "longFmt": "44,502,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 12007000,
+                    "fmt": "12.01M",
+                    "longFmt": "12,007,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -33275000,
+                    "fmt": "-33.27M",
+                    "longFmt": "-33,275,000"
+                  },
+                  "ebit": {
+                    "raw": 12007000,
+                    "fmt": "12.01M",
+                    "longFmt": "12,007,000"
+                  },
+                  "interestExpense": {
+                    "raw": -10806000,
+                    "fmt": "-10.81M",
+                    "longFmt": "-10,806,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -21268000,
+                    "fmt": "-21.27M",
+                    "longFmt": "-21,268,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 258000,
+                    "fmt": "258k",
+                    "longFmt": "258,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -75403000,
+                    "fmt": "-75.4M",
+                    "longFmt": "-75,403,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -21526000,
+                    "fmt": "-21.53M",
+                    "longFmt": "-21,526,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -2432000,
+                    "fmt": "-2.43M",
+                    "longFmt": "-2,432,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -3629000,
+                    "fmt": "-3.63M",
+                    "longFmt": "-3,629,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 65033000,
+                    "fmt": "65.03M",
+                    "longFmt": "65,033,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 25374000,
+                    "fmt": "25.37M",
+                    "longFmt": "25,374,000"
+                  },
+                  "grossProfit": {
+                    "raw": 39659000,
+                    "fmt": "39.66M",
+                    "longFmt": "39,659,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 13045000,
+                    "fmt": "13.04M",
+                    "longFmt": "13,045,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 38419000,
+                    "fmt": "38.42M",
+                    "longFmt": "38,419,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 26614000,
+                    "fmt": "26.61M",
+                    "longFmt": "26,614,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -7349000,
+                    "fmt": "-7.35M",
+                    "longFmt": "-7,349,000"
+                  },
+                  "ebit": {
+                    "raw": 26614000,
+                    "fmt": "26.61M",
+                    "longFmt": "26,614,000"
+                  },
+                  "interestExpense": {
+                    "raw": -11855000,
+                    "fmt": "-11.86M",
+                    "longFmt": "-11,855,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 19265000,
+                    "fmt": "19.27M",
+                    "longFmt": "19,265,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 1956000,
+                    "fmt": "1.96M",
+                    "longFmt": "1,956,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -15362000,
+                    "fmt": "-15.36M",
+                    "longFmt": "-15,362,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 17309000,
+                    "fmt": "17.31M",
+                    "longFmt": "17,309,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 927000,
+                    "fmt": "927k",
+                    "longFmt": "927,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 376000,
+                    "fmt": "376k",
+                    "longFmt": "376,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1483142400,
+                    "fmt": "2016-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 75941000,
+                    "fmt": "75.94M",
+                    "longFmt": "75,941,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 27263000,
+                    "fmt": "27.26M",
+                    "longFmt": "27,263,000"
+                  },
+                  "grossProfit": {
+                    "raw": 48678000,
+                    "fmt": "48.68M",
+                    "longFmt": "48,678,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 28540000,
+                    "fmt": "28.54M",
+                    "longFmt": "28,540,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 55803000,
+                    "fmt": "55.8M",
+                    "longFmt": "55,803,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 20138000,
+                    "fmt": "20.14M",
+                    "longFmt": "20,138,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -9123000,
+                    "fmt": "-9.12M",
+                    "longFmt": "-9,123,000"
+                  },
+                  "ebit": {
+                    "raw": 20138000,
+                    "fmt": "20.14M",
+                    "longFmt": "20,138,000"
+                  },
+                  "interestExpense": {
+                    "raw": -9226000,
+                    "fmt": "-9.23M",
+                    "longFmt": "-9,226,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 11015000,
+                    "fmt": "11.02M",
+                    "longFmt": "11,015,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 1063000,
+                    "fmt": "1.06M",
+                    "longFmt": "1,063,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -15004000,
+                    "fmt": "-15M",
+                    "longFmt": "-15,004,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 9952000,
+                    "fmt": "9.95M",
+                    "longFmt": "9,952,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 997000,
+                    "fmt": "997k",
+                    "longFmt": "997,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 105000,
+                    "fmt": "105k",
+                    "longFmt": "105,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistory-SI.json
+++ b/tests/http/quoteSummary-incomeStatementHistory-SI.json
@@ -1,0 +1,426 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=incomeStatementHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "4qeqrilg2vsee"
+      ],
+      "x-yahoo-request-id": [
+        "4qeqrilg2vsee"
+      ],
+      "x-request-id": [
+        "14bc0a3d-647b-46d6-b5eb-a0a372da7d18"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1031"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:49 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistory": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 89874000,
+                    "fmt": "89.87M",
+                    "longFmt": "89,874,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "grossProfit": {
+                    "raw": 89874000,
+                    "fmt": "89.87M",
+                    "longFmt": "89,874,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 56574000,
+                    "fmt": "56.57M",
+                    "longFmt": "56,574,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 1859000,
+                    "fmt": "1.86M",
+                    "longFmt": "1,859,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 58433000,
+                    "fmt": "58.43M",
+                    "longFmt": "58,433,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 31441000,
+                    "fmt": "31.44M",
+                    "longFmt": "31,441,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -247000,
+                    "fmt": "-247k",
+                    "longFmt": "-247,000"
+                  },
+                  "ebit": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "interestExpense": {},
+                  "incomeBeforeTax": {
+                    "raw": 31194000,
+                    "fmt": "31.19M",
+                    "longFmt": "31,194,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 5156000,
+                    "fmt": "5.16M",
+                    "longFmt": "5,156,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 26038000,
+                    "fmt": "26.04M",
+                    "longFmt": "26,038,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 26038000,
+                    "fmt": "26.04M",
+                    "longFmt": "26,038,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 26038000,
+                    "fmt": "26.04M",
+                    "longFmt": "26,038,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 87150000,
+                    "fmt": "87.15M",
+                    "longFmt": "87,150,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "grossProfit": {
+                    "raw": 87150000,
+                    "fmt": "87.15M",
+                    "longFmt": "87,150,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 50290000,
+                    "fmt": "50.29M",
+                    "longFmt": "50,290,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 1603000,
+                    "fmt": "1.6M",
+                    "longFmt": "1,603,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 51893000,
+                    "fmt": "51.89M",
+                    "longFmt": "51,893,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 35257000,
+                    "fmt": "35.26M",
+                    "longFmt": "35,257,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -585000,
+                    "fmt": "-585k",
+                    "longFmt": "-585,000"
+                  },
+                  "ebit": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "interestExpense": {},
+                  "incomeBeforeTax": {
+                    "raw": 34672000,
+                    "fmt": "34.67M",
+                    "longFmt": "34,672,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 9826000,
+                    "fmt": "9.83M",
+                    "longFmt": "9,826,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 24846000,
+                    "fmt": "24.85M",
+                    "longFmt": "24,846,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 24846000,
+                    "fmt": "24.85M",
+                    "longFmt": "24,846,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 24846000,
+                    "fmt": "24.85M",
+                    "longFmt": "24,846,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1546214400,
+                    "fmt": "2018-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 78713000,
+                    "fmt": "78.71M",
+                    "longFmt": "78,713,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "grossProfit": {
+                    "raw": 78713000,
+                    "fmt": "78.71M",
+                    "longFmt": "78,713,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 45475000,
+                    "fmt": "45.48M",
+                    "longFmt": "45,475,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 1582000,
+                    "fmt": "1.58M",
+                    "longFmt": "1,582,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 47057000,
+                    "fmt": "47.06M",
+                    "longFmt": "47,057,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 31656000,
+                    "fmt": "31.66M",
+                    "longFmt": "31,656,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -1257000,
+                    "fmt": "-1.26M",
+                    "longFmt": "-1,257,000"
+                  },
+                  "ebit": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "interestExpense": {},
+                  "incomeBeforeTax": {
+                    "raw": 30399000,
+                    "fmt": "30.4M",
+                    "longFmt": "30,399,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 8066000,
+                    "fmt": "8.07M",
+                    "longFmt": "8,066,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 22333000,
+                    "fmt": "22.33M",
+                    "longFmt": "22,333,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 22333000,
+                    "fmt": "22.33M",
+                    "longFmt": "22,333,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 22333000,
+                    "fmt": "22.33M",
+                    "longFmt": "22,333,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1514678400,
+                    "fmt": "2017-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 45137000,
+                    "fmt": "45.14M",
+                    "longFmt": "45,137,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "grossProfit": {
+                    "raw": 45137000,
+                    "fmt": "45.14M",
+                    "longFmt": "45,137,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 28631000,
+                    "fmt": "28.63M",
+                    "longFmt": "28,631,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 1370000,
+                    "fmt": "1.37M",
+                    "longFmt": "1,370,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 30001000,
+                    "fmt": "30M",
+                    "longFmt": "30,001,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 15136000,
+                    "fmt": "15.14M",
+                    "longFmt": "15,136,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -705000,
+                    "fmt": "-705k",
+                    "longFmt": "-705,000"
+                  },
+                  "ebit": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "interestExpense": {},
+                  "incomeBeforeTax": {
+                    "raw": 14431000,
+                    "fmt": "14.43M",
+                    "longFmt": "14,431,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 6788000,
+                    "fmt": "6.79M",
+                    "longFmt": "6,788,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 7643000,
+                    "fmt": "7.64M",
+                    "longFmt": "7,643,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 7643000,
+                    "fmt": "7.64M",
+                    "longFmt": "7,643,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 7643000,
+                    "fmt": "7.64M",
+                    "longFmt": "7,643,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistoryQuarterly-ABBV.json
+++ b/tests/http/quoteSummary-incomeStatementHistoryQuarterly-ABBV.json
@@ -1,0 +1,454 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=incomeStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "7aqnsmdg2vsef"
+      ],
+      "x-yahoo-request-id": [
+        "7aqnsmdg2vsef"
+      ],
+      "x-request-id": [
+        "d0bcdf8a-2934-4d49-8f26-5f9de190174f"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1184"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:51 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 13858000000,
+                    "fmt": "13.86B",
+                    "longFmt": "13,858,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 4412000000,
+                    "fmt": "4.41B",
+                    "longFmt": "4,412,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 9446000000,
+                    "fmt": "9.45B",
+                    "longFmt": "9,446,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 1821000000,
+                    "fmt": "1.82B",
+                    "longFmt": "1,821,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 3105000000,
+                    "fmt": "3.1B",
+                    "longFmt": "3,105,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 9338000000,
+                    "fmt": "9.34B",
+                    "longFmt": "9,338,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 4520000000,
+                    "fmt": "4.52B",
+                    "longFmt": "4,520,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -6027000000,
+                    "fmt": "-6.03B",
+                    "longFmt": "-6,027,000,000"
+                  },
+                  "ebit": {
+                    "raw": 4520000000,
+                    "fmt": "4.52B",
+                    "longFmt": "4,520,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -618000000,
+                    "fmt": "-618M",
+                    "longFmt": "-618,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -1507000000,
+                    "fmt": "-1.51B",
+                    "longFmt": "-1,507,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -1545000000,
+                    "fmt": "-1.54B",
+                    "longFmt": "-1,545,000,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 38000000,
+                    "fmt": "38M",
+                    "longFmt": "38,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 36000000,
+                    "fmt": "36M",
+                    "longFmt": "36,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 36000000,
+                    "fmt": "36M",
+                    "longFmt": "36,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 12902000000,
+                    "fmt": "12.9B",
+                    "longFmt": "12,902,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 5028000000,
+                    "fmt": "5.03B",
+                    "longFmt": "5,028,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 7874000000,
+                    "fmt": "7.87B",
+                    "longFmt": "7,874,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 1575000000,
+                    "fmt": "1.57B",
+                    "longFmt": "1,575,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 2752000000,
+                    "fmt": "2.75B",
+                    "longFmt": "2,752,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 9355000000,
+                    "fmt": "9.36B",
+                    "longFmt": "9,355,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 3547000000,
+                    "fmt": "3.55B",
+                    "longFmt": "3,547,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -1047000000,
+                    "fmt": "-1.05B",
+                    "longFmt": "-1,047,000,000"
+                  },
+                  "ebit": {
+                    "raw": 3547000000,
+                    "fmt": "3.55B",
+                    "longFmt": "3,547,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -630000000,
+                    "fmt": "-630M",
+                    "longFmt": "-630,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 2500000000,
+                    "fmt": "2.5B",
+                    "longFmt": "2,500,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 187000000,
+                    "fmt": "187M",
+                    "longFmt": "187,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 19000000,
+                    "fmt": "19M",
+                    "longFmt": "19,000,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 2313000000,
+                    "fmt": "2.31B",
+                    "longFmt": "2,313,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 2308000000,
+                    "fmt": "2.31B",
+                    "longFmt": "2,308,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 2291000000,
+                    "fmt": "2.29B",
+                    "longFmt": "2,291,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 10425000000,
+                    "fmt": "10.43B",
+                    "longFmt": "10,425,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 3246000000,
+                    "fmt": "3.25B",
+                    "longFmt": "3,246,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 7179000000,
+                    "fmt": "7.18B",
+                    "longFmt": "7,179,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 1406000000,
+                    "fmt": "1.41B",
+                    "longFmt": "1,406,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 2367000000,
+                    "fmt": "2.37B",
+                    "longFmt": "2,367,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 7019000000,
+                    "fmt": "7.02B",
+                    "longFmt": "7,019,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 3406000000,
+                    "fmt": "3.41B",
+                    "longFmt": "3,406,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -4099000000,
+                    "fmt": "-4.1B",
+                    "longFmt": "-4,099,000,000"
+                  },
+                  "ebit": {
+                    "raw": 3406000000,
+                    "fmt": "3.41B",
+                    "longFmt": "3,406,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -632000000,
+                    "fmt": "-632M",
+                    "longFmt": "-632,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -693000000,
+                    "fmt": "-693M",
+                    "longFmt": "-693,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 46000000,
+                    "fmt": "46M",
+                    "longFmt": "46,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 24000000,
+                    "fmt": "24M",
+                    "longFmt": "24,000,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -739000000,
+                    "fmt": "-739M",
+                    "longFmt": "-739,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -738000000,
+                    "fmt": "-738M",
+                    "longFmt": "-738,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -756000000,
+                    "fmt": "-756M",
+                    "longFmt": "-756,000,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 8619000000,
+                    "fmt": "8.62B",
+                    "longFmt": "8,619,000,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 2373000000,
+                    "fmt": "2.37B",
+                    "longFmt": "2,373,000,000"
+                  },
+                  "grossProfit": {
+                    "raw": 6246000000,
+                    "fmt": "6.25B",
+                    "longFmt": "6,246,000,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 1379000000,
+                    "fmt": "1.38B",
+                    "longFmt": "1,379,000,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 1649000000,
+                    "fmt": "1.65B",
+                    "longFmt": "1,649,000,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 5401000000,
+                    "fmt": "5.4B",
+                    "longFmt": "5,401,000,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 3218000000,
+                    "fmt": "3.22B",
+                    "longFmt": "3,218,000,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -120000000,
+                    "fmt": "-120M",
+                    "longFmt": "-120,000,000"
+                  },
+                  "ebit": {
+                    "raw": 3218000000,
+                    "fmt": "3.22B",
+                    "longFmt": "3,218,000,000"
+                  },
+                  "interestExpense": {
+                    "raw": -563000000,
+                    "fmt": "-563M",
+                    "longFmt": "-563,000,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 3098000000,
+                    "fmt": "3.1B",
+                    "longFmt": "3,098,000,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 88000000,
+                    "fmt": "88M",
+                    "longFmt": "88,000,000"
+                  },
+                  "minorityInterest": {
+                    "raw": 24000000,
+                    "fmt": "24M",
+                    "longFmt": "24,000,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 3010000000,
+                    "fmt": "3.01B",
+                    "longFmt": "3,010,000,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 3010000000,
+                    "fmt": "3.01B",
+                    "longFmt": "3,010,000,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 3000000000,
+                    "fmt": "3B",
+                    "longFmt": "3,000,000,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistoryQuarterly-BRKS.json
+++ b/tests/http/quoteSummary-incomeStatementHistoryQuarterly-BRKS.json
@@ -1,0 +1,458 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=incomeStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "22i5e95g2vsef"
+      ],
+      "x-yahoo-request-id": [
+        "22i5e95g2vsef"
+      ],
+      "x-request-id": [
+        "12834a27-e462-41d3-a6b9-325563dd8b27"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1255"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:51 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "3"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 249503000,
+                    "fmt": "249.5M",
+                    "longFmt": "249,503,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 136375000,
+                    "fmt": "136.38M",
+                    "longFmt": "136,375,000"
+                  },
+                  "grossProfit": {
+                    "raw": 113128000,
+                    "fmt": "113.13M",
+                    "longFmt": "113,128,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 16083000,
+                    "fmt": "16.08M",
+                    "longFmt": "16,083,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 63030000,
+                    "fmt": "63.03M",
+                    "longFmt": "63,030,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 215488000,
+                    "fmt": "215.49M",
+                    "longFmt": "215,488,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 34015000,
+                    "fmt": "34.02M",
+                    "longFmt": "34,015,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -2238000,
+                    "fmt": "-2.24M",
+                    "longFmt": "-2,238,000"
+                  },
+                  "ebit": {
+                    "raw": 34015000,
+                    "fmt": "34.02M",
+                    "longFmt": "34,015,000"
+                  },
+                  "interestExpense": {
+                    "raw": -556000,
+                    "fmt": "-556k",
+                    "longFmt": "-556,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 31777000,
+                    "fmt": "31.78M",
+                    "longFmt": "31,777,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 4770000,
+                    "fmt": "4.77M",
+                    "longFmt": "4,770,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 27007000,
+                    "fmt": "27.01M",
+                    "longFmt": "27,007,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -979000,
+                    "fmt": "-979k",
+                    "longFmt": "-979,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 26028000,
+                    "fmt": "26.03M",
+                    "longFmt": "26,028,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 26028000,
+                    "fmt": "26.03M",
+                    "longFmt": "26,028,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 246196000,
+                    "fmt": "246.2M",
+                    "longFmt": "246,196,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 134226000,
+                    "fmt": "134.23M",
+                    "longFmt": "134,226,000"
+                  },
+                  "grossProfit": {
+                    "raw": 111970000,
+                    "fmt": "111.97M",
+                    "longFmt": "111,970,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 15336000,
+                    "fmt": "15.34M",
+                    "longFmt": "15,336,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 62471000,
+                    "fmt": "62.47M",
+                    "longFmt": "62,471,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 212033000,
+                    "fmt": "212.03M",
+                    "longFmt": "212,033,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 34163000,
+                    "fmt": "34.16M",
+                    "longFmt": "34,163,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -810000,
+                    "fmt": "-810k",
+                    "longFmt": "-810,000"
+                  },
+                  "ebit": {
+                    "raw": 34163000,
+                    "fmt": "34.16M",
+                    "longFmt": "34,163,000"
+                  },
+                  "interestExpense": {
+                    "raw": -695000,
+                    "fmt": "-695k",
+                    "longFmt": "-695,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 33353000,
+                    "fmt": "33.35M",
+                    "longFmt": "33,353,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 4380000,
+                    "fmt": "4.38M",
+                    "longFmt": "4,380,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 28973000,
+                    "fmt": "28.97M",
+                    "longFmt": "28,973,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -979000,
+                    "fmt": "-979k",
+                    "longFmt": "-979,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 28973000,
+                    "fmt": "28.97M",
+                    "longFmt": "28,973,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 28973000,
+                    "fmt": "28.97M",
+                    "longFmt": "28,973,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 220350000,
+                    "fmt": "220.35M",
+                    "longFmt": "220,350,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 127262000,
+                    "fmt": "127.26M",
+                    "longFmt": "127,262,000"
+                  },
+                  "grossProfit": {
+                    "raw": 93088000,
+                    "fmt": "93.09M",
+                    "longFmt": "93,088,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 14004000,
+                    "fmt": "14M",
+                    "longFmt": "14,004,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 59714000,
+                    "fmt": "59.71M",
+                    "longFmt": "59,714,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 200980000,
+                    "fmt": "200.98M",
+                    "longFmt": "200,980,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 19370000,
+                    "fmt": "19.37M",
+                    "longFmt": "19,370,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -554000,
+                    "fmt": "-554k",
+                    "longFmt": "-554,000"
+                  },
+                  "ebit": {
+                    "raw": 19370000,
+                    "fmt": "19.37M",
+                    "longFmt": "19,370,000"
+                  },
+                  "interestExpense": {
+                    "raw": -810000,
+                    "fmt": "-810k",
+                    "longFmt": "-810,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 18816000,
+                    "fmt": "18.82M",
+                    "longFmt": "18,816,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 5120000,
+                    "fmt": "5.12M",
+                    "longFmt": "5,120,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 13696000,
+                    "fmt": "13.7M",
+                    "longFmt": "13,696,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -979000,
+                    "fmt": "-979k",
+                    "longFmt": "-979,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 13696000,
+                    "fmt": "13.7M",
+                    "longFmt": "13,696,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 13696000,
+                    "fmt": "13.7M",
+                    "longFmt": "13,696,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 220227000,
+                    "fmt": "220.23M",
+                    "longFmt": "220,227,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 129946000,
+                    "fmt": "129.95M",
+                    "longFmt": "129,946,000"
+                  },
+                  "grossProfit": {
+                    "raw": 90281000,
+                    "fmt": "90.28M",
+                    "longFmt": "90,281,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 15322000,
+                    "fmt": "15.32M",
+                    "longFmt": "15,322,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 59609000,
+                    "fmt": "59.61M",
+                    "longFmt": "59,609,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 204877000,
+                    "fmt": "204.88M",
+                    "longFmt": "204,877,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 15350000,
+                    "fmt": "15.35M",
+                    "longFmt": "15,350,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -2758000,
+                    "fmt": "-2.76M",
+                    "longFmt": "-2,758,000"
+                  },
+                  "ebit": {
+                    "raw": 15350000,
+                    "fmt": "15.35M",
+                    "longFmt": "15,350,000"
+                  },
+                  "interestExpense": {
+                    "raw": -718000,
+                    "fmt": "-718k",
+                    "longFmt": "-718,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 12592000,
+                    "fmt": "12.59M",
+                    "longFmt": "12,592,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 3400000,
+                    "fmt": "3.4M",
+                    "longFmt": "3,400,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 9192000,
+                    "fmt": "9.19M",
+                    "longFmt": "9,192,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -65000,
+                    "fmt": "-65k",
+                    "longFmt": "-65,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 9127000,
+                    "fmt": "9.13M",
+                    "longFmt": "9,127,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 9127000,
+                    "fmt": "9.13M",
+                    "longFmt": "9,127,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistoryQuarterly-CRON.json
+++ b/tests/http/quoteSummary-incomeStatementHistoryQuarterly-CRON.json
@@ -1,0 +1,478 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=incomeStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "5o9thdpg2vseg"
+      ],
+      "x-yahoo-request-id": [
+        "5o9thdpg2vseg"
+      ],
+      "x-request-id": [
+        "42cd4174-dd67-4d37-ba17-e862b82ac787"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1340"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:52 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 11358000,
+                    "fmt": "11.36M",
+                    "longFmt": "11,358,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 12895000,
+                    "fmt": "12.89M",
+                    "longFmt": "12,895,000"
+                  },
+                  "grossProfit": {
+                    "raw": -1537000,
+                    "fmt": "-1.54M",
+                    "longFmt": "-1,537,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 4734000,
+                    "fmt": "4.73M",
+                    "longFmt": "4,734,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 26096000,
+                    "fmt": "26.1M",
+                    "longFmt": "26,096,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 52527000,
+                    "fmt": "52.53M",
+                    "longFmt": "52,527,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -41169000,
+                    "fmt": "-41.17M",
+                    "longFmt": "-41,169,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 111094000,
+                    "fmt": "111.09M",
+                    "longFmt": "111,094,000"
+                  },
+                  "ebit": {
+                    "raw": -41169000,
+                    "fmt": "-41.17M",
+                    "longFmt": "-41,169,000"
+                  },
+                  "interestExpense": {
+                    "raw": -66000,
+                    "fmt": "-66k",
+                    "longFmt": "-66,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 69925000,
+                    "fmt": "69.92M",
+                    "longFmt": "69,925,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 988000,
+                    "fmt": "988k",
+                    "longFmt": "988,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -2503000,
+                    "fmt": "-2.5M",
+                    "longFmt": "-2,503,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 68937000,
+                    "fmt": "68.94M",
+                    "longFmt": "68,937,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -473000,
+                    "fmt": "-473k",
+                    "longFmt": "-473,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 69033000,
+                    "fmt": "69.03M",
+                    "longFmt": "69,033,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 69033000,
+                    "fmt": "69.03M",
+                    "longFmt": "69,033,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 9883000,
+                    "fmt": "9.88M",
+                    "longFmt": "9,883,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 12836000,
+                    "fmt": "12.84M",
+                    "longFmt": "12,836,000"
+                  },
+                  "grossProfit": {
+                    "raw": -2953000,
+                    "fmt": "-2.95M",
+                    "longFmt": "-2,953,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 3631000,
+                    "fmt": "3.63M",
+                    "longFmt": "3,631,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 24941000,
+                    "fmt": "24.94M",
+                    "longFmt": "24,941,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 44638000,
+                    "fmt": "44.64M",
+                    "longFmt": "44,638,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -34755000,
+                    "fmt": "-34.76M",
+                    "longFmt": "-34,755,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -72948000,
+                    "fmt": "-72.95M",
+                    "longFmt": "-72,948,000"
+                  },
+                  "ebit": {
+                    "raw": -34755000,
+                    "fmt": "-34.76M",
+                    "longFmt": "-34,755,000"
+                  },
+                  "interestExpense": {
+                    "raw": -83000,
+                    "fmt": "-83k",
+                    "longFmt": "-83,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -107703000,
+                    "fmt": "-107.7M",
+                    "longFmt": "-107,703,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "minorityInterest": {
+                    "raw": -1951000,
+                    "fmt": "-1.95M",
+                    "longFmt": "-1,951,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -107703000,
+                    "fmt": "-107.7M",
+                    "longFmt": "-107,703,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -473000,
+                    "fmt": "-473k",
+                    "longFmt": "-473,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -106977000,
+                    "fmt": "-106.98M",
+                    "longFmt": "-106,977,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -106977000,
+                    "fmt": "-106.98M",
+                    "longFmt": "-106,977,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 8432000,
+                    "fmt": "8.43M",
+                    "longFmt": "8,432,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 14908000,
+                    "fmt": "14.91M",
+                    "longFmt": "14,908,000"
+                  },
+                  "grossProfit": {
+                    "raw": -6476000,
+                    "fmt": "-6.48M",
+                    "longFmt": "-6,476,000"
+                  },
+                  "researchDevelopment": {
+                    "raw": 4590000,
+                    "fmt": "4.59M",
+                    "longFmt": "4,590,000"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 30871000,
+                    "fmt": "30.87M",
+                    "longFmt": "30,871,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 53492000,
+                    "fmt": "53.49M",
+                    "longFmt": "53,492,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -45060000,
+                    "fmt": "-45.06M",
+                    "longFmt": "-45,060,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 120741000,
+                    "fmt": "120.74M",
+                    "longFmt": "120,741,000"
+                  },
+                  "ebit": {
+                    "raw": -45060000,
+                    "fmt": "-45.06M",
+                    "longFmt": "-45,060,000"
+                  },
+                  "interestExpense": {
+                    "raw": -83000,
+                    "fmt": "-83k",
+                    "longFmt": "-83,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 75681000,
+                    "fmt": "75.68M",
+                    "longFmt": "75,681,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "minorityInterest": {
+                    "raw": -1189000,
+                    "fmt": "-1.19M",
+                    "longFmt": "-1,189,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 75681000,
+                    "fmt": "75.68M",
+                    "longFmt": "75,681,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -473000,
+                    "fmt": "-473k",
+                    "longFmt": "-473,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 76040000,
+                    "fmt": "76.04M",
+                    "longFmt": "76,040,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 76040000,
+                    "fmt": "76.04M",
+                    "longFmt": "76,040,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 6889242,
+                    "fmt": "6.89M",
+                    "longFmt": "6,889,242"
+                  },
+                  "costOfRevenue": {
+                    "raw": 21429996,
+                    "fmt": "21.43M",
+                    "longFmt": "21,429,996"
+                  },
+                  "grossProfit": {
+                    "raw": -14540754,
+                    "fmt": "-14.54M",
+                    "longFmt": "-14,540,754"
+                  },
+                  "researchDevelopment": {
+                    "raw": 5931577,
+                    "fmt": "5.93M",
+                    "longFmt": "5,931,577"
+                  },
+                  "sellingGeneralAdministrative": {
+                    "raw": 26950237,
+                    "fmt": "26.95M",
+                    "longFmt": "26,950,237"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 5328000,
+                    "fmt": "5.33M",
+                    "longFmt": "5,328,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 67406232,
+                    "fmt": "67.41M",
+                    "longFmt": "67,406,232"
+                  },
+                  "operatingIncome": {
+                    "raw": -60516991,
+                    "fmt": "-60.52M",
+                    "longFmt": "-60,516,991"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 97996076,
+                    "fmt": "98M",
+                    "longFmt": "97,996,076"
+                  },
+                  "ebit": {
+                    "raw": -60516991,
+                    "fmt": "-60.52M",
+                    "longFmt": "-60,516,991"
+                  },
+                  "interestExpense": {
+                    "raw": -1244000,
+                    "fmt": "-1.24M",
+                    "longFmt": "-1,244,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 37479086,
+                    "fmt": "37.48M",
+                    "longFmt": "37,479,086"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 1628329,
+                    "fmt": "1.63M",
+                    "longFmt": "1,628,329"
+                  },
+                  "minorityInterest": {
+                    "raw": -853000,
+                    "fmt": "-853k",
+                    "longFmt": "-853,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": 35850757,
+                    "fmt": "35.85M",
+                    "longFmt": "35,850,757"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -473000,
+                    "fmt": "-473k",
+                    "longFmt": "-473,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 36276217,
+                    "fmt": "36.28M",
+                    "longFmt": "36,276,217"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 36276217,
+                    "fmt": "36.28M",
+                    "longFmt": "36,276,217"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistoryQuarterly-EPAC.json
+++ b/tests/http/quoteSummary-incomeStatementHistoryQuarterly-EPAC.json
@@ -1,0 +1,442 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=incomeStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "8fkfoddg2vseg"
+      ],
+      "x-yahoo-request-id": [
+        "8fkfoddg2vseg"
+      ],
+      "x-request-id": [
+        "6b900b77-4939-4a58-8be6-cd3d6a5324bd"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1244"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:52 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1606694400,
+                    "fmt": "2020-11-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 119430000,
+                    "fmt": "119.43M",
+                    "longFmt": "119,430,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 64166000,
+                    "fmt": "64.17M",
+                    "longFmt": "64,166,000"
+                  },
+                  "grossProfit": {
+                    "raw": 55264000,
+                    "fmt": "55.26M",
+                    "longFmt": "55,264,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 43710000,
+                    "fmt": "43.71M",
+                    "longFmt": "43,710,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 110012000,
+                    "fmt": "110.01M",
+                    "longFmt": "110,012,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 9418000,
+                    "fmt": "9.42M",
+                    "longFmt": "9,418,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -2338000,
+                    "fmt": "-2.34M",
+                    "longFmt": "-2,338,000"
+                  },
+                  "ebit": {
+                    "raw": 9418000,
+                    "fmt": "9.42M",
+                    "longFmt": "9,418,000"
+                  },
+                  "interestExpense": {
+                    "raw": -1716000,
+                    "fmt": "-1.72M",
+                    "longFmt": "-1,716,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 7080000,
+                    "fmt": "7.08M",
+                    "longFmt": "7,080,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 2258000,
+                    "fmt": "2.26M",
+                    "longFmt": "2,258,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 4822000,
+                    "fmt": "4.82M",
+                    "longFmt": "4,822,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -224000,
+                    "fmt": "-224k",
+                    "longFmt": "-224,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 4598000,
+                    "fmt": "4.6M",
+                    "longFmt": "4,598,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 4598000,
+                    "fmt": "4.6M",
+                    "longFmt": "4,598,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1598832000,
+                    "fmt": "2020-08-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 111353000,
+                    "fmt": "111.35M",
+                    "longFmt": "111,353,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 66888000,
+                    "fmt": "66.89M",
+                    "longFmt": "66,888,000"
+                  },
+                  "grossProfit": {
+                    "raw": 44465000,
+                    "fmt": "44.47M",
+                    "longFmt": "44,465,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 38771000,
+                    "fmt": "38.77M",
+                    "longFmt": "38,771,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 107815000,
+                    "fmt": "107.81M",
+                    "longFmt": "107,815,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 3538000,
+                    "fmt": "3.54M",
+                    "longFmt": "3,538,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -2398000,
+                    "fmt": "-2.4M",
+                    "longFmt": "-2,398,000"
+                  },
+                  "ebit": {
+                    "raw": 3538000,
+                    "fmt": "3.54M",
+                    "longFmt": "3,538,000"
+                  },
+                  "interestExpense": {
+                    "raw": -3607000,
+                    "fmt": "-3.61M",
+                    "longFmt": "-3,607,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 1140000,
+                    "fmt": "1.14M",
+                    "longFmt": "1,140,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 943000,
+                    "fmt": "943k",
+                    "longFmt": "943,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 197000,
+                    "fmt": "197k",
+                    "longFmt": "197,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": 1242000,
+                    "fmt": "1.24M",
+                    "longFmt": "1,242,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 1439000,
+                    "fmt": "1.44M",
+                    "longFmt": "1,439,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 1439000,
+                    "fmt": "1.44M",
+                    "longFmt": "1,439,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1590883200,
+                    "fmt": "2020-05-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 101879000,
+                    "fmt": "101.88M",
+                    "longFmt": "101,879,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 59132000,
+                    "fmt": "59.13M",
+                    "longFmt": "59,132,000"
+                  },
+                  "grossProfit": {
+                    "raw": 42747000,
+                    "fmt": "42.75M",
+                    "longFmt": "42,747,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 40766000,
+                    "fmt": "40.77M",
+                    "longFmt": "40,766,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 102072000,
+                    "fmt": "102.07M",
+                    "longFmt": "102,072,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -193000,
+                    "fmt": "-193k",
+                    "longFmt": "-193,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -5144000,
+                    "fmt": "-5.14M",
+                    "longFmt": "-5,144,000"
+                  },
+                  "ebit": {
+                    "raw": -193000,
+                    "fmt": "-193k",
+                    "longFmt": "-193,000"
+                  },
+                  "interestExpense": {
+                    "raw": -4552000,
+                    "fmt": "-4.55M",
+                    "longFmt": "-4,552,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -5337000,
+                    "fmt": "-5.34M",
+                    "longFmt": "-5,337,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -407000,
+                    "fmt": "-407k",
+                    "longFmt": "-407,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": -4930000,
+                    "fmt": "-4.93M",
+                    "longFmt": "-4,930,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -69000,
+                    "fmt": "-69k",
+                    "longFmt": "-69,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -4999000,
+                    "fmt": "-5M",
+                    "longFmt": "-4,999,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -4999000,
+                    "fmt": "-5M",
+                    "longFmt": "-4,999,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1582934400,
+                    "fmt": "2020-02-29"
+                  },
+                  "totalRevenue": {
+                    "raw": 133386000,
+                    "fmt": "133.39M",
+                    "longFmt": "133,386,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 71293000,
+                    "fmt": "71.29M",
+                    "longFmt": "71,293,000"
+                  },
+                  "grossProfit": {
+                    "raw": 62093000,
+                    "fmt": "62.09M",
+                    "longFmt": "62,093,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 50045000,
+                    "fmt": "50.05M",
+                    "longFmt": "50,045,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 123458000,
+                    "fmt": "123.46M",
+                    "longFmt": "123,458,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 9928000,
+                    "fmt": "9.93M",
+                    "longFmt": "9,928,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -5204000,
+                    "fmt": "-5.2M",
+                    "longFmt": "-5,204,000"
+                  },
+                  "ebit": {
+                    "raw": 9928000,
+                    "fmt": "9.93M",
+                    "longFmt": "9,928,000"
+                  },
+                  "interestExpense": {
+                    "raw": -4630000,
+                    "fmt": "-4.63M",
+                    "longFmt": "-4,630,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": 4724000,
+                    "fmt": "4.72M",
+                    "longFmt": "4,724,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 806000,
+                    "fmt": "806k",
+                    "longFmt": "806,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 3918000,
+                    "fmt": "3.92M",
+                    "longFmt": "3,918,000"
+                  },
+                  "discontinuedOperations": {
+                    "raw": -1756000,
+                    "fmt": "-1.76M",
+                    "longFmt": "-1,756,000"
+                  },
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 2162000,
+                    "fmt": "2.16M",
+                    "longFmt": "2,162,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 2162000,
+                    "fmt": "2.16M",
+                    "longFmt": "2,162,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistoryQuarterly-MDLY.json
+++ b/tests/http/quoteSummary-incomeStatementHistoryQuarterly-MDLY.json
@@ -1,0 +1,442 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=incomeStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "co3mv8tg2vsef"
+      ],
+      "x-yahoo-request-id": [
+        "co3mv8tg2vsef"
+      ],
+      "x-request-id": [
+        "c666eebc-2190-48d7-ba45-40a603ec63e6"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1226"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:51 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 8326000,
+                    "fmt": "8.33M",
+                    "longFmt": "8,326,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 4054000,
+                    "fmt": "4.05M",
+                    "longFmt": "4,054,000"
+                  },
+                  "grossProfit": {
+                    "raw": 4272000,
+                    "fmt": "4.27M",
+                    "longFmt": "4,272,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 2599000,
+                    "fmt": "2.6M",
+                    "longFmt": "2,599,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 6653000,
+                    "fmt": "6.65M",
+                    "longFmt": "6,653,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 1673000,
+                    "fmt": "1.67M",
+                    "longFmt": "1,673,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -3688000,
+                    "fmt": "-3.69M",
+                    "longFmt": "-3,688,000"
+                  },
+                  "ebit": {
+                    "raw": 1673000,
+                    "fmt": "1.67M",
+                    "longFmt": "1,673,000"
+                  },
+                  "interestExpense": {
+                    "raw": -2535000,
+                    "fmt": "-2.54M",
+                    "longFmt": "-2,535,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -2015000,
+                    "fmt": "-2.02M",
+                    "longFmt": "-2,015,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -320000,
+                    "fmt": "-320k",
+                    "longFmt": "-320,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -123848000,
+                    "fmt": "-123.85M",
+                    "longFmt": "-123,848,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -1695000,
+                    "fmt": "-1.7M",
+                    "longFmt": "-1,695,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -122000,
+                    "fmt": "-122k",
+                    "longFmt": "-122,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -122000,
+                    "fmt": "-122k",
+                    "longFmt": "-122,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 8577000,
+                    "fmt": "8.58M",
+                    "longFmt": "8,577,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 4905000,
+                    "fmt": "4.91M",
+                    "longFmt": "4,905,000"
+                  },
+                  "grossProfit": {
+                    "raw": 3672000,
+                    "fmt": "3.67M",
+                    "longFmt": "3,672,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 2546000,
+                    "fmt": "2.55M",
+                    "longFmt": "2,546,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 7451000,
+                    "fmt": "7.45M",
+                    "longFmt": "7,451,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 1126000,
+                    "fmt": "1.13M",
+                    "longFmt": "1,126,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -10742000,
+                    "fmt": "-10.74M",
+                    "longFmt": "-10,742,000"
+                  },
+                  "ebit": {
+                    "raw": 1126000,
+                    "fmt": "1.13M",
+                    "longFmt": "1,126,000"
+                  },
+                  "interestExpense": {
+                    "raw": -2622000,
+                    "fmt": "-2.62M",
+                    "longFmt": "-2,622,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -9616000,
+                    "fmt": "-9.62M",
+                    "longFmt": "-9,616,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -1356000,
+                    "fmt": "-1.36M",
+                    "longFmt": "-1,356,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -122161000,
+                    "fmt": "-122.16M",
+                    "longFmt": "-122,161,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -8260000,
+                    "fmt": "-8.26M",
+                    "longFmt": "-8,260,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -814000,
+                    "fmt": "-814k",
+                    "longFmt": "-814,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -742000,
+                    "fmt": "-742k",
+                    "longFmt": "-742,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 7872000,
+                    "fmt": "7.87M",
+                    "longFmt": "7,872,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 6202000,
+                    "fmt": "6.2M",
+                    "longFmt": "6,202,000"
+                  },
+                  "grossProfit": {
+                    "raw": 1670000,
+                    "fmt": "1.67M",
+                    "longFmt": "1,670,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 3037000,
+                    "fmt": "3.04M",
+                    "longFmt": "3,037,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 9239000,
+                    "fmt": "9.24M",
+                    "longFmt": "9,239,000"
+                  },
+                  "operatingIncome": {
+                    "raw": -1367000,
+                    "fmt": "-1.37M",
+                    "longFmt": "-1,367,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -4433000,
+                    "fmt": "-4.43M",
+                    "longFmt": "-4,433,000"
+                  },
+                  "ebit": {
+                    "raw": -1367000,
+                    "fmt": "-1.37M",
+                    "longFmt": "-1,367,000"
+                  },
+                  "interestExpense": {
+                    "raw": -2793000,
+                    "fmt": "-2.79M",
+                    "longFmt": "-2,793,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -5800000,
+                    "fmt": "-5.8M",
+                    "longFmt": "-5,800,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 39000,
+                    "fmt": "39k",
+                    "longFmt": "39,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -114679000,
+                    "fmt": "-114.68M",
+                    "longFmt": "-114,679,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -5839000,
+                    "fmt": "-5.84M",
+                    "longFmt": "-5,839,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -1130000,
+                    "fmt": "-1.13M",
+                    "longFmt": "-1,130,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -1275000,
+                    "fmt": "-1.27M",
+                    "longFmt": "-1,275,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1577750400,
+                    "fmt": "2019-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 10653000,
+                    "fmt": "10.65M",
+                    "longFmt": "10,653,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 5298000,
+                    "fmt": "5.3M",
+                    "longFmt": "5,298,000"
+                  },
+                  "grossProfit": {
+                    "raw": 5355000,
+                    "fmt": "5.36M",
+                    "longFmt": "5,355,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 3323000,
+                    "fmt": "3.32M",
+                    "longFmt": "3,323,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {},
+                  "totalOperatingExpenses": {
+                    "raw": 8621000,
+                    "fmt": "8.62M",
+                    "longFmt": "8,621,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 2032000,
+                    "fmt": "2.03M",
+                    "longFmt": "2,032,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -9103000,
+                    "fmt": "-9.1M",
+                    "longFmt": "-9,103,000"
+                  },
+                  "ebit": {
+                    "raw": 2032000,
+                    "fmt": "2.03M",
+                    "longFmt": "2,032,000"
+                  },
+                  "interestExpense": {
+                    "raw": -2851000,
+                    "fmt": "-2.85M",
+                    "longFmt": "-2,851,000"
+                  },
+                  "incomeBeforeTax": {
+                    "raw": -7071000,
+                    "fmt": "-7.07M",
+                    "longFmt": "-7,071,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 4991000,
+                    "fmt": "4.99M",
+                    "longFmt": "4,991,000"
+                  },
+                  "minorityInterest": {
+                    "raw": -109714000,
+                    "fmt": "-109.71M",
+                    "longFmt": "-109,714,000"
+                  },
+                  "netIncomeFromContinuingOps": {
+                    "raw": -12062000,
+                    "fmt": "-12.06M",
+                    "longFmt": "-12,062,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": -2609000,
+                    "fmt": "-2.61M",
+                    "longFmt": "-2,609,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": -2760000,
+                    "fmt": "-2.76M",
+                    "longFmt": "-2,760,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-incomeStatementHistoryQuarterly-SI.json
+++ b/tests/http/quoteSummary-incomeStatementHistoryQuarterly-SI.json
@@ -1,0 +1,426 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=incomeStatementHistoryQuarterly"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "2lmbaj9g2vsef"
+      ],
+      "x-yahoo-request-id": [
+        "2lmbaj9g2vsef"
+      ],
+      "x-request-id": [
+        "8416296e-dea8-4f2f-aa09-644c5022f195"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "991"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:51 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "incomeStatementHistoryQuarterly": {
+              "incomeStatementHistory": [
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 26603000,
+                    "fmt": "26.6M",
+                    "longFmt": "26,603,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "grossProfit": {
+                    "raw": 26603000,
+                    "fmt": "26.6M",
+                    "longFmt": "26,603,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 16512000,
+                    "fmt": "16.51M",
+                    "longFmt": "16,512,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 455000,
+                    "fmt": "455k",
+                    "longFmt": "455,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 16967000,
+                    "fmt": "16.97M",
+                    "longFmt": "16,967,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 9636000,
+                    "fmt": "9.64M",
+                    "longFmt": "9,636,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -658000,
+                    "fmt": "-658k",
+                    "longFmt": "-658,000"
+                  },
+                  "ebit": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "interestExpense": {},
+                  "incomeBeforeTax": {
+                    "raw": 8978000,
+                    "fmt": "8.98M",
+                    "longFmt": "8,978,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": -141000,
+                    "fmt": "-141k",
+                    "longFmt": "-141,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 9119000,
+                    "fmt": "9.12M",
+                    "longFmt": "9,119,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 9119000,
+                    "fmt": "9.12M",
+                    "longFmt": "9,119,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 9119000,
+                    "fmt": "9.12M",
+                    "longFmt": "9,119,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 22890000,
+                    "fmt": "22.89M",
+                    "longFmt": "22,890,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "grossProfit": {
+                    "raw": 22890000,
+                    "fmt": "22.89M",
+                    "longFmt": "22,890,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 13438000,
+                    "fmt": "13.44M",
+                    "longFmt": "13,438,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 463000,
+                    "fmt": "463k",
+                    "longFmt": "463,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 13901000,
+                    "fmt": "13.9M",
+                    "longFmt": "13,901,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 8989000,
+                    "fmt": "8.99M",
+                    "longFmt": "8,989,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -232000,
+                    "fmt": "-232k",
+                    "longFmt": "-232,000"
+                  },
+                  "ebit": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "interestExpense": {},
+                  "incomeBeforeTax": {
+                    "raw": 8757000,
+                    "fmt": "8.76M",
+                    "longFmt": "8,757,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 1697000,
+                    "fmt": "1.7M",
+                    "longFmt": "1,697,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 7060000,
+                    "fmt": "7.06M",
+                    "longFmt": "7,060,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 7060000,
+                    "fmt": "7.06M",
+                    "longFmt": "7,060,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 7060000,
+                    "fmt": "7.06M",
+                    "longFmt": "7,060,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "totalRevenue": {
+                    "raw": 21264000,
+                    "fmt": "21.26M",
+                    "longFmt": "21,264,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "grossProfit": {
+                    "raw": 21264000,
+                    "fmt": "21.26M",
+                    "longFmt": "21,264,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 13344000,
+                    "fmt": "13.34M",
+                    "longFmt": "13,344,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 446000,
+                    "fmt": "446k",
+                    "longFmt": "446,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 13790000,
+                    "fmt": "13.79M",
+                    "longFmt": "13,790,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 7474000,
+                    "fmt": "7.47M",
+                    "longFmt": "7,474,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": -182000,
+                    "fmt": "-182k",
+                    "longFmt": "-182,000"
+                  },
+                  "ebit": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "interestExpense": {},
+                  "incomeBeforeTax": {
+                    "raw": 7292000,
+                    "fmt": "7.29M",
+                    "longFmt": "7,292,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 1826000,
+                    "fmt": "1.83M",
+                    "longFmt": "1,826,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 5466000,
+                    "fmt": "5.47M",
+                    "longFmt": "5,466,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 5466000,
+                    "fmt": "5.47M",
+                    "longFmt": "5,466,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 5466000,
+                    "fmt": "5.47M",
+                    "longFmt": "5,466,000"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "endDate": {
+                    "raw": 1585612800,
+                    "fmt": "2020-03-31"
+                  },
+                  "totalRevenue": {
+                    "raw": 19117000,
+                    "fmt": "19.12M",
+                    "longFmt": "19,117,000"
+                  },
+                  "costOfRevenue": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "grossProfit": {
+                    "raw": 19117000,
+                    "fmt": "19.12M",
+                    "longFmt": "19,117,000"
+                  },
+                  "researchDevelopment": {},
+                  "sellingGeneralAdministrative": {
+                    "raw": 13257000,
+                    "fmt": "13.26M",
+                    "longFmt": "13,257,000"
+                  },
+                  "nonRecurring": {},
+                  "otherOperatingExpenses": {
+                    "raw": 495000,
+                    "fmt": "495k",
+                    "longFmt": "495,000"
+                  },
+                  "totalOperatingExpenses": {
+                    "raw": 13752000,
+                    "fmt": "13.75M",
+                    "longFmt": "13,752,000"
+                  },
+                  "operatingIncome": {
+                    "raw": 5365000,
+                    "fmt": "5.37M",
+                    "longFmt": "5,365,000"
+                  },
+                  "totalOtherIncomeExpenseNet": {
+                    "raw": 802000,
+                    "fmt": "802k",
+                    "longFmt": "802,000"
+                  },
+                  "ebit": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "interestExpense": {},
+                  "incomeBeforeTax": {
+                    "raw": 6167000,
+                    "fmt": "6.17M",
+                    "longFmt": "6,167,000"
+                  },
+                  "incomeTaxExpense": {
+                    "raw": 1774000,
+                    "fmt": "1.77M",
+                    "longFmt": "1,774,000"
+                  },
+                  "minorityInterest": {},
+                  "netIncomeFromContinuingOps": {
+                    "raw": 4393000,
+                    "fmt": "4.39M",
+                    "longFmt": "4,393,000"
+                  },
+                  "discontinuedOperations": {},
+                  "extraordinaryItems": {},
+                  "effectOfAccountingCharges": {},
+                  "otherItems": {},
+                  "netIncome": {
+                    "raw": 4393000,
+                    "fmt": "4.39M",
+                    "longFmt": "4,393,000"
+                  },
+                  "netIncomeApplicableToCommonShares": {
+                    "raw": 4393000,
+                    "fmt": "4.39M",
+                    "longFmt": "4,393,000"
+                  }
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-indexTrend-ABBV.json
+++ b/tests/http/quoteSummary-indexTrend-ABBV.json
@@ -1,0 +1,109 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=indexTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "2lu882lg2vseg"
+      ],
+      "x-yahoo-request-id": [
+        "2lu882lg2vseg"
+      ],
+      "x-request-id": [
+        "6ffa225b-e848-4577-a736-cbf870bc2036"
+      ],
+      "content-length": [
+        "321"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:52 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 8.58013,
+              "pegRatio": 0.771291,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.286
+                },
+                {
+                  "period": "+1q",
+                  "growth": 1.032
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.175
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.15100001
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0827489
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-indexTrend-BRKS.json
+++ b/tests/http/quoteSummary-indexTrend-BRKS.json
@@ -1,0 +1,109 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=indexTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "8rp6velg2vseh"
+      ],
+      "x-yahoo-request-id": [
+        "8rp6velg2vseh"
+      ],
+      "x-request-id": [
+        "e912ea6c-9b0f-4196-b0fe-a8326ce6b2c0"
+      ],
+      "content-length": [
+        "321"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:53 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 8.58013,
+              "pegRatio": 0.771291,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.286
+                },
+                {
+                  "period": "+1q",
+                  "growth": 1.032
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.175
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.15100001
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0827489
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-indexTrend-CRON.json
+++ b/tests/http/quoteSummary-indexTrend-CRON.json
@@ -1,0 +1,109 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=indexTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "36p0549g2vseh"
+      ],
+      "x-yahoo-request-id": [
+        "36p0549g2vseh"
+      ],
+      "x-request-id": [
+        "adbc9b4d-80d9-4a3b-985b-75e1f467135d"
+      ],
+      "content-length": [
+        "321"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:53 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 8.58013,
+              "pegRatio": 0.771291,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.286
+                },
+                {
+                  "period": "+1q",
+                  "growth": 1.032
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.175
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.15100001
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0827489
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-indexTrend-EPAC.json
+++ b/tests/http/quoteSummary-indexTrend-EPAC.json
@@ -1,0 +1,109 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=indexTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "1lr4mapg2vseh"
+      ],
+      "x-yahoo-request-id": [
+        "1lr4mapg2vseh"
+      ],
+      "x-request-id": [
+        "16fc45ae-1c39-45de-bdae-3098c924b6d8"
+      ],
+      "content-length": [
+        "321"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:53 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 8.58013,
+              "pegRatio": 0.771291,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.286
+                },
+                {
+                  "period": "+1q",
+                  "growth": 1.032
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.175
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.15100001
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0827489
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-indexTrend-MDLY.json
+++ b/tests/http/quoteSummary-indexTrend-MDLY.json
@@ -1,0 +1,109 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=indexTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "58qe5s9g2vseg"
+      ],
+      "x-yahoo-request-id": [
+        "58qe5s9g2vseg"
+      ],
+      "x-request-id": [
+        "af61384b-b42a-4f11-a4e8-e23ffd73eb32"
+      ],
+      "content-length": [
+        "321"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:52 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 8.58013,
+              "pegRatio": 0.771291,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.286
+                },
+                {
+                  "period": "+1q",
+                  "growth": 1.032
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.175
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.15100001
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0827489
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-indexTrend-SI.json
+++ b/tests/http/quoteSummary-indexTrend-SI.json
@@ -1,0 +1,109 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=indexTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "d8qrallg2vseg"
+      ],
+      "x-yahoo-request-id": [
+        "d8qrallg2vseg"
+      ],
+      "x-request-id": [
+        "16a01519-8843-4b66-9753-0fbae9ed1e10"
+      ],
+      "content-length": [
+        "321"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:52 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "indexTrend": {
+              "maxAge": 1,
+              "symbol": "SP5",
+              "peRatio": 8.58013,
+              "pegRatio": 0.771291,
+              "estimates": [
+                {
+                  "period": "0q",
+                  "growth": 0.286
+                },
+                {
+                  "period": "+1q",
+                  "growth": 1.032
+                },
+                {
+                  "period": "0y",
+                  "growth": 0.175
+                },
+                {
+                  "period": "+1y",
+                  "growth": 0.15100001
+                },
+                {
+                  "period": "+5y",
+                  "growth": 0.0827489
+                },
+                {
+                  "period": "-5y"
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-industryTrend-ABBV.json
+++ b/tests/http/quoteSummary-industryTrend-ABBV.json
@@ -1,0 +1,83 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=industryTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "9hhofdlg2vsei"
+      ],
+      "x-yahoo-request-id": [
+        "9hhofdlg2vsei"
+      ],
+      "x-request-id": [
+        "4687e0c4-b145-9338-98ea-a1fc4ca3dbb9"
+      ],
+      "content-length": [
+        "102"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:53 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-industryTrend-BRKS.json
+++ b/tests/http/quoteSummary-industryTrend-BRKS.json
@@ -1,0 +1,83 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=industryTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "6f04b55g2vsei"
+      ],
+      "x-yahoo-request-id": [
+        "6f04b55g2vsei"
+      ],
+      "x-request-id": [
+        "813bb942-86d3-4977-a7db-e72890a32779"
+      ],
+      "content-length": [
+        "102"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:54 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-industryTrend-CRON.json
+++ b/tests/http/quoteSummary-industryTrend-CRON.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=industryTrend"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "8e3sia1g2vsei"
+      ],
+      "x-yahoo-request-id": [
+        "8e3sia1g2vsei"
+      ],
+      "x-request-id": [
+        "06a04e2e-e109-44a2-a4cb-d48ea89dfaf9"
+      ],
+      "content-length": [
+        "146"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:54 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=industryTrend"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-industryTrend-EPAC.json
+++ b/tests/http/quoteSummary-industryTrend-EPAC.json
@@ -1,0 +1,83 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=industryTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "db9vmspg2vsei"
+      ],
+      "x-yahoo-request-id": [
+        "db9vmspg2vsei"
+      ],
+      "x-request-id": [
+        "6e310c6d-b3a5-4abf-9cb6-6a59ad4660de"
+      ],
+      "content-length": [
+        "102"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:54 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-industryTrend-MDLY.json
+++ b/tests/http/quoteSummary-industryTrend-MDLY.json
@@ -1,0 +1,83 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=industryTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "7l1nnihg2vseh"
+      ],
+      "x-yahoo-request-id": [
+        "7l1nnihg2vseh"
+      ],
+      "x-request-id": [
+        "6350a927-a6b0-4ad0-8d5f-a20aa8d3357d"
+      ],
+      "content-length": [
+        "102"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:53 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "3"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-industryTrend-SI.json
+++ b/tests/http/quoteSummary-industryTrend-SI.json
@@ -1,0 +1,83 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=industryTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "b77v9glg2vseh"
+      ],
+      "x-yahoo-request-id": [
+        "b77v9glg2vseh"
+      ],
+      "x-request-id": [
+        "7d183a3a-1317-4e3e-b361-20bb2d71b4d9"
+      ],
+      "content-length": [
+        "102"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:53 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "industryTrend": {
+              "maxAge": 1,
+              "symbol": null,
+              "estimates": []
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderHolders-ABBV.json
+++ b/tests/http/quoteSummary-insiderHolders-ABBV.json
@@ -1,0 +1,281 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=insiderHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "d0fpuq9g2vsej"
+      ],
+      "x-yahoo-request-id": [
+        "d0fpuq9g2vsej"
+      ],
+      "x-request-id": [
+        "60d97590-d8b0-4c75-a54c-652d9e879c18"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "708"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:55 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "insiderHolders": {
+              "holders": [
+                {
+                  "maxAge": 1,
+                  "name": "ALBAN CARLOS",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  },
+                  "positionDirect": {
+                    "raw": 155341,
+                    "fmt": "155.34k",
+                    "longFmt": "155,341"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "GONZALEZ RICHARD A",
+                  "relation": "Chief Executive Officer",
+                  "url": "",
+                  "transactionDescription": "Stock Gift",
+                  "latestTransDate": {
+                    "raw": 1608681600,
+                    "fmt": "2020-12-23"
+                  },
+                  "positionDirect": {
+                    "raw": 315815,
+                    "fmt": "315.81k",
+                    "longFmt": "315,815"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1608681600,
+                    "fmt": "2020-12-23"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "GOSEBRUCH HENRY O",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1605830400,
+                    "fmt": "2020-11-20"
+                  },
+                  "positionDirect": {
+                    "raw": 71370,
+                    "fmt": "71.37k",
+                    "longFmt": "71,370"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605830400,
+                    "fmt": "2020-11-20"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "RAPP EDWARD J",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Gift",
+                  "latestTransDate": {
+                    "raw": 1599091200,
+                    "fmt": "2020-09-03"
+                  },
+                  "positionDirect": {
+                    "raw": 35870,
+                    "fmt": "35.87k",
+                    "longFmt": "35,870"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1599091200,
+                    "fmt": "2020-09-03"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "RICHMOND TIMOTHY J",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1606435200,
+                    "fmt": "2020-11-27"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1606435200,
+                    "fmt": "2020-11-27"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "SALEKI-GERHARDT AZITA PH.D.",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1604966400,
+                    "fmt": "2020-11-10"
+                  },
+                  "positionDirect": {
+                    "raw": 102507,
+                    "fmt": "102.51k",
+                    "longFmt": "102,507"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1604966400,
+                    "fmt": "2020-11-10"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "SCHUMACHER LAURA J",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Stock Gift",
+                  "latestTransDate": {
+                    "raw": 1608681600,
+                    "fmt": "2020-12-23"
+                  },
+                  "positionDirect": {
+                    "raw": 177541,
+                    "fmt": "177.54k",
+                    "longFmt": "177,541"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1608681600,
+                    "fmt": "2020-12-23"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "SEVERINO MICHAEL E. M.D.",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1604448000,
+                    "fmt": "2020-11-04"
+                  },
+                  "positionDirect": {
+                    "raw": 67281,
+                    "fmt": "67.28k",
+                    "longFmt": "67,281"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1604448000,
+                    "fmt": "2020-11-04"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "STEWART JEFFREY RYAN",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1609200000,
+                    "fmt": "2020-12-29"
+                  },
+                  "positionDirect": {
+                    "raw": 52307,
+                    "fmt": "52.31k",
+                    "longFmt": "52,307"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1609200000,
+                    "fmt": "2020-12-29"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "STROM CARRIE C",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1589155200,
+                    "fmt": "2020-05-11"
+                  },
+                  "positionDirect": {
+                    "raw": 63538,
+                    "fmt": "63.54k",
+                    "longFmt": "63,538"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1589155200,
+                    "fmt": "2020-05-11"
+                  }
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderHolders-BRKS.json
+++ b/tests/http/quoteSummary-insiderHolders-BRKS.json
@@ -1,0 +1,286 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=insiderHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "90snidlg2vsej"
+      ],
+      "x-yahoo-request-id": [
+        "90snidlg2vsej"
+      ],
+      "x-request-id": [
+        "8af841ed-f403-4803-894a-8562f9d53a71"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "601"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:55 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "insiderHolders": {
+              "holders": [
+                {
+                  "maxAge": 1,
+                  "name": "DAVIS ROBYN C",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "positionDirect": {
+                    "raw": 21596,
+                    "fmt": "21.6k",
+                    "longFmt": "21,596"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "GRAY DAVID C",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "positionDirect": {
+                    "raw": 77265,
+                    "fmt": "77.27k",
+                    "longFmt": "77,265"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "JOSEPH JASON W",
+                  "relation": "General Counsel",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "positionDirect": {
+                    "raw": 85855,
+                    "fmt": "85.86k",
+                    "longFmt": "85,855"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "MARTIN JOSEPH R",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "positionDirect": {
+                    "raw": 85881,
+                    "fmt": "85.88k",
+                    "longFmt": "85,881"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "MCLAUGHLIN ERICA",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "positionDirect": {
+                    "raw": 4827,
+                    "fmt": "4.83k",
+                    "longFmt": "4,827"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "PALEPU KRISHNA G",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "positionDirect": {
+                    "raw": 99867,
+                    "fmt": "99.87k",
+                    "longFmt": "99,867"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "ROSENBLATT MICHAEL",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "positionDirect": {
+                    "raw": 9642,
+                    "fmt": "9.64k",
+                    "longFmt": "9,642"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "SCHWARTZ STEPHEN S",
+                  "relation": "Chief Executive Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "positionDirect": {
+                    "raw": 377711,
+                    "fmt": "377.71k",
+                    "longFmt": "377,711"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "WRIGHTON MARK S",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "positionDirect": {
+                    "raw": 109896,
+                    "fmt": "109.9k",
+                    "longFmt": "109,896"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "ZANE ELLEN M",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "positionDirect": {
+                    "raw": 54374,
+                    "fmt": "54.37k",
+                    "longFmt": "54,374"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  }
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderHolders-CRON.json
+++ b/tests/http/quoteSummary-insiderHolders-CRON.json
@@ -1,0 +1,186 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=insiderHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "epcdv2lg2vsej"
+      ],
+      "x-yahoo-request-id": [
+        "epcdv2lg2vsej"
+      ],
+      "x-request-id": [
+        "bd4d8d24-1293-43b1-ae02-db84c332cf46"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "534"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:55 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "insiderHolders": {
+              "holders": [
+                {
+                  "maxAge": 1,
+                  "name": "Abraham (Todd Kevin Ph.D.)",
+                  "relation": "Senior Officer of Issuer",
+                  "url": "",
+                  "transactionDescription": "Acquisition or disposition in the public market",
+                  "latestTransDate": {
+                    "raw": 1596758400,
+                    "fmt": "2020-08-07"
+                  },
+                  "positionDirect": {
+                    "raw": 15000,
+                    "fmt": "15k",
+                    "longFmt": "15,000"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1596758400,
+                    "fmt": "2020-08-07"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Adler (Jason Marc)",
+                  "relation": "Director of Issuer",
+                  "url": "",
+                  "transactionDescription": "Acquisition or disposition in the public market",
+                  "latestTransDate": {
+                    "raw": 1605571200,
+                    "fmt": "2020-11-17"
+                  },
+                  "positionDirect": {
+                    "raw": 5479092,
+                    "fmt": "5.48M",
+                    "longFmt": "5,479,092"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605571200,
+                    "fmt": "2020-11-17"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Gorenstein (Michael Ryan)",
+                  "relation": "Director of Issuer",
+                  "url": "",
+                  "transactionDescription": "Exercise for cash",
+                  "latestTransDate": {
+                    "raw": 1605139200,
+                    "fmt": "2020-11-12"
+                  },
+                  "positionDirect": {
+                    "raw": 4512396,
+                    "fmt": "4.51M",
+                    "longFmt": "4,512,396"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605139200,
+                    "fmt": "2020-11-12"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Jacobson (Jeffrey David)",
+                  "relation": "Senior Officer of Issuer",
+                  "url": "",
+                  "transactionDescription": "Other",
+                  "latestTransDate": {
+                    "raw": 1597363200,
+                    "fmt": "2020-08-14"
+                  },
+                  "positionDirect": {
+                    "raw": 4500,
+                    "fmt": "4.5k",
+                    "longFmt": "4,500"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1597363200,
+                    "fmt": "2020-08-14"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "Shlimak (Anna)",
+                  "relation": "Senior Officer of Issuer",
+                  "url": "",
+                  "transactionDescription": "Opening Balance-Initial SEDI Report",
+                  "latestTransDate": {
+                    "raw": 1582243200,
+                    "fmt": "2020-02-21"
+                  },
+                  "positionDirect": {
+                    "raw": 10000,
+                    "fmt": "10k",
+                    "longFmt": "10,000"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1582243200,
+                    "fmt": "2020-02-21"
+                  }
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderHolders-EPAC.json
+++ b/tests/http/quoteSummary-insiderHolders-EPAC.json
@@ -1,0 +1,286 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=insiderHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "5c27u9tg2vsej"
+      ],
+      "x-yahoo-request-id": [
+        "5c27u9tg2vsej"
+      ],
+      "x-request-id": [
+        "dff688d6-2b2b-485d-9779-d12dd8f45622"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "591"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:55 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "insiderHolders": {
+              "holders": [
+                {
+                  "maxAge": 1,
+                  "name": "ALTAVILLA ALFREDO",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionDirect": {
+                    "raw": 20787,
+                    "fmt": "20.79k",
+                    "longFmt": "20,787"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "ALTMAIER JUDY L",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionDirect": {
+                    "raw": 9395,
+                    "fmt": "9.39k",
+                    "longFmt": "9,395"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "BAKER RANDAL W",
+                  "relation": "Chief Executive Officer",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionDirect": {
+                    "raw": 323244,
+                    "fmt": "323.24k",
+                    "longFmt": "323,244"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "BOLENS BARBARA",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionDirect": {
+                    "raw": 29105,
+                    "fmt": "29.11k",
+                    "longFmt": "29,105"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "CLARKSON J PALMER",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionDirect": {
+                    "raw": 17787,
+                    "fmt": "17.79k",
+                    "longFmt": "17,787"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "CUNNINGHAM DANNY L.",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionDirect": {
+                    "raw": 24030,
+                    "fmt": "24.03k",
+                    "longFmt": "24,030"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "DILLON RICKY T",
+                  "relation": "Chief Financial Officer",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionDirect": {
+                    "raw": 63270,
+                    "fmt": "63.27k",
+                    "longFmt": "63,270"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "FERLAND E JAMES JR",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionDirect": {
+                    "raw": 51160,
+                    "fmt": "51.16k",
+                    "longFmt": "51,160"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "HOLDER RICHARD D",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionDirect": {
+                    "raw": 21618,
+                    "fmt": "21.62k",
+                    "longFmt": "21,618"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "SCHMALING JOHN JEFFREY",
+                  "relation": "Chief Operating Officer",
+                  "url": "",
+                  "transactionDescription": "Stock Award(Grant)",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionDirect": {
+                    "raw": 48108,
+                    "fmt": "48.11k",
+                    "longFmt": "48,108"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderHolders-MDLY.json
+++ b/tests/http/quoteSummary-insiderHolders-MDLY.json
@@ -1,0 +1,286 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=insiderHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "2kkm5d5g2vsej"
+      ],
+      "x-yahoo-request-id": [
+        "2kkm5d5g2vsej"
+      ],
+      "x-request-id": [
+        "14074f4f-e96f-4796-b474-e7af7cfdf027"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "682"
+      ],
+      "x-envoy-upstream-service-time": [
+        "11"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:54 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "insiderHolders": {
+              "holders": [
+                {
+                  "maxAge": 1,
+                  "name": "ALLORTO RICHARD T JR",
+                  "relation": "Chief Financial Officer",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionIndirect": {
+                    "raw": 192977,
+                    "fmt": "192.98k",
+                    "longFmt": "192,977"
+                  },
+                  "positionIndirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "EATON JAMES GEORGE",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1590710400,
+                    "fmt": "2020-05-29"
+                  },
+                  "positionDirect": {
+                    "raw": 57356,
+                    "fmt": "57.36k",
+                    "longFmt": "57,356"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1590710400,
+                    "fmt": "2020-05-29"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "FREEDOM 2021 L.L.C.",
+                  "relation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionDirect": {
+                    "raw": 450000,
+                    "fmt": "450k",
+                    "longFmt": "450,000"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "JAM PARTNERS, L.P.",
+                  "relation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1564444800,
+                    "fmt": "2019-07-30"
+                  },
+                  "positionIndirect": {
+                    "raw": 574718,
+                    "fmt": "574.72k",
+                    "longFmt": "574,718"
+                  },
+                  "positionIndirectDate": {
+                    "raw": 1564444800,
+                    "fmt": "2019-07-30"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "LEEDS JEFFREY T",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1597104000,
+                    "fmt": "2020-08-11"
+                  },
+                  "positionDirect": {
+                    "raw": 98989,
+                    "fmt": "98.99k",
+                    "longFmt": "98,989"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1597104000,
+                    "fmt": "2020-08-11"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "ROUNSAVILLE GUYJR",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1590710400,
+                    "fmt": "2020-05-29"
+                  },
+                  "positionDirect": {
+                    "raw": 38125,
+                    "fmt": "38.12k",
+                    "longFmt": "38,125"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1590710400,
+                    "fmt": "2020-05-29"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "SANDY POINT L.L.C.",
+                  "relation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionDirect": {
+                    "raw": 999999,
+                    "fmt": "1,000k",
+                    "longFmt": "999,999"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "TAUBE ANGELIC DIAZ",
+                  "relation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionDirect": {
+                    "raw": 500000,
+                    "fmt": "500k",
+                    "longFmt": "500,000"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "TAUBE BROOK",
+                  "relation": "Chief Executive Officer",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionIndirect": {
+                    "raw": 999999,
+                    "fmt": "1,000k",
+                    "longFmt": "999,999"
+                  },
+                  "positionIndirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "TAUBE SETH",
+                  "relation": "Chief Executive Officer",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "positionIndirect": {
+                    "raw": 450000,
+                    "fmt": "450k",
+                    "longFmt": "450,000"
+                  },
+                  "positionIndirectDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  }
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderHolders-SI.json
+++ b/tests/http/quoteSummary-insiderHolders-SI.json
@@ -1,0 +1,286 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=insiderHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "4i1s2b5g2vsei"
+      ],
+      "x-yahoo-request-id": [
+        "4i1s2b5g2vsei"
+      ],
+      "x-request-id": [
+        "b9382525-7825-436a-818c-f29b3ce9ae79"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "712"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:54 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "3"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "insiderHolders": {
+              "holders": [
+                {
+                  "maxAge": 1,
+                  "name": "BONINO JOHN M",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1611273600,
+                    "fmt": "2021-01-22"
+                  },
+                  "positionDirect": {
+                    "raw": 40643,
+                    "fmt": "40.64k",
+                    "longFmt": "40,643"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1611273600,
+                    "fmt": "2021-01-22"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "BRASSFIELD KAREN F",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1610064000,
+                    "fmt": "2021-01-08"
+                  },
+                  "positionDirect": {
+                    "raw": 32742,
+                    "fmt": "32.74k",
+                    "longFmt": "32,742"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1610064000,
+                    "fmt": "2021-01-08"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "COLUCCI PAUL D",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "positionDirect": {
+                    "raw": 92706,
+                    "fmt": "92.71k",
+                    "longFmt": "92,706"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "DIRCKS THOMAS C",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Stock Gift",
+                  "latestTransDate": {
+                    "raw": 1608595200,
+                    "fmt": "2020-12-22"
+                  },
+                  "positionDirect": {
+                    "raw": 178147,
+                    "fmt": "178.15k",
+                    "longFmt": "178,147"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1608595200,
+                    "fmt": "2020-12-22"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "EISELE DEREK J",
+                  "relation": "Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1607299200,
+                    "fmt": "2020-12-07"
+                  },
+                  "positionIndirect": {
+                    "raw": 109969,
+                    "fmt": "109.97k",
+                    "longFmt": "109,969"
+                  },
+                  "positionIndirectDate": {
+                    "raw": 1607299200,
+                    "fmt": "2020-12-07"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "FRAHER KATHLEEN",
+                  "relation": "Chief Operating Officer",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1606694400,
+                    "fmt": "2020-11-30"
+                  },
+                  "positionDirect": {
+                    "raw": 20084,
+                    "fmt": "20.08k",
+                    "longFmt": "20,084"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1606694400,
+                    "fmt": "2020-11-30"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "FRANK DENNIS S",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "positionDirect": {
+                    "raw": 227344,
+                    "fmt": "227.34k",
+                    "longFmt": "227,344"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "LANE ALAN J",
+                  "relation": "Chief Executive Officer",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1606435200,
+                    "fmt": "2020-11-27"
+                  },
+                  "positionDirect": {
+                    "raw": 228993,
+                    "fmt": "228.99k",
+                    "longFmt": "228,993"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1606435200,
+                    "fmt": "2020-11-27"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "LEMPRES MICHAEL",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Conversion of Exercise of derivative security",
+                  "latestTransDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "positionDirect": {
+                    "raw": 1833,
+                    "fmt": "1.83k",
+                    "longFmt": "1,833"
+                  },
+                  "positionDirectDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "name": "REED SCOTT A",
+                  "relation": "Director",
+                  "url": "",
+                  "transactionDescription": "Sale",
+                  "latestTransDate": {
+                    "raw": 1607904000,
+                    "fmt": "2020-12-14"
+                  },
+                  "positionIndirect": {
+                    "raw": 1004700,
+                    "fmt": "1M",
+                    "longFmt": "1,004,700"
+                  },
+                  "positionIndirectDate": {
+                    "raw": 1607904000,
+                    "fmt": "2020-12-14"
+                  }
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderTransactions-ABBV.json
+++ b/tests/http/quoteSummary-insiderTransactions-ABBV.json
@@ -1,0 +1,3536 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=insiderTransactions"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "6bmf2jpg2vsek"
+      ],
+      "x-yahoo-request-id": [
+        "6bmf2jpg2vsek"
+      ],
+      "x-request-id": [
+        "630c4da4-c2fb-4697-8e70-272bc1071c11"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:56 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "insiderTransactions": {
+              "transactions": [
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 25290,
+                    "fmt": "25.29k",
+                    "longFmt": "25,290"
+                  },
+                  "value": {
+                    "raw": 2655450,
+                    "fmt": "2.66M",
+                    "longFmt": "2,655,450"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 105.00 per share.",
+                  "filerName": "STEWART JEFFREY RYAN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1609200000,
+                    "fmt": "2020-12-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 25290,
+                    "fmt": "25.29k",
+                    "longFmt": "25,290"
+                  },
+                  "value": {
+                    "raw": 1300412,
+                    "fmt": "1.3M",
+                    "longFmt": "1,300,412"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 51.42 per share.",
+                  "filerName": "STEWART JEFFREY RYAN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1609200000,
+                    "fmt": "2020-12-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 29017,
+                    "fmt": "29.02k",
+                    "longFmt": "29,017"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1608681600,
+                    "fmt": "2020-12-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 28950,
+                    "fmt": "28.95k",
+                    "longFmt": "28,950"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1608681600,
+                    "fmt": "2020-12-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3225,
+                    "fmt": "3.23k",
+                    "longFmt": "3,225"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1607299200,
+                    "fmt": "2020-12-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 51990,
+                    "fmt": "51.99k",
+                    "longFmt": "51,990"
+                  },
+                  "value": {
+                    "raw": 5458950,
+                    "fmt": "5.46M",
+                    "longFmt": "5,458,950"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 105.00 per share.",
+                  "filerName": "RICHMOND TIMOTHY J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606435200,
+                    "fmt": "2020-11-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 51990,
+                    "fmt": "51.99k",
+                    "longFmt": "51,990"
+                  },
+                  "value": {
+                    "raw": 2673326,
+                    "fmt": "2.67M",
+                    "longFmt": "2,673,326"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 51.42 per share.",
+                  "filerName": "RICHMOND TIMOTHY J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606435200,
+                    "fmt": "2020-11-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 40000,
+                    "fmt": "40k",
+                    "longFmt": "40,000"
+                  },
+                  "value": {
+                    "raw": 3975046,
+                    "fmt": "3.98M",
+                    "longFmt": "3,975,046"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 98.83 - 99.49 per share.",
+                  "filerName": "GOSEBRUCH HENRY O",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605830400,
+                    "fmt": "2020-11-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 115830,
+                    "fmt": "115.83k",
+                    "longFmt": "115,830"
+                  },
+                  "value": {
+                    "raw": 11583000,
+                    "fmt": "11.58M",
+                    "longFmt": "11,583,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 100.00 per share.",
+                  "filerName": "ALBAN CARLOS",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 115830,
+                    "fmt": "115.83k",
+                    "longFmt": "115,830"
+                  },
+                  "value": {
+                    "raw": 4155980,
+                    "fmt": "4.16M",
+                    "longFmt": "4,155,980"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 35.88 per share.",
+                  "filerName": "ALBAN CARLOS",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605484800,
+                    "fmt": "2020-11-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 231604,
+                    "fmt": "231.6k",
+                    "longFmt": "231,604"
+                  },
+                  "value": {
+                    "raw": 22437253,
+                    "fmt": "22.44M",
+                    "longFmt": "22,437,253"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 95.74 - 97.49 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605139200,
+                    "fmt": "2020-11-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 194154,
+                    "fmt": "194.15k",
+                    "longFmt": "194,154"
+                  },
+                  "value": {
+                    "raw": 11089858,
+                    "fmt": "11.09M",
+                    "longFmt": "11,089,858"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 54.86 - 58.88 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605139200,
+                    "fmt": "2020-11-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 17426,
+                    "fmt": "17.43k",
+                    "longFmt": "17,426"
+                  },
+                  "value": {
+                    "raw": 1707748,
+                    "fmt": "1.71M",
+                    "longFmt": "1,707,748"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 98.00 per share.",
+                  "filerName": "SALEKI-GERHARDT AZITA PH.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604966400,
+                    "fmt": "2020-11-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4800,
+                    "fmt": "4.8k",
+                    "longFmt": "4,800"
+                  },
+                  "value": {
+                    "raw": 449328,
+                    "fmt": "449.33k",
+                    "longFmt": "449,328"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 93.61 per share.",
+                  "filerName": "SALEKI-GERHARDT AZITA PH.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604448000,
+                    "fmt": "2020-11-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4800,
+                    "fmt": "4.8k",
+                    "longFmt": "4,800"
+                  },
+                  "value": {
+                    "raw": 449328,
+                    "fmt": "449.33k",
+                    "longFmt": "449,328"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 93.61 per share.",
+                  "filerName": "SALEKI-GERHARDT AZITA PH.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604448000,
+                    "fmt": "2020-11-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4800,
+                    "fmt": "4.8k",
+                    "longFmt": "4,800"
+                  },
+                  "value": {
+                    "raw": 116199,
+                    "fmt": "116.2k",
+                    "longFmt": "116,199"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 24.21 per share.",
+                  "filerName": "SALEKI-GERHARDT AZITA PH.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604448000,
+                    "fmt": "2020-11-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 90679,
+                    "fmt": "90.68k",
+                    "longFmt": "90,679"
+                  },
+                  "value": {
+                    "raw": 8488461,
+                    "fmt": "8.49M",
+                    "longFmt": "8,488,461"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 93.61 per share.",
+                  "filerName": "SEVERINO MICHAEL E. M.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604448000,
+                    "fmt": "2020-11-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7513,
+                    "fmt": "7.51k",
+                    "longFmt": "7,513"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "RAPP EDWARD J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1599091200,
+                    "fmt": "2020-09-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 53325,
+                    "fmt": "53.33k",
+                    "longFmt": "53,325"
+                  },
+                  "value": {
+                    "raw": 5332555,
+                    "fmt": "5.33M",
+                    "longFmt": "5,332,555"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 100.00 per share.",
+                  "filerName": "ALBAN CARLOS",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1594080000,
+                    "fmt": "2020-07-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 23024,
+                    "fmt": "23.02k",
+                    "longFmt": "23,024"
+                  },
+                  "value": {
+                    "raw": 2072211,
+                    "fmt": "2.07M",
+                    "longFmt": "2,072,211"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 90.00 per share.",
+                  "filerName": "STEWART JEFFREY RYAN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589241600,
+                    "fmt": "2020-05-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 63538,
+                    "fmt": "63.54k",
+                    "longFmt": "63,538"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "STROM CARRIE C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589155200,
+                    "fmt": "2020-05-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4916,
+                    "fmt": "4.92k",
+                    "longFmt": "4,916"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "FREYMAN THOMAS C",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588896000,
+                    "fmt": "2020-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4916,
+                    "fmt": "4.92k",
+                    "longFmt": "4,916"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "FREYMAN THOMAS C",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588896000,
+                    "fmt": "2020-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2333,
+                    "fmt": "2.33k",
+                    "longFmt": "2,333"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "LIDDY EDWARD M",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588896000,
+                    "fmt": "2020-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2333,
+                    "fmt": "2.33k",
+                    "longFmt": "2,333"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "AUSTIN ROXANNE SCHUH",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588896000,
+                    "fmt": "2020-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2333,
+                    "fmt": "2.33k",
+                    "longFmt": "2,333"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "TILTON GLENN FLETCHER",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588896000,
+                    "fmt": "2020-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2333,
+                    "fmt": "2.33k",
+                    "longFmt": "2,333"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WADDELL FREDERICK H",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588896000,
+                    "fmt": "2020-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2333,
+                    "fmt": "2.33k",
+                    "longFmt": "2,333"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RAPP EDWARD J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588896000,
+                    "fmt": "2020-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2333,
+                    "fmt": "2.33k",
+                    "longFmt": "2,333"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALPERN ROBERT J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588896000,
+                    "fmt": "2020-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2333,
+                    "fmt": "2.33k",
+                    "longFmt": "2,333"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "HART BRETT J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588896000,
+                    "fmt": "2020-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2333,
+                    "fmt": "2.33k",
+                    "longFmt": "2,333"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BURNSIDE WILLIAM H L",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588896000,
+                    "fmt": "2020-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2333,
+                    "fmt": "2.33k",
+                    "longFmt": "2,333"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MEYER MELODY B",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588896000,
+                    "fmt": "2020-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2333,
+                    "fmt": "2.33k",
+                    "longFmt": "2,333"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROBERTS REBECCA B",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588896000,
+                    "fmt": "2020-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 60,
+                    "fmt": "60",
+                    "longFmt": "60"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DURKIN BRIAN L.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588896000,
+                    "fmt": "2020-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 19445,
+                    "fmt": "19.45k",
+                    "longFmt": "19,445"
+                  },
+                  "value": {
+                    "raw": 1652825,
+                    "fmt": "1.65M",
+                    "longFmt": "1,652,825"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 85.00 per share.",
+                  "filerName": "RICHMOND TIMOTHY J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588636800,
+                    "fmt": "2020-05-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 21800,
+                    "fmt": "21.8k",
+                    "longFmt": "21,800"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588032000,
+                    "fmt": "2020-04-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 18500,
+                    "fmt": "18.5k",
+                    "longFmt": "18,500"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GOSEBRUCH HENRY O",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1586131200,
+                    "fmt": "2020-04-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 410,
+                    "fmt": "410",
+                    "longFmt": "410"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1585785600,
+                    "fmt": "2020-04-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 56950,
+                    "fmt": "56.95k",
+                    "longFmt": "56,950"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1585094400,
+                    "fmt": "2020-03-25"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3675,
+                    "fmt": "3.67k",
+                    "longFmt": "3,675"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582243200,
+                    "fmt": "2020-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 200262,
+                    "fmt": "200.26k",
+                    "longFmt": "200,262"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582156800,
+                    "fmt": "2020-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 76166,
+                    "fmt": "76.17k",
+                    "longFmt": "76,166"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582156800,
+                    "fmt": "2020-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 72439,
+                    "fmt": "72.44k",
+                    "longFmt": "72,439"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALBAN CARLOS",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582156800,
+                    "fmt": "2020-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 34907,
+                    "fmt": "34.91k",
+                    "longFmt": "34,907"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RICHMOND TIMOTHY J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582156800,
+                    "fmt": "2020-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 36897,
+                    "fmt": "36.9k",
+                    "longFmt": "36,897"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SALEKI-GERHARDT AZITA PH.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582156800,
+                    "fmt": "2020-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 75595,
+                    "fmt": "75.59k",
+                    "longFmt": "75,595"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SEVERINO MICHAEL E. M.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582156800,
+                    "fmt": "2020-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 58781,
+                    "fmt": "58.78k",
+                    "longFmt": "58,781"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "GOSEBRUCH HENRY O",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582156800,
+                    "fmt": "2020-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 16795,
+                    "fmt": "16.8k",
+                    "longFmt": "16,795"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MICHAEL ROBERT A.",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582156800,
+                    "fmt": "2020-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6527,
+                    "fmt": "6.53k",
+                    "longFmt": "6,527"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DURKIN BRIAN L.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582156800,
+                    "fmt": "2020-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 21896,
+                    "fmt": "21.9k",
+                    "longFmt": "21,896"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "STEWART JEFFREY RYAN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582156800,
+                    "fmt": "2020-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5316,
+                    "fmt": "5.32k",
+                    "longFmt": "5,316"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DONOGHOE NICHOLAS",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582156800,
+                    "fmt": "2020-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12372,
+                    "fmt": "12.37k",
+                    "longFmt": "12,372"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "HUDSON THOMAS J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582156800,
+                    "fmt": "2020-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4000,
+                    "fmt": "4k",
+                    "longFmt": "4,000"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1575417600,
+                    "fmt": "2019-12-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 358,
+                    "fmt": "358",
+                    "longFmt": "358"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1572825600,
+                    "fmt": "2019-11-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15515,
+                    "fmt": "15.52k",
+                    "longFmt": "15,515"
+                  },
+                  "value": {
+                    "raw": 1163873,
+                    "fmt": "1.16M",
+                    "longFmt": "1,163,873"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 75.02 per share.",
+                  "filerName": "RICHMOND TIMOTHY J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1569542400,
+                    "fmt": "2019-09-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15010,
+                    "fmt": "15.01k",
+                    "longFmt": "15,010"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1568073600,
+                    "fmt": "2019-09-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3050,
+                    "fmt": "3.05k",
+                    "longFmt": "3,050"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1566950400,
+                    "fmt": "2019-08-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 30000,
+                    "fmt": "30k",
+                    "longFmt": "30,000"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GOSEBRUCH HENRY O",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1565740800,
+                    "fmt": "2019-08-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 21708,
+                    "fmt": "21.71k",
+                    "longFmt": "21,708"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1564704000,
+                    "fmt": "2019-08-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2419,
+                    "fmt": "2.42k",
+                    "longFmt": "2,419"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "LIDDY EDWARD M",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556841600,
+                    "fmt": "2019-05-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2419,
+                    "fmt": "2.42k",
+                    "longFmt": "2,419"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "AUSTIN ROXANNE SCHUH",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556841600,
+                    "fmt": "2019-05-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2419,
+                    "fmt": "2.42k",
+                    "longFmt": "2,419"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "TILTON GLENN FLETCHER",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556841600,
+                    "fmt": "2019-05-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2419,
+                    "fmt": "2.42k",
+                    "longFmt": "2,419"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WADDELL FREDERICK H",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556841600,
+                    "fmt": "2019-05-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2419,
+                    "fmt": "2.42k",
+                    "longFmt": "2,419"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RAPP EDWARD J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556841600,
+                    "fmt": "2019-05-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2419,
+                    "fmt": "2.42k",
+                    "longFmt": "2,419"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALPERN ROBERT J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556841600,
+                    "fmt": "2019-05-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2419,
+                    "fmt": "2.42k",
+                    "longFmt": "2,419"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "HART BRETT J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556841600,
+                    "fmt": "2019-05-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2419,
+                    "fmt": "2.42k",
+                    "longFmt": "2,419"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BURNSIDE WILLIAM H L",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556841600,
+                    "fmt": "2019-05-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2419,
+                    "fmt": "2.42k",
+                    "longFmt": "2,419"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MEYER MELODY B",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556841600,
+                    "fmt": "2019-05-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2419,
+                    "fmt": "2.42k",
+                    "longFmt": "2,419"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROBERTS REBECCA B",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556841600,
+                    "fmt": "2019-05-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 475,
+                    "fmt": "475",
+                    "longFmt": "475"
+                  },
+                  "value": {
+                    "raw": 37853,
+                    "fmt": "37.85k",
+                    "longFmt": "37,853"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 79.69 per share.",
+                  "filerName": "DURKIN BRIAN L.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1553472000,
+                    "fmt": "2019-03-25"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 25000,
+                    "fmt": "25k",
+                    "longFmt": "25,000"
+                  },
+                  "value": {
+                    "raw": 2000000,
+                    "fmt": "2M",
+                    "longFmt": "2,000,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 80.00 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1552521600,
+                    "fmt": "2019-03-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15797,
+                    "fmt": "15.8k",
+                    "longFmt": "15,797"
+                  },
+                  "value": {
+                    "raw": 1248480,
+                    "fmt": "1.25M",
+                    "longFmt": "1,248,480"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 79.03 per share.",
+                  "filerName": "SALEKI-GERHARDT AZITA PH.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1551744000,
+                    "fmt": "2019-03-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 164609,
+                    "fmt": "164.61k",
+                    "longFmt": "164,609"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550707200,
+                    "fmt": "2019-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 54791,
+                    "fmt": "54.79k",
+                    "longFmt": "54,791"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550707200,
+                    "fmt": "2019-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 54450,
+                    "fmt": "54.45k",
+                    "longFmt": "54,450"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALBAN CARLOS",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550707200,
+                    "fmt": "2019-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 61565,
+                    "fmt": "61.56k",
+                    "longFmt": "61,565"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CHASE WILLIAM J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550707200,
+                    "fmt": "2019-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 27860,
+                    "fmt": "27.86k",
+                    "longFmt": "27,860"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RICHMOND TIMOTHY J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550707200,
+                    "fmt": "2019-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 28366,
+                    "fmt": "28.37k",
+                    "longFmt": "28,366"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SALEKI-GERHARDT AZITA PH.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550707200,
+                    "fmt": "2019-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 60286,
+                    "fmt": "60.29k",
+                    "longFmt": "60,286"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SEVERINO MICHAEL E. M.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550707200,
+                    "fmt": "2019-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 51815,
+                    "fmt": "51.81k",
+                    "longFmt": "51,815"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "GOSEBRUCH HENRY O",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550707200,
+                    "fmt": "2019-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7243,
+                    "fmt": "7.24k",
+                    "longFmt": "7,243"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MICHAEL ROBERT A.",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550707200,
+                    "fmt": "2019-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3737,
+                    "fmt": "3.74k",
+                    "longFmt": "3,737"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DURKIN BRIAN L.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550707200,
+                    "fmt": "2019-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15586,
+                    "fmt": "15.59k",
+                    "longFmt": "15,586"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "STEWART JEFFREY RYAN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550707200,
+                    "fmt": "2019-02-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2964,
+                    "fmt": "2.96k",
+                    "longFmt": "2,964"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1546992000,
+                    "fmt": "2019-01-09"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5565,
+                    "fmt": "5.57k",
+                    "longFmt": "5,565"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DONOGHOE NICHOLAS",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1546387200,
+                    "fmt": "2019-01-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 25000,
+                    "fmt": "25k",
+                    "longFmt": "25,000"
+                  },
+                  "value": {
+                    "raw": 2250000,
+                    "fmt": "2.25M",
+                    "longFmt": "2,250,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 90.00 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1545955200,
+                    "fmt": "2018-12-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1614,
+                    "fmt": "1.61k",
+                    "longFmt": "1,614"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1545609600,
+                    "fmt": "2018-12-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 112530,
+                    "fmt": "112.53k",
+                    "longFmt": "112,530"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1544659200,
+                    "fmt": "2018-12-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 60000,
+                    "fmt": "60k",
+                    "longFmt": "60,000"
+                  },
+                  "value": {
+                    "raw": 5400000,
+                    "fmt": "5.4M",
+                    "longFmt": "5,400,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 90.00 per share.",
+                  "filerName": "CHASE WILLIAM J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1544572800,
+                    "fmt": "2018-12-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 16850,
+                    "fmt": "16.85k",
+                    "longFmt": "16,850"
+                  },
+                  "value": {
+                    "raw": 1495438,
+                    "fmt": "1.5M",
+                    "longFmt": "1,495,438"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 88.75 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1544486400,
+                    "fmt": "2018-12-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 11595,
+                    "fmt": "11.6k",
+                    "longFmt": "11,595"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "STEWART JEFFREY RYAN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1544400000,
+                    "fmt": "2018-12-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 94140,
+                    "fmt": "94.14k",
+                    "longFmt": "94,140"
+                  },
+                  "value": {
+                    "raw": 8809552,
+                    "fmt": "8.81M",
+                    "longFmt": "8,809,552"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 91.77 - 94.34 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543881600,
+                    "fmt": "2018-12-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 94140,
+                    "fmt": "94.14k",
+                    "longFmt": "94,140"
+                  },
+                  "value": {
+                    "raw": 4840679,
+                    "fmt": "4.84M",
+                    "longFmt": "4,840,679"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 51.42 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543881600,
+                    "fmt": "2018-12-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4237,
+                    "fmt": "4.24k",
+                    "longFmt": "4,237"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543449600,
+                    "fmt": "2018-11-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 42450,
+                    "fmt": "42.45k",
+                    "longFmt": "42,450"
+                  },
+                  "value": {
+                    "raw": 3824940,
+                    "fmt": "3.82M",
+                    "longFmt": "3,824,940"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 90.10 per share.",
+                  "filerName": "GOSEBRUCH HENRY O",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543449600,
+                    "fmt": "2018-11-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 59,
+                    "fmt": "59",
+                    "longFmt": "59"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543276800,
+                    "fmt": "2018-11-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 50000,
+                    "fmt": "50k",
+                    "longFmt": "50,000"
+                  },
+                  "value": {
+                    "raw": 4876060,
+                    "fmt": "4.88M",
+                    "longFmt": "4,876,060"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 96.97 - 97.91 per share.",
+                  "filerName": "SEVERINO MICHAEL E. M.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1534464000,
+                    "fmt": "2018-08-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 17588,
+                    "fmt": "17.59k",
+                    "longFmt": "17,588"
+                  },
+                  "value": {
+                    "raw": 1749485,
+                    "fmt": "1.75M",
+                    "longFmt": "1,749,485"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 99.47 per share.",
+                  "filerName": "RICHMOND TIMOTHY J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1529020800,
+                    "fmt": "2018-06-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1899,
+                    "fmt": "1.9k",
+                    "longFmt": "1,899"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "LIDDY EDWARD M",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525392000,
+                    "fmt": "2018-05-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1899,
+                    "fmt": "1.9k",
+                    "longFmt": "1,899"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "AUSTIN ROXANNE SCHUH",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525392000,
+                    "fmt": "2018-05-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1899,
+                    "fmt": "1.9k",
+                    "longFmt": "1,899"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "TILTON GLENN FLETCHER",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525392000,
+                    "fmt": "2018-05-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1899,
+                    "fmt": "1.9k",
+                    "longFmt": "1,899"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WADDELL FREDERICK H",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525392000,
+                    "fmt": "2018-05-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1899,
+                    "fmt": "1.9k",
+                    "longFmt": "1,899"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RAPP EDWARD J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525392000,
+                    "fmt": "2018-05-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1899,
+                    "fmt": "1.9k",
+                    "longFmt": "1,899"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALPERN ROBERT J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525392000,
+                    "fmt": "2018-05-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1899,
+                    "fmt": "1.9k",
+                    "longFmt": "1,899"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "HART BRETT J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525392000,
+                    "fmt": "2018-05-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1899,
+                    "fmt": "1.9k",
+                    "longFmt": "1,899"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BURNSIDE WILLIAM H L",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525392000,
+                    "fmt": "2018-05-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1899,
+                    "fmt": "1.9k",
+                    "longFmt": "1,899"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MEYER MELODY B",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525392000,
+                    "fmt": "2018-05-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1899,
+                    "fmt": "1.9k",
+                    "longFmt": "1,899"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROBERTS REBECCA B",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525392000,
+                    "fmt": "2018-05-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5722,
+                    "fmt": "5.72k",
+                    "longFmt": "5,722"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1521158400,
+                    "fmt": "2018-03-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 25000,
+                    "fmt": "25k",
+                    "longFmt": "25,000"
+                  },
+                  "value": {
+                    "raw": 2946148,
+                    "fmt": "2.95M",
+                    "longFmt": "2,946,148"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 117.85 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519862400,
+                    "fmt": "2018-03-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 83574,
+                    "fmt": "83.57k",
+                    "longFmt": "83,574"
+                  },
+                  "value": {
+                    "raw": 9568737,
+                    "fmt": "9.57M",
+                    "longFmt": "9,568,737"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 113.75 - 117.85 per share.",
+                  "filerName": "ALBAN CARLOS",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519862400,
+                    "fmt": "2018-03-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 48100,
+                    "fmt": "48.1k",
+                    "longFmt": "48,100"
+                  },
+                  "value": {
+                    "raw": 1405795,
+                    "fmt": "1.41M",
+                    "longFmt": "1,405,795"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 29.23 per share.",
+                  "filerName": "ALBAN CARLOS",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519862400,
+                    "fmt": "2018-03-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 70928,
+                    "fmt": "70.93k",
+                    "longFmt": "70,928"
+                  },
+                  "value": {
+                    "raw": 8311640,
+                    "fmt": "8.31M",
+                    "longFmt": "8,311,640"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 114.50 - 119.44 per share.",
+                  "filerName": "CHASE WILLIAM J",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519862400,
+                    "fmt": "2018-03-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 32400,
+                    "fmt": "32.4k",
+                    "longFmt": "32,400"
+                  },
+                  "value": {
+                    "raw": 839339,
+                    "fmt": "839.34k",
+                    "longFmt": "839,339"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 24.21 - 28.31 per share.",
+                  "filerName": "CHASE WILLIAM J",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519862400,
+                    "fmt": "2018-03-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8280,
+                    "fmt": "8.28k",
+                    "longFmt": "8,280"
+                  },
+                  "value": {
+                    "raw": 976084,
+                    "fmt": "976.08k",
+                    "longFmt": "976,084"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 117.88 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519776000,
+                    "fmt": "2018-02-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 18129,
+                    "fmt": "18.13k",
+                    "longFmt": "18,129"
+                  },
+                  "value": {
+                    "raw": 2151452,
+                    "fmt": "2.15M",
+                    "longFmt": "2,151,452"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 118.67 per share.",
+                  "filerName": "RICHMOND TIMOTHY J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519776000,
+                    "fmt": "2018-02-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1337,
+                    "fmt": "1.34k",
+                    "longFmt": "1,337"
+                  },
+                  "value": {
+                    "raw": 157458,
+                    "fmt": "157.46k",
+                    "longFmt": "157,458"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 117.77 per share.",
+                  "filerName": "SALEKI-GERHARDT AZITA PH.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519776000,
+                    "fmt": "2018-02-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2643,
+                    "fmt": "2.64k",
+                    "longFmt": "2,643"
+                  },
+                  "value": {
+                    "raw": 311684,
+                    "fmt": "311.68k",
+                    "longFmt": "311,684"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 117.93 per share.",
+                  "filerName": "SEVERINO MICHAEL E. M.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519776000,
+                    "fmt": "2018-02-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4294,
+                    "fmt": "4.29k",
+                    "longFmt": "4,294"
+                  },
+                  "value": {
+                    "raw": 512853,
+                    "fmt": "512.85k",
+                    "longFmt": "512,853"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 119.43 per share.",
+                  "filerName": "MICHAEL ROBERT A.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519776000,
+                    "fmt": "2018-02-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 992,
+                    "fmt": "992",
+                    "longFmt": "992"
+                  },
+                  "value": {
+                    "raw": 119351,
+                    "fmt": "119.35k",
+                    "longFmt": "119,351"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 120.29 - 120.33 per share.",
+                  "filerName": "MICHAEL ROBERT A.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1519084800,
+                    "fmt": "2018-02-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 126946,
+                    "fmt": "126.95k",
+                    "longFmt": "126,946"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518652800,
+                    "fmt": "2018-02-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 45420,
+                    "fmt": "45.42k",
+                    "longFmt": "45,420"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518652800,
+                    "fmt": "2018-02-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 44257,
+                    "fmt": "44.26k",
+                    "longFmt": "44,257"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALBAN CARLOS",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518652800,
+                    "fmt": "2018-02-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 48255,
+                    "fmt": "48.26k",
+                    "longFmt": "48,255"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CHASE WILLIAM J",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518652800,
+                    "fmt": "2018-02-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 21822,
+                    "fmt": "21.82k",
+                    "longFmt": "21,822"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RICHMOND TIMOTHY J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518652800,
+                    "fmt": "2018-02-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 22533,
+                    "fmt": "22.53k",
+                    "longFmt": "22,533"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SALEKI-GERHARDT AZITA PH.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518652800,
+                    "fmt": "2018-02-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 47685,
+                    "fmt": "47.69k",
+                    "longFmt": "47,685"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SEVERINO MICHAEL E. M.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518652800,
+                    "fmt": "2018-02-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 39316,
+                    "fmt": "39.32k",
+                    "longFmt": "39,316"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "GOSEBRUCH HENRY O",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518652800,
+                    "fmt": "2018-02-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5380,
+                    "fmt": "5.38k",
+                    "longFmt": "5,380"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MICHAEL ROBERT A.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518652800,
+                    "fmt": "2018-02-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 87040,
+                    "fmt": "87.04k",
+                    "longFmt": "87,040"
+                  },
+                  "value": {
+                    "raw": 8569053,
+                    "fmt": "8.57M",
+                    "longFmt": "8,569,053"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 98.45 per share.",
+                  "filerName": "RICHMOND TIMOTHY J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1513555200,
+                    "fmt": "2017-12-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 87040,
+                    "fmt": "87.04k",
+                    "longFmt": "87,040"
+                  },
+                  "value": {
+                    "raw": 3122995,
+                    "fmt": "3.12M",
+                    "longFmt": "3,122,995"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 35.88 per share.",
+                  "filerName": "RICHMOND TIMOTHY J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1513555200,
+                    "fmt": "2017-12-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 145510,
+                    "fmt": "145.51k",
+                    "longFmt": "145,510"
+                  },
+                  "value": {
+                    "raw": 14071982,
+                    "fmt": "14.07M",
+                    "longFmt": "14,071,982"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 96.71 - 96.86 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1513296000,
+                    "fmt": "2017-12-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 145510,
+                    "fmt": "145.51k",
+                    "longFmt": "145,510"
+                  },
+                  "value": {
+                    "raw": 5220899,
+                    "fmt": "5.22M",
+                    "longFmt": "5,220,899"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 35.88 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1513296000,
+                    "fmt": "2017-12-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 218193,
+                    "fmt": "218.19k",
+                    "longFmt": "218,193"
+                  },
+                  "value": {
+                    "raw": 20511800,
+                    "fmt": "20.51M",
+                    "longFmt": "20,511,800"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 94.01 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1511222400,
+                    "fmt": "2017-11-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 218193,
+                    "fmt": "218.19k",
+                    "longFmt": "218,193"
+                  },
+                  "value": {
+                    "raw": 12847204,
+                    "fmt": "12.85M",
+                    "longFmt": "12,847,204"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 58.88 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1511222400,
+                    "fmt": "2017-11-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 25633,
+                    "fmt": "25.63k",
+                    "longFmt": "25,633"
+                  },
+                  "value": {
+                    "raw": 2427212,
+                    "fmt": "2.43M",
+                    "longFmt": "2,427,212"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 94.69 per share.",
+                  "filerName": "SEVERINO MICHAEL E. M.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1510272000,
+                    "fmt": "2017-11-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 18300,
+                    "fmt": "18.3k",
+                    "longFmt": "18,300"
+                  },
+                  "value": {
+                    "raw": 1657037,
+                    "fmt": "1.66M",
+                    "longFmt": "1,657,037"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 89.38 - 92.02 per share.",
+                  "filerName": "GOSEBRUCH HENRY O",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1509321600,
+                    "fmt": "2017-10-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6699,
+                    "fmt": "6.7k",
+                    "longFmt": "6,699"
+                  },
+                  "value": {
+                    "raw": 589512,
+                    "fmt": "589.51k",
+                    "longFmt": "589,512"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 88.00 per share.",
+                  "filerName": "MICHAEL ROBERT A.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1506556800,
+                    "fmt": "2017-09-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2093,
+                    "fmt": "2.09k",
+                    "longFmt": "2,093"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1505088000,
+                    "fmt": "2017-09-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8300,
+                    "fmt": "8.3k",
+                    "longFmt": "8,300"
+                  },
+                  "value": {
+                    "raw": 705655,
+                    "fmt": "705.65k",
+                    "longFmt": "705,655"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 84.99 - 85.06 per share.",
+                  "filerName": "SALEKI-GERHARDT AZITA PH.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1505088000,
+                    "fmt": "2017-09-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4800,
+                    "fmt": "4.8k",
+                    "longFmt": "4,800"
+                  },
+                  "value": {
+                    "raw": 116199,
+                    "fmt": "116.2k",
+                    "longFmt": "116,199"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 24.21 per share.",
+                  "filerName": "SALEKI-GERHARDT AZITA PH.D.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1505088000,
+                    "fmt": "2017-09-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 193131,
+                    "fmt": "193.13k",
+                    "longFmt": "193,131"
+                  },
+                  "value": {
+                    "raw": 13713186,
+                    "fmt": "13.71M",
+                    "longFmt": "13,713,186"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 71.00 - 71.06 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1502064000,
+                    "fmt": "2017-08-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 193131,
+                    "fmt": "193.13k",
+                    "longFmt": "193,131"
+                  },
+                  "value": {
+                    "raw": 9930796,
+                    "fmt": "9.93M",
+                    "longFmt": "9,930,796"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 51.42 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1502064000,
+                    "fmt": "2017-08-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 87899,
+                    "fmt": "87.9k",
+                    "longFmt": "87,899"
+                  },
+                  "value": {
+                    "raw": 6242297,
+                    "fmt": "6.24M",
+                    "longFmt": "6,242,297"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 71.00 - 71.13 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1501804800,
+                    "fmt": "2017-08-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 87899,
+                    "fmt": "87.9k",
+                    "longFmt": "87,899"
+                  },
+                  "value": {
+                    "raw": 4519767,
+                    "fmt": "4.52M",
+                    "longFmt": "4,519,767"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 51.42 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1501804800,
+                    "fmt": "2017-08-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 18000,
+                    "fmt": "18k",
+                    "longFmt": "18,000"
+                  },
+                  "value": {
+                    "raw": 1261638,
+                    "fmt": "1.26M",
+                    "longFmt": "1,261,638"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 70.00 - 70.34 per share.",
+                  "filerName": "GOSEBRUCH HENRY O",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1501459200,
+                    "fmt": "2017-07-31"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 300,
+                    "fmt": "300",
+                    "longFmt": "300"
+                  },
+                  "value": {
+                    "raw": 21127,
+                    "fmt": "21.13k",
+                    "longFmt": "21,127"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 70.37 - 70.45 per share.",
+                  "filerName": "GOSEBRUCH HENRY O",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1501459200,
+                    "fmt": "2017-07-31"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2235,
+                    "fmt": "2.23k",
+                    "longFmt": "2,235"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "GONZALEZ RICHARD A",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1498521600,
+                    "fmt": "2017-06-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 79800,
+                    "fmt": "79.8k",
+                    "longFmt": "79,800"
+                  },
+                  "value": {
+                    "raw": 5586000,
+                    "fmt": "5.59M",
+                    "longFmt": "5,586,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 70.00 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1497398400,
+                    "fmt": "2017-06-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 79800,
+                    "fmt": "79.8k",
+                    "longFmt": "79,800"
+                  },
+                  "value": {
+                    "raw": 2332275,
+                    "fmt": "2.33M",
+                    "longFmt": "2,332,275"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 29.23 per share.",
+                  "filerName": "SCHUMACHER LAURA J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1497398400,
+                    "fmt": "2017-06-14"
+                  },
+                  "ownership": "D"
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderTransactions-BRKS.json
+++ b/tests/http/quoteSummary-insiderTransactions-BRKS.json
@@ -1,0 +1,3531 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=insiderTransactions"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "avokj5lg2vsek"
+      ],
+      "x-yahoo-request-id": [
+        "avokj5lg2vsek"
+      ],
+      "x-request-id": [
+        "54ec0c15-8f96-492b-94bb-aadb114fbe58"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:56 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "insiderTransactions": {
+              "transactions": [
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1760,
+                    "fmt": "1.76k",
+                    "longFmt": "1,760"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROSENBLATT MICHAEL",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1760,
+                    "fmt": "1.76k",
+                    "longFmt": "1,760"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WRIGHTON MARK S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2262,
+                    "fmt": "2.26k",
+                    "longFmt": "2,262"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MARTIN JOSEPH R",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1760,
+                    "fmt": "1.76k",
+                    "longFmt": "1,760"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ZANE ELLEN M",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1760,
+                    "fmt": "1.76k",
+                    "longFmt": "1,760"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PALEPU KRISHNA G",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1760,
+                    "fmt": "1.76k",
+                    "longFmt": "1,760"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DAVIS ROBYN C",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1760,
+                    "fmt": "1.76k",
+                    "longFmt": "1,760"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MCLAUGHLIN ERICA",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1612483200,
+                    "fmt": "2021-02-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1450,
+                    "fmt": "1.45k",
+                    "longFmt": "1,450"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "WRIGHTON MARK S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5925,
+                    "fmt": "5.92k",
+                    "longFmt": "5,925"
+                  },
+                  "value": {
+                    "raw": 412498,
+                    "fmt": "412.5k",
+                    "longFmt": "412,498"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 69.62 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 27822,
+                    "fmt": "27.82k",
+                    "longFmt": "27,822"
+                  },
+                  "value": {
+                    "raw": 1936968,
+                    "fmt": "1.94M",
+                    "longFmt": "1,936,968"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 69.62 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8777,
+                    "fmt": "8.78k",
+                    "longFmt": "8,777"
+                  },
+                  "value": {
+                    "raw": 606676,
+                    "fmt": "606.68k",
+                    "longFmt": "606,676"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 68.19 - 69.62 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 13983,
+                    "fmt": "13.98k",
+                    "longFmt": "13,983"
+                  },
+                  "value": {
+                    "raw": 973496,
+                    "fmt": "973.5k",
+                    "longFmt": "973,496"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 69.62 per share.",
+                  "filerName": "ROBERTSON LINDON GENE",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5496,
+                    "fmt": "5.5k",
+                    "longFmt": "5,496"
+                  },
+                  "value": {
+                    "raw": 382632,
+                    "fmt": "382.63k",
+                    "longFmt": "382,632"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 69.62 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3457,
+                    "fmt": "3.46k",
+                    "longFmt": "3,457"
+                  },
+                  "value": {
+                    "raw": 240676,
+                    "fmt": "240.68k",
+                    "longFmt": "240,676"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 69.62 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 53050,
+                    "fmt": "53.05k",
+                    "longFmt": "53,050"
+                  },
+                  "value": {
+                    "raw": 3664672,
+                    "fmt": "3.66M",
+                    "longFmt": "3,664,672"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 69.03 - 69.62 per share.",
+                  "filerName": "JARZYNKA DAVID E",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1354,
+                    "fmt": "1.35k",
+                    "longFmt": "1,354"
+                  },
+                  "value": {
+                    "raw": 94265,
+                    "fmt": "94.27k",
+                    "longFmt": "94,265"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 69.62 per share.",
+                  "filerName": "LIAO GUOJUAN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6490,
+                    "fmt": "6.49k",
+                    "longFmt": "6,490"
+                  },
+                  "value": {
+                    "raw": 451834,
+                    "fmt": "451.83k",
+                    "longFmt": "451,834"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 69.62 per share.",
+                  "filerName": "VACHA ROBIN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 14319,
+                    "fmt": "14.32k",
+                    "longFmt": "14,319"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 59490,
+                    "fmt": "59.49k",
+                    "longFmt": "59,490"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 13863,
+                    "fmt": "13.86k",
+                    "longFmt": "13,863"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 27427,
+                    "fmt": "27.43k",
+                    "longFmt": "27,427"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROBERTSON LINDON GENE",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8980,
+                    "fmt": "8.98k",
+                    "longFmt": "8,980"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7582,
+                    "fmt": "7.58k",
+                    "longFmt": "7,582"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 17704,
+                    "fmt": "17.7k",
+                    "longFmt": "17,704"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JARZYNKA DAVID E",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3102,
+                    "fmt": "3.1k",
+                    "longFmt": "3,102"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "LIAO GUOJUAN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 14684,
+                    "fmt": "14.68k",
+                    "longFmt": "14,684"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "VACHA ROBIN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605225600,
+                    "fmt": "2020-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 69291,
+                    "fmt": "69.29k",
+                    "longFmt": "69,291"
+                  },
+                  "value": {
+                    "raw": 3122833,
+                    "fmt": "3.12M",
+                    "longFmt": "3,122,833"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 45.00 - 45.51 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1600300800,
+                    "fmt": "2020-09-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 33910,
+                    "fmt": "33.91k",
+                    "longFmt": "33,910"
+                  },
+                  "value": {
+                    "raw": 1526536,
+                    "fmt": "1.53M",
+                    "longFmt": "1,526,536"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 45.00 - 45.15 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1599696000,
+                    "fmt": "2020-09-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 90000,
+                    "fmt": "90k",
+                    "longFmt": "90,000"
+                  },
+                  "value": {
+                    "raw": 4234800,
+                    "fmt": "4.23M",
+                    "longFmt": "4,234,800"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 45.30 - 48.87 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1599523200,
+                    "fmt": "2020-09-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 39238,
+                    "fmt": "39.24k",
+                    "longFmt": "39,238"
+                  },
+                  "value": {
+                    "raw": 2170048,
+                    "fmt": "2.17M",
+                    "longFmt": "2,170,048"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 55.26 - 55.34 per share.",
+                  "filerName": "ROBERTSON LINDON GENE",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597622400,
+                    "fmt": "2020-08-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4343,
+                    "fmt": "4.34k",
+                    "longFmt": "4,343"
+                  },
+                  "value": {
+                    "raw": 236911,
+                    "fmt": "236.91k",
+                    "longFmt": "236,911"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 54.55 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596412800,
+                    "fmt": "2020-08-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4877,
+                    "fmt": "4.88k",
+                    "longFmt": "4,877"
+                  },
+                  "value": {
+                    "raw": 243850,
+                    "fmt": "243.85k",
+                    "longFmt": "243,850"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 50.00 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596153600,
+                    "fmt": "2020-07-31"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12000,
+                    "fmt": "12k",
+                    "longFmt": "12,000"
+                  },
+                  "value": {
+                    "raw": 585000,
+                    "fmt": "585k",
+                    "longFmt": "585,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 47.50 - 50.00 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596153600,
+                    "fmt": "2020-07-31"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6000,
+                    "fmt": "6k",
+                    "longFmt": "6,000"
+                  },
+                  "value": {
+                    "raw": 270000,
+                    "fmt": "270k",
+                    "longFmt": "270,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 45.00 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1593993600,
+                    "fmt": "2020-07-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 20000,
+                    "fmt": "20k",
+                    "longFmt": "20,000"
+                  },
+                  "value": {
+                    "raw": 900000,
+                    "fmt": "900k",
+                    "longFmt": "900,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 45.00 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1593993600,
+                    "fmt": "2020-07-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4000,
+                    "fmt": "4k",
+                    "longFmt": "4,000"
+                  },
+                  "value": {
+                    "raw": 180000,
+                    "fmt": "180k",
+                    "longFmt": "180,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 45.00 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1593993600,
+                    "fmt": "2020-07-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1612,
+                    "fmt": "1.61k",
+                    "longFmt": "1,612"
+                  },
+                  "value": {
+                    "raw": 72540,
+                    "fmt": "72.54k",
+                    "longFmt": "72,540"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 45.00 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1593993600,
+                    "fmt": "2020-07-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4000,
+                    "fmt": "4k",
+                    "longFmt": "4,000"
+                  },
+                  "value": {
+                    "raw": 176000,
+                    "fmt": "176k",
+                    "longFmt": "176,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 44.00 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1593475200,
+                    "fmt": "2020-06-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3196,
+                    "fmt": "3.2k",
+                    "longFmt": "3,196"
+                  },
+                  "value": {
+                    "raw": 139505,
+                    "fmt": "139.5k",
+                    "longFmt": "139,505"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 43.65 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1591574400,
+                    "fmt": "2020-06-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12132,
+                    "fmt": "12.13k",
+                    "longFmt": "12,132"
+                  },
+                  "value": {
+                    "raw": 537448,
+                    "fmt": "537.45k",
+                    "longFmt": "537,448"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 44.30 per share.",
+                  "filerName": "ROBERTSON LINDON GENE",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1591315200,
+                    "fmt": "2020-06-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5000,
+                    "fmt": "5k",
+                    "longFmt": "5,000"
+                  },
+                  "value": {
+                    "raw": 212800,
+                    "fmt": "212.8k",
+                    "longFmt": "212,800"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 42.56 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1591142400,
+                    "fmt": "2020-06-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5000,
+                    "fmt": "5k",
+                    "longFmt": "5,000"
+                  },
+                  "value": {
+                    "raw": 202700,
+                    "fmt": "202.7k",
+                    "longFmt": "202,700"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 40.54 per share.",
+                  "filerName": "MARTIN JOSEPH R",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589932800,
+                    "fmt": "2020-05-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12000,
+                    "fmt": "12k",
+                    "longFmt": "12,000"
+                  },
+                  "value": {
+                    "raw": 468060,
+                    "fmt": "468.06k",
+                    "longFmt": "468,060"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 37.50 - 40.51 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588118400,
+                    "fmt": "2020-04-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4000,
+                    "fmt": "4k",
+                    "longFmt": "4,000"
+                  },
+                  "value": {
+                    "raw": 170000,
+                    "fmt": "170k",
+                    "longFmt": "170,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 42.50 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1588118400,
+                    "fmt": "2020-04-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3067,
+                    "fmt": "3.07k",
+                    "longFmt": "3,067"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MCLAUGHLIN ERICA",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1586304000,
+                    "fmt": "2020-04-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6000,
+                    "fmt": "6k",
+                    "longFmt": "6,000"
+                  },
+                  "value": {
+                    "raw": 248040,
+                    "fmt": "248.04k",
+                    "longFmt": "248,040"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 41.34 per share.",
+                  "filerName": "MARTIN JOSEPH R",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582070400,
+                    "fmt": "2020-02-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 83088,
+                    "fmt": "83.09k",
+                    "longFmt": "83,088"
+                  },
+                  "value": {
+                    "raw": 3442321,
+                    "fmt": "3.44M",
+                    "longFmt": "3,442,321"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 41.29 - 41.49 per share.",
+                  "filerName": "ROBERTSON LINDON GENE",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582070400,
+                    "fmt": "2020-02-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 500,
+                    "fmt": "500",
+                    "longFmt": "500"
+                  },
+                  "value": {
+                    "raw": 21500,
+                    "fmt": "21.5k",
+                    "longFmt": "21,500"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 43.00 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581465600,
+                    "fmt": "2020-02-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2831,
+                    "fmt": "2.83k",
+                    "longFmt": "2,831"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROSENBLATT MICHAEL",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581379200,
+                    "fmt": "2020-02-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2831,
+                    "fmt": "2.83k",
+                    "longFmt": "2,831"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WRIGHTON MARK S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581379200,
+                    "fmt": "2020-02-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2831,
+                    "fmt": "2.83k",
+                    "longFmt": "2,831"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALLEN A CLINTON",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581379200,
+                    "fmt": "2020-02-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3774,
+                    "fmt": "3.77k",
+                    "longFmt": "3,774"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MARTIN JOSEPH R",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581379200,
+                    "fmt": "2020-02-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2831,
+                    "fmt": "2.83k",
+                    "longFmt": "2,831"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ZANE ELLEN M",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581379200,
+                    "fmt": "2020-02-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2831,
+                    "fmt": "2.83k",
+                    "longFmt": "2,831"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PALEPU KRISHNA G",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1581379200,
+                    "fmt": "2020-02-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6000,
+                    "fmt": "6k",
+                    "longFmt": "6,000"
+                  },
+                  "value": {
+                    "raw": 255780,
+                    "fmt": "255.78k",
+                    "longFmt": "255,780"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 42.63 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1577923200,
+                    "fmt": "2020-01-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 22500,
+                    "fmt": "22.5k",
+                    "longFmt": "22,500"
+                  },
+                  "value": {
+                    "raw": 955600,
+                    "fmt": "955.6k",
+                    "longFmt": "955,600"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 42.32 - 43.00 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1576540800,
+                    "fmt": "2019-12-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 26950,
+                    "fmt": "26.95k",
+                    "longFmt": "26,950"
+                  },
+                  "value": {
+                    "raw": 1213901,
+                    "fmt": "1.21M",
+                    "longFmt": "1,213,901"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 43.22 - 45.25 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1574294400,
+                    "fmt": "2019-11-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 112320,
+                    "fmt": "112.32k",
+                    "longFmt": "112,320"
+                  },
+                  "value": {
+                    "raw": 5074504,
+                    "fmt": "5.07M",
+                    "longFmt": "5,074,504"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 43.22 - 45.25 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1574294400,
+                    "fmt": "2019-11-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 26143,
+                    "fmt": "26.14k",
+                    "longFmt": "26,143"
+                  },
+                  "value": {
+                    "raw": 1181294,
+                    "fmt": "1.18M",
+                    "longFmt": "1,181,294"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 43.22 - 45.25 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1574294400,
+                    "fmt": "2019-11-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 50505,
+                    "fmt": "50.51k",
+                    "longFmt": "50,505"
+                  },
+                  "value": {
+                    "raw": 2279448,
+                    "fmt": "2.28M",
+                    "longFmt": "2,279,448"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 43.22 - 45.25 per share.",
+                  "filerName": "ROBERTSON LINDON GENE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1574294400,
+                    "fmt": "2019-11-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 36353,
+                    "fmt": "36.35k",
+                    "longFmt": "36,353"
+                  },
+                  "value": {
+                    "raw": 1621308,
+                    "fmt": "1.62M",
+                    "longFmt": "1,621,308"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 43.22 - 45.25 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1574294400,
+                    "fmt": "2019-11-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15948,
+                    "fmt": "15.95k",
+                    "longFmt": "15,948"
+                  },
+                  "value": {
+                    "raw": 716858,
+                    "fmt": "716.86k",
+                    "longFmt": "716,858"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 43.22 - 45.25 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1574294400,
+                    "fmt": "2019-11-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 34002,
+                    "fmt": "34k",
+                    "longFmt": "34,002"
+                  },
+                  "value": {
+                    "raw": 1536037,
+                    "fmt": "1.54M",
+                    "longFmt": "1,536,037"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 43.22 - 45.25 per share.",
+                  "filerName": "JARZYNKA DAVID E",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1574294400,
+                    "fmt": "2019-11-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 966,
+                    "fmt": "966",
+                    "longFmt": "966"
+                  },
+                  "value": {
+                    "raw": 41751,
+                    "fmt": "41.75k",
+                    "longFmt": "41,751"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 43.22 per share.",
+                  "filerName": "LIAO GUOJUAN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1574294400,
+                    "fmt": "2019-11-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 50767,
+                    "fmt": "50.77k",
+                    "longFmt": "50,767"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 215672,
+                    "fmt": "215.67k",
+                    "longFmt": "215,672"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 50767,
+                    "fmt": "50.77k",
+                    "longFmt": "50,767"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 94572,
+                    "fmt": "94.57k",
+                    "longFmt": "94,572"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROBERTSON LINDON GENE",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 50767,
+                    "fmt": "50.77k",
+                    "longFmt": "50,767"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 27557,
+                    "fmt": "27.56k",
+                    "longFmt": "27,557"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 65272,
+                    "fmt": "65.27k",
+                    "longFmt": "65,272"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JARZYNKA DAVID E",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6000,
+                    "fmt": "6k",
+                    "longFmt": "6,000"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573516800,
+                    "fmt": "2019-11-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3989,
+                    "fmt": "3.99k",
+                    "longFmt": "3,989"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573430400,
+                    "fmt": "2019-11-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 13295,
+                    "fmt": "13.29k",
+                    "longFmt": "13,295"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573430400,
+                    "fmt": "2019-11-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2792,
+                    "fmt": "2.79k",
+                    "longFmt": "2,792"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573430400,
+                    "fmt": "2019-11-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5584,
+                    "fmt": "5.58k",
+                    "longFmt": "5,584"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROBERTSON LINDON GENE",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573430400,
+                    "fmt": "2019-11-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10637,
+                    "fmt": "10.64k",
+                    "longFmt": "10,637"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573430400,
+                    "fmt": "2019-11-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1728,
+                    "fmt": "1.73k",
+                    "longFmt": "1,728"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573430400,
+                    "fmt": "2019-11-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4520,
+                    "fmt": "4.52k",
+                    "longFmt": "4,520"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JARZYNKA DAVID E",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573430400,
+                    "fmt": "2019-11-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4254,
+                    "fmt": "4.25k",
+                    "longFmt": "4,254"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "LIAO GUOJUAN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573430400,
+                    "fmt": "2019-11-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7500,
+                    "fmt": "7.5k",
+                    "longFmt": "7,500"
+                  },
+                  "value": {
+                    "raw": 350700,
+                    "fmt": "350.7k",
+                    "longFmt": "350,700"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 46.76 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573171200,
+                    "fmt": "2019-11-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 49417,
+                    "fmt": "49.42k",
+                    "longFmt": "49,417"
+                  },
+                  "value": {
+                    "raw": 2299708,
+                    "fmt": "2.3M",
+                    "longFmt": "2,299,708"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 46.14 - 46.75 per share.",
+                  "filerName": "JARZYNKA DAVID E",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573171200,
+                    "fmt": "2019-11-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4334,
+                    "fmt": "4.33k",
+                    "longFmt": "4,334"
+                  },
+                  "value": {
+                    "raw": 203698,
+                    "fmt": "203.7k",
+                    "longFmt": "203,698"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 47.00 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573084800,
+                    "fmt": "2019-11-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3333,
+                    "fmt": "3.33k",
+                    "longFmt": "3,333"
+                  },
+                  "value": {
+                    "raw": 146652,
+                    "fmt": "146.65k",
+                    "longFmt": "146,652"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 44.00 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1572220800,
+                    "fmt": "2019-10-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5478,
+                    "fmt": "5.48k",
+                    "longFmt": "5,478"
+                  },
+                  "value": {
+                    "raw": 232815,
+                    "fmt": "232.81k",
+                    "longFmt": "232,815"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 42.50 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1571875200,
+                    "fmt": "2019-10-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3333,
+                    "fmt": "3.33k",
+                    "longFmt": "3,333"
+                  },
+                  "value": {
+                    "raw": 136653,
+                    "fmt": "136.65k",
+                    "longFmt": "136,653"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 41.00 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1563840000,
+                    "fmt": "2019-07-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3000,
+                    "fmt": "3k",
+                    "longFmt": "3,000"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "WOOLLACOTT ALFREDIII",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1557360000,
+                    "fmt": "2019-05-09"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4355,
+                    "fmt": "4.36k",
+                    "longFmt": "4,355"
+                  },
+                  "value": {
+                    "raw": 169540,
+                    "fmt": "169.54k",
+                    "longFmt": "169,540"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 38.93 per share.",
+                  "filerName": "WOOLLACOTT ALFREDIII",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1557273600,
+                    "fmt": "2019-05-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3000,
+                    "fmt": "3k",
+                    "longFmt": "3,000"
+                  },
+                  "value": {
+                    "raw": 118500,
+                    "fmt": "118.5k",
+                    "longFmt": "118,500"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 39.50 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1557100800,
+                    "fmt": "2019-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2577,
+                    "fmt": "2.58k",
+                    "longFmt": "2,577"
+                  },
+                  "value": {
+                    "raw": 100374,
+                    "fmt": "100.37k",
+                    "longFmt": "100,374"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 38.95 per share.",
+                  "filerName": "JARZYNKA DAVID E",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1557100800,
+                    "fmt": "2019-05-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1692,
+                    "fmt": "1.69k",
+                    "longFmt": "1,692"
+                  },
+                  "value": {
+                    "raw": 64398,
+                    "fmt": "64.4k",
+                    "longFmt": "64,398"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 38.06 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556755200,
+                    "fmt": "2019-05-02"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4539,
+                    "fmt": "4.54k",
+                    "longFmt": "4,539"
+                  },
+                  "value": {
+                    "raw": 156788,
+                    "fmt": "156.79k",
+                    "longFmt": "156,788"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 34.10 - 35.00 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556582400,
+                    "fmt": "2019-04-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8000,
+                    "fmt": "8k",
+                    "longFmt": "8,000"
+                  },
+                  "value": {
+                    "raw": 284040,
+                    "fmt": "284.04k",
+                    "longFmt": "284,040"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 34.01 - 37.00 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1556582400,
+                    "fmt": "2019-04-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6000,
+                    "fmt": "6k",
+                    "longFmt": "6,000"
+                  },
+                  "value": {
+                    "raw": 178860,
+                    "fmt": "178.86k",
+                    "longFmt": "178,860"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 29.81 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1554076800,
+                    "fmt": "2019-04-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3000,
+                    "fmt": "3k",
+                    "longFmt": "3,000"
+                  },
+                  "value": {
+                    "raw": 100500,
+                    "fmt": "100.5k",
+                    "longFmt": "100,500"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 33.50 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550534400,
+                    "fmt": "2019-02-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10204,
+                    "fmt": "10.2k",
+                    "longFmt": "10,204"
+                  },
+                  "value": {
+                    "raw": 331732,
+                    "fmt": "331.73k",
+                    "longFmt": "331,732"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 32.51 per share.",
+                  "filerName": "TENNEY MAURICE H III",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550188800,
+                    "fmt": "2019-02-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4033,
+                    "fmt": "4.03k",
+                    "longFmt": "4,033"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROSENBLATT MICHAEL",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1549584000,
+                    "fmt": "2019-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4033,
+                    "fmt": "4.03k",
+                    "longFmt": "4,033"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WRIGHTON MARK S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1549584000,
+                    "fmt": "2019-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4033,
+                    "fmt": "4.03k",
+                    "longFmt": "4,033"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALLEN A CLINTON",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1549584000,
+                    "fmt": "2019-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4033,
+                    "fmt": "4.03k",
+                    "longFmt": "4,033"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WOOLLACOTT ALFREDIII",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1549584000,
+                    "fmt": "2019-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5377,
+                    "fmt": "5.38k",
+                    "longFmt": "5,377"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MARTIN JOSEPH R",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1549584000,
+                    "fmt": "2019-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4033,
+                    "fmt": "4.03k",
+                    "longFmt": "4,033"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ZANE ELLEN M",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1549584000,
+                    "fmt": "2019-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4033,
+                    "fmt": "4.03k",
+                    "longFmt": "4,033"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PALEPU KRISHNA G",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1549584000,
+                    "fmt": "2019-02-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7500,
+                    "fmt": "7.5k",
+                    "longFmt": "7,500"
+                  },
+                  "value": {
+                    "raw": 243750,
+                    "fmt": "243.75k",
+                    "longFmt": "243,750"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 32.50 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1549411200,
+                    "fmt": "2019-02-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8164,
+                    "fmt": "8.16k",
+                    "longFmt": "8,164"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "DAVIS ROBYN C",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548979200,
+                    "fmt": "2019-02-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3000,
+                    "fmt": "3k",
+                    "longFmt": "3,000"
+                  },
+                  "value": {
+                    "raw": 91500,
+                    "fmt": "91.5k",
+                    "longFmt": "91,500"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 30.50 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548374400,
+                    "fmt": "2019-01-25"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 300,
+                    "fmt": "300",
+                    "longFmt": "300"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "ALLEN A CLINTON",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543449600,
+                    "fmt": "2018-11-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5356,
+                    "fmt": "5.36k",
+                    "longFmt": "5,356"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543449600,
+                    "fmt": "2018-11-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 24347,
+                    "fmt": "24.35k",
+                    "longFmt": "24,347"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543449600,
+                    "fmt": "2018-11-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5113,
+                    "fmt": "5.11k",
+                    "longFmt": "5,113"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543449600,
+                    "fmt": "2018-11-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 18018,
+                    "fmt": "18.02k",
+                    "longFmt": "18,018"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROBERTSON LINDON GENE",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543449600,
+                    "fmt": "2018-11-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7791,
+                    "fmt": "7.79k",
+                    "longFmt": "7,791"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "TENNEY MAURICE H III",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543449600,
+                    "fmt": "2018-11-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15583,
+                    "fmt": "15.58k",
+                    "longFmt": "15,583"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543449600,
+                    "fmt": "2018-11-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2921,
+                    "fmt": "2.92k",
+                    "longFmt": "2,921"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543449600,
+                    "fmt": "2018-11-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7791,
+                    "fmt": "7.79k",
+                    "longFmt": "7,791"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JARZYNKA DAVID E",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543449600,
+                    "fmt": "2018-11-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7791,
+                    "fmt": "7.79k",
+                    "longFmt": "7,791"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "LIAO GUOJUAN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1543449600,
+                    "fmt": "2018-11-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3896,
+                    "fmt": "3.9k",
+                    "longFmt": "3,896"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1542931200,
+                    "fmt": "2018-11-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3896,
+                    "fmt": "3.9k",
+                    "longFmt": "3,896"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1542931200,
+                    "fmt": "2018-11-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3896,
+                    "fmt": "3.9k",
+                    "longFmt": "3,896"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1542931200,
+                    "fmt": "2018-11-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2636,
+                    "fmt": "2.64k",
+                    "longFmt": "2,636"
+                  },
+                  "value": {
+                    "raw": 74618,
+                    "fmt": "74.62k",
+                    "longFmt": "74,618"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 27.51 - 28.59 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1542585600,
+                    "fmt": "2018-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1946,
+                    "fmt": "1.95k",
+                    "longFmt": "1,946"
+                  },
+                  "value": {
+                    "raw": 55636,
+                    "fmt": "55.64k",
+                    "longFmt": "55,636"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 28.59 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1542326400,
+                    "fmt": "2018-11-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8127,
+                    "fmt": "8.13k",
+                    "longFmt": "8,127"
+                  },
+                  "value": {
+                    "raw": 232351,
+                    "fmt": "232.35k",
+                    "longFmt": "232,351"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 28.59 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1542326400,
+                    "fmt": "2018-11-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3675,
+                    "fmt": "3.67k",
+                    "longFmt": "3,675"
+                  },
+                  "value": {
+                    "raw": 105068,
+                    "fmt": "105.07k",
+                    "longFmt": "105,068"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 28.59 per share.",
+                  "filerName": "ROBERTSON LINDON GENE",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1542326400,
+                    "fmt": "2018-11-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3461,
+                    "fmt": "3.46k",
+                    "longFmt": "3,461"
+                  },
+                  "value": {
+                    "raw": 98950,
+                    "fmt": "98.95k",
+                    "longFmt": "98,950"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 28.59 per share.",
+                  "filerName": "TENNEY MAURICE H III",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1542326400,
+                    "fmt": "2018-11-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1337,
+                    "fmt": "1.34k",
+                    "longFmt": "1,337"
+                  },
+                  "value": {
+                    "raw": 38225,
+                    "fmt": "38.23k",
+                    "longFmt": "38,225"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 28.59 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1542326400,
+                    "fmt": "2018-11-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1048,
+                    "fmt": "1.05k",
+                    "longFmt": "1,048"
+                  },
+                  "value": {
+                    "raw": 29962,
+                    "fmt": "29.96k",
+                    "longFmt": "29,962"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 28.59 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1542326400,
+                    "fmt": "2018-11-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5058,
+                    "fmt": "5.06k",
+                    "longFmt": "5,058"
+                  },
+                  "value": {
+                    "raw": 143986,
+                    "fmt": "143.99k",
+                    "longFmt": "143,986"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 28.35 - 28.59 per share.",
+                  "filerName": "JARZYNKA DAVID E",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1542326400,
+                    "fmt": "2018-11-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 34153,
+                    "fmt": "34.15k",
+                    "longFmt": "34,153"
+                  },
+                  "value": {
+                    "raw": 1037023,
+                    "fmt": "1.04M",
+                    "longFmt": "1,037,023"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 29.04 - 30.93 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1542067200,
+                    "fmt": "2018-11-13"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 20704,
+                    "fmt": "20.7k",
+                    "longFmt": "20,704"
+                  },
+                  "value": {
+                    "raw": 640375,
+                    "fmt": "640.38k",
+                    "longFmt": "640,375"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 30.93 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541980800,
+                    "fmt": "2018-11-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 94826,
+                    "fmt": "94.83k",
+                    "longFmt": "94,826"
+                  },
+                  "value": {
+                    "raw": 2932968,
+                    "fmt": "2.93M",
+                    "longFmt": "2,932,968"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 30.93 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541980800,
+                    "fmt": "2018-11-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 40040,
+                    "fmt": "40.04k",
+                    "longFmt": "40,040"
+                  },
+                  "value": {
+                    "raw": 1238437,
+                    "fmt": "1.24M",
+                    "longFmt": "1,238,437"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 30.93 per share.",
+                  "filerName": "ROBERTSON LINDON GENE",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541980800,
+                    "fmt": "2018-11-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 46487,
+                    "fmt": "46.49k",
+                    "longFmt": "46,487"
+                  },
+                  "value": {
+                    "raw": 1437843,
+                    "fmt": "1.44M",
+                    "longFmt": "1,437,843"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 30.93 per share.",
+                  "filerName": "TENNEY MAURICE H III",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541980800,
+                    "fmt": "2018-11-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 20704,
+                    "fmt": "20.7k",
+                    "longFmt": "20,704"
+                  },
+                  "value": {
+                    "raw": 640375,
+                    "fmt": "640.38k",
+                    "longFmt": "640,375"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 30.93 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541980800,
+                    "fmt": "2018-11-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9899,
+                    "fmt": "9.9k",
+                    "longFmt": "9,899"
+                  },
+                  "value": {
+                    "raw": 306176,
+                    "fmt": "306.18k",
+                    "longFmt": "306,176"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 30.93 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541980800,
+                    "fmt": "2018-11-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 27896,
+                    "fmt": "27.9k",
+                    "longFmt": "27,896"
+                  },
+                  "value": {
+                    "raw": 862823,
+                    "fmt": "862.82k",
+                    "longFmt": "862,823"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 30.93 per share.",
+                  "filerName": "JARZYNKA DAVID E",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541980800,
+                    "fmt": "2018-11-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 83582,
+                    "fmt": "83.58k",
+                    "longFmt": "83,582"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541462400,
+                    "fmt": "2018-11-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 24265,
+                    "fmt": "24.27k",
+                    "longFmt": "24,265"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541462400,
+                    "fmt": "2018-11-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1933,
+                    "fmt": "1.93k",
+                    "longFmt": "1,933"
+                  },
+                  "value": {
+                    "raw": 61415,
+                    "fmt": "61.41k",
+                    "longFmt": "61,415"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 31.76 - 31.79 per share.",
+                  "filerName": "GRAY DAVID C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541462400,
+                    "fmt": "2018-11-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 37747,
+                    "fmt": "37.75k",
+                    "longFmt": "37,747"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROBERTSON LINDON GENE",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541462400,
+                    "fmt": "2018-11-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 43140,
+                    "fmt": "43.14k",
+                    "longFmt": "43,140"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "TENNEY MAURICE H III",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541462400,
+                    "fmt": "2018-11-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 21570,
+                    "fmt": "21.57k",
+                    "longFmt": "21,570"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541462400,
+                    "fmt": "2018-11-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12132,
+                    "fmt": "12.13k",
+                    "longFmt": "12,132"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541462400,
+                    "fmt": "2018-11-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 24265,
+                    "fmt": "24.27k",
+                    "longFmt": "24,265"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JARZYNKA DAVID E",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541462400,
+                    "fmt": "2018-11-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1026,
+                    "fmt": "1.03k",
+                    "longFmt": "1,026"
+                  },
+                  "value": {
+                    "raw": 32586,
+                    "fmt": "32.59k",
+                    "longFmt": "32,586"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 31.76 per share.",
+                  "filerName": "JOSEPH JASON W",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541376000,
+                    "fmt": "2018-11-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3976,
+                    "fmt": "3.98k",
+                    "longFmt": "3,976"
+                  },
+                  "value": {
+                    "raw": 126278,
+                    "fmt": "126.28k",
+                    "longFmt": "126,278"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 31.76 per share.",
+                  "filerName": "SCHWARTZ STEPHEN S",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541376000,
+                    "fmt": "2018-11-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1796,
+                    "fmt": "1.8k",
+                    "longFmt": "1,796"
+                  },
+                  "value": {
+                    "raw": 57041,
+                    "fmt": "57.04k",
+                    "longFmt": "57,041"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 31.76 per share.",
+                  "filerName": "ROBERTSON LINDON GENE",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541376000,
+                    "fmt": "2018-11-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2052,
+                    "fmt": "2.05k",
+                    "longFmt": "2,052"
+                  },
+                  "value": {
+                    "raw": 65172,
+                    "fmt": "65.17k",
+                    "longFmt": "65,172"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 31.76 per share.",
+                  "filerName": "TENNEY MAURICE H III",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541376000,
+                    "fmt": "2018-11-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1026,
+                    "fmt": "1.03k",
+                    "longFmt": "1,026"
+                  },
+                  "value": {
+                    "raw": 32586,
+                    "fmt": "32.59k",
+                    "longFmt": "32,586"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 31.76 per share.",
+                  "filerName": "MONTONE WILLIAM T",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541376000,
+                    "fmt": "2018-11-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 577,
+                    "fmt": "577",
+                    "longFmt": "577"
+                  },
+                  "value": {
+                    "raw": 18326,
+                    "fmt": "18.33k",
+                    "longFmt": "18,326"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 31.76 per share.",
+                  "filerName": "PIETRANTONI DAVID F.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541376000,
+                    "fmt": "2018-11-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1661,
+                    "fmt": "1.66k",
+                    "longFmt": "1,661"
+                  },
+                  "value": {
+                    "raw": 52753,
+                    "fmt": "52.75k",
+                    "longFmt": "52,753"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 31.76 per share.",
+                  "filerName": "JARZYNKA DAVID E",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1541376000,
+                    "fmt": "2018-11-05"
+                  },
+                  "ownership": "D"
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderTransactions-CRON.json
+++ b/tests/http/quoteSummary-insiderTransactions-CRON.json
@@ -1,0 +1,365 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=insiderTransactions"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "9oh1kfdg2vsek"
+      ],
+      "x-yahoo-request-id": [
+        "9oh1kfdg2vsek"
+      ],
+      "x-request-id": [
+        "911c80d2-cdd5-4bbc-87d3-90ce3df37ec4"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "866"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:56 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "insiderTransactions": {
+              "transactions": [
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 100000,
+                    "fmt": "100k",
+                    "longFmt": "100,000"
+                  },
+                  "value": {
+                    "raw": 733400,
+                    "fmt": "733.4k",
+                    "longFmt": "733,400"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Acquisition or disposition in the public market at price 7.33 per share.",
+                  "filerName": "Adler (Jason Marc)",
+                  "filerRelation": "Director of Issuer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605571200,
+                    "fmt": "2020-11-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 105151,
+                    "fmt": "105.15k",
+                    "longFmt": "105,151"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "Gorenstein (Michael Ryan)",
+                  "filerRelation": "Director of Issuer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605139200,
+                    "fmt": "2020-11-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4000000,
+                    "fmt": "4M",
+                    "longFmt": "4,000,000"
+                  },
+                  "value": {
+                    "raw": 744000,
+                    "fmt": "744k",
+                    "longFmt": "744,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Exercise of warrants at price 0.19 per share.",
+                  "filerName": "Gorenstein (Michael Ryan)",
+                  "filerRelation": "Director of Issuer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605139200,
+                    "fmt": "2020-11-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9300,
+                    "fmt": "9.3k",
+                    "longFmt": "9,300"
+                  },
+                  "value": {
+                    "raw": 67890,
+                    "fmt": "67.89k",
+                    "longFmt": "67,890"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Acquisition or disposition in the public market at price 7.30 per share.",
+                  "filerName": "Adler (Jason Marc)",
+                  "filerRelation": "Director of Issuer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605052800,
+                    "fmt": "2020-11-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 21361,
+                    "fmt": "21.36k",
+                    "longFmt": "21,361"
+                  },
+                  "value": {
+                    "raw": 155956,
+                    "fmt": "155.96k",
+                    "longFmt": "155,956"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Acquisition or disposition in the public market at price 7.30 per share.",
+                  "filerName": "Adler (Jason Marc)",
+                  "filerRelation": "Director of Issuer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604966400,
+                    "fmt": "2020-11-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 769339,
+                    "fmt": "769.34k",
+                    "longFmt": "769,339"
+                  },
+                  "value": {
+                    "raw": 5946221,
+                    "fmt": "5.95M",
+                    "longFmt": "5,946,221"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Acquisition or disposition in the public market at price 7.73 per share.",
+                  "filerName": "Adler (Jason Marc)",
+                  "filerRelation": "Director of Issuer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604880000,
+                    "fmt": "2020-11-09"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 100000,
+                    "fmt": "100k",
+                    "longFmt": "100,000"
+                  },
+                  "value": {
+                    "raw": 760200,
+                    "fmt": "760.2k",
+                    "longFmt": "760,200"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Acquisition or disposition in the public market at price 7.60 per share.",
+                  "filerName": "Adler (Jason Marc)",
+                  "filerRelation": "Director of Issuer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604620800,
+                    "fmt": "2020-11-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1289350,
+                    "fmt": "1.29M",
+                    "longFmt": "1,289,350"
+                  },
+                  "value": {
+                    "raw": 9315553,
+                    "fmt": "9.32M",
+                    "longFmt": "9,315,553"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Acquisition or disposition in the public market at price 7.22 per share.",
+                  "filerName": "Gorenstein (Michael Ryan)",
+                  "filerRelation": "Director of Issuer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604620800,
+                    "fmt": "2020-11-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 645555,
+                    "fmt": "645.55k",
+                    "longFmt": "645,555"
+                  },
+                  "value": {
+                    "raw": 151705,
+                    "fmt": "151.71k",
+                    "longFmt": "151,705"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Exercise of warrants at price 0.23 per share.",
+                  "filerName": "Gorenstein (Michael Ryan)",
+                  "filerRelation": "Director of Issuer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1600128000,
+                    "fmt": "2020-09-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 28108,
+                    "fmt": "28.11k",
+                    "longFmt": "28,108"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "Gorenstein (Michael Ryan)",
+                  "filerRelation": "Director of Issuer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1600128000,
+                    "fmt": "2020-09-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2500,
+                    "fmt": "2.5k",
+                    "longFmt": "2,500"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "Jacobson (Jeffrey David)",
+                  "filerRelation": "Senior Officer of Issuer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597363200,
+                    "fmt": "2020-08-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15000,
+                    "fmt": "15k",
+                    "longFmt": "15,000"
+                  },
+                  "value": {
+                    "raw": 64830,
+                    "fmt": "64.83k",
+                    "longFmt": "64,830"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Acquisition or disposition in the public market at price 4.32 per share.",
+                  "filerName": "Abraham (Todd Kevin Ph.D.)",
+                  "filerRelation": "Senior Officer of Issuer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596758400,
+                    "fmt": "2020-08-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "Shlimak (Anna)",
+                  "filerRelation": "Senior Officer of Issuer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1582243200,
+                    "fmt": "2020-02-21"
+                  },
+                  "ownership": "D"
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderTransactions-EPAC.json
+++ b/tests/http/quoteSummary-insiderTransactions-EPAC.json
@@ -1,0 +1,3536 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=insiderTransactions"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "dbe78ghg2vsek"
+      ],
+      "x-yahoo-request-id": [
+        "dbe78ghg2vsek"
+      ],
+      "x-request-id": [
+        "fb7e393b-166f-474c-9e00-635862b15b07"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:57 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "insiderTransactions": {
+              "transactions": [
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15672,
+                    "fmt": "15.67k",
+                    "longFmt": "15,672"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DILLON RICKY T",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7124,
+                    "fmt": "7.12k",
+                    "longFmt": "7,124"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BOLENS BARBARA",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4480,
+                    "fmt": "4.48k",
+                    "longFmt": "4,480"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "HOLDER RICHARD D",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8961,
+                    "fmt": "8.96k",
+                    "longFmt": "8,961"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "FERLAND E JAMES JR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4480,
+                    "fmt": "4.48k",
+                    "longFmt": "4,480"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALTMAIER JUDY L",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 61744,
+                    "fmt": "61.74k",
+                    "longFmt": "61,744"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BAKER RANDAL W",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4480,
+                    "fmt": "4.48k",
+                    "longFmt": "4,480"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALTAVILLA ALFREDO",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4480,
+                    "fmt": "4.48k",
+                    "longFmt": "4,480"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CUNNINGHAM DANNY L.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4480,
+                    "fmt": "4.48k",
+                    "longFmt": "4,480"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CLARKSON J PALMER",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15672,
+                    "fmt": "15.67k",
+                    "longFmt": "15,672"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SCHMALING JOHN JEFFREY",
+                  "filerRelation": "Chief Operating Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4480,
+                    "fmt": "4.48k",
+                    "longFmt": "4,480"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SIMMONS SIDNEY S. II",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 11828,
+                    "fmt": "11.83k",
+                    "longFmt": "11,828"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RASETTI FABRIZIO",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8961,
+                    "fmt": "8.96k",
+                    "longFmt": "8,961"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JOHNSON BRYAN R.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2005,
+                    "fmt": "2k",
+                    "longFmt": "2,005"
+                  },
+                  "value": {
+                    "raw": 40352,
+                    "fmt": "40.35k",
+                    "longFmt": "40,352"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 20.13 per share.",
+                  "filerName": "DILLON RICKY T",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1604880000,
+                    "fmt": "2020-11-09"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2588,
+                    "fmt": "2.59k",
+                    "longFmt": "2,588"
+                  },
+                  "value": {
+                    "raw": 46248,
+                    "fmt": "46.25k",
+                    "longFmt": "46,248"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 17.87 per share.",
+                  "filerName": "BOLENS BARBARA",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1603929600,
+                    "fmt": "2020-10-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3514,
+                    "fmt": "3.51k",
+                    "longFmt": "3,514"
+                  },
+                  "value": {
+                    "raw": 67609,
+                    "fmt": "67.61k",
+                    "longFmt": "67,609"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 19.24 per share.",
+                  "filerName": "DILLON RICKY T",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1603670400,
+                    "fmt": "2020-10-26"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 16769,
+                    "fmt": "16.77k",
+                    "longFmt": "16,769"
+                  },
+                  "value": {
+                    "raw": 322636,
+                    "fmt": "322.64k",
+                    "longFmt": "322,636"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 19.24 per share.",
+                  "filerName": "BAKER RANDAL W",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1603670400,
+                    "fmt": "2020-10-26"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3571,
+                    "fmt": "3.57k",
+                    "longFmt": "3,571"
+                  },
+                  "value": {
+                    "raw": 68706,
+                    "fmt": "68.71k",
+                    "longFmt": "68,706"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 19.24 per share.",
+                  "filerName": "SCHMALING JOHN JEFFREY",
+                  "filerRelation": "Chief Operating Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1603670400,
+                    "fmt": "2020-10-26"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 341,
+                    "fmt": "341",
+                    "longFmt": "341"
+                  },
+                  "value": {
+                    "raw": 6786,
+                    "fmt": "6.79k",
+                    "longFmt": "6,786"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 19.90 per share.",
+                  "filerName": "JOHNSON BRYAN R.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596153600,
+                    "fmt": "2020-07-31"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2128,
+                    "fmt": "2.13k",
+                    "longFmt": "2,128"
+                  },
+                  "value": {
+                    "raw": 50753,
+                    "fmt": "50.75k",
+                    "longFmt": "50,753"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 23.85 per share.",
+                  "filerName": "DILLON RICKY T",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580774400,
+                    "fmt": "2020-02-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12420,
+                    "fmt": "12.42k",
+                    "longFmt": "12,420"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DILLON RICKY T",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580169600,
+                    "fmt": "2020-01-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5646,
+                    "fmt": "5.65k",
+                    "longFmt": "5,646"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BOLENS BARBARA",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580169600,
+                    "fmt": "2020-01-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4261,
+                    "fmt": "4.26k",
+                    "longFmt": "4,261"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "HOLDER RICHARD D",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580169600,
+                    "fmt": "2020-01-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8522,
+                    "fmt": "8.52k",
+                    "longFmt": "8,522"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "FERLAND E JAMES JR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580169600,
+                    "fmt": "2020-01-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4261,
+                    "fmt": "4.26k",
+                    "longFmt": "4,261"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALTMAIER JUDY L",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580169600,
+                    "fmt": "2020-01-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 58719,
+                    "fmt": "58.72k",
+                    "longFmt": "58,719"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BAKER RANDAL W",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580169600,
+                    "fmt": "2020-01-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4261,
+                    "fmt": "4.26k",
+                    "longFmt": "4,261"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALTAVILLA ALFREDO",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580169600,
+                    "fmt": "2020-01-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4261,
+                    "fmt": "4.26k",
+                    "longFmt": "4,261"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CUNNINGHAM DANNY L.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580169600,
+                    "fmt": "2020-01-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4261,
+                    "fmt": "4.26k",
+                    "longFmt": "4,261"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CLARKSON J PALMER",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580169600,
+                    "fmt": "2020-01-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12420,
+                    "fmt": "12.42k",
+                    "longFmt": "12,420"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SCHMALING JOHN JEFFREY",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580169600,
+                    "fmt": "2020-01-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4261,
+                    "fmt": "4.26k",
+                    "longFmt": "4,261"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SIMMONS SIDNEY S. II",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580169600,
+                    "fmt": "2020-01-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9374,
+                    "fmt": "9.37k",
+                    "longFmt": "9,374"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RASETTI FABRIZIO",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580169600,
+                    "fmt": "2020-01-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8522,
+                    "fmt": "8.52k",
+                    "longFmt": "8,522"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JOHNSON BRYAN R.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1580169600,
+                    "fmt": "2020-01-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15000,
+                    "fmt": "15k",
+                    "longFmt": "15,000"
+                  },
+                  "value": {
+                    "raw": 375315,
+                    "fmt": "375.31k",
+                    "longFmt": "375,315"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 25.02 per share.",
+                  "filerName": "BAKER RANDAL W",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1579132800,
+                    "fmt": "2020-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2432,
+                    "fmt": "2.43k",
+                    "longFmt": "2,432"
+                  },
+                  "value": {
+                    "raw": 62963,
+                    "fmt": "62.96k",
+                    "longFmt": "62,963"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 25.89 per share.",
+                  "filerName": "DILLON RICKY T",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1572912000,
+                    "fmt": "2019-11-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2432,
+                    "fmt": "2.43k",
+                    "longFmt": "2,432"
+                  },
+                  "value": {
+                    "raw": 62963,
+                    "fmt": "62.96k",
+                    "longFmt": "62,963"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 25.89 per share.",
+                  "filerName": "DILLON RICKY T",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1572912000,
+                    "fmt": "2019-11-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 654,
+                    "fmt": "654",
+                    "longFmt": "654"
+                  },
+                  "value": {
+                    "raw": 16716,
+                    "fmt": "16.72k",
+                    "longFmt": "16,716"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 25.56 per share.",
+                  "filerName": "ALTMAIER JUDY L",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1572566400,
+                    "fmt": "2019-11-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 20990,
+                    "fmt": "20.99k",
+                    "longFmt": "20,990"
+                  },
+                  "value": {
+                    "raw": 519922,
+                    "fmt": "519.92k",
+                    "longFmt": "519,922"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 24.77 per share.",
+                  "filerName": "ROUNDHOUSE ROGER A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1572480000,
+                    "fmt": "2019-10-31"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3582,
+                    "fmt": "3.58k",
+                    "longFmt": "3,582"
+                  },
+                  "value": {
+                    "raw": 88834,
+                    "fmt": "88.83k",
+                    "longFmt": "88,834"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 24.80 per share.",
+                  "filerName": "DILLON RICKY T",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1572307200,
+                    "fmt": "2019-10-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 19716,
+                    "fmt": "19.72k",
+                    "longFmt": "19,716"
+                  },
+                  "value": {
+                    "raw": 488957,
+                    "fmt": "488.96k",
+                    "longFmt": "488,957"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 24.80 per share.",
+                  "filerName": "BAKER RANDAL W",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1572307200,
+                    "fmt": "2019-10-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4101,
+                    "fmt": "4.1k",
+                    "longFmt": "4,101"
+                  },
+                  "value": {
+                    "raw": 101705,
+                    "fmt": "101.7k",
+                    "longFmt": "101,705"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 24.80 per share.",
+                  "filerName": "ROUNDHOUSE ROGER A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1572307200,
+                    "fmt": "2019-10-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1919,
+                    "fmt": "1.92k",
+                    "longFmt": "1,919"
+                  },
+                  "value": {
+                    "raw": 43369,
+                    "fmt": "43.37k",
+                    "longFmt": "43,369"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 22.60 per share.",
+                  "filerName": "JOHNSON BRYAN R.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1571270400,
+                    "fmt": "2019-10-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3275,
+                    "fmt": "3.27k",
+                    "longFmt": "3,275"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JOHNSON BRYAN R.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1564531200,
+                    "fmt": "2019-07-31"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10266,
+                    "fmt": "10.27k",
+                    "longFmt": "10,266"
+                  },
+                  "value": {
+                    "raw": 231901,
+                    "fmt": "231.9k",
+                    "longFmt": "231,901"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 22.59 per share.",
+                  "filerName": "ROUNDHOUSE ROGER A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548806400,
+                    "fmt": "2019-01-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12438,
+                    "fmt": "12.44k",
+                    "longFmt": "12,438"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DILLON RICKY T",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9046,
+                    "fmt": "9.05k",
+                    "longFmt": "9,046"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "HOLDER RICHARD D",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 14114,
+                    "fmt": "14.11k",
+                    "longFmt": "14,114"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "VAN DEURSEN HOLLY A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 13569,
+                    "fmt": "13.57k",
+                    "longFmt": "13,569"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "FERLAND E JAMES JR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 62330,
+                    "fmt": "62.33k",
+                    "longFmt": "62,330"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BAKER RANDAL W",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9046,
+                    "fmt": "9.05k",
+                    "longFmt": "9,046"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALTAVILLA ALFREDO",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12438,
+                    "fmt": "12.44k",
+                    "longFmt": "12,438"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROUNDHOUSE ROGER A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9046,
+                    "fmt": "9.05k",
+                    "longFmt": "9,046"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CUNNINGHAM DANNY L.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9046,
+                    "fmt": "9.05k",
+                    "longFmt": "9,046"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CLARKSON J PALMER",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5654,
+                    "fmt": "5.65k",
+                    "longFmt": "5,654"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WILLIAMS ANDRE L",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12438,
+                    "fmt": "12.44k",
+                    "longFmt": "12,438"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SCHMALING JOHN JEFFREY",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9046,
+                    "fmt": "9.05k",
+                    "longFmt": "9,046"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SIMMONS SIDNEY S. II",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9046,
+                    "fmt": "9.05k",
+                    "longFmt": "9,046"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RASETTI FABRIZIO",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6491,
+                    "fmt": "6.49k",
+                    "longFmt": "6,491"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JOHNSON BRYAN R.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6784,
+                    "fmt": "6.78k",
+                    "longFmt": "6,784"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "JOHNSON BRYAN R.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1548115200,
+                    "fmt": "2019-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6939,
+                    "fmt": "6.94k",
+                    "longFmt": "6,939"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROUNDHOUSE ROGER A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1540771200,
+                    "fmt": "2018-10-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12500,
+                    "fmt": "12.5k",
+                    "longFmt": "12,500"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RASETTI FABRIZIO",
+                  "filerRelation": "General Counsel",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1525651200,
+                    "fmt": "2018-05-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10730,
+                    "fmt": "10.73k",
+                    "longFmt": "10,730"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SCHMALING JOHN JEFFREY",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1518393600,
+                    "fmt": "2018-02-12"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3831,
+                    "fmt": "3.83k",
+                    "longFmt": "3,831"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "HUNTER R ALAN JR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1516665600,
+                    "fmt": "2018-01-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3831,
+                    "fmt": "3.83k",
+                    "longFmt": "3,831"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BEDI GURMINDER S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1516665600,
+                    "fmt": "2018-01-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3831,
+                    "fmt": "3.83k",
+                    "longFmt": "3,831"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WILLIAMS DENNIS K",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1516665600,
+                    "fmt": "2018-01-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4693,
+                    "fmt": "4.69k",
+                    "longFmt": "4,693"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETERSON ROBERT A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1516665600,
+                    "fmt": "2018-01-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3831,
+                    "fmt": "3.83k",
+                    "longFmt": "3,831"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "HOLDER RICHARD D",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1516665600,
+                    "fmt": "2018-01-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3831,
+                    "fmt": "3.83k",
+                    "longFmt": "3,831"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "VAN DEURSEN HOLLY A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1516665600,
+                    "fmt": "2018-01-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3831,
+                    "fmt": "3.83k",
+                    "longFmt": "3,831"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "FERLAND E JAMES JR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1516665600,
+                    "fmt": "2018-01-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3831,
+                    "fmt": "3.83k",
+                    "longFmt": "3,831"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CUNNINGHAM DANNY L.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1516665600,
+                    "fmt": "2018-01-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10516,
+                    "fmt": "10.52k",
+                    "longFmt": "10,516"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DILLON RICKY T",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1516579200,
+                    "fmt": "2018-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 50191,
+                    "fmt": "50.19k",
+                    "longFmt": "50,191"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BAKER RANDAL W",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1516579200,
+                    "fmt": "2018-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10516,
+                    "fmt": "10.52k",
+                    "longFmt": "10,516"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROUNDHOUSE ROGER A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1516579200,
+                    "fmt": "2018-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2868,
+                    "fmt": "2.87k",
+                    "longFmt": "2,868"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WROCKLAGE ROBERT A.",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1516579200,
+                    "fmt": "2018-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4780,
+                    "fmt": "4.78k",
+                    "longFmt": "4,780"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WILLIAMS ANDRE L",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1516579200,
+                    "fmt": "2018-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6000,
+                    "fmt": "6k",
+                    "longFmt": "6,000"
+                  },
+                  "value": {
+                    "raw": 153960,
+                    "fmt": "153.96k",
+                    "longFmt": "153,960"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 25.66 per share.",
+                  "filerName": "WOZNIAK THEODORE C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1514419200,
+                    "fmt": "2017-12-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3002,
+                    "fmt": "3k",
+                    "longFmt": "3,002"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROUNDHOUSE ROGER A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1508112000,
+                    "fmt": "2017-10-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5000,
+                    "fmt": "5k",
+                    "longFmt": "5,000"
+                  },
+                  "value": {
+                    "raw": 130950,
+                    "fmt": "130.95k",
+                    "longFmt": "130,950"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 26.19 per share.",
+                  "filerName": "WOZNIAK THEODORE C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1507593600,
+                    "fmt": "2017-10-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 876,
+                    "fmt": "876",
+                    "longFmt": "876"
+                  },
+                  "value": {
+                    "raw": 22268,
+                    "fmt": "22.27k",
+                    "longFmt": "22,268"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 25.42 per share.",
+                  "filerName": "RENNIE STEPHEN J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1506556800,
+                    "fmt": "2017-09-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 500,
+                    "fmt": "500",
+                    "longFmt": "500"
+                  },
+                  "value": {
+                    "raw": 12665,
+                    "fmt": "12.66k",
+                    "longFmt": "12,665"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 25.33 per share.",
+                  "filerName": "WOZNIAK THEODORE C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1491350400,
+                    "fmt": "2017-04-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1000,
+                    "fmt": "1k",
+                    "longFmt": "1,000"
+                  },
+                  "value": {
+                    "raw": 25640,
+                    "fmt": "25.64k",
+                    "longFmt": "25,640"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 25.64 per share.",
+                  "filerName": "WOZNIAK THEODORE C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1490832000,
+                    "fmt": "2017-03-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2647,
+                    "fmt": "2.65k",
+                    "longFmt": "2,647"
+                  },
+                  "value": {
+                    "raw": 66704,
+                    "fmt": "66.7k",
+                    "longFmt": "66,704"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 25.20 per share.",
+                  "filerName": "RENNIE STEPHEN J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1490745600,
+                    "fmt": "2017-03-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2412,
+                    "fmt": "2.41k",
+                    "longFmt": "2,412"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "HUNTER R ALAN JR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2412,
+                    "fmt": "2.41k",
+                    "longFmt": "2,412"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BEDI GURMINDER S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2412,
+                    "fmt": "2.41k",
+                    "longFmt": "2,412"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WILLIAMS DENNIS K",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2955,
+                    "fmt": "2.96k",
+                    "longFmt": "2,955"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETERSON ROBERT A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7143,
+                    "fmt": "7.14k",
+                    "longFmt": "7,143"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DILLON RICKY T",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6680,
+                    "fmt": "6.68k",
+                    "longFmt": "6,680"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WOZNIAK THEODORE C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2412,
+                    "fmt": "2.41k",
+                    "longFmt": "2,412"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "VAN DEURSEN HOLLY A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2412,
+                    "fmt": "2.41k",
+                    "longFmt": "2,412"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "FERLAND E JAMES JR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 32468,
+                    "fmt": "32.47k",
+                    "longFmt": "32,468"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BAKER RANDAL W",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12987,
+                    "fmt": "12.99k",
+                    "longFmt": "12,987"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PAULI MATTHEW",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6753,
+                    "fmt": "6.75k",
+                    "longFmt": "6,753"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROUNDHOUSE ROGER A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4675,
+                    "fmt": "4.67k",
+                    "longFmt": "4,675"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SKOGG EUGENE EDWARD",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2412,
+                    "fmt": "2.41k",
+                    "longFmt": "2,412"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "CUNNINGHAM DANNY L.",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5520,
+                    "fmt": "5.52k",
+                    "longFmt": "5,520"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BOCKHORST KENNETH C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5520,
+                    "fmt": "5.52k",
+                    "longFmt": "5,520"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "RENNIE STEPHEN J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484524800,
+                    "fmt": "2017-01-16"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15000,
+                    "fmt": "15k",
+                    "longFmt": "15,000"
+                  },
+                  "value": {
+                    "raw": 397255,
+                    "fmt": "397.25k",
+                    "longFmt": "397,255"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 26.10 - 26.64 per share.",
+                  "filerName": "WOZNIAK THEODORE C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484006400,
+                    "fmt": "2017-01-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15000,
+                    "fmt": "15k",
+                    "longFmt": "15,000"
+                  },
+                  "value": {
+                    "raw": 354600,
+                    "fmt": "354.6k",
+                    "longFmt": "354,600"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 23.64 per share.",
+                  "filerName": "WOZNIAK THEODORE C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484006400,
+                    "fmt": "2017-01-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4339,
+                    "fmt": "4.34k",
+                    "longFmt": "4,339"
+                  },
+                  "value": {
+                    "raw": 115417,
+                    "fmt": "115.42k",
+                    "longFmt": "115,417"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 26.60 per share.",
+                  "filerName": "SKOGG EUGENE EDWARD",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1484006400,
+                    "fmt": "2017-01-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 183865,
+                    "fmt": "183.87k",
+                    "longFmt": "183,865"
+                  },
+                  "value": {
+                    "raw": 4846835,
+                    "fmt": "4.85M",
+                    "longFmt": "4,846,835"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 26.24 - 26.56 per share.",
+                  "filerName": "ARZBAECHER ROBERT C",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1483401600,
+                    "fmt": "2017-01-03"
+                  },
+                  "ownership": "D/I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8000,
+                    "fmt": "8k",
+                    "longFmt": "8,000"
+                  },
+                  "value": {
+                    "raw": 213440,
+                    "fmt": "213.44k",
+                    "longFmt": "213,440"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 26.68 per share.",
+                  "filerName": "WILLIAMS DENNIS K",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1483401600,
+                    "fmt": "2017-01-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8000,
+                    "fmt": "8k",
+                    "longFmt": "8,000"
+                  },
+                  "value": {
+                    "raw": 189120,
+                    "fmt": "189.12k",
+                    "longFmt": "189,120"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 23.64 per share.",
+                  "filerName": "WILLIAMS DENNIS K",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1483401600,
+                    "fmt": "2017-01-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5000,
+                    "fmt": "5k",
+                    "longFmt": "5,000"
+                  },
+                  "value": {
+                    "raw": 130200,
+                    "fmt": "130.2k",
+                    "longFmt": "130,200"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 26.04 per share.",
+                  "filerName": "WOZNIAK THEODORE C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1483056000,
+                    "fmt": "2016-12-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5000,
+                    "fmt": "5k",
+                    "longFmt": "5,000"
+                  },
+                  "value": {
+                    "raw": 118200,
+                    "fmt": "118.2k",
+                    "longFmt": "118,200"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 23.64 per share.",
+                  "filerName": "WOZNIAK THEODORE C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1483056000,
+                    "fmt": "2016-12-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 11900,
+                    "fmt": "11.9k",
+                    "longFmt": "11,900"
+                  },
+                  "value": {
+                    "raw": 318087,
+                    "fmt": "318.09k",
+                    "longFmt": "318,087"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 26.73 per share.",
+                  "filerName": "ARZBAECHER ROBERT C",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1482796800,
+                    "fmt": "2016-12-27"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8000,
+                    "fmt": "8k",
+                    "longFmt": "8,000"
+                  },
+                  "value": {
+                    "raw": 215360,
+                    "fmt": "215.36k",
+                    "longFmt": "215,360"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 26.92 per share.",
+                  "filerName": "FISCHER THOMAS J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1482796800,
+                    "fmt": "2016-12-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8000,
+                    "fmt": "8k",
+                    "longFmt": "8,000"
+                  },
+                  "value": {
+                    "raw": 189120,
+                    "fmt": "189.12k",
+                    "longFmt": "189,120"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 23.64 per share.",
+                  "filerName": "FISCHER THOMAS J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1482796800,
+                    "fmt": "2016-12-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8000,
+                    "fmt": "8k",
+                    "longFmt": "8,000"
+                  },
+                  "value": {
+                    "raw": 214400,
+                    "fmt": "214.4k",
+                    "longFmt": "214,400"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 26.80 per share.",
+                  "filerName": "PETERSON ROBERT A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1482796800,
+                    "fmt": "2016-12-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 8000,
+                    "fmt": "8k",
+                    "longFmt": "8,000"
+                  },
+                  "value": {
+                    "raw": 189120,
+                    "fmt": "189.12k",
+                    "longFmt": "189,120"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 23.64 per share.",
+                  "filerName": "PETERSON ROBERT A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1482796800,
+                    "fmt": "2016-12-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 22263,
+                    "fmt": "22.26k",
+                    "longFmt": "22,263"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "DILLON RICKY T",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1482796800,
+                    "fmt": "2016-12-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1926,
+                    "fmt": "1.93k",
+                    "longFmt": "1,926"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PAULI MATTHEW",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1479427200,
+                    "fmt": "2016-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2963,
+                    "fmt": "2.96k",
+                    "longFmt": "2,963"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "LAMPEREUR ANDREW G",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1476662400,
+                    "fmt": "2016-10-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12500,
+                    "fmt": "12.5k",
+                    "longFmt": "12,500"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BAKER RANDAL W",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1476403200,
+                    "fmt": "2016-10-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5397,
+                    "fmt": "5.4k",
+                    "longFmt": "5,397"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BAKER RANDAL W",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1468195200,
+                    "fmt": "2016-07-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2031,
+                    "fmt": "2.03k",
+                    "longFmt": "2,031"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BAKER RANDAL W",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1459728000,
+                    "fmt": "2016-04-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3250,
+                    "fmt": "3.25k",
+                    "longFmt": "3,250"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SEFCIK MARK",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1459728000,
+                    "fmt": "2016-04-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5000,
+                    "fmt": "5k",
+                    "longFmt": "5,000"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SKOGG EUGENE EDWARD",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1459728000,
+                    "fmt": "2016-04-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1934,
+                    "fmt": "1.93k",
+                    "longFmt": "1,934"
+                  },
+                  "value": {
+                    "raw": 48195,
+                    "fmt": "48.2k",
+                    "longFmt": "48,195"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 24.92 per share.",
+                  "filerName": "PAULI MATTHEW",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1459296000,
+                    "fmt": "2016-03-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 47092,
+                    "fmt": "47.09k",
+                    "longFmt": "47,092"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BAKER RANDAL W",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1458518400,
+                    "fmt": "2016-03-21"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 20000,
+                    "fmt": "20k",
+                    "longFmt": "20,000"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "KOBYLINSKI BRIAN K",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1458172800,
+                    "fmt": "2016-03-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 20000,
+                    "fmt": "20k",
+                    "longFmt": "20,000"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROUNDHOUSE ROGER A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1458172800,
+                    "fmt": "2016-03-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3036,
+                    "fmt": "3.04k",
+                    "longFmt": "3,036"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "HUNTER R ALAN JR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 11035,
+                    "fmt": "11.04k",
+                    "longFmt": "11,035"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "LAMPEREUR ANDREW G",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3036,
+                    "fmt": "3.04k",
+                    "longFmt": "3,036"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "BEDI GURMINDER S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3036,
+                    "fmt": "3.04k",
+                    "longFmt": "3,036"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WILLIAMS DENNIS K",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9400,
+                    "fmt": "9.4k",
+                    "longFmt": "9,400"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "KOBYLINSKI BRIAN K",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3036,
+                    "fmt": "3.04k",
+                    "longFmt": "3,036"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "FISCHER THOMAS J",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3036,
+                    "fmt": "3.04k",
+                    "longFmt": "3,036"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PETERSON ROBERT A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7006,
+                    "fmt": "7.01k",
+                    "longFmt": "7,006"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WOZNIAK THEODORE C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3036,
+                    "fmt": "3.04k",
+                    "longFmt": "3,036"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "VAN DEURSEN HOLLY A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3036,
+                    "fmt": "3.04k",
+                    "longFmt": "3,036"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "FERLAND E JAMES JR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6539,
+                    "fmt": "6.54k",
+                    "longFmt": "6,539"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "PAULI MATTHEW",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7356,
+                    "fmt": "7.36k",
+                    "longFmt": "7,356"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SEFCIK MARK",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7519,
+                    "fmt": "7.52k",
+                    "longFmt": "7,519"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROUNDHOUSE ROGER A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4904,
+                    "fmt": "4.9k",
+                    "longFmt": "4,904"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SKOGG EUGENE EDWARD",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1453161600,
+                    "fmt": "2016-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 105000,
+                    "fmt": "105k",
+                    "longFmt": "105,000"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ARZBAECHER ROBERT C",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1452038400,
+                    "fmt": "2016-01-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 28174,
+                    "fmt": "28.17k",
+                    "longFmt": "28,174"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "LAMPEREUR ANDREW G",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1452038400,
+                    "fmt": "2016-01-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15000,
+                    "fmt": "15k",
+                    "longFmt": "15,000"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SKOGG EUGENE EDWARD",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1452038400,
+                    "fmt": "2016-01-06"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 93,
+                    "fmt": "93",
+                    "longFmt": "93"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 0.00 per share.",
+                  "filerName": "ARZBAECHER ROBERT C",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1446508800,
+                    "fmt": "2015-11-03"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15450,
+                    "fmt": "15.45k",
+                    "longFmt": "15,450"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "LAMPEREUR ANDREW G",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1446163200,
+                    "fmt": "2015-10-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 15000,
+                    "fmt": "15k",
+                    "longFmt": "15,000"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "KOBYLINSKI BRIAN K",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1446163200,
+                    "fmt": "2015-10-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2650,
+                    "fmt": "2.65k",
+                    "longFmt": "2,650"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WOZNIAK THEODORE C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1446163200,
+                    "fmt": "2015-10-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4600,
+                    "fmt": "4.6k",
+                    "longFmt": "4,600"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ROUNDHOUSE ROGER A",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1446163200,
+                    "fmt": "2015-10-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6257,
+                    "fmt": "6.26k",
+                    "longFmt": "6,257"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "SKOGG EUGENE EDWARD",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1446163200,
+                    "fmt": "2015-10-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 46840,
+                    "fmt": "46.84k",
+                    "longFmt": "46,840"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ARZBAECHER ROBERT C",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1445212800,
+                    "fmt": "2015-10-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3819,
+                    "fmt": "3.82k",
+                    "longFmt": "3,819"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "LAMPEREUR ANDREW G",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1445212800,
+                    "fmt": "2015-10-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2749,
+                    "fmt": "2.75k",
+                    "longFmt": "2,749"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "KOBYLINSKI BRIAN K",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1445212800,
+                    "fmt": "2015-10-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1833,
+                    "fmt": "1.83k",
+                    "longFmt": "1,833"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "WOZNIAK THEODORE C",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1445212800,
+                    "fmt": "2015-10-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 70256,
+                    "fmt": "70.26k",
+                    "longFmt": "70,256"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 0.00 per share.",
+                  "filerName": "ARZBAECHER ROBERT C",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1442448000,
+                    "fmt": "2015-09-17"
+                  },
+                  "ownership": "D"
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderTransactions-MDLY.json
+++ b/tests/http/quoteSummary-insiderTransactions-MDLY.json
@@ -1,0 +1,855 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=insiderTransactions"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "5q0lur9g2vsek"
+      ],
+      "x-yahoo-request-id": [
+        "5q0lur9g2vsek"
+      ],
+      "x-request-id": [
+        "98edb5cd-5921-4dee-a3de-7533799bffa2"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:56 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "insiderTransactions": {
+              "transactions": [
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 73471,
+                    "fmt": "73.47k",
+                    "longFmt": "73,471"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "ALLORTO RICHARD T JR",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 999999,
+                    "fmt": "1,000k",
+                    "longFmt": "999,999"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "TAUBE BROOK",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 450000,
+                    "fmt": "450k",
+                    "longFmt": "450,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "TAUBE SETH",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 999999,
+                    "fmt": "1,000k",
+                    "longFmt": "999,999"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "SANDY POINT L.L.C.",
+                  "filerRelation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 450000,
+                    "fmt": "450k",
+                    "longFmt": "450,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "FREEDOM 2021 L.L.C.",
+                  "filerRelation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 500000,
+                    "fmt": "500k",
+                    "longFmt": "500,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "TAUBE ANGELIC DIAZ",
+                  "filerRelation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611014400,
+                    "fmt": "2021-01-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 59753,
+                    "fmt": "59.75k",
+                    "longFmt": "59,753"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Award(Grant) at price 0.00 per share.",
+                  "filerName": "ALLORTO RICHARD T JR",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1610668800,
+                    "fmt": "2021-01-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10457,
+                    "fmt": "10.46k",
+                    "longFmt": "10,457"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "LEEDS JEFFREY T",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1597104000,
+                    "fmt": "2020-08-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 30465,
+                    "fmt": "30.46k",
+                    "longFmt": "30,465"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "LEEDS JEFFREY T",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1590710400,
+                    "fmt": "2020-05-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 12544,
+                    "fmt": "12.54k",
+                    "longFmt": "12,544"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "ROUNSAVILLE GUYJR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1590710400,
+                    "fmt": "2020-05-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 25089,
+                    "fmt": "25.09k",
+                    "longFmt": "25,089"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "EATON JAMES GEORGE",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1590710400,
+                    "fmt": "2020-05-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 51336,
+                    "fmt": "51.34k",
+                    "longFmt": "51,336"
+                  },
+                  "value": {
+                    "raw": 161987,
+                    "fmt": "161.99k",
+                    "longFmt": "161,987"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3.14 - 3.17 per share.",
+                  "filerName": "JAM PARTNERS, L.P.",
+                  "filerRelation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1564444800,
+                    "fmt": "2019-07-30"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 23944,
+                    "fmt": "23.94k",
+                    "longFmt": "23,944"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "LEEDS JEFFREY T",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1557446400,
+                    "fmt": "2019-05-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9860,
+                    "fmt": "9.86k",
+                    "longFmt": "9,860"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "ROUNSAVILLE GUYJR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1557446400,
+                    "fmt": "2019-05-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 19719,
+                    "fmt": "19.72k",
+                    "longFmt": "19,719"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "EATON JAMES GEORGE",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1557446400,
+                    "fmt": "2019-05-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 300,
+                    "fmt": "300",
+                    "longFmt": "300"
+                  },
+                  "value": {
+                    "raw": 1020,
+                    "fmt": "1.02k",
+                    "longFmt": "1,020"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3.40 per share.",
+                  "filerName": "JAM PARTNERS, L.P.",
+                  "filerRelation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1555459200,
+                    "fmt": "2019-04-17"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4223,
+                    "fmt": "4.22k",
+                    "longFmt": "4,223"
+                  },
+                  "value": {
+                    "raw": 14316,
+                    "fmt": "14.32k",
+                    "longFmt": "14,316"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3.39 per share.",
+                  "filerName": "JAM PARTNERS, L.P.",
+                  "filerRelation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1554422400,
+                    "fmt": "2019-04-05"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 32737,
+                    "fmt": "32.74k",
+                    "longFmt": "32,737"
+                  },
+                  "value": {
+                    "raw": 110334,
+                    "fmt": "110.33k",
+                    "longFmt": "110,334"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 3.32 - 3.56 per share.",
+                  "filerName": "JAM PARTNERS, L.P.",
+                  "filerRelation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1553731200,
+                    "fmt": "2019-03-28"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 11808,
+                    "fmt": "11.81k",
+                    "longFmt": "11,808"
+                  },
+                  "value": {
+                    "raw": 47822,
+                    "fmt": "47.82k",
+                    "longFmt": "47,822"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 4.05 per share.",
+                  "filerName": "JAM PARTNERS, L.P.",
+                  "filerRelation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1550188800,
+                    "fmt": "2019-02-15"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 78436,
+                    "fmt": "78.44k",
+                    "longFmt": "78,436"
+                  },
+                  "value": {
+                    "raw": 315718,
+                    "fmt": "315.72k",
+                    "longFmt": "315,718"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 4.01 - 4.05 per share.",
+                  "filerName": "JAM PARTNERS, L.P.",
+                  "filerRelation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1549929600,
+                    "fmt": "2019-02-12"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9788,
+                    "fmt": "9.79k",
+                    "longFmt": "9,788"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "LEEDS JEFFREY T",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1533600000,
+                    "fmt": "2018-08-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3703,
+                    "fmt": "3.7k",
+                    "longFmt": "3,703"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "ROUNSAVILLE GUYJR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1533600000,
+                    "fmt": "2018-08-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 11111,
+                    "fmt": "11.11k",
+                    "longFmt": "11,111"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "EATON JAMES GEORGE",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1533600000,
+                    "fmt": "2018-08-07"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2860,
+                    "fmt": "2.86k",
+                    "longFmt": "2,860"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "LEEDS JEFFREY T",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1506643200,
+                    "fmt": "2017-09-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1430,
+                    "fmt": "1.43k",
+                    "longFmt": "1,430"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "ROUNSAVILLE GUYJR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1506643200,
+                    "fmt": "2017-09-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 6017,
+                    "fmt": "6.02k",
+                    "longFmt": "6,017"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "LEEDS JEFFREY T",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1494374400,
+                    "fmt": "2017-05-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1437,
+                    "fmt": "1.44k",
+                    "longFmt": "1,437"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "EATON JAMES GEORGE",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1494374400,
+                    "fmt": "2017-05-10"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 4792,
+                    "fmt": "4.79k",
+                    "longFmt": "4,792"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "RYAN PHILIP K",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1489708800,
+                    "fmt": "2017-03-17"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 11570,
+                    "fmt": "11.57k",
+                    "longFmt": "11,570"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 0.00 per share.",
+                  "filerName": "LEEDS JEFFREY T",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1475107200,
+                    "fmt": "2016-09-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5785,
+                    "fmt": "5.79k",
+                    "longFmt": "5,785"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 0.00 per share.",
+                  "filerName": "ROUNSAVILLE GUYJR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1475107200,
+                    "fmt": "2016-09-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 14049,
+                    "fmt": "14.05k",
+                    "longFmt": "14,049"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 0.00 per share.",
+                  "filerName": "RYAN PHILIP K",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1475107200,
+                    "fmt": "2016-09-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 95370,
+                    "fmt": "95.37k",
+                    "longFmt": "95,370"
+                  },
+                  "value": {
+                    "raw": 700433,
+                    "fmt": "700.43k",
+                    "longFmt": "700,433"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 7.32 - 7.41 per share.",
+                  "filerName": "MANGROVE PARTNERS MASTER FUND, LTD.",
+                  "filerRelation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1471910400,
+                    "fmt": "2016-08-23"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1866,
+                    "fmt": "1.87k",
+                    "longFmt": "1,866"
+                  },
+                  "value": {
+                    "raw": 13437,
+                    "fmt": "13.44k",
+                    "longFmt": "13,437"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 7.20 per share.",
+                  "filerName": "MANGROVE PARTNERS MASTER FUND, LTD.",
+                  "filerRelation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1471824000,
+                    "fmt": "2016-08-22"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5400,
+                    "fmt": "5.4k",
+                    "longFmt": "5,400"
+                  },
+                  "value": {
+                    "raw": 40814,
+                    "fmt": "40.81k",
+                    "longFmt": "40,814"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 7.55 - 7.56 per share.",
+                  "filerName": "MANGROVE PARTNERS MASTER FUND, LTD.",
+                  "filerRelation": "Beneficial Owner of more than 10% of a Class of Security",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1471564800,
+                    "fmt": "2016-08-19"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 926,
+                    "fmt": "926",
+                    "longFmt": "926"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 0.00 per share.",
+                  "filerName": "RYAN PHILIP K",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1447200000,
+                    "fmt": "2015-11-11"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3888,
+                    "fmt": "3.89k",
+                    "longFmt": "3,888"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 0.00 per share.",
+                  "filerName": "LEEDS JEFFREY T",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1443484800,
+                    "fmt": "2015-09-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1944,
+                    "fmt": "1.94k",
+                    "longFmt": "1,944"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 0.00 per share.",
+                  "filerName": "ROUNSAVILLE GUYJR",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1443484800,
+                    "fmt": "2015-09-29"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 3888,
+                    "fmt": "3.89k",
+                    "longFmt": "3,888"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 0.00 per share.",
+                  "filerName": "RYAN PHILIP K",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1443484800,
+                    "fmt": "2015-09-29"
+                  },
+                  "ownership": "D"
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-insiderTransactions-SI.json
+++ b/tests/http/quoteSummary-insiderTransactions-SI.json
@@ -1,0 +1,1240 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=insiderTransactions"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "9n4qj3dg2vsek"
+      ],
+      "x-yahoo-request-id": [
+        "9n4qj3dg2vsek"
+      ],
+      "x-request-id": [
+        "14ed5bd3-bb6f-40df-9e4c-ff83cca4410c"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:55 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "insiderTransactions": {
+              "transactions": [
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 22263,
+                    "fmt": "22.26k",
+                    "longFmt": "22,263"
+                  },
+                  "value": {
+                    "raw": 118212,
+                    "fmt": "118.21k",
+                    "longFmt": "118,212"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 4.09 - 16.09 per share.",
+                  "filerName": "BONINO JOHN M",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1611273600,
+                    "fmt": "2021-01-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 27500,
+                    "fmt": "27.5k",
+                    "longFmt": "27,500"
+                  },
+                  "value": {
+                    "raw": 112475,
+                    "fmt": "112.47k",
+                    "longFmt": "112,475"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 4.09 per share.",
+                  "filerName": "BRASSFIELD KAREN F",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1610064000,
+                    "fmt": "2021-01-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10000,
+                    "fmt": "10k",
+                    "longFmt": "10,000"
+                  },
+                  "value": {
+                    "raw": 40900,
+                    "fmt": "40.9k",
+                    "longFmt": "40,900"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 4.09 per share.",
+                  "filerName": "BONINO JOHN M",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1608681600,
+                    "fmt": "2020-12-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 46299,
+                    "fmt": "46.3k",
+                    "longFmt": "46,299"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "DIRCKS THOMAS C",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1608595200,
+                    "fmt": "2020-12-22"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 426488,
+                    "fmt": "426.49k",
+                    "longFmt": "426,488"
+                  },
+                  "value": {
+                    "raw": 17059520,
+                    "fmt": "17.06M",
+                    "longFmt": "17,059,520"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 40.00 per share.",
+                  "filerName": "REED SCOTT A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1607904000,
+                    "fmt": "2020-12-14"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 60000,
+                    "fmt": "60k",
+                    "longFmt": "60,000"
+                  },
+                  "value": {
+                    "raw": 2439626,
+                    "fmt": "2.44M",
+                    "longFmt": "2,439,626"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 39.67 - 42.51 per share.",
+                  "filerName": "DIRCKS THOMAS C",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1607385600,
+                    "fmt": "2020-12-08"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 595,
+                    "fmt": "595",
+                    "longFmt": "595"
+                  },
+                  "value": {
+                    "raw": 26507,
+                    "fmt": "26.51k",
+                    "longFmt": "26,507"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 44.55 per share.",
+                  "filerName": "EISELE DEREK J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1607299200,
+                    "fmt": "2020-12-07"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5000,
+                    "fmt": "5k",
+                    "longFmt": "5,000"
+                  },
+                  "value": {
+                    "raw": 196500,
+                    "fmt": "196.5k",
+                    "longFmt": "196,500"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 39.30 per share.",
+                  "filerName": "EISELE DEREK J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606867200,
+                    "fmt": "2020-12-02"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2500,
+                    "fmt": "2.5k",
+                    "longFmt": "2,500"
+                  },
+                  "value": {
+                    "raw": 90000,
+                    "fmt": "90k",
+                    "longFmt": "90,000"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 36.00 per share.",
+                  "filerName": "BRASSFIELD KAREN F",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606780800,
+                    "fmt": "2020-12-01"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 565,
+                    "fmt": "565",
+                    "longFmt": "565"
+                  },
+                  "value": {
+                    "raw": 20260,
+                    "fmt": "20.26k",
+                    "longFmt": "20,260"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 35.86 per share.",
+                  "filerName": "FRAHER KATHLEEN",
+                  "filerRelation": "Chief Operating Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606694400,
+                    "fmt": "2020-11-30"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 119964,
+                    "fmt": "119.96k",
+                    "longFmt": "119,964"
+                  },
+                  "value": {
+                    "raw": 482255,
+                    "fmt": "482.25k",
+                    "longFmt": "482,255"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 4.02 per share.",
+                  "filerName": "LANE ALAN J",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606435200,
+                    "fmt": "2020-11-27"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 44789,
+                    "fmt": "44.79k",
+                    "longFmt": "44,789"
+                  },
+                  "value": {
+                    "raw": 452193,
+                    "fmt": "452.19k",
+                    "longFmt": "452,193"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 4.09 - 16.09 per share.",
+                  "filerName": "FRAHER KATHLEEN",
+                  "filerRelation": "Chief Operating Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606176000,
+                    "fmt": "2020-11-24"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 33183,
+                    "fmt": "33.18k",
+                    "longFmt": "33,183"
+                  },
+                  "value": {
+                    "raw": 0,
+                    "fmt": null,
+                    "longFmt": "0"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Stock Gift at price 0.00 per share.",
+                  "filerName": "DIRCKS THOMAS C",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1606089600,
+                    "fmt": "2020-11-23"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2500,
+                    "fmt": "2.5k",
+                    "longFmt": "2,500"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "DIRCKS THOMAS C",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2500,
+                    "fmt": "2.5k",
+                    "longFmt": "2,500"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "FRANK DENNIS S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2774,
+                    "fmt": "2.77k",
+                    "longFmt": "2,774"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "LANE ALAN J",
+                  "filerRelation": "Chief Executive Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2500,
+                    "fmt": "2.5k",
+                    "longFmt": "2,500"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "REED SCOTT A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2500,
+                    "fmt": "2.5k",
+                    "longFmt": "2,500"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "COLUCCI PAUL D",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 833,
+                    "fmt": "833",
+                    "longFmt": "833"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "LEMPRES MICHAEL",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1166,
+                    "fmt": "1.17k",
+                    "longFmt": "1,166"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "MARTINO ANTONIO",
+                  "filerRelation": "Chief Financial Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 583,
+                    "fmt": "583",
+                    "longFmt": "583"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "REYNOLDS BEN",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 1203,
+                    "fmt": "1.2k",
+                    "longFmt": "1,203"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "FRAHER KATHLEEN",
+                  "filerRelation": "Chief Operating Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2500,
+                    "fmt": "2.5k",
+                    "longFmt": "2,500"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "BRASSFIELD KAREN F",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2500,
+                    "fmt": "2.5k",
+                    "longFmt": "2,500"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "CAMPBELL ROBERT CHARLES",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 770,
+                    "fmt": "770",
+                    "longFmt": "770"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "BONINO JOHN M",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 911,
+                    "fmt": "911",
+                    "longFmt": "911"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "",
+                  "filerName": "EISELE DEREK J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605744000,
+                    "fmt": "2020-11-19"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10000,
+                    "fmt": "10k",
+                    "longFmt": "10,000"
+                  },
+                  "value": {
+                    "raw": 300828,
+                    "fmt": "300.83k",
+                    "longFmt": "300,828"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 30.08 per share.",
+                  "filerName": "COLUCCI PAUL D",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1605657600,
+                    "fmt": "2020-11-18"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5000,
+                    "fmt": "5k",
+                    "longFmt": "5,000"
+                  },
+                  "value": {
+                    "raw": 76044,
+                    "fmt": "76.04k",
+                    "longFmt": "76,044"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 15.21 per share.",
+                  "filerName": "EISELE DEREK J",
+                  "filerRelation": "Officer",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598486400,
+                    "fmt": "2020-08-27"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 20000,
+                    "fmt": "20k",
+                    "longFmt": "20,000"
+                  },
+                  "value": {
+                    "raw": 81800,
+                    "fmt": "81.8k",
+                    "longFmt": "81,800"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 4.09 per share.",
+                  "filerName": "BRASSFIELD KAREN F",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1598400000,
+                    "fmt": "2020-08-26"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 225000,
+                    "fmt": "225k",
+                    "longFmt": "225,000"
+                  },
+                  "value": {
+                    "raw": 3181380,
+                    "fmt": "3.18M",
+                    "longFmt": "3,181,380"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 14.04 - 14.19 per share.",
+                  "filerName": "FRANK DENNIS S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1596672000,
+                    "fmt": "2020-08-06"
+                  },
+                  "ownership": "D/I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 7000,
+                    "fmt": "7k",
+                    "longFmt": "7,000"
+                  },
+                  "value": {
+                    "raw": 103734,
+                    "fmt": "103.73k",
+                    "longFmt": "103,734"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 14.80 - 14.90 per share.",
+                  "filerName": "CAMPBELL ROBERT CHARLES",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1591660800,
+                    "fmt": "2020-06-09"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5000,
+                    "fmt": "5k",
+                    "longFmt": "5,000"
+                  },
+                  "value": {
+                    "raw": 75156,
+                    "fmt": "75.16k",
+                    "longFmt": "75,156"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 15.00 - 15.10 per share.",
+                  "filerName": "CAMPBELL ROBERT CHARLES",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1591574400,
+                    "fmt": "2020-06-08"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5000,
+                    "fmt": "5k",
+                    "longFmt": "5,000"
+                  },
+                  "value": {
+                    "raw": 74254,
+                    "fmt": "74.25k",
+                    "longFmt": "74,254"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 14.85 - 14.86 per share.",
+                  "filerName": "CAMPBELL ROBERT CHARLES",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1591315200,
+                    "fmt": "2020-06-05"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 14680,
+                    "fmt": "14.68k",
+                    "longFmt": "14,680"
+                  },
+                  "value": {
+                    "raw": 217895,
+                    "fmt": "217.9k",
+                    "longFmt": "217,895"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 14.81 - 14.87 per share.",
+                  "filerName": "CAMPBELL ROBERT CHARLES",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1591228800,
+                    "fmt": "2020-06-04"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10297,
+                    "fmt": "10.3k",
+                    "longFmt": "10,297"
+                  },
+                  "value": {
+                    "raw": 151445,
+                    "fmt": "151.44k",
+                    "longFmt": "151,445"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 14.70 - 14.80 per share.",
+                  "filerName": "CAMPBELL ROBERT CHARLES",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1591142400,
+                    "fmt": "2020-06-03"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 20023,
+                    "fmt": "20.02k",
+                    "longFmt": "20,023"
+                  },
+                  "value": {
+                    "raw": 286590,
+                    "fmt": "286.59k",
+                    "longFmt": "286,590"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 14.10 - 14.80 per share.",
+                  "filerName": "CAMPBELL ROBERT CHARLES",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1591056000,
+                    "fmt": "2020-06-02"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5000,
+                    "fmt": "5k",
+                    "longFmt": "5,000"
+                  },
+                  "value": {
+                    "raw": 73150,
+                    "fmt": "73.15k",
+                    "longFmt": "73,150"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 14.63 per share.",
+                  "filerName": "CAMPBELL ROBERT CHARLES",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1590710400,
+                    "fmt": "2020-05-29"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 14921,
+                    "fmt": "14.92k",
+                    "longFmt": "14,921"
+                  },
+                  "value": {
+                    "raw": 218203,
+                    "fmt": "218.2k",
+                    "longFmt": "218,203"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 14.56 - 14.90 per share.",
+                  "filerName": "CAMPBELL ROBERT CHARLES",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1590624000,
+                    "fmt": "2020-05-28"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10431,
+                    "fmt": "10.43k",
+                    "longFmt": "10,431"
+                  },
+                  "value": {
+                    "raw": 155086,
+                    "fmt": "155.09k",
+                    "longFmt": "155,086"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 14.80 - 14.93 per share.",
+                  "filerName": "CAMPBELL ROBERT CHARLES",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1590537600,
+                    "fmt": "2020-05-27"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9248,
+                    "fmt": "9.25k",
+                    "longFmt": "9,248"
+                  },
+                  "value": {
+                    "raw": 141019,
+                    "fmt": "141.02k",
+                    "longFmt": "141,019"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 14.85 - 15.40 per share.",
+                  "filerName": "CAMPBELL ROBERT CHARLES",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1590451200,
+                    "fmt": "2020-05-26"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10922,
+                    "fmt": "10.92k",
+                    "longFmt": "10,922"
+                  },
+                  "value": {
+                    "raw": 166129,
+                    "fmt": "166.13k",
+                    "longFmt": "166,129"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 14.85 - 15.40 per share.",
+                  "filerName": "CAMPBELL ROBERT CHARLES",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1590451200,
+                    "fmt": "2020-05-26"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10922,
+                    "fmt": "10.92k",
+                    "longFmt": "10,922"
+                  },
+                  "value": {
+                    "raw": 166129,
+                    "fmt": "166.13k",
+                    "longFmt": "166,129"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 14.85 - 15.40 per share.",
+                  "filerName": "CAMPBELL ROBERT CHARLES",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1590451200,
+                    "fmt": "2020-05-26"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 5000,
+                    "fmt": "5k",
+                    "longFmt": "5,000"
+                  },
+                  "value": {
+                    "raw": 75500,
+                    "fmt": "75.5k",
+                    "longFmt": "75,500"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 15.10 per share.",
+                  "filerName": "EISELE DEREK J",
+                  "filerRelation": "Officer and Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1590105600,
+                    "fmt": "2020-05-22"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 10000,
+                    "fmt": "10k",
+                    "longFmt": "10,000"
+                  },
+                  "value": {
+                    "raw": 40900,
+                    "fmt": "40.9k",
+                    "longFmt": "40,900"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 4.09 per share.",
+                  "filerName": "BRASSFIELD KAREN F",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589932800,
+                    "fmt": "2020-05-20"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 2500,
+                    "fmt": "2.5k",
+                    "longFmt": "2,500"
+                  },
+                  "value": {
+                    "raw": 10225,
+                    "fmt": "10.22k",
+                    "longFmt": "10,225"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Conversion of Exercise of derivative security at price 4.09 per share.",
+                  "filerName": "BRASSFIELD KAREN F",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1589414400,
+                    "fmt": "2020-05-14"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 78561,
+                    "fmt": "78.56k",
+                    "longFmt": "78,561"
+                  },
+                  "value": {
+                    "raw": 1186271,
+                    "fmt": "1.19M",
+                    "longFmt": "1,186,271"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 15.10 per share.",
+                  "filerName": "FRANK DENNIS S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D/I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 63915,
+                    "fmt": "63.91k",
+                    "longFmt": "63,915"
+                  },
+                  "value": {
+                    "raw": 965116,
+                    "fmt": "965.12k",
+                    "longFmt": "965,116"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 15.10 per share.",
+                  "filerName": "FRIEDMAN MARTIN S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 41834,
+                    "fmt": "41.83k",
+                    "longFmt": "41,834"
+                  },
+                  "value": {
+                    "raw": 631693,
+                    "fmt": "631.69k",
+                    "longFmt": "631,693"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 15.10 per share.",
+                  "filerName": "REED SCOTT A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 9462,
+                    "fmt": "9.46k",
+                    "longFmt": "9,462"
+                  },
+                  "value": {
+                    "raw": 142876,
+                    "fmt": "142.88k",
+                    "longFmt": "142,876"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 15.10 per share.",
+                  "filerName": "COLUCCI PAUL D",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573776000,
+                    "fmt": "2019-11-15"
+                  },
+                  "ownership": "D"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 394181,
+                    "fmt": "394.18k",
+                    "longFmt": "394,181"
+                  },
+                  "value": {
+                    "raw": 4399060,
+                    "fmt": "4.4M",
+                    "longFmt": "4,399,060"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 11.16 per share.",
+                  "filerName": "FRANK DENNIS S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573516800,
+                    "fmt": "2019-11-12"
+                  },
+                  "ownership": "D/I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 320693,
+                    "fmt": "320.69k",
+                    "longFmt": "320,693"
+                  },
+                  "value": {
+                    "raw": 3578934,
+                    "fmt": "3.58M",
+                    "longFmt": "3,578,934"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 11.16 per share.",
+                  "filerName": "FRIEDMAN MARTIN S",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573516800,
+                    "fmt": "2019-11-12"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 62079,
+                    "fmt": "62.08k",
+                    "longFmt": "62,079"
+                  },
+                  "value": {
+                    "raw": 692802,
+                    "fmt": "692.8k",
+                    "longFmt": "692,802"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 11.16 per share.",
+                  "filerName": "REED SCOTT A",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573516800,
+                    "fmt": "2019-11-12"
+                  },
+                  "ownership": "I"
+                },
+                {
+                  "maxAge": 1,
+                  "shares": {
+                    "raw": 47474,
+                    "fmt": "47.47k",
+                    "longFmt": "47,474"
+                  },
+                  "value": {
+                    "raw": 529810,
+                    "fmt": "529.81k",
+                    "longFmt": "529,810"
+                  },
+                  "filerUrl": "",
+                  "transactionText": "Sale at price 11.16 per share.",
+                  "filerName": "COLUCCI PAUL D",
+                  "filerRelation": "Director",
+                  "moneyText": "",
+                  "startDate": {
+                    "raw": 1573516800,
+                    "fmt": "2019-11-12"
+                  },
+                  "ownership": "D"
+                }
+              ],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-institutionOwnership-ABBV.json
+++ b/tests/http/quoteSummary-institutionOwnership-ABBV.json
@@ -1,0 +1,306 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=institutionOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "fn5j7k9g2vsel"
+      ],
+      "x-yahoo-request-id": [
+        "fn5j7k9g2vsel"
+      ],
+      "x-request-id": [
+        "e270fe76-679d-4323-b5dc-55ecd5e8a003"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "883"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:57 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Group, Inc. (The)",
+                  "pctHeld": {
+                    "raw": 0.08180001,
+                    "fmt": "8.18%"
+                  },
+                  "position": {
+                    "raw": 144334850,
+                    "fmt": "144.33M",
+                    "longFmt": "144,334,850"
+                  },
+                  "value": {
+                    "raw": 12642289511,
+                    "fmt": "12.64B",
+                    "longFmt": "12,642,289,511"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Blackrock Inc.",
+                  "pctHeld": {
+                    "raw": 0.0705,
+                    "fmt": "7.05%"
+                  },
+                  "position": {
+                    "raw": 124423484,
+                    "fmt": "124.42M",
+                    "longFmt": "124,423,484"
+                  },
+                  "value": {
+                    "raw": 13331976310,
+                    "fmt": "13.33B",
+                    "longFmt": "13,331,976,310"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "State Street Corporation",
+                  "pctHeld": {
+                    "raw": 0.044299997,
+                    "fmt": "4.43%"
+                  },
+                  "position": {
+                    "raw": 78208461,
+                    "fmt": "78.21M",
+                    "longFmt": "78,208,461"
+                  },
+                  "value": {
+                    "raw": 6850279098,
+                    "fmt": "6.85B",
+                    "longFmt": "6,850,279,098"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Capital Research Global Investors",
+                  "pctHeld": {
+                    "raw": 0.0231,
+                    "fmt": "2.31%"
+                  },
+                  "position": {
+                    "raw": 40804113,
+                    "fmt": "40.8M",
+                    "longFmt": "40,804,113"
+                  },
+                  "value": {
+                    "raw": 3574032257,
+                    "fmt": "3.57B",
+                    "longFmt": "3,574,032,257"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Price (T.Rowe) Associates Inc",
+                  "pctHeld": {
+                    "raw": 0.0185,
+                    "fmt": "1.85%"
+                  },
+                  "position": {
+                    "raw": 32739879,
+                    "fmt": "32.74M",
+                    "longFmt": "32,739,879"
+                  },
+                  "value": {
+                    "raw": 2867686001,
+                    "fmt": "2.87B",
+                    "longFmt": "2,867,686,001"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "JP Morgan Chase & Company",
+                  "pctHeld": {
+                    "raw": 0.0165,
+                    "fmt": "1.65%"
+                  },
+                  "position": {
+                    "raw": 29190573,
+                    "fmt": "29.19M",
+                    "longFmt": "29,190,573"
+                  },
+                  "value": {
+                    "raw": 2556802289,
+                    "fmt": "2.56B",
+                    "longFmt": "2,556,802,289"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "FMR, LLC",
+                  "pctHeld": {
+                    "raw": 0.0165,
+                    "fmt": "1.65%"
+                  },
+                  "position": {
+                    "raw": 29054142,
+                    "fmt": "29.05M",
+                    "longFmt": "29,054,142"
+                  },
+                  "value": {
+                    "raw": 3113151315,
+                    "fmt": "3.11B",
+                    "longFmt": "3,113,151,315"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Geode Capital Management, LLC",
+                  "pctHeld": {
+                    "raw": 0.0148,
+                    "fmt": "1.48%"
+                  },
+                  "position": {
+                    "raw": 26135072,
+                    "fmt": "26.14M",
+                    "longFmt": "26,135,072"
+                  },
+                  "value": {
+                    "raw": 2289170956,
+                    "fmt": "2.29B",
+                    "longFmt": "2,289,170,956"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Northern Trust Corporation",
+                  "pctHeld": {
+                    "raw": 0.0138,
+                    "fmt": "1.38%"
+                  },
+                  "position": {
+                    "raw": 24363192,
+                    "fmt": "24.36M",
+                    "longFmt": "24,363,192"
+                  },
+                  "value": {
+                    "raw": 2133971987,
+                    "fmt": "2.13B",
+                    "longFmt": "2,133,971,987"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Berkshire Hathaway, Inc",
+                  "pctHeld": {
+                    "raw": 0.012,
+                    "fmt": "1.20%"
+                  },
+                  "position": {
+                    "raw": 21264316,
+                    "fmt": "21.26M",
+                    "longFmt": "21,264,316"
+                  },
+                  "value": {
+                    "raw": 1862541438,
+                    "fmt": "1.86B",
+                    "longFmt": "1,862,541,438"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-institutionOwnership-BRKS.json
+++ b/tests/http/quoteSummary-institutionOwnership-BRKS.json
@@ -1,0 +1,306 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=institutionOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "8bsmk6hg2vsel"
+      ],
+      "x-yahoo-request-id": [
+        "8bsmk6hg2vsel"
+      ],
+      "x-request-id": [
+        "c56a6c4a-3950-40b5-93c3-c5aa83689e7a"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "879"
+      ],
+      "x-envoy-upstream-service-time": [
+        "98"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:57 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Blackrock Inc.",
+                  "pctHeld": {
+                    "raw": 0.1552,
+                    "fmt": "15.52%"
+                  },
+                  "position": {
+                    "raw": 11519488,
+                    "fmt": "11.52M",
+                    "longFmt": "11,519,488"
+                  },
+                  "value": {
+                    "raw": 781597260,
+                    "fmt": "781.6M",
+                    "longFmt": "781,597,260"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Group, Inc. (The)",
+                  "pctHeld": {
+                    "raw": 0.106000006,
+                    "fmt": "10.60%"
+                  },
+                  "position": {
+                    "raw": 7864600,
+                    "fmt": "7.86M",
+                    "longFmt": "7,864,600"
+                  },
+                  "value": {
+                    "raw": 363816396,
+                    "fmt": "363.82M",
+                    "longFmt": "363,816,396"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Kayne Anderson Rudnick Investment Management LLC",
+                  "pctHeld": {
+                    "raw": 0.056500003,
+                    "fmt": "5.65%"
+                  },
+                  "position": {
+                    "raw": 4196259,
+                    "fmt": "4.2M",
+                    "longFmt": "4,196,259"
+                  },
+                  "value": {
+                    "raw": 194118941,
+                    "fmt": "194.12M",
+                    "longFmt": "194,118,941"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "William Blair Investment Management, LLC",
+                  "pctHeld": {
+                    "raw": 0.0517,
+                    "fmt": "5.17%"
+                  },
+                  "position": {
+                    "raw": 3839521,
+                    "fmt": "3.84M",
+                    "longFmt": "3,839,521"
+                  },
+                  "value": {
+                    "raw": 260511499,
+                    "fmt": "260.51M",
+                    "longFmt": "260,511,499"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Silvercrest Asset Management Group LLC",
+                  "pctHeld": {
+                    "raw": 0.0317,
+                    "fmt": "3.17%"
+                  },
+                  "position": {
+                    "raw": 2351652,
+                    "fmt": "2.35M",
+                    "longFmt": "2,351,652"
+                  },
+                  "value": {
+                    "raw": 108787421,
+                    "fmt": "108.79M",
+                    "longFmt": "108,787,421"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "State Street Corporation",
+                  "pctHeld": {
+                    "raw": 0.0296,
+                    "fmt": "2.96%"
+                  },
+                  "position": {
+                    "raw": 2194903,
+                    "fmt": "2.19M",
+                    "longFmt": "2,194,903"
+                  },
+                  "value": {
+                    "raw": 101536212,
+                    "fmt": "101.54M",
+                    "longFmt": "101,536,212"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Dimensional Fund Advisors LP",
+                  "pctHeld": {
+                    "raw": 0.0286,
+                    "fmt": "2.86%"
+                  },
+                  "position": {
+                    "raw": 2125368,
+                    "fmt": "2.13M",
+                    "longFmt": "2,125,368"
+                  },
+                  "value": {
+                    "raw": 98319523,
+                    "fmt": "98.32M",
+                    "longFmt": "98,319,523"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Wells Fargo & Company",
+                  "pctHeld": {
+                    "raw": 0.0248,
+                    "fmt": "2.48%"
+                  },
+                  "position": {
+                    "raw": 1840894,
+                    "fmt": "1.84M",
+                    "longFmt": "1,840,894"
+                  },
+                  "value": {
+                    "raw": 124904657,
+                    "fmt": "124.9M",
+                    "longFmt": "124,904,657"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Mirae Asset Global Investments Co., Ltd.",
+                  "pctHeld": {
+                    "raw": 0.0229,
+                    "fmt": "2.29%"
+                  },
+                  "position": {
+                    "raw": 1696024,
+                    "fmt": "1.7M",
+                    "longFmt": "1,696,024"
+                  },
+                  "value": {
+                    "raw": 115075228,
+                    "fmt": "115.08M",
+                    "longFmt": "115,075,228"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Macquarie Group Limited",
+                  "pctHeld": {
+                    "raw": 0.0208,
+                    "fmt": "2.08%"
+                  },
+                  "position": {
+                    "raw": 1543755,
+                    "fmt": "1.54M",
+                    "longFmt": "1,543,755"
+                  },
+                  "value": {
+                    "raw": 71414106,
+                    "fmt": "71.41M",
+                    "longFmt": "71,414,106"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-institutionOwnership-CRON.json
+++ b/tests/http/quoteSummary-institutionOwnership-CRON.json
@@ -1,0 +1,306 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=institutionOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "9gu0p9lg2vsem"
+      ],
+      "x-yahoo-request-id": [
+        "9gu0p9lg2vsem"
+      ],
+      "x-request-id": [
+        "fb9b74b0-638c-4ad8-b324-60f39acfbec9"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "803"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:57 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Chescapmanager LLC",
+                  "pctHeld": {
+                    "raw": 0.024600001,
+                    "fmt": "2.46%"
+                  },
+                  "position": {
+                    "raw": 8873890,
+                    "fmt": "8.87M",
+                    "longFmt": "8,873,890"
+                  },
+                  "value": {
+                    "raw": 44458188,
+                    "fmt": "44.46M",
+                    "longFmt": "44,458,188"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "ETF Managers Group, LLC",
+                  "pctHeld": {
+                    "raw": 0.020299999,
+                    "fmt": "2.03%"
+                  },
+                  "position": {
+                    "raw": 7321147,
+                    "fmt": "7.32M",
+                    "longFmt": "7,321,147"
+                  },
+                  "value": {
+                    "raw": 36678946,
+                    "fmt": "36.68M",
+                    "longFmt": "36,678,946"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Group, Inc. (The)",
+                  "pctHeld": {
+                    "raw": 0.0146,
+                    "fmt": "1.46%"
+                  },
+                  "position": {
+                    "raw": 5272821,
+                    "fmt": "5.27M",
+                    "longFmt": "5,272,821"
+                  },
+                  "value": {
+                    "raw": 26416833,
+                    "fmt": "26.42M",
+                    "longFmt": "26,416,833"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Susquehanna International Group, LLP",
+                  "pctHeld": {
+                    "raw": 0.008,
+                    "fmt": "0.80%"
+                  },
+                  "position": {
+                    "raw": 2894379,
+                    "fmt": "2.89M",
+                    "longFmt": "2,894,379"
+                  },
+                  "value": {
+                    "raw": 14500838,
+                    "fmt": "14.5M",
+                    "longFmt": "14,500,838"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Connor Clark & Lunn Investment Management Ltd",
+                  "pctHeld": {
+                    "raw": 0.0029,
+                    "fmt": "0.29%"
+                  },
+                  "position": {
+                    "raw": 1040800,
+                    "fmt": "1.04M",
+                    "longFmt": "1,040,800"
+                  },
+                  "value": {
+                    "raw": 5214408,
+                    "fmt": "5.21M",
+                    "longFmt": "5,214,408"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Citadel Advisors LLC",
+                  "pctHeld": {
+                    "raw": 0.0023,
+                    "fmt": "0.23%"
+                  },
+                  "position": {
+                    "raw": 833915,
+                    "fmt": "833.91k",
+                    "longFmt": "833,915"
+                  },
+                  "value": {
+                    "raw": 4177914,
+                    "fmt": "4.18M",
+                    "longFmt": "4,177,914"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "TD Asset Management, Inc",
+                  "pctHeld": {
+                    "raw": 0.0021,
+                    "fmt": "0.21%"
+                  },
+                  "position": {
+                    "raw": 771934,
+                    "fmt": "771.93k",
+                    "longFmt": "771,934"
+                  },
+                  "value": {
+                    "raw": 3867389,
+                    "fmt": "3.87M",
+                    "longFmt": "3,867,389"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Shaw D.E. & Co., Inc.",
+                  "pctHeld": {
+                    "raw": 0.0021,
+                    "fmt": "0.21%"
+                  },
+                  "position": {
+                    "raw": 766059,
+                    "fmt": "766.06k",
+                    "longFmt": "766,059"
+                  },
+                  "value": {
+                    "raw": 3837955,
+                    "fmt": "3.84M",
+                    "longFmt": "3,837,955"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Man Group PLC",
+                  "pctHeld": {
+                    "raw": 0.002,
+                    "fmt": "0.20%"
+                  },
+                  "position": {
+                    "raw": 718830,
+                    "fmt": "718.83k",
+                    "longFmt": "718,830"
+                  },
+                  "value": {
+                    "raw": 3601338,
+                    "fmt": "3.6M",
+                    "longFmt": "3,601,338"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Bank of Montreal/Can/",
+                  "pctHeld": {
+                    "raw": 0.0017,
+                    "fmt": "0.17%"
+                  },
+                  "position": {
+                    "raw": 627351,
+                    "fmt": "627.35k",
+                    "longFmt": "627,351"
+                  },
+                  "value": {
+                    "raw": 3143028,
+                    "fmt": "3.14M",
+                    "longFmt": "3,143,028"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-institutionOwnership-EPAC.json
+++ b/tests/http/quoteSummary-institutionOwnership-EPAC.json
@@ -1,0 +1,306 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=institutionOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "7p1ernhg2vsem"
+      ],
+      "x-yahoo-request-id": [
+        "7p1ernhg2vsem"
+      ],
+      "x-request-id": [
+        "caad2c36-52f6-4a55-b36f-800f42e2fa78"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "890"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:57 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Blackrock Inc.",
+                  "pctHeld": {
+                    "raw": 0.14729999,
+                    "fmt": "14.73%"
+                  },
+                  "position": {
+                    "raw": 8821106,
+                    "fmt": "8.82M",
+                    "longFmt": "8,821,106"
+                  },
+                  "value": {
+                    "raw": 199445206,
+                    "fmt": "199.45M",
+                    "longFmt": "199,445,206"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Price (T.Rowe) Associates Inc",
+                  "pctHeld": {
+                    "raw": 0.1129,
+                    "fmt": "11.29%"
+                  },
+                  "position": {
+                    "raw": 6758433,
+                    "fmt": "6.76M",
+                    "longFmt": "6,758,433"
+                  },
+                  "value": {
+                    "raw": 127126124,
+                    "fmt": "127.13M",
+                    "longFmt": "127,126,124"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Group, Inc. (The)",
+                  "pctHeld": {
+                    "raw": 0.1042,
+                    "fmt": "10.42%"
+                  },
+                  "position": {
+                    "raw": 6236385,
+                    "fmt": "6.24M",
+                    "longFmt": "6,236,385"
+                  },
+                  "value": {
+                    "raw": 117306401,
+                    "fmt": "117.31M",
+                    "longFmt": "117,306,401"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Wellington Management Company, LLP",
+                  "pctHeld": {
+                    "raw": 0.0845,
+                    "fmt": "8.45%"
+                  },
+                  "position": {
+                    "raw": 5057252,
+                    "fmt": "5.06M",
+                    "longFmt": "5,057,252"
+                  },
+                  "value": {
+                    "raw": 95126910,
+                    "fmt": "95.13M",
+                    "longFmt": "95,126,910"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Clarkston Capital Partners LLC",
+                  "pctHeld": {
+                    "raw": 0.0792,
+                    "fmt": "7.92%"
+                  },
+                  "position": {
+                    "raw": 4743797,
+                    "fmt": "4.74M",
+                    "longFmt": "4,743,797"
+                  },
+                  "value": {
+                    "raw": 89230821,
+                    "fmt": "89.23M",
+                    "longFmt": "89,230,821"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Pzena Investment Management, LLC",
+                  "pctHeld": {
+                    "raw": 0.0704,
+                    "fmt": "7.04%"
+                  },
+                  "position": {
+                    "raw": 4214374,
+                    "fmt": "4.21M",
+                    "longFmt": "4,214,374"
+                  },
+                  "value": {
+                    "raw": 95286996,
+                    "fmt": "95.29M",
+                    "longFmt": "95,286,996"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Barrow, Hanley Mewhinney & Strauss, LLC",
+                  "pctHeld": {
+                    "raw": 0.0414,
+                    "fmt": "4.14%"
+                  },
+                  "position": {
+                    "raw": 2481485,
+                    "fmt": "2.48M",
+                    "longFmt": "2,481,485"
+                  },
+                  "value": {
+                    "raw": 46676732,
+                    "fmt": "46.68M",
+                    "longFmt": "46,676,732"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Dimensional Fund Advisors LP",
+                  "pctHeld": {
+                    "raw": 0.0323,
+                    "fmt": "3.23%"
+                  },
+                  "position": {
+                    "raw": 1936696,
+                    "fmt": "1.94M",
+                    "longFmt": "1,936,696"
+                  },
+                  "value": {
+                    "raw": 36429251,
+                    "fmt": "36.43M",
+                    "longFmt": "36,429,251"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "State Street Corporation",
+                  "pctHeld": {
+                    "raw": 0.0293,
+                    "fmt": "2.93%"
+                  },
+                  "position": {
+                    "raw": 1756727,
+                    "fmt": "1.76M",
+                    "longFmt": "1,756,727"
+                  },
+                  "value": {
+                    "raw": 33044034,
+                    "fmt": "33.04M",
+                    "longFmt": "33,044,034"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Massachusetts Financial Services Co.",
+                  "pctHeld": {
+                    "raw": 0.019299999,
+                    "fmt": "1.93%"
+                  },
+                  "position": {
+                    "raw": 1157989,
+                    "fmt": "1.16M",
+                    "longFmt": "1,157,989"
+                  },
+                  "value": {
+                    "raw": 21781773,
+                    "fmt": "21.78M",
+                    "longFmt": "21,781,773"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-institutionOwnership-MDLY.json
+++ b/tests/http/quoteSummary-institutionOwnership-MDLY.json
@@ -1,0 +1,306 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=institutionOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "044n9fpg2vsel"
+      ],
+      "x-yahoo-request-id": [
+        "044n9fpg2vsel"
+      ],
+      "x-request-id": [
+        "43adc580-467f-4b80-8a26-609e0bc62561"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "729"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:57 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "American Financial Group Inc.",
+                  "pctHeld": {
+                    "raw": 0.0865,
+                    "fmt": "8.65%"
+                  },
+                  "position": {
+                    "raw": 57910,
+                    "fmt": "57.91k",
+                    "longFmt": "57,910"
+                  },
+                  "value": {
+                    "raw": 337036,
+                    "fmt": "337.04k",
+                    "longFmt": "337,036"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Group, Inc. (The)",
+                  "pctHeld": {
+                    "raw": 0.0148,
+                    "fmt": "1.48%"
+                  },
+                  "position": {
+                    "raw": 9945,
+                    "fmt": "9.95k",
+                    "longFmt": "9,945"
+                  },
+                  "value": {
+                    "raw": 57879,
+                    "fmt": "57.88k",
+                    "longFmt": "57,879"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Virtu Financial LLC",
+                  "pctHeld": {
+                    "raw": 0.0115,
+                    "fmt": "1.15%"
+                  },
+                  "position": {
+                    "raw": 7685,
+                    "fmt": "7.68k",
+                    "longFmt": "7,685"
+                  },
+                  "value": {
+                    "raw": 44726,
+                    "fmt": "44.73k",
+                    "longFmt": "44,726"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Advisor Group, Inc.",
+                  "pctHeld": {
+                    "raw": 0.0083,
+                    "fmt": "0.83%"
+                  },
+                  "position": {
+                    "raw": 5528,
+                    "fmt": "5.53k",
+                    "longFmt": "5,528"
+                  },
+                  "value": {
+                    "raw": 44168,
+                    "fmt": "44.17k",
+                    "longFmt": "44,168"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "West Family Investments, Inc.",
+                  "pctHeld": {
+                    "raw": 0.006,
+                    "fmt": "0.60%"
+                  },
+                  "position": {
+                    "raw": 4013,
+                    "fmt": "4.01k",
+                    "longFmt": "4,013"
+                  },
+                  "value": {
+                    "raw": 23355,
+                    "fmt": "23.36k",
+                    "longFmt": "23,355"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Geode Capital Management, LLC",
+                  "pctHeld": {
+                    "raw": 0.0049,
+                    "fmt": "0.49%"
+                  },
+                  "position": {
+                    "raw": 3271,
+                    "fmt": "3.27k",
+                    "longFmt": "3,271"
+                  },
+                  "value": {
+                    "raw": 19037,
+                    "fmt": "19.04k",
+                    "longFmt": "19,037"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Tower Research Capital LLC (TRC)",
+                  "pctHeld": {
+                    "raw": 0.0044,
+                    "fmt": "0.44%"
+                  },
+                  "position": {
+                    "raw": 2934,
+                    "fmt": "2.93k",
+                    "longFmt": "2,934"
+                  },
+                  "value": {
+                    "raw": 17075,
+                    "fmt": "17.07k",
+                    "longFmt": "17,075"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Shelton Capital Management LLC",
+                  "pctHeld": {
+                    "raw": 0.0028,
+                    "fmt": "0.28%"
+                  },
+                  "position": {
+                    "raw": 1864,
+                    "fmt": "1.86k",
+                    "longFmt": "1,864"
+                  },
+                  "value": {
+                    "raw": 10848,
+                    "fmt": "10.85k",
+                    "longFmt": "10,848"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "UBS Group AG",
+                  "pctHeld": {
+                    "raw": 0.0026,
+                    "fmt": "0.26%"
+                  },
+                  "position": {
+                    "raw": 1761,
+                    "fmt": "1.76k",
+                    "longFmt": "1,761"
+                  },
+                  "value": {
+                    "raw": 10249,
+                    "fmt": "10.25k",
+                    "longFmt": "10,249"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Citadel Advisors LLC",
+                  "pctHeld": {
+                    "raw": 0.0023,
+                    "fmt": "0.23%"
+                  },
+                  "position": {
+                    "raw": 1529,
+                    "fmt": "1.53k",
+                    "longFmt": "1,529"
+                  },
+                  "value": {
+                    "raw": 8898,
+                    "fmt": "8.9k",
+                    "longFmt": "8,898"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-institutionOwnership-SI.json
+++ b/tests/http/quoteSummary-institutionOwnership-SI.json
@@ -1,0 +1,306 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=institutionOwnership"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "98v8gplg2vsel"
+      ],
+      "x-yahoo-request-id": [
+        "98v8gplg2vsel"
+      ],
+      "x-request-id": [
+        "2b0044f8-c799-4a25-acda-ae1619856857"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "807"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:57 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "institutionOwnership": {
+              "maxAge": 1,
+              "ownershipList": [
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Senvest Management LLC",
+                  "pctHeld": {
+                    "raw": 0.0842,
+                    "fmt": "8.42%"
+                  },
+                  "position": {
+                    "raw": 1581333,
+                    "fmt": "1.58M",
+                    "longFmt": "1,581,333"
+                  },
+                  "value": {
+                    "raw": 22771195,
+                    "fmt": "22.77M",
+                    "longFmt": "22,771,195"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Park West Asset Management LLC",
+                  "pctHeld": {
+                    "raw": 0.082600005,
+                    "fmt": "8.26%"
+                  },
+                  "position": {
+                    "raw": 1552000,
+                    "fmt": "1.55M",
+                    "longFmt": "1,552,000"
+                  },
+                  "value": {
+                    "raw": 22348800,
+                    "fmt": "22.35M",
+                    "longFmt": "22,348,800"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Blackrock Inc.",
+                  "pctHeld": {
+                    "raw": 0.060900003,
+                    "fmt": "6.09%"
+                  },
+                  "position": {
+                    "raw": 1144811,
+                    "fmt": "1.14M",
+                    "longFmt": "1,144,811"
+                  },
+                  "value": {
+                    "raw": 85070905,
+                    "fmt": "85.07M",
+                    "longFmt": "85,070,905"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "EJF Capital LLC",
+                  "pctHeld": {
+                    "raw": 0.0444,
+                    "fmt": "4.44%"
+                  },
+                  "position": {
+                    "raw": 833350,
+                    "fmt": "833.35k",
+                    "longFmt": "833,350"
+                  },
+                  "value": {
+                    "raw": 12000240,
+                    "fmt": "12M",
+                    "longFmt": "12,000,240"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Vanguard Group, Inc. (The)",
+                  "pctHeld": {
+                    "raw": 0.0337,
+                    "fmt": "3.37%"
+                  },
+                  "position": {
+                    "raw": 633506,
+                    "fmt": "633.51k",
+                    "longFmt": "633,506"
+                  },
+                  "value": {
+                    "raw": 9122486,
+                    "fmt": "9.12M",
+                    "longFmt": "9,122,486"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1609372800,
+                    "fmt": "2020-12-31"
+                  },
+                  "organization": "Bank Of New York Mellon Corporation",
+                  "pctHeld": {
+                    "raw": 0.0216,
+                    "fmt": "2.16%"
+                  },
+                  "position": {
+                    "raw": 404851,
+                    "fmt": "404.85k",
+                    "longFmt": "404,851"
+                  },
+                  "value": {
+                    "raw": 30084477,
+                    "fmt": "30.08M",
+                    "longFmt": "30,084,477"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "Ameriprise Financial, Inc.",
+                  "pctHeld": {
+                    "raw": 0.021300001,
+                    "fmt": "2.13%"
+                  },
+                  "position": {
+                    "raw": 399968,
+                    "fmt": "399.97k",
+                    "longFmt": "399,968"
+                  },
+                  "value": {
+                    "raw": 5759539,
+                    "fmt": "5.76M",
+                    "longFmt": "5,759,539"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "CSat Investment Advisory, L.P.",
+                  "pctHeld": {
+                    "raw": 0.0128,
+                    "fmt": "1.28%"
+                  },
+                  "position": {
+                    "raw": 239754,
+                    "fmt": "239.75k",
+                    "longFmt": "239,754"
+                  },
+                  "value": {
+                    "raw": 3452457,
+                    "fmt": "3.45M",
+                    "longFmt": "3,452,457"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "State Street Corporation",
+                  "pctHeld": {
+                    "raw": 0.0128,
+                    "fmt": "1.28%"
+                  },
+                  "position": {
+                    "raw": 239536,
+                    "fmt": "239.54k",
+                    "longFmt": "239,536"
+                  },
+                  "value": {
+                    "raw": 3449318,
+                    "fmt": "3.45M",
+                    "longFmt": "3,449,318"
+                  }
+                },
+                {
+                  "maxAge": 1,
+                  "reportDate": {
+                    "raw": 1601424000,
+                    "fmt": "2020-09-30"
+                  },
+                  "organization": "ARK Investment Management, LLC",
+                  "pctHeld": {
+                    "raw": 0.0121,
+                    "fmt": "1.21%"
+                  },
+                  "position": {
+                    "raw": 226764,
+                    "fmt": "226.76k",
+                    "longFmt": "226,764"
+                  },
+                  "value": {
+                    "raw": 3265401,
+                    "fmt": "3.27M",
+                    "longFmt": "3,265,401"
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorDirectHolders-ABBV.json
+++ b/tests/http/quoteSummary-majorDirectHolders-ABBV.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=majorDirectHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "avge9htg2vsem"
+      ],
+      "x-yahoo-request-id": [
+        "avge9htg2vsem"
+      ],
+      "x-request-id": [
+        "e6899755-5b08-4411-8958-8a543142aec1"
+      ],
+      "content-length": [
+        "91"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:58 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorDirectHolders-BRKS.json
+++ b/tests/http/quoteSummary-majorDirectHolders-BRKS.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=majorDirectHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "6tg6emlg2vsem"
+      ],
+      "x-yahoo-request-id": [
+        "6tg6emlg2vsem"
+      ],
+      "x-request-id": [
+        "bf521824-ecb9-4bb4-b7af-cadf1a32573a"
+      ],
+      "content-length": [
+        "91"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:58 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorDirectHolders-CRON.json
+++ b/tests/http/quoteSummary-majorDirectHolders-CRON.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=majorDirectHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "31efk35g2vsen"
+      ],
+      "x-yahoo-request-id": [
+        "31efk35g2vsen"
+      ],
+      "x-request-id": [
+        "b27b77d1-603e-439b-977f-7bb8237d4c5f"
+      ],
+      "content-length": [
+        "91"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:59 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorDirectHolders-EPAC.json
+++ b/tests/http/quoteSummary-majorDirectHolders-EPAC.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=majorDirectHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "arrnb85g2vsen"
+      ],
+      "x-yahoo-request-id": [
+        "arrnb85g2vsen"
+      ],
+      "x-request-id": [
+        "17b9c985-1624-46d3-b9a8-06cc0287b28e"
+      ],
+      "content-length": [
+        "91"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:59 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorDirectHolders-MDLY.json
+++ b/tests/http/quoteSummary-majorDirectHolders-MDLY.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=majorDirectHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "7r2mrodg2vsem"
+      ],
+      "x-yahoo-request-id": [
+        "7r2mrodg2vsem"
+      ],
+      "x-request-id": [
+        "c109ca32-884f-4018-95d1-a28077141c4d"
+      ],
+      "content-length": [
+        "91"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:58 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorDirectHolders-SI.json
+++ b/tests/http/quoteSummary-majorDirectHolders-SI.json
@@ -1,0 +1,82 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=majorDirectHolders"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "bcr20vhg2vsem"
+      ],
+      "x-yahoo-request-id": [
+        "bcr20vhg2vsem"
+      ],
+      "x-request-id": [
+        "531d2875-06ba-4da0-ba64-7f824f32b445"
+      ],
+      "content-length": [
+        "91"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:58 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorDirectHolders": {
+              "holders": [],
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorHoldersBreakdown-ABBV.json
+++ b/tests/http/quoteSummary-majorHoldersBreakdown-ABBV.json
@@ -1,0 +1,85 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=majorHoldersBreakdown"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "4luru5pg2vsen"
+      ],
+      "x-yahoo-request-id": [
+        "4luru5pg2vsen"
+      ],
+      "x-request-id": [
+        "1d71f197-f9b5-49c0-bc8b-a27a4685c9b5"
+      ],
+      "content-length": [
+        "206"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:59 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.001,
+              "institutionsPercentHeld": 0.70001,
+              "institutionsFloatPercentHeld": 0.7007,
+              "institutionsCount": 2979
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorHoldersBreakdown-BRKS.json
+++ b/tests/http/quoteSummary-majorHoldersBreakdown-BRKS.json
@@ -1,0 +1,85 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=majorHoldersBreakdown"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "4jleci9g2vsen"
+      ],
+      "x-yahoo-request-id": [
+        "4jleci9g2vsen"
+      ],
+      "x-request-id": [
+        "682ca6b1-abb8-40e1-bf7d-ccf1efbc845b"
+      ],
+      "content-length": [
+        "208"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:59 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "2"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.01582,
+              "institutionsPercentHeld": 1.00236,
+              "institutionsFloatPercentHeld": 1.01848,
+              "institutionsCount": 385
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorHoldersBreakdown-CRON.json
+++ b/tests/http/quoteSummary-majorHoldersBreakdown-CRON.json
@@ -1,0 +1,85 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=majorHoldersBreakdown"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "0dlb5rdg2vseo"
+      ],
+      "x-yahoo-request-id": [
+        "0dlb5rdg2vseo"
+      ],
+      "x-request-id": [
+        "8a86e831-c1cc-40ec-9e58-5887ac2f126c"
+      ],
+      "content-length": [
+        "211"
+      ],
+      "x-envoy-upstream-service-time": [
+        "6"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:59 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.49218,
+              "institutionsPercentHeld": 0.14603,
+              "institutionsFloatPercentHeld": 0.28756002,
+              "institutionsCount": 320
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorHoldersBreakdown-EPAC.json
+++ b/tests/http/quoteSummary-majorHoldersBreakdown-EPAC.json
@@ -1,0 +1,85 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=majorHoldersBreakdown"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "2pipnupg2vseo"
+      ],
+      "x-yahoo-request-id": [
+        "2pipnupg2vseo"
+      ],
+      "x-request-id": [
+        "8f39bd92-e232-4e79-b9cd-8d74f27eff9b"
+      ],
+      "content-length": [
+        "208"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:00 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.00569,
+              "institutionsPercentHeld": 1.04787,
+              "institutionsFloatPercentHeld": 1.05387,
+              "institutionsCount": 227
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorHoldersBreakdown-MDLY.json
+++ b/tests/http/quoteSummary-majorHoldersBreakdown-MDLY.json
@@ -1,0 +1,85 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=majorHoldersBreakdown"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "51pank5g2vsen"
+      ],
+      "x-yahoo-request-id": [
+        "51pank5g2vsen"
+      ],
+      "x-request-id": [
+        "50dd2290-3ea0-432e-b3b6-09ff75ac3fc2"
+      ],
+      "content-length": [
+        "210"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:59 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.12206,
+              "institutionsPercentHeld": 0.17618999,
+              "institutionsFloatPercentHeld": 0.20068,
+              "institutionsCount": 21
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-majorHoldersBreakdown-SI.json
+++ b/tests/http/quoteSummary-majorHoldersBreakdown-SI.json
@@ -1,0 +1,85 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=majorHoldersBreakdown"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "ac7mr61g2vsen"
+      ],
+      "x-yahoo-request-id": [
+        "ac7mr61g2vsen"
+      ],
+      "x-request-id": [
+        "d610e010-5a4c-43ab-ae77-4f939230b4fe"
+      ],
+      "content-length": [
+        "211"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:59 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "majorHoldersBreakdown": {
+              "maxAge": 1,
+              "insidersPercentHeld": 0.05487,
+              "institutionsPercentHeld": 0.65436995,
+              "institutionsFloatPercentHeld": 0.69236,
+              "institutionsCount": 108
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-netSharePurchaseActivity-ABBV.json
+++ b/tests/http/quoteSummary-netSharePurchaseActivity-ABBV.json
@@ -1,0 +1,92 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=netSharePurchaseActivity"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "1p0i4ulg2vseo"
+      ],
+      "x-yahoo-request-id": [
+        "1p0i4ulg2vseo"
+      ],
+      "x-request-id": [
+        "a540bac7-c86b-4c9a-a6d1-c23bc4331f68"
+      ],
+      "content-length": [
+        "349"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:00 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "3"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 9,
+              "buyInfoShares": 460769,
+              "buyPercentInsiderShares": 0.244,
+              "sellInfoCount": 9,
+              "sellInfoShares": 582419,
+              "sellPercentInsiderShares": 0.309,
+              "netInfoCount": 18,
+              "netInfoShares": -121650,
+              "netPercentInsiderShares": -0.064,
+              "totalInsiderShares": 1765474
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-netSharePurchaseActivity-BRKS.json
+++ b/tests/http/quoteSummary-netSharePurchaseActivity-BRKS.json
@@ -1,0 +1,92 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=netSharePurchaseActivity"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "2h927v1g2vsep"
+      ],
+      "x-yahoo-request-id": [
+        "2h927v1g2vsep"
+      ],
+      "x-request-id": [
+        "a1a9d811-27ee-4987-ad21-43ac923dc0c7"
+      ],
+      "content-length": [
+        "355"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:00 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 17,
+              "buyInfoShares": 181423,
+              "buyPercentInsiderShares": 0.14,
+              "sellInfoCount": 12,
+              "sellInfoShares": 319555,
+              "sellPercentInsiderShares": 0.24700001,
+              "netInfoCount": 29,
+              "netInfoShares": -138132,
+              "netPercentInsiderShares": -0.107,
+              "totalInsiderShares": 1157346
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-netSharePurchaseActivity-CRON.json
+++ b/tests/http/quoteSummary-netSharePurchaseActivity-CRON.json
@@ -1,0 +1,89 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=netSharePurchaseActivity"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "0875p65g2vsep"
+      ],
+      "x-yahoo-request-id": [
+        "0875p65g2vsep"
+      ],
+      "x-request-id": [
+        "419f6cc1-dc41-4fa3-810b-d45c17721696"
+      ],
+      "content-length": [
+        "247"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:01 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 0,
+              "buyInfoShares": 0,
+              "sellInfoCount": 0,
+              "netInfoCount": 0,
+              "netInfoShares": 0,
+              "netPercentInsiderShares": 0,
+              "totalInsiderShares": 175085120
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-netSharePurchaseActivity-EPAC.json
+++ b/tests/http/quoteSummary-netSharePurchaseActivity-EPAC.json
@@ -1,0 +1,92 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=netSharePurchaseActivity"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "eu13q3lg2vsep"
+      ],
+      "x-yahoo-request-id": [
+        "eu13q3lg2vsep"
+      ],
+      "x-request-id": [
+        "29bc7020-1183-452a-81ba-f569887aa608"
+      ],
+      "content-length": [
+        "351"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:01 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 19,
+              "buyInfoShares": 183357,
+              "buyPercentInsiderShares": 1.151,
+              "sellInfoCount": 1,
+              "sellInfoShares": 2005,
+              "sellPercentInsiderShares": 0.012999999,
+              "netInfoCount": 20,
+              "netInfoShares": 181352,
+              "netPercentInsiderShares": 1.138,
+              "totalInsiderShares": 340666
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-netSharePurchaseActivity-MDLY.json
+++ b/tests/http/quoteSummary-netSharePurchaseActivity-MDLY.json
@@ -1,0 +1,89 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=netSharePurchaseActivity"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "5o5fradg2vseo"
+      ],
+      "x-yahoo-request-id": [
+        "5o5fradg2vseo"
+      ],
+      "x-request-id": [
+        "29dbd292-7ed5-4e7d-88ca-735276c3d0ee"
+      ],
+      "content-length": [
+        "258"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:00 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 8,
+              "buyInfoShares": 3543679,
+              "sellInfoCount": 0,
+              "netInfoCount": 8,
+              "netInfoShares": 3543679,
+              "netPercentInsiderShares": -1.024,
+              "totalInsiderShares": 81750
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-netSharePurchaseActivity-SI.json
+++ b/tests/http/quoteSummary-netSharePurchaseActivity-SI.json
@@ -1,0 +1,92 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=netSharePurchaseActivity"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "3nnpjmdg2vseo"
+      ],
+      "x-yahoo-request-id": [
+        "3nnpjmdg2vseo"
+      ],
+      "x-request-id": [
+        "af715279-1827-4306-ac7e-a21f8313dcfc"
+      ],
+      "content-length": [
+        "355"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:00 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "netSharePurchaseActivity": {
+              "maxAge": 1,
+              "period": "6m",
+              "buyInfoCount": 22,
+              "buyInfoShares": 357238,
+              "buyPercentInsiderShares": 0.30200002,
+              "sellInfoCount": 8,
+              "sellInfoShares": 510148,
+              "sellPercentInsiderShares": 0.432,
+              "netInfoCount": 30,
+              "netInfoShares": -152910,
+              "netPercentInsiderShares": -0.129,
+              "totalInsiderShares": 1028483
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-price-ABBV.json
+++ b/tests/http/quoteSummary-price-ABBV.json
@@ -1,0 +1,116 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=price"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "45pjen5g2vseq"
+      ],
+      "x-yahoo-request-id": [
+        "45pjen5g2vseq"
+      ],
+      "x-request-id": [
+        "4c654625-604c-4367-a32a-ee4c2383ed0f"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "455"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:01 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": 0.00226292,
+              "preMarketChange": 0.240005,
+              "preMarketTime": 1613744999,
+              "preMarketPrice": 106.3,
+              "preMarketSource": "FREE_REALTIME",
+              "regularMarketChangePercent": -0.0046200063,
+              "regularMarketChange": -0.48999786,
+              "regularMarketTime": 1613754838,
+              "priceHint": 2,
+              "regularMarketPrice": 105.57,
+              "regularMarketDayHigh": 106.35,
+              "regularMarketDayLow": 104.91,
+              "regularMarketVolume": 2383590,
+              "regularMarketPreviousClose": 106.06,
+              "regularMarketSource": "FREE_REALTIME",
+              "regularMarketOpen": 106.23,
+              "exchange": "NYQ",
+              "exchangeName": "NYSE",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "EQUITY",
+              "symbol": "ABBV",
+              "underlyingSymbol": null,
+              "shortName": "AbbVie Inc.",
+              "longName": "AbbVie Inc.",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 186380664832
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-price-BRKS.json
+++ b/tests/http/quoteSummary-price-BRKS.json
@@ -1,0 +1,116 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=price"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "3vvq6q9g2vseq"
+      ],
+      "x-yahoo-request-id": [
+        "3vvq6q9g2vseq"
+      ],
+      "x-request-id": [
+        "4f5ed991-2927-4dbc-80f1-176b69cafad1"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "454"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:02 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": 0.020725401,
+              "preMarketChange": 1.72,
+              "preMarketTime": 1613744999,
+              "preMarketPrice": 84.71,
+              "preMarketSource": "FREE_REALTIME",
+              "regularMarketChangePercent": 0.052897934,
+              "regularMarketChange": 4.3899994,
+              "regularMarketTime": 1613754822,
+              "priceHint": 2,
+              "regularMarketPrice": 87.38,
+              "regularMarketDayHigh": 87.9,
+              "regularMarketDayLow": 84.56,
+              "regularMarketVolume": 146528,
+              "regularMarketPreviousClose": 82.99,
+              "regularMarketSource": "FREE_REALTIME",
+              "regularMarketOpen": 84.56,
+              "exchange": "NMS",
+              "exchangeName": "NasdaqGS",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "EQUITY",
+              "symbol": "BRKS",
+              "underlyingSymbol": null,
+              "shortName": "Brooks Automation, Inc.",
+              "longName": "Brooks Automation, Inc.",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 6485351936
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-price-CRON.json
+++ b/tests/http/quoteSummary-price-CRON.json
@@ -1,0 +1,116 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=price"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "68bmrd1g2vseq"
+      ],
+      "x-yahoo-request-id": [
+        "68bmrd1g2vseq"
+      ],
+      "x-request-id": [
+        "fdae2ec6-0024-46f4-a5ad-8d66ed5609c0"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "473"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:02 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": 0.0051194085,
+              "preMarketChange": 0.059999466,
+              "preMarketTime": 1613744995,
+              "preMarketPrice": 11.78,
+              "preMarketSource": "DELAYED",
+              "regularMarketChangePercent": 0.037124537,
+              "regularMarketChange": 0.4350996,
+              "regularMarketTime": 1613754832,
+              "priceHint": 2,
+              "regularMarketPrice": 12.1551,
+              "regularMarketDayHigh": 12.38,
+              "regularMarketDayLow": 11.77,
+              "regularMarketVolume": 2580169,
+              "regularMarketPreviousClose": 11.72,
+              "regularMarketSource": "FREE_REALTIME",
+              "regularMarketOpen": 11.79,
+              "exchange": "NMS",
+              "exchangeName": "NasdaqGS",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "EQUITY",
+              "symbol": "CRON",
+              "underlyingSymbol": null,
+              "shortName": "Cronos Group Inc. Common Share",
+              "longName": "Cronos Group Inc.",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 4318755840
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-price-EPAC.json
+++ b/tests/http/quoteSummary-price-EPAC.json
@@ -1,0 +1,116 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=price"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "faivihpg2vseq"
+      ],
+      "x-yahoo-request-id": [
+        "faivihpg2vseq"
+      ],
+      "x-request-id": [
+        "916979c3-bf09-4f04-bbde-e3d004e34e00"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "440"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:02 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": 0,
+              "preMarketChange": 0,
+              "preMarketTime": 1613740999,
+              "preMarketPrice": 22.66,
+              "preMarketSource": "FREE_REALTIME",
+              "regularMarketChangePercent": 0.028243575,
+              "regularMarketChange": 0.6399994,
+              "regularMarketTime": 1613754689,
+              "priceHint": 2,
+              "regularMarketPrice": 23.3,
+              "regularMarketDayHigh": 23.3,
+              "regularMarketDayLow": 22.77,
+              "regularMarketVolume": 62262,
+              "regularMarketPreviousClose": 22.66,
+              "regularMarketSource": "FREE_REALTIME",
+              "regularMarketOpen": 22.79,
+              "exchange": "NYQ",
+              "exchangeName": "NYSE",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "EQUITY",
+              "symbol": "EPAC",
+              "underlyingSymbol": null,
+              "shortName": "Enerpac Tool Group Corp.",
+              "longName": "Enerpac Tool Group Corp.",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 1394996608
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-price-MDLY.json
+++ b/tests/http/quoteSummary-price-MDLY.json
@@ -1,0 +1,116 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=price"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "dj1oovdg2vsep"
+      ],
+      "x-yahoo-request-id": [
+        "dj1oovdg2vsep"
+      ],
+      "x-request-id": [
+        "0059b5a8-e58d-44f3-9dc3-376475146b3e"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "447"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:01 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "3"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": 0.0375866,
+              "preMarketChange": 0.38,
+              "preMarketTime": 1613744144,
+              "preMarketPrice": 10.49,
+              "preMarketSource": "FREE_REALTIME",
+              "regularMarketChangePercent": 0.029871421,
+              "regularMarketChange": 0.30200005,
+              "regularMarketTime": 1613753447,
+              "priceHint": 2,
+              "regularMarketPrice": 10.412,
+              "regularMarketDayHigh": 10.42,
+              "regularMarketDayLow": 10.14,
+              "regularMarketVolume": 19267,
+              "regularMarketPreviousClose": 10.11,
+              "regularMarketSource": "FREE_REALTIME",
+              "regularMarketOpen": 10.22,
+              "exchange": "NYQ",
+              "exchangeName": "NYSE",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "EQUITY",
+              "symbol": "MDLY",
+              "underlyingSymbol": null,
+              "shortName": "Medley Management Inc.",
+              "longName": "Medley Management Inc.",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 59543104
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-price-SI.json
+++ b/tests/http/quoteSummary-price-SI.json
@@ -1,0 +1,116 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=price"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "3g1oajhg2vsep"
+      ],
+      "x-yahoo-request-id": [
+        "3g1oajhg2vsep"
+      ],
+      "x-request-id": [
+        "24d320d3-4f66-46e6-a35f-7a66f06d67d4"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "468"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:01 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "price": {
+              "maxAge": 1,
+              "preMarketChangePercent": 0.024390198,
+              "preMarketChange": 3.75,
+              "preMarketTime": 1613744822,
+              "preMarketPrice": 157.5,
+              "preMarketSource": "FREE_REALTIME",
+              "regularMarketChangePercent": 0.11960906,
+              "regularMarketChange": 18.389893,
+              "regularMarketTime": 1613754825,
+              "priceHint": 2,
+              "regularMarketPrice": 172.1399,
+              "regularMarketDayHigh": 174.5,
+              "regularMarketDayLow": 154.0101,
+              "regularMarketVolume": 571007,
+              "regularMarketPreviousClose": 153.75,
+              "regularMarketSource": "FREE_REALTIME",
+              "regularMarketOpen": 157.91,
+              "exchange": "NYQ",
+              "exchangeName": "NYSE",
+              "exchangeDataDelayedBy": 0,
+              "marketState": "REGULAR",
+              "quoteType": "EQUITY",
+              "symbol": "SI",
+              "underlyingSymbol": null,
+              "shortName": "Silvergate Capital Corporation",
+              "longName": "Silvergate Capital Corporation",
+              "currency": "USD",
+              "quoteSourceName": "Nasdaq Real Time Price",
+              "currencySymbol": "$",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "marketCap": 3928008448
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-quoteType-ABBV.json
+++ b/tests/http/quoteSummary-quoteType-ABBV.json
@@ -1,0 +1,93 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=quoteType"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "42lc045g2vser"
+      ],
+      "x-yahoo-request-id": [
+        "42lc045g2vser"
+      ],
+      "x-request-id": [
+        "92b28126-359c-42a6-a386-3b3f70c7f258"
+      ],
+      "content-length": [
+        "415"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:03 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "quoteType": {
+              "exchange": "NYQ",
+              "quoteType": "EQUITY",
+              "symbol": "ABBV",
+              "underlyingSymbol": "ABBV",
+              "shortName": "AbbVie Inc.",
+              "longName": "AbbVie Inc.",
+              "firstTradeDateEpochUtc": 1357137000,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "73238d42-cdcc-3f92-8141-dd675addae10",
+              "messageBoardId": "finmb_141885706",
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-quoteType-BRKS.json
+++ b/tests/http/quoteSummary-quoteType-BRKS.json
@@ -1,0 +1,93 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=quoteType"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "0u3fd0dg2vser"
+      ],
+      "x-yahoo-request-id": [
+        "0u3fd0dg2vser"
+      ],
+      "x-request-id": [
+        "01d5f3b4-6244-4d31-95be-d3c13d4d9325"
+      ],
+      "content-length": [
+        "435"
+      ],
+      "x-envoy-upstream-service-time": [
+        "1"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:03 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "quoteType": {
+              "exchange": "NMS",
+              "quoteType": "EQUITY",
+              "symbol": "BRKS",
+              "underlyingSymbol": "BRKS",
+              "shortName": "Brooks Automation, Inc.",
+              "longName": "Brooks Automation, Inc.",
+              "firstTradeDateEpochUtc": 791735400,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "35dd4682-0b8a-3535-ae1c-cde5d5fbf2a6",
+              "messageBoardId": "finmb_336648",
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-quoteType-CRON.json
+++ b/tests/http/quoteSummary-quoteType-CRON.json
@@ -1,0 +1,93 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=quoteType"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "bi59blhg2vser"
+      ],
+      "x-yahoo-request-id": [
+        "bi59blhg2vser"
+      ],
+      "x-request-id": [
+        "7310001a-0dd2-4956-97d2-69a3c3e95219"
+      ],
+      "content-length": [
+        "440"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:03 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "quoteType": {
+              "exchange": "NMS",
+              "quoteType": "EQUITY",
+              "symbol": "CRON",
+              "underlyingSymbol": "CRON",
+              "shortName": "Cronos Group Inc. Common Share",
+              "longName": "Cronos Group Inc.",
+              "firstTradeDateEpochUtc": 1519741800,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "c16afd87-8f99-3c59-851c-860ea909059d",
+              "messageBoardId": "finmb_253038643",
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-quoteType-EPAC.json
+++ b/tests/http/quoteSummary-quoteType-EPAC.json
@@ -1,0 +1,93 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=quoteType"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "fos0mr9g2vser"
+      ],
+      "x-yahoo-request-id": [
+        "fos0mr9g2vser"
+      ],
+      "x-request-id": [
+        "651d5d49-7dd6-4260-bac8-c6b0ebb26ca4"
+      ],
+      "content-length": [
+        "437"
+      ],
+      "x-envoy-upstream-service-time": [
+        "85"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:03 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "2"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "quoteType": {
+              "exchange": "NYQ",
+              "quoteType": "EQUITY",
+              "symbol": "EPAC",
+              "underlyingSymbol": "EPAC",
+              "shortName": "Enerpac Tool Group Corp.",
+              "longName": "Enerpac Tool Group Corp.",
+              "firstTradeDateEpochUtc": 964445400,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "2d82682e-c536-3e44-8626-b4fbe62d66ab",
+              "messageBoardId": "finmb_251258",
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-quoteType-MDLY.json
+++ b/tests/http/quoteSummary-quoteType-MDLY.json
@@ -1,0 +1,93 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=quoteType"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "6vf816dg2vser"
+      ],
+      "x-yahoo-request-id": [
+        "6vf816dg2vser"
+      ],
+      "x-request-id": [
+        "feb9a45d-5cba-4a20-b60f-6b83ff32d138"
+      ],
+      "content-length": [
+        "437"
+      ],
+      "x-envoy-upstream-service-time": [
+        "1"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:02 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "quoteType": {
+              "exchange": "NYQ",
+              "quoteType": "EQUITY",
+              "symbol": "MDLY",
+              "underlyingSymbol": "MDLY",
+              "shortName": "Medley Management Inc.",
+              "longName": "Medley Management Inc.",
+              "firstTradeDateEpochUtc": 1411565400,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "5c7a2af9-da78-3b57-8755-1c4c2ec9ea8b",
+              "messageBoardId": "finmb_269214791",
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-quoteType-SI.json
+++ b/tests/http/quoteSummary-quoteType-SI.json
@@ -1,0 +1,93 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=quoteType"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "0kqumc9g2vseq"
+      ],
+      "x-yahoo-request-id": [
+        "0kqumc9g2vseq"
+      ],
+      "x-request-id": [
+        "de6f10c4-bfd9-4e0d-b3e7-899fe8555238"
+      ],
+      "content-length": [
+        "448"
+      ],
+      "x-envoy-upstream-service-time": [
+        "87"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:02 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "3"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "quoteType": {
+              "exchange": "NYQ",
+              "quoteType": "EQUITY",
+              "symbol": "SI",
+              "underlyingSymbol": "SI",
+              "shortName": "Silvergate Capital Corporation",
+              "longName": "Silvergate Capital Corporation",
+              "firstTradeDateEpochUtc": 1573137000,
+              "timeZoneFullName": "America/New_York",
+              "timeZoneShortName": "EST",
+              "uuid": "ce774d9c-ab3a-30bd-b522-cd0839bed364",
+              "messageBoardId": "finmb_53838840",
+              "gmtOffSetMilliseconds": -18000000,
+              "maxAge": 1
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-recommendationTrend-ABBV.json
+++ b/tests/http/quoteSummary-recommendationTrend-ABBV.json
@@ -1,0 +1,115 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=recommendationTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "dde0j3tg2vses"
+      ],
+      "x-yahoo-request-id": [
+        "dde0j3tg2vses"
+      ],
+      "x-request-id": [
+        "d7720a9f-14b2-4a24-91fa-e0f4f9373293"
+      ],
+      "content-length": [
+        "384"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:04 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 4,
+                  "buy": 6,
+                  "hold": 10,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 6,
+                  "buy": 11,
+                  "hold": 5,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 6,
+                  "buy": 11,
+                  "hold": 5,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 1,
+                  "buy": 3,
+                  "hold": 10,
+                  "sell": 1,
+                  "strongSell": 1
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-recommendationTrend-BRKS.json
+++ b/tests/http/quoteSummary-recommendationTrend-BRKS.json
@@ -1,0 +1,115 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=recommendationTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "1qnp20hg2vses"
+      ],
+      "x-yahoo-request-id": [
+        "1qnp20hg2vses"
+      ],
+      "x-request-id": [
+        "cd43e879-b025-4c4a-8bd7-e175059a09ae"
+      ],
+      "content-length": [
+        "380"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:04 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 3,
+                  "buy": 1,
+                  "hold": 2,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 2,
+                  "buy": 3,
+                  "hold": 2,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 2,
+                  "buy": 3,
+                  "hold": 2,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 1,
+                  "buy": 1,
+                  "hold": 4,
+                  "sell": 0,
+                  "strongSell": 0
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-recommendationTrend-CRON.json
+++ b/tests/http/quoteSummary-recommendationTrend-CRON.json
@@ -1,0 +1,81 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=recommendationTrend"
+  },
+  "response": {
+    "ok": false,
+    "status": 404,
+    "statusText": "Not Found",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "y-rid": [
+        "1qct7f5g2vses"
+      ],
+      "x-yahoo-request-id": [
+        "1qct7f5g2vses"
+      ],
+      "x-request-id": [
+        "83b25b08-805d-4349-8e78-de6ea1e6fed1"
+      ],
+      "content-length": [
+        "152"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:04 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "cache-control": [
+        "max-age=0, private"
+      ],
+      "expires": [
+        "-1"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": null,
+        "error": {
+          "code": "Not Found",
+          "description": "No fundamentals data found for any of the summaryTypes=recommendationTrend"
+        }
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-recommendationTrend-EPAC.json
+++ b/tests/http/quoteSummary-recommendationTrend-EPAC.json
@@ -1,0 +1,115 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=recommendationTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "6o4hjvpg2vset"
+      ],
+      "x-yahoo-request-id": [
+        "6o4hjvpg2vset"
+      ],
+      "x-request-id": [
+        "527d956b-a9d4-4bc0-9b2b-9a3494ef5f66"
+      ],
+      "content-length": [
+        "380"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:04 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 5,
+                  "sell": 1,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 0,
+                  "buy": 1,
+                  "hold": 4,
+                  "sell": 1,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-recommendationTrend-MDLY.json
+++ b/tests/http/quoteSummary-recommendationTrend-MDLY.json
@@ -1,0 +1,115 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=recommendationTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "bktrbb5g2vses"
+      ],
+      "x-yahoo-request-id": [
+        "bktrbb5g2vses"
+      ],
+      "x-request-id": [
+        "9f2a2e9e-b47b-49fc-b4a9-b1734c1cb65c"
+      ],
+      "content-length": [
+        "380"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:04 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 1,
+                  "buy": 0,
+                  "hold": 3,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 1,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 1,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 1,
+                  "buy": 0,
+                  "hold": 3,
+                  "sell": 0,
+                  "strongSell": 0
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-recommendationTrend-SI.json
+++ b/tests/http/quoteSummary-recommendationTrend-SI.json
@@ -1,0 +1,115 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=recommendationTrend"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "erfrbl5g2vses"
+      ],
+      "x-yahoo-request-id": [
+        "erfrbl5g2vses"
+      ],
+      "x-request-id": [
+        "c3e739dc-9b15-4fd5-ac77-65a118d4169e"
+      ],
+      "content-length": [
+        "380"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:03 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "recommendationTrend": {
+              "trend": [
+                {
+                  "period": "0m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-1m",
+                  "strongBuy": 3,
+                  "buy": 2,
+                  "hold": 1,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-2m",
+                  "strongBuy": 2,
+                  "buy": 3,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                },
+                {
+                  "period": "-3m",
+                  "strongBuy": 0,
+                  "buy": 0,
+                  "hold": 0,
+                  "sell": 0,
+                  "strongSell": 0
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-secFilings-ABBV.json
+++ b/tests/http/quoteSummary-secFilings-ABBV.json
@@ -1,0 +1,462 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=secFilings"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "fii5bq1g2vset"
+      ],
+      "x-yahoo-request-id": [
+        "fii5bq1g2vset"
+      ],
+      "x-request-id": [
+        "d8e230a0-a808-4820-ae78-34f9df79cc06"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:05 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "secFilings": {
+              "filings": [
+                {
+                  "date": "2021-02-03",
+                  "epochDate": 1612356124,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001551152-21-000003&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-01-12",
+                  "epochDate": 1610487133,
+                  "type": "8-K",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-21-003462&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-01-06",
+                  "epochDate": 1609970467,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-21-001570&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-11-18",
+                  "epochDate": 1605737834,
+                  "type": "8-K",
+                  "title": "Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-126925&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-11-12",
+                  "epochDate": 1605193572,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-124093&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-11-04",
+                  "epochDate": 1604501677,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001551152-20-000032&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-30",
+                  "epochDate": 1604062390,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001551152-20-000029&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-19",
+                  "epochDate": 1603116885,
+                  "type": "8-K",
+                  "title": "Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-115857&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-02",
+                  "epochDate": 1601672779,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-111687&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-08-04",
+                  "epochDate": 1596553047,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001551152-20-000023&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-07-31",
+                  "epochDate": 1596203025,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001551152-20-000019&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-14",
+                  "epochDate": 1589490080,
+                  "type": "8-K/A",
+                  "title": "ABBVIE INC. FILES (8-K/A) Disclosing Completion of Acquisition or Disposition of Assets, Financial Statements and Exhibi",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-061687&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-14",
+                  "epochDate": 1589487483,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Creation of a Direct Financial Obligation",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-061621&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-12",
+                  "epochDate": 1589317905,
+                  "type": "8-K",
+                  "title": "Disclosing Submission of Matters to a Vote of Security Holders",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-060256&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-08",
+                  "epochDate": 1588969976,
+                  "type": "8-K",
+                  "title": "Disclosing Completion of Acquisition or Disposition of Assets, Creation of a Direct Financial Ob",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-058837&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-08",
+                  "epochDate": 1588932759,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001551152-20-000015&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-06",
+                  "epochDate": 1588759551,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-057093&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-01",
+                  "epochDate": 1588333539,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001551152-20-000010&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-27",
+                  "epochDate": 1587989675,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-051316&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-20",
+                  "epochDate": 1587384867,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-048487&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-06",
+                  "epochDate": 1586174946,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-043408&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-03-23",
+                  "epochDate": 1584965668,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-037093&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-03-09",
+                  "epochDate": 1583761537,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-030507&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-02-24",
+                  "epochDate": 1582553626,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-024097&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-02-21",
+                  "epochDate": 1582300388,
+                  "type": "10-K",
+                  "title": "Annual Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001551152-20-000007&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-02-14",
+                  "epochDate": 1581721519,
+                  "type": "8-K",
+                  "title": "Disclosing Termination of a Material Definitive Agreement",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-022002&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-02-07",
+                  "epochDate": 1581079738,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001551152-20-000004&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-01-27",
+                  "epochDate": 1580131627,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-20-006940&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-12-20",
+                  "epochDate": 1576850543,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-19-074689&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-26",
+                  "epochDate": 1574776012,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Creation of a Direct Financial Obligation",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-19-067264&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-18",
+                  "epochDate": 1574083314,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-19-064905&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-13",
+                  "epochDate": 1573681496,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-19-063366&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-08",
+                  "epochDate": 1573211272,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-19-061290&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-07",
+                  "epochDate": 1573136325,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-19-060862&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-06",
+                  "epochDate": 1573072291,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure, Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-19-060477&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-06",
+                  "epochDate": 1573053495,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001551152-19-000030&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-01",
+                  "epochDate": 1572609095,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001551152-19-000026&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-10-25",
+                  "epochDate": 1572006398,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-19-056315&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-10-22",
+                  "epochDate": 1571776970,
+                  "type": "8-K",
+                  "title": "Disclosing Amendments to Articles of Inc. or Bylaws; Change in Fiscal Year, Financial Statements",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-19-055567&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-09-26",
+                  "epochDate": 1569528434,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Creation of a Direct Financial Obligation",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001410578-19-001438&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-09-23",
+                  "epochDate": 1569270339,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001410578-19-001379&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-09-16",
+                  "epochDate": 1568635072,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001410578-19-001244&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-08-30",
+                  "epochDate": 1567196448,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Creation of a Direct Financial Obligation",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001410578-19-000980&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-08-05",
+                  "epochDate": 1565022903,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001551152-19-000023&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-07-26",
+                  "epochDate": 1564141489,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001551152-19-000021&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-07-16",
+                  "epochDate": 1563309841,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Creation of a Direct Financial Obligation",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-19-040574&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-06-25",
+                  "epochDate": 1561498049,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Creation of a Direct Financial Obligation",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-19-037446&nav=1&src=Yahoo",
+                  "maxAge": 1
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-secFilings-BRKS.json
+++ b/tests/http/quoteSummary-secFilings-BRKS.json
@@ -1,0 +1,254 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=secFilings"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "2cv6ritg2vset"
+      ],
+      "x-yahoo-request-id": [
+        "2cv6ritg2vset"
+      ],
+      "x-request-id": [
+        "8dfa4507-1fd4-4235-809e-4fc24cfac23f"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "842"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:05 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "secFilings": {
+              "filings": [
+                {
+                  "date": "2021-02-03",
+                  "epochDate": 1612390320,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001558370-21-000702&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-02-02",
+                  "epochDate": 1612300597,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-21-000008&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-02-01",
+                  "epochDate": 1612214814,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-21-000005&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-01-28",
+                  "epochDate": 1611870228,
+                  "type": "8-K",
+                  "title": "Submission of Matters to a Vote of Security Holders",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-21-000002&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-12-10",
+                  "epochDate": 1607634609,
+                  "type": "8-K",
+                  "title": "Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-20-000034&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-11-18",
+                  "epochDate": 1605733974,
+                  "type": "10-K",
+                  "title": "Annual Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001558370-20-013971&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-11-10",
+                  "epochDate": 1605042486,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-20-000028&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-07-31",
+                  "epochDate": 1596233317,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001558370-20-008910&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-07-31",
+                  "epochDate": 1596193625,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-20-000025&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-01",
+                  "epochDate": 1588365708,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001558370-20-004927&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-30",
+                  "epochDate": 1588277507,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and E",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-20-000014&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-13",
+                  "epochDate": 1586810221,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and E",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-20-000011&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-07",
+                  "epochDate": 1586291288,
+                  "type": "8-K",
+                  "title": "Disclosing Change in Directors or Principal Officers, Financial Statements and Exhib",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-20-000008&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-02-06",
+                  "epochDate": 1581024552,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001558370-20-000586&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-02-06",
+                  "epochDate": 1581023295,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and E",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-20-000005&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-12-17",
+                  "epochDate": 1576587551,
+                  "type": "10-K",
+                  "title": "Annual Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001558370-19-011541&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-06",
+                  "epochDate": 1573074797,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and E",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-19-000035&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-08-02",
+                  "epochDate": 1564779064,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001558370-19-006962&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-08-01",
+                  "epochDate": 1564690437,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and E",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-19-000028&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-07-05",
+                  "epochDate": 1562326896,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Completion of Acquisition or ",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-19-000025&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-06-18",
+                  "epochDate": 1560889297,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000933974-19-000023&nav=1&src=Yahoo",
+                  "maxAge": 1
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-secFilings-CRON.json
+++ b/tests/http/quoteSummary-secFilings-CRON.json
@@ -1,0 +1,198 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=secFilings"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "djrmc3hg2vseu"
+      ],
+      "x-yahoo-request-id": [
+        "djrmc3hg2vseu"
+      ],
+      "x-request-id": [
+        "d5fac0b1-7eba-4ad8-9e76-86079b2c83c4"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "653"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:06 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "secFilings": {
+              "filings": [
+                {
+                  "date": "2020-11-05",
+                  "epochDate": 1604579840,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001656472-20-000093&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-11-05",
+                  "epochDate": 1604579641,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001656472-20-000092&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-09-09",
+                  "epochDate": 1599656772,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001656472-20-000079&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-08-06",
+                  "epochDate": 1596717503,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001656472-20-000073&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-08-06",
+                  "epochDate": 1596717231,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001656472-20-000072&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-07-20",
+                  "epochDate": 1595250075,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001656472-20-000065&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-07-09",
+                  "epochDate": 1594330444,
+                  "type": "8-K",
+                  "title": "Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001656472-20-000063&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-06-25",
+                  "epochDate": 1593123828,
+                  "type": "8-K",
+                  "title": "Submission of Matters to a Vote of Security Holders, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001656472-20-000058&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-08",
+                  "epochDate": 1588937995,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001656472-20-000052&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-08",
+                  "epochDate": 1588937574,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and Exhibit",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001171843-20-003537&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-03-30",
+                  "epochDate": 1585599740,
+                  "type": "10-K/A",
+                  "title": "Annual Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001656472-20-000033&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-03-30",
+                  "epochDate": 1585598973,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Regulation FD Disclosure, Financ",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001656472-20-000031&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-03-17",
+                  "epochDate": 1584479569,
+                  "type": "8-K",
+                  "title": "Disclosing Change in Directors or Principal Officers",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001656472-20-000019&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-01-22",
+                  "epochDate": 1579728712,
+                  "type": "8-K",
+                  "title": "Disclosing Change in Directors or Principal Officers",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001656472-20-000005&nav=1&src=Yahoo",
+                  "maxAge": 1
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-secFilings-EPAC.json
+++ b/tests/http/quoteSummary-secFilings-EPAC.json
@@ -1,0 +1,342 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=secFilings"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "ak7ho21g2vseu"
+      ],
+      "x-yahoo-request-id": [
+        "ak7ho21g2vseu"
+      ],
+      "x-request-id": [
+        "7442f736-6c88-4c83-b2b7-e033edf06aa4"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "5"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:05 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "secFilings": {
+              "filings": [
+                {
+                  "date": "2021-01-20",
+                  "epochDate": 1611165669,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers, Submission of Matters to a Vote of Security Holders, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-21-000008&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-01-05",
+                  "epochDate": 1609882964,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-21-000003&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-12-21",
+                  "epochDate": 1608557489,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001157523-20-001615&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-11-19",
+                  "epochDate": 1605783694,
+                  "type": "8-K",
+                  "title": "Changes in Registrant's Certifying Accountant",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-20-000048&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-26",
+                  "epochDate": 1603749650,
+                  "type": "10-K",
+                  "title": "Annual Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-20-000046&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-09-30",
+                  "epochDate": 1601472687,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001157523-20-001277&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-07-31",
+                  "epochDate": 1596231144,
+                  "type": "8-K",
+                  "title": "Amendments to Articles of Inc. or Bylaws; Change in Fiscal Year, Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001157523-20-001094&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-07-01",
+                  "epochDate": 1593630817,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-20-000039&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-06-25",
+                  "epochDate": 1593091882,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001157523-20-000933&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-06-15",
+                  "epochDate": 1592259576,
+                  "type": "8-K",
+                  "title": "Creation of a Direct Financial Obligation or an Obligation under an Off-Balance Sheet Arrangement of a Registrant",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-20-000026&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-14",
+                  "epochDate": 1589490150,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001157523-20-000748&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-05",
+                  "epochDate": 1588673209,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-20-000022&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-08",
+                  "epochDate": 1586349081,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001157523-20-000482&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-03-25",
+                  "epochDate": 1585153420,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-20-000020&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-03-19",
+                  "epochDate": 1584630829,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Regulation FD Disclosure, ",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001157523-20-000381&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-01-30",
+                  "epochDate": 1580421873,
+                  "type": "8-K/A",
+                  "title": "ENERPAC TOOL GROUP CORP FILES (8-K/A) Disclosing Amendments to Articles of Inc. or Bylaws; Change in Fiscal Year",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-20-000011&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-01-30",
+                  "epochDate": 1580410160,
+                  "type": "8-K",
+                  "title": "Disclosing Amendments to Articles of Inc. or Bylaws; Change in Fiscal Year",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-20-000008&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-01-06",
+                  "epochDate": 1578346014,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-20-000003&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-12-19",
+                  "epochDate": 1576762299,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001157523-19-002360&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-05",
+                  "epochDate": 1572970227,
+                  "type": "8-K",
+                  "title": "Disclosing Change in Directors or Principal Officers",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-19-000037&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-01",
+                  "epochDate": 1572622541,
+                  "type": "8-K",
+                  "title": "Disclosing Completion of Acquisition or Disposition of Assets, Other Events, Financial Statemen",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001157523-19-002172&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-10-30",
+                  "epochDate": 1572450764,
+                  "type": "8-K",
+                  "title": "Disclosing Amendments to Articles of Inc. or Bylaws; Change in Fiscal Year, Financial Statement",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-19-000035&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-10-29",
+                  "epochDate": 1572343481,
+                  "type": "10-K",
+                  "title": "Annual Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-19-000033&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-09-27",
+                  "epochDate": 1569596567,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-19-000030&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-09-26",
+                  "epochDate": 1569501070,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001157523-19-002008&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-08-07",
+                  "epochDate": 1565191960,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-19-000028&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-07-31",
+                  "epochDate": 1564595235,
+                  "type": "8-K",
+                  "title": "Disclosing Change in Directors or Principal Officers, Other Events, Financial Statements and Ex",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-19-000026&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-07-22",
+                  "epochDate": 1563807526,
+                  "type": "8-K",
+                  "title": "Disclosing Change in Directors or Principal Officers, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-19-000024&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-07-18",
+                  "epochDate": 1563449314,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-19-000022&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-07-09",
+                  "epochDate": 1562673713,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Material Impairments, Regulation FD Disc",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001157523-19-001508&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-07-01",
+                  "epochDate": 1561975814,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0000006955-19-000020&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-06-26",
+                  "epochDate": 1561552289,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001157523-19-001440&nav=1&src=Yahoo",
+                  "maxAge": 1
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-secFilings-MDLY.json
+++ b/tests/http/quoteSummary-secFilings-MDLY.json
@@ -1,0 +1,278 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=secFilings"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "00iehghg2vset"
+      ],
+      "x-yahoo-request-id": [
+        "00iehghg2vset"
+      ],
+      "x-request-id": [
+        "60f90021-cd5b-44f2-a055-4d0d11a04a30"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1090"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:05 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "secFilings": {
+              "filings": [
+                {
+                  "date": "2021-02-16",
+                  "epochDate": 1613511368,
+                  "type": "8-K",
+                  "title": "Triggering Events That Accelerate or Increase a Direct Financial Obligation or an Obligation under an Off-Balance Sheet Arrangement",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001437749-21-003006&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-02-09",
+                  "epochDate": 1612905812,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers, Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001437749-21-002335&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-02-02",
+                  "epochDate": 1612263998,
+                  "type": "8-K",
+                  "title": "Triggering Events That Accelerate or Increase a Direct Financial Obligation or an Obligation under an Off-Balance Sheet Arrangement",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001437749-21-001699&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-01-19",
+                  "epochDate": 1611095408,
+                  "type": "8-K",
+                  "title": "Triggering Events That Accelerate or Increase a Direct Financial Obligation or an Obligation under an Off-Balance Sheet Arrangement, Unregistered Sale of Equity Securities, Change in Directors or Principal Officers",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001437749-21-000889&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-11-24",
+                  "epochDate": 1606256428,
+                  "type": "8-K",
+                  "title": "Other Events",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-20-000046&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-11-16",
+                  "epochDate": 1605526545,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-20-000039&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-11-16",
+                  "epochDate": 1605526078,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-20-000037&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-22",
+                  "epochDate": 1603403147,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers, Amendments to Articles of Inc. or Bylaws; Change in Fiscal Year, Submission of Matters to a Vote of Security Holders, Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-20-000035&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-08-14",
+                  "epochDate": 1597442037,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-20-000025&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-08-14",
+                  "epochDate": 1597441613,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-20-000024&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-15",
+                  "epochDate": 1589575423,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-20-000019&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-15",
+                  "epochDate": 1589575228,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-20-000018&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-05",
+                  "epochDate": 1588682528,
+                  "type": "8-K",
+                  "title": "Disclosing Termination of a Material Definitive Agreement, Financial Statements and E",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001213900-20-010961&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-23",
+                  "epochDate": 1587674506,
+                  "type": "8-K",
+                  "title": "Disclosing Notice of Delisting or Failure to Satisfy a Continued Listing Rule or Stan",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-20-000010&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-03-30",
+                  "epochDate": 1585562909,
+                  "type": "10-K",
+                  "title": "Annual Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-20-000006&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-03-30",
+                  "epochDate": 1585562908,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-20-000007&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-14",
+                  "epochDate": 1573766649,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-19-000047&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-14",
+                  "epochDate": 1573766303,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-19-000046&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-10-29",
+                  "epochDate": 1572343509,
+                  "type": "8-K",
+                  "title": "Disclosing Other Events",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001213900-19-021319&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-08-14",
+                  "epochDate": 1565813757,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-19-000042&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-08-14",
+                  "epochDate": 1565813391,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-19-000041&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-08-02",
+                  "epochDate": 1564780767,
+                  "type": "8-K",
+                  "title": "Disclosing Entry into a Material Definitive Agreement, Financial Statements and Exhib",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001213900-19-014504&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-07-29",
+                  "epochDate": 1564400949,
+                  "type": "8-K",
+                  "title": "Disclosing Change in Directors or Principal Officers, Other Events, Financial Stateme",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001213900-19-013820&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-05-31",
+                  "epochDate": 1559333651,
+                  "type": "8-K",
+                  "title": "Disclosing Change in Directors or Principal Officers, Submission of Matters to a Vote",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001611110-19-000029&nav=1&src=Yahoo",
+                  "maxAge": 1
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-secFilings-SI.json
+++ b/tests/http/quoteSummary-secFilings-SI.json
@@ -1,0 +1,342 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=secFilings"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "5l82hudg2vset"
+      ],
+      "x-yahoo-request-id": [
+        "5l82hudg2vset"
+      ],
+      "x-request-id": [
+        "4a053abe-9832-4036-ad23-4816e8908e52"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:05 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "secFilings": {
+              "filings": [
+                {
+                  "date": "2021-02-17",
+                  "epochDate": 1613601023,
+                  "type": "8-K",
+                  "title": "Other Events",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-21-000026&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-01-28",
+                  "epochDate": 1611868524,
+                  "type": "8-K",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-21-000017&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-01-25",
+                  "epochDate": 1611613361,
+                  "type": "8-K",
+                  "title": "Entry into a Material Definitive Agreement, Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-21-007264&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-01-22",
+                  "epochDate": 1611332199,
+                  "type": "8-K",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-21-000010&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-01-20",
+                  "epochDate": 1611178399,
+                  "type": "8-K",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001104659-21-005855&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-01-20",
+                  "epochDate": 1611176650,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-21-000008&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2021-01-12",
+                  "epochDate": 1610460116,
+                  "type": "8-K",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-21-000006&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-11-20",
+                  "epochDate": 1605878768,
+                  "type": "8-K",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000153&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-11-10",
+                  "epochDate": 1605042651,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000150&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-29",
+                  "epochDate": 1604005600,
+                  "type": "8-K",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000146&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-26",
+                  "epochDate": 1603711694,
+                  "type": "8-K",
+                  "title": "Results of Operations and Financial Condition, Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000142&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-13",
+                  "epochDate": 1602623893,
+                  "type": "8-K",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000137&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-10-06",
+                  "epochDate": 1601991249,
+                  "type": "8-K",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000135&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-08-11",
+                  "epochDate": 1597180409,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000125&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-08-10",
+                  "epochDate": 1597094145,
+                  "type": "8-K",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000121&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-07-30",
+                  "epochDate": 1596117405,
+                  "type": "8-K",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000109&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-07-15",
+                  "epochDate": 1594849919,
+                  "type": "8-K",
+                  "title": "Change in Directors or Principal Officers, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000099&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-07-13",
+                  "epochDate": 1594674899,
+                  "type": "8-K",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000095&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-06-16",
+                  "epochDate": 1592341966,
+                  "type": "8-K",
+                  "title": "Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000088&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-06-02",
+                  "epochDate": 1591102186,
+                  "type": "8-K",
+                  "title": "Disclosing Submission of Matters to a Vote of Security Holders",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000056&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-12",
+                  "epochDate": 1589316194,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000041&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-05-05",
+                  "epochDate": 1588672961,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000037&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-29",
+                  "epochDate": 1588156121,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Regulation FD Disclosure, ",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000035&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-04-16",
+                  "epochDate": 1587042217,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000028&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-03-10",
+                  "epochDate": 1583871811,
+                  "type": "10-K",
+                  "title": "Annual Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000020&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-02-04",
+                  "epochDate": 1580851173,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000015&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-01-29",
+                  "epochDate": 1580297803,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Change in Directors or Pri",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000012&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-01-15",
+                  "epochDate": 1579122854,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000009&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2020-01-14",
+                  "epochDate": 1579036654,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-20-000006&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-12-04",
+                  "epochDate": 1575496467,
+                  "type": "10-Q",
+                  "title": "Quarterly Report",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-19-000064&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-12-04",
+                  "epochDate": 1575494130,
+                  "type": "8-K",
+                  "title": "Disclosing Results of Operations and Financial Condition, Financial Statements and E",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001312109-19-000062&nav=1&src=Yahoo",
+                  "maxAge": 1
+                },
+                {
+                  "date": "2019-11-18",
+                  "epochDate": 1574080314,
+                  "type": "8-K",
+                  "title": "Disclosing Regulation FD Disclosure, Other Events, Financial Statements and Exhibits",
+                  "edgarUrl": "https://yahoo.brand.edgar-online.com/DisplayFiling.aspx?TabIndex=2&dcn=0001193125-19-293950&nav=1&src=Yahoo",
+                  "maxAge": 1
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryDetail-ABBV.json
+++ b/tests/http/quoteSummary-summaryDetail-ABBV.json
@@ -1,0 +1,124 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=summaryDetail"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "59r35ilg2vseu"
+      ],
+      "x-yahoo-request-id": [
+        "59r35ilg2vseu"
+      ],
+      "x-request-id": [
+        "74e48c06-d8d5-445e-b27e-5b40a64316f4"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "526"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:06 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 106.06,
+              "open": 106.23,
+              "dayLow": 104.91,
+              "dayHigh": 106.35,
+              "regularMarketPreviousClose": 106.06,
+              "regularMarketOpen": 106.23,
+              "regularMarketDayLow": 104.91,
+              "regularMarketDayHigh": 106.35,
+              "dividendRate": 5.2,
+              "dividendYield": 0.049000002,
+              "exDividendDate": 1610582400,
+              "payoutRatio": 1.8053,
+              "fiveYearAvgDividendYield": 4.14,
+              "beta": 0.80683,
+              "trailingPE": 38.8125,
+              "forwardPE": 7.6778183,
+              "volume": 2383616,
+              "regularMarketVolume": 2383616,
+              "averageVolume": 7408847,
+              "averageVolume10days": 5676571,
+              "averageDailyVolume10Day": 5676571,
+              "bid": 105.64,
+              "ask": 105.65,
+              "bidSize": 1200,
+              "askSize": 800,
+              "marketCap": 186380664832,
+              "fiftyTwoWeekLow": 62.55,
+              "fiftyTwoWeekHigh": 113.41,
+              "priceToSalesTrailing12Months": 4.0690913,
+              "fiftyDayAverage": 107.234245,
+              "twoHundredDayAverage": 97.44348,
+              "trailingAnnualDividendRate": 4.84,
+              "trailingAnnualDividendYield": 0.04563455,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryDetail-BRKS.json
+++ b/tests/http/quoteSummary-summaryDetail-BRKS.json
@@ -1,0 +1,124 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=summaryDetail"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "1i0no8dg2vsev"
+      ],
+      "x-yahoo-request-id": [
+        "1i0no8dg2vsev"
+      ],
+      "x-request-id": [
+        "a8fe5f71-9342-4721-a7c3-f105b2665bf9"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "522"
+      ],
+      "x-envoy-upstream-service-time": [
+        "5"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:06 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 82.99,
+              "open": 84.56,
+              "dayLow": 84.56,
+              "dayHigh": 87.9,
+              "regularMarketPreviousClose": 82.99,
+              "regularMarketOpen": 84.56,
+              "regularMarketDayLow": 84.56,
+              "regularMarketDayHigh": 87.9,
+              "dividendRate": 0.4,
+              "dividendYield": 0.0047999998,
+              "exDividendDate": 1614816000,
+              "payoutRatio": 0.3774,
+              "fiveYearAvgDividendYield": 1.62,
+              "beta": 1.930096,
+              "trailingPE": 83.537285,
+              "forwardPE": 38.493393,
+              "volume": 146528,
+              "regularMarketVolume": 146528,
+              "averageVolume": 865460,
+              "averageVolume10days": 520785,
+              "averageDailyVolume10Day": 520785,
+              "bid": 87.55,
+              "ask": 87.74,
+              "bidSize": 1300,
+              "askSize": 1000,
+              "marketCap": 6485351936,
+              "fiftyTwoWeekLow": 21.19,
+              "fiftyTwoWeekHigh": 91.78,
+              "priceToSalesTrailing12Months": 6.9267526,
+              "fiftyDayAverage": 78.746666,
+              "twoHundredDayAverage": 62.45348,
+              "trailingAnnualDividendRate": 0.4,
+              "trailingAnnualDividendYield": 0.004819858,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryDetail-CRON.json
+++ b/tests/http/quoteSummary-summaryDetail-CRON.json
@@ -1,0 +1,117 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=summaryDetail"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "8tposspg2vsev"
+      ],
+      "x-yahoo-request-id": [
+        "8tposspg2vsev"
+      ],
+      "x-request-id": [
+        "fc7be8bb-9541-49b2-b0c9-580b222384b4"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "429"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:06 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 11.72,
+              "open": 11.79,
+              "dayLow": 11.77,
+              "dayHigh": 12.38,
+              "regularMarketPreviousClose": 11.72,
+              "regularMarketOpen": 11.79,
+              "regularMarketDayLow": 11.77,
+              "regularMarketDayHigh": 12.38,
+              "payoutRatio": 0,
+              "beta": 1.990234,
+              "trailingPE": 42.352264,
+              "volume": 2580169,
+              "regularMarketVolume": 2580169,
+              "averageVolume": 6821504,
+              "averageVolume10days": 16615528,
+              "averageDailyVolume10Day": 16615528,
+              "bid": 12.17,
+              "ask": 12.18,
+              "bidSize": 900,
+              "askSize": 1400,
+              "marketCap": 4318755840,
+              "fiftyTwoWeekLow": 4,
+              "fiftyTwoWeekHigh": 15.83,
+              "priceToSalesTrailing12Months": 116.783104,
+              "fiftyDayAverage": 10.839394,
+              "twoHundredDayAverage": 7.409601,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryDetail-EPAC.json
+++ b/tests/http/quoteSummary-summaryDetail-EPAC.json
@@ -1,0 +1,120 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=summaryDetail"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "b9hskclg2vsev"
+      ],
+      "x-yahoo-request-id": [
+        "b9hskclg2vsev"
+      ],
+      "x-request-id": [
+        "4bb9afb3-ac94-41f4-9ddc-63d087d885b0"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "465"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:07 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 22.66,
+              "open": 22.79,
+              "dayLow": 22.77,
+              "dayHigh": 23.3,
+              "regularMarketPreviousClose": 22.66,
+              "regularMarketOpen": 22.79,
+              "regularMarketDayLow": 22.77,
+              "regularMarketDayHigh": 23.3,
+              "dividendRate": 0.04,
+              "dividendYield": 0.0018000001,
+              "exDividendDate": 1601510400,
+              "payoutRatio": 0.6667,
+              "fiveYearAvgDividendYield": 0.17,
+              "beta": 1.450373,
+              "volume": 62262,
+              "regularMarketVolume": 62262,
+              "averageVolume": 299491,
+              "averageVolume10days": 263085,
+              "averageDailyVolume10Day": 263085,
+              "bid": 23.21,
+              "ask": 23.24,
+              "bidSize": 800,
+              "askSize": 800,
+              "marketCap": 1394996608,
+              "fiftyTwoWeekLow": 13.28,
+              "fiftyTwoWeekHigh": 25.6,
+              "priceToSalesTrailing12Months": 2.9932466,
+              "fiftyDayAverage": 22.127274,
+              "twoHundredDayAverage": 21.097826,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryDetail-MDLY.json
+++ b/tests/http/quoteSummary-summaryDetail-MDLY.json
@@ -1,0 +1,120 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=summaryDetail"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "bhla275g2vseu"
+      ],
+      "x-yahoo-request-id": [
+        "bhla275g2vseu"
+      ],
+      "x-request-id": [
+        "30ac6556-5383-4c1b-aef8-1321b4464d09"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "477"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:06 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 10.11,
+              "open": 10.22,
+              "dayLow": 10.14,
+              "dayHigh": 10.42,
+              "regularMarketPreviousClose": 10.11,
+              "regularMarketOpen": 10.22,
+              "regularMarketDayLow": 10.14,
+              "regularMarketDayHigh": 10.42,
+              "exDividendDate": 1585267200,
+              "fiveYearAvgDividendYield": 14.12,
+              "beta": 1.89381,
+              "forwardPE": 41.648,
+              "volume": 19267,
+              "regularMarketVolume": 19267,
+              "averageVolume": 205062,
+              "averageVolume10days": 167414,
+              "averageDailyVolume10Day": 167414,
+              "bid": 10.3,
+              "ask": 10.41,
+              "bidSize": 1400,
+              "askSize": 1200,
+              "marketCap": 59543104,
+              "fiftyTwoWeekLow": 2.8,
+              "fiftyTwoWeekHigh": 29,
+              "priceToSalesTrailing12Months": 1.6806792,
+              "fiftyDayAverage": 9.882728,
+              "twoHundredDayAverage": 7.6748624,
+              "trailingAnnualDividendRate": 0.03,
+              "trailingAnnualDividendYield": 0.002967359,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryDetail-SI.json
+++ b/tests/http/quoteSummary-summaryDetail-SI.json
@@ -1,0 +1,117 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=summaryDetail"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "a4poek1g2vseu"
+      ],
+      "x-yahoo-request-id": [
+        "a4poek1g2vseu"
+      ],
+      "x-request-id": [
+        "84a67d83-86d1-4738-9ea0-c5ec4430a2e8"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "443"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:06 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryDetail": {
+              "maxAge": 1,
+              "priceHint": 2,
+              "previousClose": 153.75,
+              "open": 157.91,
+              "dayLow": 154.0101,
+              "dayHigh": 174.5,
+              "regularMarketPreviousClose": 153.75,
+              "regularMarketOpen": 157.91,
+              "regularMarketDayLow": 154.0101,
+              "regularMarketDayHigh": 174.5,
+              "payoutRatio": 0,
+              "trailingPE": 126.57345,
+              "forwardPE": 68.581635,
+              "volume": 571007,
+              "regularMarketVolume": 571007,
+              "averageVolume": 1145291,
+              "averageVolume10days": 1460285,
+              "averageDailyVolume10Day": 1460285,
+              "bid": 171.5,
+              "ask": 172.21,
+              "bidSize": 3100,
+              "askSize": 1400,
+              "marketCap": 3928008448,
+              "fiftyTwoWeekLow": 7.6,
+              "fiftyTwoWeekHigh": 187.864,
+              "priceToSalesTrailing12Months": 43.705727,
+              "fiftyDayAverage": 99.940605,
+              "twoHundredDayAverage": 43.128407,
+              "currency": "USD",
+              "fromCurrency": null,
+              "toCurrency": null,
+              "lastMarket": null,
+              "algorithm": null,
+              "tradeable": false
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryProfile-ABBV.json
+++ b/tests/http/quoteSummary-summaryProfile-ABBV.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=summaryProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "4ooaru9g2vsev"
+      ],
+      "x-yahoo-request-id": [
+        "4ooaru9g2vsev"
+      ],
+      "x-request-id": [
+        "2cdb6df0-e6ef-4669-b58e-f0250498b52a"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1327"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:07 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "2"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryProfile": {
+              "address1": "1 North Waukegan Road",
+              "city": "North Chicago",
+              "state": "IL",
+              "zip": "60064",
+              "country": "United States",
+              "phone": "847 932 7900",
+              "website": "http://www.abbvie.com",
+              "industry": "Drug Manufacturers—General",
+              "sector": "Healthcare",
+              "longBusinessSummary": "AbbVie Inc. discovers, develops, manufactures, and sells pharmaceuticals in the United States, Japan, Germany, Canada, France, Spain, Italy, the Netherlands, the United Kingdom, Brazil, and internationally. The company offers HUMIRA, a therapy administered as an injection for autoimmune and intestinal BehÃ§et's diseases; SKYRIZI to treat moderate to severe plaque psoriasis in adults; RINVOQ, a JAK inhibitor for the treatment of moderate to severe active rheumatoid arthritis in adult patients; IMBRUVICA to treat adult patients with chronic lymphocytic leukemia (CLL), small lymphocytic lymphoma (SLL), mantle cell lymphoma, waldenstrÃ¶m's macroglobulinemia, marginal zone lymphoma, and chronic graft versus host disease; VENCLEXTA, a BCL-2 inhibitor used to treat adults with CLL or SLL; VIEKIRA PAK, an interferon-free therapy to treat adults with genotype 1 chronic hepatitis C virus (HCV); TECHNIVIE to treat adults with genotype 4 HCV infection; and MAVYRET to treat patients with chronic HCV genotype 1-6 infection. It also provides SYNAGIS that protects at-risk infants from severe respiratory disease; KALETRA, a prescription anti-HIV-1 medicine; CREON, a pancreatic enzyme therapy for exocrine pancreatic insufficiency; Synthroid used in the treatment of hypothyroidism; AndroGel for males diagnosed with symptomatic low testosterone; and Lupron, a product for the palliative treatment of advanced prostate cancer, endometriosis and central precocious puberty, and patients with anemia caused by uterine fibroids. In addition, the company offers ORILISSA, a nonpeptide small molecule gonadotropin-releasing hormone antagonist; Duopa and Duodopa, a levodopa-carbidopa intestinal gel to treat Parkinson's disease; and Sevoflurane, an anesthesia product. It has collaborations with Calico Life Sciences LLC; Alector, Inc.; Janssen Biotech, Inc.; Frontier Medicines, Corp.; Jacobio Pharmaceuticals; I-Mab; and Genmab A/S. The company was incorporated in 2012 and is based in North Chicago, Illinois.",
+              "companyOfficers": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryProfile-BRKS.json
+++ b/tests/http/quoteSummary-summaryProfile-BRKS.json
@@ -1,0 +1,97 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=summaryProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "4g0miclg2vsf0"
+      ],
+      "x-yahoo-request-id": [
+        "4g0miclg2vsf0"
+      ],
+      "x-request-id": [
+        "408cc650-9726-4a31-9d5f-64241ba95228"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1126"
+      ],
+      "x-envoy-upstream-service-time": [
+        "1"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:08 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryProfile": {
+              "address1": "15 Elizabeth Drive",
+              "city": "Chelmsford",
+              "state": "MA",
+              "zip": "01824",
+              "country": "United States",
+              "phone": "978 262 2400",
+              "fax": "978 262 2500",
+              "website": "http://www.brooks.com",
+              "industry": "Semiconductor Equipment & Materials",
+              "sector": "Technology",
+              "longBusinessSummary": "Brooks Automation, Inc. provides manufacturing automation solutions for the semiconductor industry, and life science sample-based services and solutions for the life sciences market worldwide. The company operates in three segments: Brooks Semiconductor Solutions Group, Brooks Life Sciences Services, and Brooks Life Sciences Products. The Brooks Semiconductor Solutions Group segment offers wafer automation and contamination controls solutions and services. Its products include atmospheric and vacuum robots, robotic modules, and tool automation systems that offer precision handling and clean wafer environments; and automated cleaning and inspection systems for wafer carriers, reticle pod cleaners, and stockers. It also offers repair and refurbishment, diagnostics, and installation services, as well as spare parts and productivity enhancement upgrade services. The Brooks Life Sciences Services segment provides gene sequencing and gene synthesis services, including next generation sequencing, sanger sequencing, gene synthesis, bioinformatics, and good laboratory practices regulatory services; on-site and off-site sample storage, cold chain logistics, sample transport and collection relocation, bio-processing solutions, disaster recovery, and business continuity, as well as project management and consulting services; and sample intelligence software solutions and integration of customer technology. The Brooks Life Sciences Products segment offers automated cold storage systems; consumables, such as various formats of racks, tubes, caps, plates, and foils used for the storage and handling of samples in cold storage environments; and instruments used for labeling, bar coding, capping, de-capping, auditing, sealing, peeling, and piercing tubes and plates. The company serves semiconductor capital equipment and life sciences sample management markets in approximately 50 countries. Brooks Automation, Inc. was founded in 1978 and is headquartered in Chelmsford, Massachusetts.",
+              "fullTimeEmployees": 3200,
+              "companyOfficers": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryProfile-CRON.json
+++ b/tests/http/quoteSummary-summaryProfile-CRON.json
@@ -1,0 +1,97 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=summaryProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "fmj6ghhg2vsf0"
+      ],
+      "x-yahoo-request-id": [
+        "fmj6ghhg2vsf0"
+      ],
+      "x-request-id": [
+        "df615b22-13e3-4453-9490-037cb74c59cf"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "646"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:08 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryProfile": {
+              "address1": "720 King Street West",
+              "address2": "Suite 320",
+              "city": "Toronto",
+              "state": "ON",
+              "zip": "M5V 2T3",
+              "country": "Canada",
+              "phone": "416-504-0004",
+              "website": "http://www.thecronosgroup.com",
+              "industry": "Drug Manufacturers—Specialty & Generic",
+              "sector": "Healthcare",
+              "longBusinessSummary": "Cronos Group Inc. operates as a cannabinoid company in the United States and internationally. It manufactures, markets, and distributes hemp-derived supplements and cosmetic products through ecommerce, retail, and hospitality partner channels. The company is also involved in the cultivation, manufacture, and marketing of cannabis and cannabis-derived products for the medical and adult-use markets. Its brand portfolio includes PEACE NATURALS, a global wellness platform; adult-use brands comprise COVE and Spinach; and hemp-derived CBD brands consists of Lord Jones and PEACE+. Cronos Group Inc. is based in Toronto, Canada.",
+              "fullTimeEmployees": 631,
+              "companyOfficers": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryProfile-EPAC.json
+++ b/tests/http/quoteSummary-summaryProfile-EPAC.json
@@ -1,0 +1,96 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=summaryProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "09oncb5g2vsf0"
+      ],
+      "x-yahoo-request-id": [
+        "09oncb5g2vsf0"
+      ],
+      "x-request-id": [
+        "88385ecc-98be-4559-bed4-4067b536df7e"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "829"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:08 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryProfile": {
+              "address1": "N86 W12500 Westbrook Crossing",
+              "city": "Menomonee Falls",
+              "state": "WI",
+              "zip": "53051",
+              "country": "United States",
+              "phone": "262 293 1500",
+              "website": "http://www.enerpactoolgroup.com",
+              "industry": "Specialty Industrial Machinery",
+              "sector": "Industrials",
+              "longBusinessSummary": "Enerpac Tool Group Corp. manufactures and sells a range of industrial products and solutions worldwide. It operates in two segments, Industrial Tools & Services (IT&S) and Other. The IT&S segment designs, manufactures, and distributes branded hydraulic and mechanical tools; and provides services and tool rentals to the industrial, maintenance, infrastructure, oil and gas, energy, and other markets. It also offers branded tools and engineered heavy lifting technology solutions, and hydraulic torque wrenches; energy maintenance and manpower services; high-force hydraulic and mechanical tools, including cylinders, pumps, valves, and specialty tools; and bolt tensioners and other miscellaneous products. This segment markets its branded tools and services primarily under the Enerpac, Hydratight, Larzep, and Simplex brands. The Other segment designs and manufactures synthetic ropes and biomedical assemblies. The company was formerly known as Actuant Corporation and changed its name to Enerpac Tool Group Corp. in January 2020. Enerpac Tool Group Corp. was founded in 1910 and is headquartered in Menomonee Falls, Wisconsin.",
+              "fullTimeEmployees": 2300,
+              "companyOfficers": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryProfile-MDLY.json
+++ b/tests/http/quoteSummary-summaryProfile-MDLY.json
@@ -1,0 +1,97 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=summaryProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "d2dmhalg2vsev"
+      ],
+      "x-yahoo-request-id": [
+        "d2dmhalg2vsev"
+      ],
+      "x-request-id": [
+        "df015ce1-33a2-487a-ade4-cfc3c0148304"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "420"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:07 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryProfile": {
+              "address1": "280 Park Avenue",
+              "address2": "6th Floor East",
+              "city": "New York",
+              "state": "NY",
+              "zip": "10017",
+              "country": "United States",
+              "phone": "212-759-0777",
+              "website": "http://www.mdly.com",
+              "industry": "Asset Management",
+              "sector": "Financial Services",
+              "longBusinessSummary": "Medley Management Inc. is an investment holding company and operate and control all of the business and affairs of Medley LLC and its subsidiaries. Medley Management Inc. was incorporated on June 13, 2014 and is based in New York, New York.",
+              "fullTimeEmployees": 65,
+              "companyOfficers": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-summaryProfile-SI.json
+++ b/tests/http/quoteSummary-summaryProfile-SI.json
@@ -1,0 +1,97 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=summaryProfile"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "8tl5695g2vsev"
+      ],
+      "x-yahoo-request-id": [
+        "8tl5695g2vsev"
+      ],
+      "x-request-id": [
+        "07c0f99d-a526-4863-a44a-c6cc15bc9d6e"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "687"
+      ],
+      "x-envoy-upstream-service-time": [
+        "2"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:07 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "summaryProfile": {
+              "address1": "4250 Executive Square",
+              "address2": "Suite 300",
+              "city": "La Jolla",
+              "state": "CA",
+              "zip": "92037",
+              "country": "United States",
+              "phone": "858-362-6300",
+              "website": "http://www.silvergatebank.com",
+              "industry": "Banks—Regional",
+              "sector": "Financial Services",
+              "longBusinessSummary": "Silvergate Capital Corporation operates as a bank holding company for Silvergate Bank that provides banking products and services to business and individual clients in the United States and internationally. The company accepts deposit products, including interest and noninterest bearing demand accounts, money market and savings accounts, and certificates of deposit accounts. Its loan products include one-to-four family real estate loans, multi-family real estate loans, commercial real estate loans, construction loans, commercial and industrial loans, mortgage warehouse loans, and reverse mortgage loans, as well as consumer loans and other loans secured by personal property. The company also provides cash management services for digital currency-related businesses. The company was founded in 1988 and is headquartered in La Jolla, California.",
+              "fullTimeEmployees": 218,
+              "companyOfficers": [],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-upgradeDowngradeHistory-ABBV.json
+++ b/tests/http/quoteSummary-upgradeDowngradeHistory-ABBV.json
@@ -1,0 +1,1017 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/ABBV?formatted=false&modules=upgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "9f3lb9hg2vsf1"
+      ],
+      "x-yahoo-request-id": [
+        "9f3lb9hg2vsf1"
+      ],
+      "x-request-id": [
+        "91f28c8a-5bfc-4784-9d03-6470e427ca5f"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:08 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "transfer-encoding": [
+        "chunked"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "upgradeDowngradeHistory": {
+              "history": [
+                {
+                  "epochGradeDate": 1612444417,
+                  "firm": "SVB Leerink",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1611838763,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1608118351,
+                  "firm": "SVB Leerink",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606744188,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1605696352,
+                  "firm": "BMO Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1605009332,
+                  "firm": "Bernstein",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1604322306,
+                  "firm": "SVB Leerink",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1603457553,
+                  "firm": "Truist Securities",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1602865351,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1601370668,
+                  "firm": "Berenberg",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1599052634,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1597922970,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1596462541,
+                  "firm": "Mizuho",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1596452036,
+                  "firm": "RBC Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1592907855,
+                  "firm": "Atlantic Equities",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1591104723,
+                  "firm": "Argus Research",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1589293439,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1589193617,
+                  "firm": "SVB Leerink",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588588230,
+                  "firm": "SVB Leerink",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1587380464,
+                  "firm": "RBC Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Sector Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1586785464,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1584957458,
+                  "firm": "Societe Generale",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1582808111,
+                  "firm": "Barclays",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1582029876,
+                  "firm": "Cowen & Co.",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1581337503,
+                  "firm": "Mizuho",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1580983772,
+                  "firm": "Mizuho",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1577366857,
+                  "firm": "Cowen & Co.",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1574259354,
+                  "firm": "Citi",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1574165810,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1569493972,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1568285548,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1567592868,
+                  "firm": "Piper Jaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1566298075,
+                  "firm": "Piper Jaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1561548212,
+                  "firm": "SVB Leerink",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1559043603,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1556533190,
+                  "firm": "BMO Capital",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "Underperformer",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1546519892,
+                  "firm": "Bank of America",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1545830036,
+                  "firm": "Standpoint Research",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1541516185,
+                  "firm": "Argus",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1541430524,
+                  "firm": "BMO Capital",
+                  "toGrade": "Underperform",
+                  "fromGrade": "Underperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1538668151,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1534954342,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1532959651,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1531397700,
+                  "firm": "Berenberg",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1528718826,
+                  "firm": "Argus",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1527856691,
+                  "firm": "PiperJaffray",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1527677434,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Underperform",
+                  "fromGrade": "Neutral",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1527078696,
+                  "firm": "BMO Capital",
+                  "toGrade": "Underperform",
+                  "fromGrade": "Underperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1525094105,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "Equal-Weight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1524833438,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Neutral",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1522950220,
+                  "firm": "Barclays",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "Equal-Weight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1521805591,
+                  "firm": "BMO Capital",
+                  "toGrade": "Underperform",
+                  "fromGrade": "Underperform",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1517583371,
+                  "firm": "Argus",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1517321253,
+                  "firm": "BMO Capital",
+                  "toGrade": "Underperform",
+                  "fromGrade": "Market Perform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1517322426,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "Equal-Weight",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1517234094,
+                  "firm": "Leerink Swann",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1510843001,
+                  "firm": "BMO Capital",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1509379355,
+                  "firm": "Leerink Swann",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1507913213,
+                  "firm": "Barclays",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1507894758,
+                  "firm": "UBS",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1507723223,
+                  "firm": "Cowen & Co.",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1507220245,
+                  "firm": "Leerink Swann",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1506945690,
+                  "firm": "Leerink Swann",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1506944848,
+                  "firm": "Leerink Swann",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1506337137,
+                  "firm": "UBS",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1505493521,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1502968716,
+                  "firm": "Evercore ISI Group",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1500309421,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1500307959,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1489152246,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1480344081,
+                  "firm": "Citigroup",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1477906447,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1476786217,
+                  "firm": "Leerink Swann",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1473310283,
+                  "firm": "JP Morgan",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1472796914,
+                  "firm": "Raymond James",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1465539883,
+                  "firm": "BMO Capital",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1465359521,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1465198474,
+                  "firm": "Cowen & Co.",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1459943194,
+                  "firm": "Societe Generale",
+                  "toGrade": "Sell",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1458013425,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1457329015,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1456201417,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1454653994,
+                  "firm": "William Blair",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1452779838,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1450428830,
+                  "firm": "Atlantic Equities",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1448945874,
+                  "firm": "Barclays",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1446452173,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Equal-Weight",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1443416557,
+                  "firm": "Citigroup",
+                  "toGrade": "",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1438150675,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1437549227,
+                  "firm": "SunTrust Robinson Humphrey",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1434472615,
+                  "firm": "PiperJaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1433748419,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1429866000,
+                  "firm": "BMO Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1428905117,
+                  "firm": "BMO Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1423462299,
+                  "firm": "Citigroup",
+                  "toGrade": "Sell",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1422954000,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1421398800,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1421312400,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1420761600,
+                  "firm": "Bank of America",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1418300965,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1417683600,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1415945061,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1415091600,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1415005200,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1413528428,
+                  "firm": "ISI Group",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1412230174,
+                  "firm": "Guggenheim",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1407360502,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1406537390,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1405691807,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1405381691,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1404281721,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Equal-weight",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1403296430,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1399445710,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Equal-weight",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1398322200,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1397510413,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1392964858,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1390804859,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1388472817,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1387435425,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Equal-weight",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1382709675,
+                  "firm": "BMO Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1381248000,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1525527134,
+                  "firm": "Argus",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1370591309,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1369729504,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1368607661,
+                  "firm": "Cowen & Co.",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1367224672,
+                  "firm": "BMO Capital",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1366611299,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Equal-Weight",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1365584976,
+                  "firm": "UBS",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1365579900,
+                  "firm": "Jefferies",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1365494839,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1365147616,
+                  "firm": "BMO Capital",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1364806405,
+                  "firm": "BMO Capital",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1362989132,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-upgradeDowngradeHistory-BRKS.json
+++ b/tests/http/quoteSummary-upgradeDowngradeHistory-BRKS.json
@@ -1,0 +1,485 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/BRKS?formatted=false&modules=upgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "9jbt84dg2vsf1"
+      ],
+      "x-yahoo-request-id": [
+        "9jbt84dg2vsf1"
+      ],
+      "x-request-id": [
+        "46d1c133-668b-40f5-9c0a-860a287d7d47"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "900"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:08 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "upgradeDowngradeHistory": {
+              "history": [
+                {
+                  "epochGradeDate": 1612951408,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612364233,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1612348099,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1605110698,
+                  "firm": "Stephens & Co.",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Equal-Weight",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1605102162,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1605095791,
+                  "firm": "Needham",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1605085293,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1604999142,
+                  "firm": "KeyBanc",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1600684623,
+                  "firm": "Stifel",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1596533779,
+                  "firm": "Needham",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1592822498,
+                  "firm": "Stifel",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1588349666,
+                  "firm": "Citigroup",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1588345551,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1586777922,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1586430717,
+                  "firm": "Needham",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1584700492,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1581343474,
+                  "firm": "Citigroup",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1573147433,
+                  "firm": "B. Riley",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1573144723,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1569240895,
+                  "firm": "Citigroup",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1564762274,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1556632844,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1542810590,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1542723863,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Neutral",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1537874344,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1536065070,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1531489051,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1525528839,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1525266233,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Neutral",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1525262323,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "Buy",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1513876510,
+                  "firm": "Stephens & Co.",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1510344803,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1510144846,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1505741265,
+                  "firm": "Needham",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1502102249,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1483961183,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Underperform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1483460244,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1476267631,
+                  "firm": "Citigroup",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1473807740,
+                  "firm": "Janney Capital",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1473662772,
+                  "firm": "Citigroup",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1457420331,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Underperform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1525528836,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1439550000,
+                  "firm": "Citigroup",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1435560550,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1415869200,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1415091600,
+                  "firm": "Citigroup",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1412670600,
+                  "firm": "Furey Research",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1404109560,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1403853516,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1525528836,
+                  "firm": "B. Riley FBR",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1398209548,
+                  "firm": "Citigroup",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1384762831,
+                  "firm": "Citigroup",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1377675441,
+                  "firm": "Northland Securities",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1357215341,
+                  "firm": "Barclays",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "Underweight",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1349180160,
+                  "firm": "Barclays",
+                  "toGrade": "Underweight",
+                  "fromGrade": "Equal-Weight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1349165700,
+                  "firm": "Barclays",
+                  "toGrade": "Underweight",
+                  "fromGrade": "Equal-Weight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1344607620,
+                  "firm": "Barclays",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "",
+                  "action": "main"
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-upgradeDowngradeHistory-CRON.json
+++ b/tests/http/quoteSummary-upgradeDowngradeHistory-CRON.json
@@ -1,0 +1,212 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/CRON?formatted=false&modules=upgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "auvn865g2vsf1"
+      ],
+      "x-yahoo-request-id": [
+        "auvn865g2vsf1"
+      ],
+      "x-request-id": [
+        "b23daa9e-450d-44e4-a46b-e8e0b47e502f"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "542"
+      ],
+      "x-envoy-upstream-service-time": [
+        "4"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:09 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "upgradeDowngradeHistory": {
+              "history": [
+                {
+                  "epochGradeDate": 1586858114,
+                  "firm": "Piper Sandler",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1585653085,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Sell",
+                  "fromGrade": "Hold",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1573657972,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1571746972,
+                  "firm": "Piper Jaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1565696606,
+                  "firm": "Piper Jaffray",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1565354890,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Hold",
+                  "fromGrade": "Sell",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1561724650,
+                  "firm": "Consumer Edge",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1559818772,
+                  "firm": "Stifel Nicolaus",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1559732645,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "Underperform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1555504220,
+                  "firm": "Bank of America",
+                  "toGrade": "Underperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1553687250,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Sell",
+                  "fromGrade": "Hold",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1553632930,
+                  "firm": "PI Financial",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1552307341,
+                  "firm": "BMO Capital",
+                  "toGrade": "Underperform",
+                  "fromGrade": "Market Perform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1551788043,
+                  "firm": "Cowen & Co.",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1551118944,
+                  "firm": "Jefferies",
+                  "toGrade": "Underperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1549372986,
+                  "firm": "GMP Securities",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1547822100,
+                  "firm": "CIBC",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1534329666,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Hold",
+                  "fromGrade": "Sell",
+                  "action": "up"
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-upgradeDowngradeHistory-EPAC.json
+++ b/tests/http/quoteSummary-upgradeDowngradeHistory-EPAC.json
@@ -1,0 +1,97 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/EPAC?formatted=false&modules=upgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "3m11rb1g2vsf1"
+      ],
+      "x-yahoo-request-id": [
+        "3m11rb1g2vsf1"
+      ],
+      "x-request-id": [
+        "42693db4-bbc7-4b70-a0c6-741dc8c57c5b"
+      ],
+      "content-length": [
+        "300"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:09 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "upgradeDowngradeHistory": {
+              "history": [
+                {
+                  "epochGradeDate": 1606297035,
+                  "firm": "Stifel",
+                  "toGrade": "Hold",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606297035,
+                  "firm": "Wells Fargo",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "",
+                  "action": "main"
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-upgradeDowngradeHistory-MDLY.json
+++ b/tests/http/quoteSummary-upgradeDowngradeHistory-MDLY.json
@@ -1,0 +1,254 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/MDLY?formatted=false&modules=upgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "49vbdatg2vsf0"
+      ],
+      "x-yahoo-request-id": [
+        "49vbdatg2vsf0"
+      ],
+      "x-request-id": [
+        "83e068dd-74e2-40aa-b923-628bc30acefd"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "405"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:08 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "2"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "upgradeDowngradeHistory": {
+              "history": [
+                {
+                  "epochGradeDate": 1606297020,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Neutral",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606297004,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1606297004,
+                  "firm": "Ladenburg Thalmann",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Compass Point",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Ladenburg Thalmann",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Keefe Bruyette & Woods",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Keefe Bruyette & Woods",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Keefe Bruyette & Woods",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Keefe Bruyette & Woods",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "FBR Capital",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Keefe Bruyette & Woods",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Neutral",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Keefe Bruyette & Woods",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Keefe Bruyette & Woods",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Keefe Bruyette & Woods",
+                  "toGrade": "Market Perform",
+                  "fromGrade": "Outperform",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Keefe Bruyette & Woods",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Gilford Securities",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Credit Suisse",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1606296975,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/quoteSummary-upgradeDowngradeHistory-SI.json
+++ b/tests/http/quoteSummary-upgradeDowngradeHistory-SI.json
@@ -1,0 +1,380 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v10/finance/quoteSummary/SI?formatted=false&modules=upgradeDowngradeHistory"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "cache-control": [
+        "public, max-age=1, stale-while-revalidate=9"
+      ],
+      "vary": [
+        "Origin,Accept-Encoding"
+      ],
+      "y-rid": [
+        "6oud4ppg2vsf0"
+      ],
+      "x-yahoo-request-id": [
+        "6oud4ppg2vsf0"
+      ],
+      "x-request-id": [
+        "7d3fb0ee-d672-4cab-a03f-aaaf18e6b405"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "907"
+      ],
+      "x-envoy-upstream-service-time": [
+        "3"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:14:08 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-company-fundamentals-api--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "quoteSummary": {
+        "result": [
+          {
+            "upgradeDowngradeHistory": {
+              "history": [
+                {
+                  "epochGradeDate": 1612458732,
+                  "firm": "Craig-Hallum",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1610627376,
+                  "firm": "Barclays",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1608636683,
+                  "firm": "Wedbush",
+                  "toGrade": "Outperform",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1608213697,
+                  "firm": "Keefe, Bruyette & Woods",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Market Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1606925964,
+                  "firm": "Craig-Hallum",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1606751191,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1603810743,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "main"
+                },
+                {
+                  "epochGradeDate": 1602849526,
+                  "firm": "Compass Point",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1584353166,
+                  "firm": "Canaccord Genuity",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1575285676,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1574080657,
+                  "firm": "Compass Point",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1415606400,
+                  "firm": "JP Morgan",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1408515831,
+                  "firm": "Goldman Sachs",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1405064577,
+                  "firm": "LBBW Research",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1405064288,
+                  "firm": "RBC Capital",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Sector Perform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1396944000,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1395233052,
+                  "firm": "UBS",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1395041376,
+                  "firm": "JP Morgan",
+                  "toGrade": "Overweight",
+                  "fromGrade": "",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1395041356,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1389888000,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Equal-Weight",
+                  "fromGrade": "Overweight",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1389342600,
+                  "firm": "Berenberg",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1384760022,
+                  "firm": "LBBW Research",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1384759980,
+                  "firm": "Mainfirst",
+                  "toGrade": "Underperform",
+                  "fromGrade": "",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1384416656,
+                  "firm": "Banco Sabadell",
+                  "toGrade": "Sell",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1383214628,
+                  "firm": "Commerzbank",
+                  "toGrade": "Hold",
+                  "fromGrade": "Add",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1381476786,
+                  "firm": "DZ Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1378452356,
+                  "firm": "Societe Generale",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1378370193,
+                  "firm": "Barclays",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Equal-Weight",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1378287044,
+                  "firm": "Exane BNP Paribas",
+                  "toGrade": "Outperform",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1377590268,
+                  "firm": "Kepler Cheuvreux",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "init"
+                },
+                {
+                  "epochGradeDate": 1375718400,
+                  "firm": "LBBW Research",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1375281738,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1373358756,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Hold",
+                  "fromGrade": "Sell",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1371641896,
+                  "firm": "Nomura",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1370249424,
+                  "firm": "Commerzbank",
+                  "toGrade": "Add",
+                  "fromGrade": "Hold",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1365580525,
+                  "firm": "Exane BNP Paribas",
+                  "toGrade": "Neutral",
+                  "fromGrade": "Underperform",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1363775998,
+                  "firm": "Morgan Stanley",
+                  "toGrade": "Overweight",
+                  "fromGrade": "Equal-weight",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1363587670,
+                  "firm": "Bank of America",
+                  "toGrade": "Buy",
+                  "fromGrade": "Neutral",
+                  "action": "up"
+                },
+                {
+                  "epochGradeDate": 1353425280,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Sell",
+                  "fromGrade": "Hold",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1350030360,
+                  "firm": "Societe Generale",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1349885100,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Hold",
+                  "fromGrade": "Buy",
+                  "action": "down"
+                },
+                {
+                  "epochGradeDate": 1337928240,
+                  "firm": "Deutsche Bank",
+                  "toGrade": "Buy",
+                  "fromGrade": "",
+                  "action": "up"
+                }
+              ],
+              "maxAge": 86400
+            }
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-ABBV.json
+++ b/tests/http/recommendationsBySymbol-ABBV.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/ABBV?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "931g14pg2vsdu"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "159"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:34 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "ABBV",
+            "recommendedSymbols": [
+              {
+                "symbol": "ABT",
+                "score": 0.156853
+              },
+              {
+                "symbol": "BMY",
+                "score": 0.113094
+              },
+              {
+                "symbol": "GILD",
+                "score": 0.106048
+              },
+              {
+                "symbol": "JNJ",
+                "score": 0.0976
+              },
+              {
+                "symbol": "CVS",
+                "score": 0.091156
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-BRKS.json
+++ b/tests/http/recommendationsBySymbol-BRKS.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/BRKS?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "eic2sa5g2vsdu"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "159"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:34 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "BRKS",
+            "recommendedSymbols": [
+              {
+                "symbol": "KLIC",
+                "score": 0.069275
+              },
+              {
+                "symbol": "MKSI",
+                "score": 0.068202
+              },
+              {
+                "symbol": "COHU",
+                "score": 0.06548
+              },
+              {
+                "symbol": "AEIS",
+                "score": 0.063985
+              },
+              {
+                "symbol": "ENTG",
+                "score": 0.063925
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-CRON.json
+++ b/tests/http/recommendationsBySymbol-CRON.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/CRON?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "fcpei39g2vsdu"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "161"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:34 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "CRON",
+            "recommendedSymbols": [
+              {
+                "symbol": "CGC",
+                "score": 0.242273
+              },
+              {
+                "symbol": "TLRY",
+                "score": 0.205267
+              },
+              {
+                "symbol": "ACB",
+                "score": 0.19063
+              },
+              {
+                "symbol": "APHA",
+                "score": 0.164549
+              },
+              {
+                "symbol": "HEXO",
+                "score": 0.10912
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-EPAC.json
+++ b/tests/http/recommendationsBySymbol-EPAC.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/EPAC?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "4d7t1spg2vsdu"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "157"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:34 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "EPAC",
+            "recommendedSymbols": [
+              {
+                "symbol": "HLIO",
+                "score": 0.030446
+              },
+              {
+                "symbol": "HNGR",
+                "score": 0.026301
+              },
+              {
+                "symbol": "NTUS",
+                "score": 0.025434
+              },
+              {
+                "symbol": "NBHC",
+                "score": 0.02491
+              },
+              {
+                "symbol": "GWB",
+                "score": 0.024666
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-MDLY.json
+++ b/tests/http/recommendationsBySymbol-MDLY.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/MDLY?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "1vs8ca5g2vsdt"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "161"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:34 GMT"
+      ],
+      "age": [
+        "2"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "MDLY",
+            "recommendedSymbols": [
+              {
+                "symbol": "OXBR",
+                "score": 0.050193
+              },
+              {
+                "symbol": "HUSN",
+                "score": 0.047772
+              },
+              {
+                "symbol": "SNMP",
+                "score": 0.040781
+              },
+              {
+                "symbol": "EVK",
+                "score": 0.040398
+              },
+              {
+                "symbol": "GRNQ",
+                "score": 0.039743
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/recommendationsBySymbol-SI.json
+++ b/tests/http/recommendationsBySymbol-SI.json
@@ -1,0 +1,95 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v6/finance/recommendationsbysymbol/SI?"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "x-yahoo-request-id": [
+        "ctsnv2pg2vsdt"
+      ],
+      "cache-control": [
+        "max-age=60, stale-while-revalidate=15, stale-if-error=3600"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-type": [
+        "application/json;charset=utf-8"
+      ],
+      "vary": [
+        "Origin"
+      ],
+      "content-length": [
+        "156"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:33 GMT"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "public-key-pins-report-only": [
+        "max-age=2592000; pin-sha256=\"2fRAUXyxl4A1/XHrKNBmc8bTkzA7y4FB/GLJuNAzCqY=\"; pin-sha256=\"I/Lt/z7ekCWanjD0Cvj5EqXls2lOaThEA0H2Bg4BT/o=\"; pin-sha256=\"K87oWBWM9UZfyddvDfoxL+8lpNyoUB2ptGtn0fv6G2Q=\"; pin-sha256=\"Wd8xe/qfTwq3ylFNd3IpaqLHZbh2ZNCLluVzmeNkcpw=\"; pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\"; pin-sha256=\"cGuxAXyFXFkWm61cF4HPWX8S0srS9j0aSqN0k4AP+4A=\"; pin-sha256=\"dolnbtzEBnELx/9lOEQ22e6OZO/QNb6VSSX2XHA3E7A=\"; pin-sha256=\"i7WTqTvh0OioIruIfFR4kMPnBqrS2rdiVPl/s2uC/CY=\"; pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\"; pin-sha256=\"uUwZgwDOxcBXrQcntwu+kYFpkiVkOaezL0WYEZ3anJc=\"; includeSubdomains; report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-hpkp-report-only\""
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "finance": {
+        "result": [
+          {
+            "symbol": "SI",
+            "recommendedSymbols": [
+              {
+                "symbol": "ABB",
+                "score": 0.034072
+              },
+              {
+                "symbol": "PHG",
+                "score": 0.030163
+              },
+              {
+                "symbol": "MSTR",
+                "score": 0.027149
+              },
+              {
+                "symbol": "TEF",
+                "score": 0.026293
+              },
+              {
+                "symbol": "RIOT",
+                "score": 0.022845
+              }
+            ]
+          }
+        ],
+        "error": null
+      }
+    }
+  }
+}

--- a/tests/http/search-ABBV.json
+++ b/tests/http/search-ABBV.json
@@ -1,0 +1,194 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v1/finance/search?lang=en-US&region=US&quotesCount=6&newsCount=4&enableFuzzyQuery=false&quotesQueryId=tss_match_phrase_query&multiQuoteQueryId=multi_quote_single_token_query&newsQueryId=news_cie_vespa&enableCb=true&enableNavLinks=true&enableEnhancedTrivialQuery=true&q=ABBV"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=120, stale-while-revalidate=180"
+      ],
+      "y-rid": [
+        "dnvbg81g2vsdu"
+      ],
+      "x-yahoo-request-id": [
+        "dnvbg81g2vsdu"
+      ],
+      "x-request-id": [
+        "311b2ce4-8525-4355-adf6-0b8e8380f7ef"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "992"
+      ],
+      "x-envoy-upstream-service-time": [
+        "25"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:34 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-search--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "explains": [],
+      "count": 11,
+      "quotes": [
+        {
+          "exchange": "NYQ",
+          "shortname": "AbbVie Inc.",
+          "quoteType": "EQUITY",
+          "symbol": "ABBV",
+          "index": "quotes",
+          "score": 19953200,
+          "typeDisp": "Equity",
+          "longname": "AbbVie Inc.",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "GER",
+          "shortname": "ABBVIE INC.  DL-,01",
+          "quoteType": "EQUITY",
+          "symbol": "4AB.DE",
+          "index": "quotes",
+          "score": 20169,
+          "typeDisp": "Equity",
+          "longname": "AbbVie Inc.",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "FRA",
+          "shortname": "ABBVIE INC.  DL-,01",
+          "quoteType": "EQUITY",
+          "symbol": "4AB.F",
+          "index": "quotes",
+          "score": 20029,
+          "typeDisp": "Equity",
+          "longname": "AbbVie Inc.",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "MEX",
+          "shortname": "ABBVIE INC",
+          "quoteType": "EQUITY",
+          "symbol": "ABBV.MX",
+          "index": "quotes",
+          "score": 20028,
+          "typeDisp": "Equity",
+          "longname": "AbbVie Inc.",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "VIE",
+          "shortname": "ABBVIE INC",
+          "quoteType": "EQUITY",
+          "symbol": "ABBV.VI",
+          "index": "quotes",
+          "score": 20019,
+          "typeDisp": "Equity",
+          "longname": "AbbVie Inc.",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "OPR",
+          "shortname": "ABBV May 2021 120.000 call",
+          "quoteType": "OPTION",
+          "symbol": "ABBV210521C00120000",
+          "index": "quotes",
+          "score": 20018,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        },
+        {
+          "index": "bae05dd7cdc385c02210583852db5c44",
+          "name": "AbbVie Biotech Ventures",
+          "permalink": "abbvie-biotech-ventures",
+          "isYahooFinance": false
+        }
+      ],
+      "news": [
+        {
+          "uuid": "a9638ff8-5b6e-34c7-949b-5eca51588f89",
+          "title": "AbbVie, Evolus, and Medytox Announce Resolution of Intellectual Property Litigation",
+          "publisher": "PR Newswire",
+          "link": "https://finance.yahoo.com/news/abbvie-evolus-medytox-announce-resolution-141500404.html",
+          "providerPublishTime": 1613744100,
+          "type": "STORY"
+        },
+        {
+          "uuid": "3f4ec8ce-2e4e-35a1-a39e-77f3c79a321d",
+          "title": "AbbVie to Present at the Cowen 41st Annual Health Care Conference",
+          "publisher": "PR Newswire",
+          "link": "https://finance.yahoo.com/news/abbvie-present-cowen-41st-annual-130000689.html",
+          "providerPublishTime": 1613739600,
+          "type": "STORY"
+        },
+        {
+          "uuid": "851d67d7-26bb-3241-b279-32dd693b645e",
+          "title": "ABBV or LLY: Which Is the Better Value Stock Right Now?",
+          "publisher": "Zacks",
+          "link": "https://finance.yahoo.com/news/abbv-lly-better-value-stock-164004809.html",
+          "providerPublishTime": 1612888804,
+          "type": "STORY"
+        },
+        {
+          "uuid": "8ca02858-2c37-3699-817e-a8a0f048ee7f",
+          "title": "AbbVie (ABBV) Q4 2020 Earnings Call Transcript",
+          "publisher": "Motley Fool",
+          "link": "https://finance.yahoo.com/m/8ca02858-2c37-3699-817e-a8a0f048ee7f/abbvie-%28abbv%29-q4-2020.html",
+          "providerPublishTime": 1612405885,
+          "type": "STORY"
+        }
+      ],
+      "nav": [],
+      "lists": [],
+      "researchReports": [],
+      "totalTime": 24,
+      "timeTakenForQuotes": 418,
+      "timeTakenForNews": 600,
+      "timeTakenForAlgowatchlist": 400,
+      "timeTakenForPredefinedScreener": 400,
+      "timeTakenForCrunchbase": 400,
+      "timeTakenForNav": 400,
+      "timeTakenForResearchReports": 0
+    }
+  }
+}

--- a/tests/http/search-BRKS.json
+++ b/tests/http/search-BRKS.json
@@ -1,0 +1,185 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v1/finance/search?lang=en-US&region=US&quotesCount=6&newsCount=4&enableFuzzyQuery=false&quotesQueryId=tss_match_phrase_query&multiQuoteQueryId=multi_quote_single_token_query&newsQueryId=news_cie_vespa&enableCb=true&enableNavLinks=true&enableEnhancedTrivialQuery=true&q=BRKS"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=120, stale-while-revalidate=180"
+      ],
+      "y-rid": [
+        "3khrm49g2vsdu"
+      ],
+      "x-yahoo-request-id": [
+        "3khrm49g2vsdu"
+      ],
+      "x-request-id": [
+        "5234cf80-c23b-469e-bbf2-95486b455fec"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "964"
+      ],
+      "x-envoy-upstream-service-time": [
+        "36"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:34 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-search--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "explains": [],
+      "count": 10,
+      "quotes": [
+        {
+          "exchange": "NMS",
+          "shortname": "Brooks Automation, Inc.",
+          "quoteType": "EQUITY",
+          "symbol": "BRKS",
+          "index": "quotes",
+          "score": 2494100,
+          "typeDisp": "Equity",
+          "longname": "Brooks Automation, Inc.",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "OPR",
+          "shortname": "BRKS Apr 2021 60.000 put",
+          "quoteType": "OPTION",
+          "symbol": "BRKS210416P00060000",
+          "index": "quotes",
+          "score": 20029,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "OPR",
+          "shortname": "BRKS Feb 2021 55.000 call",
+          "quoteType": "OPTION",
+          "symbol": "BRKS210219C00055000",
+          "index": "quotes",
+          "score": 20004,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "IST",
+          "shortname": "BERKOSAN YALITIM",
+          "quoteType": "EQUITY",
+          "symbol": "BRKSN.IS",
+          "index": "quotes",
+          "score": 20004,
+          "typeDisp": "Equity",
+          "longname": "Berkosan Yalitim Ve Tecrit Maddeleri Üretim Ve Ticaret A.S.",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "OPR",
+          "shortname": "BRKS Feb 2021 77.500 call",
+          "quoteType": "OPTION",
+          "symbol": "BRKS210219C00077500",
+          "index": "quotes",
+          "score": 20003,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "OPR",
+          "shortname": "BRKS Feb 2021 87.500 call",
+          "quoteType": "OPTION",
+          "symbol": "BRKS210219C00087500",
+          "index": "quotes",
+          "score": 20003,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        }
+      ],
+      "news": [
+        {
+          "uuid": "23d77b86-f2c0-3762-b0ab-760cb73ec39e",
+          "title": "Should You Investigate Brooks Automation, Inc. (NASDAQ:BRKS) At US$82.99?",
+          "publisher": "Simply Wall St.",
+          "link": "https://finance.yahoo.com/news/investigate-brooks-automation-inc-nasdaq-052842325.html",
+          "providerPublishTime": 1613712522,
+          "type": "STORY"
+        },
+        {
+          "uuid": "38810c2a-da5e-3f7e-b237-6851baff63f9",
+          "title": "Brooks Automation (BRKS) Surpasses Q1 Earnings and Revenue Estimates",
+          "publisher": "Zacks",
+          "link": "https://finance.yahoo.com/news/brooks-automation-brks-surpasses-q1-225510117.html",
+          "providerPublishTime": 1612306510,
+          "type": "STORY"
+        },
+        {
+          "uuid": "4ff31c48-641a-3b8a-bebf-f33693aa4934",
+          "title": "Earnings Estimates Rising for Brooks (BRKS): Will It Gain?",
+          "publisher": "Zacks",
+          "link": "https://finance.yahoo.com/news/earnings-estimates-rising-brooks-brks-172005988.html",
+          "providerPublishTime": 1612545605,
+          "type": "STORY"
+        },
+        {
+          "uuid": "08565e32-d33a-312e-9099-c309180da1df",
+          "title": "Why Brooks (BRKS) Stock Might be a Great Pick",
+          "publisher": "Zacks",
+          "link": "https://finance.yahoo.com/news/why-brooks-brks-stock-might-135101124.html",
+          "providerPublishTime": 1606744261,
+          "type": "STORY"
+        }
+      ],
+      "nav": [],
+      "lists": [],
+      "researchReports": [],
+      "totalTime": 35,
+      "timeTakenForQuotes": 422,
+      "timeTakenForNews": 600,
+      "timeTakenForAlgowatchlist": 400,
+      "timeTakenForPredefinedScreener": 400,
+      "timeTakenForCrunchbase": 400,
+      "timeTakenForNav": 400,
+      "timeTakenForResearchReports": 0
+    }
+  }
+}

--- a/tests/http/search-CRON.json
+++ b/tests/http/search-CRON.json
@@ -1,0 +1,189 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v1/finance/search?lang=en-US&region=US&quotesCount=6&newsCount=4&enableFuzzyQuery=false&quotesQueryId=tss_match_phrase_query&multiQuoteQueryId=multi_quote_single_token_query&newsQueryId=news_cie_vespa&enableCb=true&enableNavLinks=true&enableEnhancedTrivialQuery=true&q=CRON"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=120, stale-while-revalidate=180"
+      ],
+      "y-rid": [
+        "4shaob9g2vsdu"
+      ],
+      "x-yahoo-request-id": [
+        "4shaob9g2vsdu"
+      ],
+      "x-request-id": [
+        "88c983f7-febc-426d-9575-b61d19f6a489"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1039"
+      ],
+      "x-envoy-upstream-service-time": [
+        "31"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:34 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-search--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "2"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "explains": [],
+      "count": 11,
+      "quotes": [
+        {
+          "exchange": "NGM",
+          "shortname": "Cronos Group Inc. Common Share",
+          "quoteType": "EQUITY",
+          "symbol": "CRON",
+          "index": "quotes",
+          "score": 8695400,
+          "typeDisp": "Equity",
+          "longname": "Cronos Group Inc.",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "TOR",
+          "shortname": "CRONOS GROUP INC",
+          "quoteType": "EQUITY",
+          "symbol": "CRON.TO",
+          "index": "quotes",
+          "score": 22122,
+          "typeDisp": "Equity",
+          "longname": "Cronos Group Inc.",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "FRA",
+          "shortname": "CRONOS GRP INC.",
+          "quoteType": "EQUITY",
+          "symbol": "7CI.F",
+          "index": "quotes",
+          "score": 20080,
+          "typeDisp": "Equity",
+          "longname": "Cronos Group Inc.",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "OPR",
+          "shortname": "CRON Apr 2021 15.000 call",
+          "quoteType": "OPTION",
+          "symbol": "CRON210416C00015000",
+          "index": "quotes",
+          "score": 20023,
+          "typeDisp": "Option",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "ASX",
+          "shortname": "CRONOS FPO",
+          "quoteType": "EQUITY",
+          "symbol": "CAU.AX",
+          "index": "quotes",
+          "score": 20017,
+          "typeDisp": "Equity",
+          "longname": "Cronos Australia Limited",
+          "isYahooFinance": true
+        },
+        {
+          "index": "60ffb9a438066c7c5b6c40fb55b1617d",
+          "name": "Cronofy",
+          "permalink": "one-diary",
+          "isYahooFinance": false
+        },
+        {
+          "index": "378a23314fc9b5373f0c7270126d60af",
+          "name": "Cronycle Ltd",
+          "permalink": "cronycle-ltd",
+          "isYahooFinance": false
+        }
+      ],
+      "news": [
+        {
+          "uuid": "c05c02fd-001d-3ad6-815f-b2641da3a9dc",
+          "title": "Bull Signal Flashing as Cannabis Stock Ignites",
+          "publisher": "Schaeffer's Investment Research",
+          "link": "https://finance.yahoo.com/news/bull-signal-flashing-cannabis-stock-185516609.html",
+          "providerPublishTime": 1612896916,
+          "type": "STORY"
+        },
+        {
+          "uuid": "b23d953c-30fb-380c-bee1-c79611baea97",
+          "title": "Cronos Group (CRON) Catches Eye: Stock Jumps 9.3%",
+          "publisher": "Zacks",
+          "link": "https://finance.yahoo.com/news/cronos-group-cron-catches-eye-153103578.html",
+          "providerPublishTime": 1606318263,
+          "type": "STORY"
+        },
+        {
+          "uuid": "ac8ad7c4-d8d4-3a14-9ea9-5ec70c18827b",
+          "title": "Cronos Group Inc. to Speak at the 24th Annual CIBC Western Institutional Investor Conference",
+          "publisher": "GlobeNewswire",
+          "link": "https://finance.yahoo.com/news/cronos-group-inc-speak-24th-140000022.html",
+          "providerPublishTime": 1611151200,
+          "type": "STORY"
+        },
+        {
+          "uuid": "d7654611-5c17-33e0-bb7c-fd01e9e3b427",
+          "title": "Cronos Group Inc. to Present at the MKM Partners Virtual Conference",
+          "publisher": "GlobeNewswire",
+          "link": "https://finance.yahoo.com/news/cronos-group-inc-present-mkm-170000171.html",
+          "providerPublishTime": 1607706000,
+          "type": "STORY"
+        }
+      ],
+      "nav": [],
+      "lists": [],
+      "researchReports": [],
+      "totalTime": 29,
+      "timeTakenForQuotes": 421,
+      "timeTakenForNews": 600,
+      "timeTakenForAlgowatchlist": 400,
+      "timeTakenForPredefinedScreener": 400,
+      "timeTakenForCrunchbase": 400,
+      "timeTakenForNav": 400,
+      "timeTakenForResearchReports": 0
+    }
+  }
+}

--- a/tests/http/search-EPAC.json
+++ b/tests/http/search-EPAC.json
@@ -1,0 +1,187 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v1/finance/search?lang=en-US&region=US&quotesCount=6&newsCount=4&enableFuzzyQuery=false&quotesQueryId=tss_match_phrase_query&multiQuoteQueryId=multi_quote_single_token_query&newsQueryId=news_cie_vespa&enableCb=true&enableNavLinks=true&enableEnhancedTrivialQuery=true&q=EPAC"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=120, stale-while-revalidate=180"
+      ],
+      "y-rid": [
+        "c0lfpp9g2vsdv"
+      ],
+      "x-yahoo-request-id": [
+        "c0lfpp9g2vsdv"
+      ],
+      "x-request-id": [
+        "26ff679b-3f8a-44f6-a2ff-514d3319fe3a"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "990"
+      ],
+      "x-envoy-upstream-service-time": [
+        "32"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:35 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-search--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "explains": [],
+      "count": 11,
+      "quotes": [
+        {
+          "exchange": "NYQ",
+          "shortname": "Enerpac Tool Group Corp.",
+          "quoteType": "EQUITY",
+          "symbol": "EPAC",
+          "index": "quotes",
+          "score": 2033800,
+          "typeDisp": "Equity",
+          "longname": "Enerpac Tool Group Corp.",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "JKT",
+          "shortname": "Megalestari Epack Sentosaraya T",
+          "quoteType": "EQUITY",
+          "symbol": "EPAC.JK",
+          "index": "quotes",
+          "score": 20039,
+          "typeDisp": "Equity",
+          "longname": "PT Megalestari Epack Sentosaraya Tbk",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "SNP",
+          "shortname": "S&P EPAC Ex-Korea LargeMidCap (",
+          "quoteType": "INDEX",
+          "symbol": "^SPCPMIRECCAD",
+          "index": "quotes",
+          "score": 20002,
+          "typeDisp": "Index",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "SNP",
+          "shortname": "S&P EPAC Ex. Korea LargeMidCap ",
+          "quoteType": "INDEX",
+          "symbol": "^SPRECMR2",
+          "index": "quotes",
+          "score": 20002,
+          "typeDisp": "Index",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "SNP",
+          "shortname": "S&P EPAC Ex-Korea LargeMidCap N",
+          "quoteType": "INDEX",
+          "symbol": "^SPKX15UT",
+          "index": "quotes",
+          "score": 20001,
+          "typeDisp": "Index",
+          "isYahooFinance": true
+        },
+        {
+          "index": "7d1aeed8594c56459b2b1abfa4bc6e22",
+          "name": "ePACT Network",
+          "permalink": "epact-network",
+          "isYahooFinance": false
+        },
+        {
+          "index": "a4804474d7f147ce9bc25a388753a7b6",
+          "name": "Epact",
+          "permalink": "epact",
+          "isYahooFinance": false
+        }
+      ],
+      "news": [
+        {
+          "uuid": "b533e392-2af0-37fb-b24e-370f9e76bedd",
+          "title": "ePac Flexible Packaging Joins Open Invention Network",
+          "publisher": "GlobeNewswire",
+          "link": "https://finance.yahoo.com/news/epac-flexible-packaging-joins-open-154100096.html",
+          "providerPublishTime": 1611589260,
+          "type": "STORY"
+        },
+        {
+          "uuid": "c89e707b-b2a8-35cf-9d94-7249a5244283",
+          "title": "ePac Flexible Packaging Extends Global Footprint into Seoul, South Korea",
+          "publisher": "GlobeNewswire",
+          "link": "https://finance.yahoo.com/news/epac-flexible-packaging-extends-global-190000516.html",
+          "providerPublishTime": 1609959600,
+          "type": "STORY"
+        },
+        {
+          "uuid": "a36745f6-e921-3b10-ad5f-f53e94556b04",
+          "title": "ePac Flexible Packaging Announces Expansion into Ghana, Africa",
+          "publisher": "GlobeNewswire",
+          "link": "https://finance.yahoo.com/news/epac-flexible-packaging-announces-expansion-190300549.html",
+          "providerPublishTime": 1606935780,
+          "type": "STORY"
+        },
+        {
+          "uuid": "6dedc3c5-e8b0-3a2a-a235-3acb43787b45",
+          "title": "Enerpac Tool Group (EPAC) Q1 2021 Earnings Call Transcript",
+          "publisher": "Motley Fool",
+          "link": "https://finance.yahoo.com/m/6dedc3c5-e8b0-3a2a-a235-3acb43787b45/enerpac-tool-group-%28epac%29-q1.html",
+          "providerPublishTime": 1608584441,
+          "type": "STORY"
+        }
+      ],
+      "nav": [],
+      "lists": [],
+      "researchReports": [],
+      "totalTime": 30,
+      "timeTakenForQuotes": 417,
+      "timeTakenForNews": 600,
+      "timeTakenForAlgowatchlist": 400,
+      "timeTakenForPredefinedScreener": 400,
+      "timeTakenForCrunchbase": 400,
+      "timeTakenForNav": 400,
+      "timeTakenForResearchReports": 0
+    }
+  }
+}

--- a/tests/http/search-MDLY.json
+++ b/tests/http/search-MDLY.json
@@ -1,0 +1,134 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v1/finance/search?lang=en-US&region=US&quotesCount=6&newsCount=4&enableFuzzyQuery=false&quotesQueryId=tss_match_phrase_query&multiQuoteQueryId=multi_quote_single_token_query&newsQueryId=news_cie_vespa&enableCb=true&enableNavLinks=true&enableEnhancedTrivialQuery=true&q=MDLY"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=120, stale-while-revalidate=180"
+      ],
+      "y-rid": [
+        "85sqba9g2vsdu"
+      ],
+      "x-yahoo-request-id": [
+        "85sqba9g2vsdu"
+      ],
+      "x-request-id": [
+        "32e59af3-f602-4aaf-aea6-d36321638fee"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "828"
+      ],
+      "x-envoy-upstream-service-time": [
+        "34"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:33 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-search--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "1"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "explains": [],
+      "count": 5,
+      "quotes": [
+        {
+          "exchange": "NYQ",
+          "shortname": "Medley Management Inc.",
+          "quoteType": "EQUITY",
+          "symbol": "MDLY",
+          "index": "quotes",
+          "score": 2086900,
+          "typeDisp": "Equity",
+          "longname": "Medley Management Inc.",
+          "isYahooFinance": true
+        }
+      ],
+      "news": [
+        {
+          "uuid": "0acb57e4-fd34-3733-a8c8-c5918c14d958",
+          "title": "Medley Management's(NYSE:MDLY) Share Price Is Down 88% Over The Past Three Years.",
+          "publisher": "Simply Wall St.",
+          "link": "https://finance.yahoo.com/news/medley-managements-nyse-mdly-share-060938407.html",
+          "providerPublishTime": 1609740578,
+          "type": "STORY"
+        },
+        {
+          "uuid": "911ada15-8a24-31a1-a1b9-fbb6203b20c3",
+          "title": "Medley Capital Corporation Announces September 30, 2020 Financial Results",
+          "publisher": "GlobeNewswire",
+          "link": "https://finance.yahoo.com/news/medley-capital-corporation-announces-september-213000874.html",
+          "providerPublishTime": 1607722200,
+          "type": "STORY"
+        },
+        {
+          "uuid": "5a52bc80-3b9e-3e1e-bbbf-f28060a02e19",
+          "title": "Is Tenax Therapeutics Inc (TENX) A Good Stock To Buy?",
+          "publisher": "Insider Monkey",
+          "link": "https://finance.yahoo.com/news/tenax-therapeutics-inc-tenx-good-002849597.html",
+          "providerPublishTime": 1606696129,
+          "type": "STORY"
+        },
+        {
+          "uuid": "bb924752-f737-3b19-8ace-5dcad8c2924d",
+          "title": "Medley LLC Retains B. Riley to Conduct Strategic Review of Bonds",
+          "publisher": "PR Newswire",
+          "link": "https://finance.yahoo.com/news/medley-llc-retains-b-riley-003000781.html",
+          "providerPublishTime": 1610411400,
+          "type": "STORY"
+        }
+      ],
+      "nav": [],
+      "lists": [],
+      "researchReports": [],
+      "totalTime": 33,
+      "timeTakenForQuotes": 415,
+      "timeTakenForNews": 600,
+      "timeTakenForAlgowatchlist": 400,
+      "timeTakenForPredefinedScreener": 400,
+      "timeTakenForCrunchbase": 400,
+      "timeTakenForNav": 400,
+      "timeTakenForResearchReports": 0
+    }
+  }
+}

--- a/tests/http/search-SI.json
+++ b/tests/http/search-SI.json
@@ -1,0 +1,228 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v1/finance/search?lang=en-US&region=US&quotesCount=6&newsCount=4&enableFuzzyQuery=false&quotesQueryId=tss_match_phrase_query&multiQuoteQueryId=multi_quote_single_token_query&newsQueryId=news_cie_vespa&enableCb=true&enableNavLinks=true&enableEnhancedTrivialQuery=true&q=SI"
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "content-type": [
+        "application/json"
+      ],
+      "vary": [
+        "Origin,Origin,Accept-Encoding"
+      ],
+      "cache-control": [
+        "public, max-age=120, stale-while-revalidate=180"
+      ],
+      "y-rid": [
+        "49iq48hg2vsdt"
+      ],
+      "x-yahoo-request-id": [
+        "49iq48hg2vsdt"
+      ],
+      "x-request-id": [
+        "33770cef-9ff7-4a85-a09d-2bb1a3ebc441"
+      ],
+      "content-encoding": [
+        "gzip"
+      ],
+      "content-length": [
+        "1444"
+      ],
+      "x-envoy-upstream-service-time": [
+        "30"
+      ],
+      "date": [
+        "Fri, 19 Feb 2021 17:13:33 GMT"
+      ],
+      "server": [
+        "ATS"
+      ],
+      "x-envoy-decorator-operation": [
+        "finance-search--mtls-production-bf1.finance-k8s.svc.yahoo.local:4080/*"
+      ],
+      "age": [
+        "0"
+      ],
+      "strict-transport-security": [
+        "max-age=15552000"
+      ],
+      "referrer-policy": [
+        "no-referrer-when-downgrade"
+      ],
+      "x-frame-options": [
+        "SAMEORIGIN"
+      ],
+      "connection": [
+        "close"
+      ],
+      "expect-ct": [
+        "max-age=31536000, report-uri=\"http://csp.yahoo.com/beacon/csp?src=yahoocom-expect-ct-report-only\""
+      ],
+      "x-xss-protection": [
+        "1; mode=block"
+      ],
+      "x-content-type-options": [
+        "nosniff"
+      ]
+    },
+    "bodyJson": {
+      "explains": [],
+      "count": 16,
+      "quotes": [
+        {
+          "exchange": "CMX",
+          "shortname": "Silver Mar 21",
+          "quoteType": "FUTURE",
+          "symbol": "SI=F",
+          "index": "quotes",
+          "score": 9815800,
+          "typeDisp": "Future",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "NYQ",
+          "shortname": "Silvergate Capital Corporation",
+          "quoteType": "EQUITY",
+          "symbol": "SI",
+          "index": "quotes",
+          "score": 6604300,
+          "typeDisp": "Equity",
+          "longname": "Silvergate Capital Corporation",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "PCX",
+          "shortname": "iShares Silver Trust",
+          "quoteType": "ETF",
+          "symbol": "SLV",
+          "index": "quotes",
+          "score": 121829,
+          "typeDisp": "ETF",
+          "longname": "iShares Silver Trust",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "NYQ",
+          "shortname": "First Majestic Silver Corp.",
+          "quoteType": "EQUITY",
+          "symbol": "AG",
+          "index": "quotes",
+          "score": 82802,
+          "typeDisp": "Equity",
+          "longname": "First Majestic Silver Corp.",
+          "isYahooFinance": true
+        },
+        {
+          "exchange": "PNK",
+          "shortname": "SOLAR INTEGRATED ROOFING CORP",
+          "quoteType": "EQUITY",
+          "symbol": "SIRC",
+          "index": "quotes",
+          "score": 81376,
+          "typeDisp": "Equity",
+          "longname": "Solar Integrated Roofing Corporation",
+          "isYahooFinance": true
+        },
+        {
+          "index": "b918293c44a94b6f9ee06fce98530f28",
+          "name": "Signal",
+          "permalink": "signal",
+          "isYahooFinance": false
+        },
+        {
+          "index": "7bbe743b7e73e6f0cfecff756701f3a1",
+          "name": "Silver Lake",
+          "permalink": "silver-lake",
+          "isYahooFinance": false
+        }
+      ],
+      "news": [
+        {
+          "uuid": "d6b876d0-7558-39de-a949-d324173d7592",
+          "title": "Gold Goes From a Star Commodity to Laggard in Shocking Reversal",
+          "publisher": "Bloomberg",
+          "link": "https://finance.yahoo.com/news/gold-driven-two-month-low-001726468.html",
+          "providerPublishTime": 1613751886,
+          "type": "STORY"
+        },
+        {
+          "uuid": "50628f31-5e77-31c5-99c2-7312d11a6668",
+          "title": "First Mover: Bitcoin Meets ‘Torrent’ as Lowly Binance Coin Gets $40B Valuation",
+          "publisher": "CoinDesk",
+          "link": "https://finance.yahoo.com/news/first-mover-bitcoin-meets-torrent-150325564.html",
+          "providerPublishTime": 1613747005,
+          "type": "STORY"
+        },
+        {
+          "uuid": "1d8e0f01-66c5-374a-b031-3f9f8e5e0594",
+          "title": "These Were The 50 Best-Performing Companies On The OTCQX Market In 2020",
+          "publisher": "Benzinga",
+          "link": "https://finance.yahoo.com/news/were-50-best-performing-companies-130530867.html",
+          "providerPublishTime": 1613739930,
+          "type": "STORY"
+        },
+        {
+          "uuid": "ff7d80db-9340-3bde-b123-7ee77ebc17cc",
+          "title": "Gold hits lowest in more than seven months as rising yields dent appeal",
+          "publisher": "Reuters",
+          "link": "https://finance.yahoo.com/news/gold-slips-over-seventh-month-033241118.html",
+          "providerPublishTime": 1613705561,
+          "type": "STORY"
+        }
+      ],
+      "nav": [
+        {
+          "navName": "Sibile Marcellus",
+          "navUrl": "https://www.yahoo.com/author/sibile-marcellus"
+        }
+      ],
+      "lists": [
+        {
+          "slug": "sinful-stocks",
+          "name": "Sinful Stocks",
+          "index": "sinful-stocks",
+          "score": 1.9286566,
+          "type": "ALGO_WATCHLIST",
+          "brandSlug": "yahoo-finance",
+          "pfId": "the_naughty_list"
+        },
+        {
+          "index": "96384b8f-b161-4eef-abf8-d1ce290da125",
+          "id": "96384b8f-b161-4eef-abf8-d1ce290da125",
+          "title": "Most Actives - Singapore",
+          "canonicalName": "MOST_ACTIVES_SG",
+          "score": 1,
+          "type": "PREDEFINED_SCREENER"
+        },
+        {
+          "index": "fd2e2676-b2a8-4c45-ac10-e76a9be49151",
+          "id": "fd2e2676-b2a8-4c45-ac10-e76a9be49151",
+          "title": "Silver",
+          "canonicalName": "SILVER",
+          "score": 1,
+          "type": "PREDEFINED_SCREENER"
+        },
+        {
+          "index": "4d834f86-c0a9-4211-b7a4-3290011892eb",
+          "id": "4d834f86-c0a9-4211-b7a4-3290011892eb",
+          "title": "Day Gainers - Singapore",
+          "canonicalName": "DAY_GAINERS_SG",
+          "score": 1,
+          "type": "PREDEFINED_SCREENER"
+        }
+      ],
+      "researchReports": [],
+      "totalTime": 29,
+      "timeTakenForQuotes": 423,
+      "timeTakenForNews": 600,
+      "timeTakenForAlgowatchlist": 400,
+      "timeTakenForPredefinedScreener": 400,
+      "timeTakenForCrunchbase": 400,
+      "timeTakenForNav": 400,
+      "timeTakenForResearchReports": 0
+    }
+  }
+}

--- a/tests/symbols.ts
+++ b/tests/symbols.ts
@@ -15,4 +15,10 @@ export const testSymbols = [
   "BABA", // NYSE
   "QQQ", // ETF
   "0P000071W8.TO", // Mutual Fund
+  "SI", // NYSE
+  "MDLY", // NYSE
+  "ABBV", // NYSE
+  "BRKS", // NMS
+  "CRON", // NMS
+  "EPAC", // NYSE
 ];


### PR DESCRIPTION
Closes #57
This PR adds more symbols to `symbols.ts` and fixes the validation for the newly added symbols.

## Changes
- Add ~5 symbols to `symbols.ts`
- Fix the validation for the symbols

## Comments
- In the `Grade` enum we already have `Underperform`. This PR adds `Underperformer` to the enum. Was `Underperform` a typo?

## Benefits
- The standard: we catch more validation bugs.