### PR TITLE
fix(validation): load process only when defined during validation logging (#50)

### DIFF
--- a/src/lib/validateAndCoerceTypes.ts
+++ b/src/lib/validateAndCoerceTypes.ts
@@ -148,9 +148,10 @@ ajv.addKeyword({
 ajv.addSchema(schema);
 
 /* istanbul ignore next */
-const logObj = process?.stdout?.isTTY
-  ? (obj: any) => console.dir(obj, { depth: 4, colors: true })
-  : (obj: any) => console.log(JSON.stringify(obj, null, 2));
+const logObj =
+  typeof process !== "undefined" && process?.stdout?.isTTY
+    ? (obj: any) => console.dir(obj, { depth: 4, colors: true })
+    : (obj: any) => console.log(JSON.stringify(obj, null, 2));
 
 export function resolvePath(obj: any, dataPath: string) {
   const path = dataPath.split("/");


### PR DESCRIPTION
Ref #50 
This PR loads `process` only when defined during validation error logging.

## Changes
- `process` is only loaded when defined, using the nice old `typeof` trick. This prevents errors in a browser environment.