### PR TITLE
chore(gh-templates): add pr and issue templates [skip ci]

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,22 @@
+---
+name: Bug Report
+about: Create a report to help the library improve
+labels: bug
+---
+
+# Bug Report
+
+## Describe the bug
+<!-- Describe the bug here -->
+
+## Minimal Reproduction
+<!-- like `await yahooFinance.quote('AAPL')` or maybe a link to a repo -->
+
+## Environment
+Browser or Node: <!-- Please state either `browser` or `node` here -->
+Node version (if applicable): 
+Npm version: 
+Browser verion (if applicable):
+Library version (e.g. `1.10.1`): 
+
+## Additional Context

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -1,0 +1,15 @@
+---
+name: Docs Improvement
+about: Suggest an improvement to the docs or README.md
+labels: documentation
+---
+
+# Docs Improvment
+
+**:exclamation: THIS IS NOT FOR TYPOS!!! PLEASE JUST FILE A PR FOR THAT! THIS IS FOR SUBSTANTIAL IMPROVEMENTS *ONLY*!**
+
+## Suggested Improvement
+<!-- E.g., add a section on this module -->
+
+## Reason For Suggestion (if not related to a module)
+<!-- Add the reason for suggestion, e.g., it would be helpful to add a section on ... so people could easily ... -->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest an idea or feature
+labels: enhancement
+---
+
+# Feature Request
+
+## Wanted Feature
+<!-- State the feature you want over here -->
+
+## Use Cases
+<!-- State the use cases of your feature, have at least 1-2 good use cases -->
+- 
+- 
+- 
+
+## Potential Example Usage
+This feature *could* be used in the following way:
+```ts
+// something here, please fill this out
+```
+

--- a/.github/ISSUE_TEMPLATE/meta.md
+++ b/.github/ISSUE_TEMPLATE/meta.md
@@ -1,0 +1,7 @@
+---
+name: Meta Issue
+about: Plans, roadmaps, and other meta issues
+labels: meta
+---
+
+<!-- This is intentionally empty since ther are a variety of meta issues, and each one will differ -->

--- a/.github/ISSUE_TEMPLATE/new-module.md
+++ b/.github/ISSUE_TEMPLATE/new-module.md
@@ -1,0 +1,26 @@
+---
+name: New Module Request
+about: Suggest a new module
+labels: enhancement, new module
+---
+
+# Feature Request
+
+## Wanted Module
+<!-- State the module you want over here, e.g., news feed -->
+
+## Endpoint (if you found one)
+<!-- please put the *actual* endpoint here, not this dummy text -->
+`https://...`
+
+### Query Params
+| Name | Type | Required |
+| ---- | ---- | -------- |
+|      |      |          |
+
+## Potential Example Usage
+This module *could* be used in the following way:
+```ts
+// something here, please fill this out
+```
+

--- a/.github/ISSUE_TEMPLATE/validation.md
+++ b/.github/ISSUE_TEMPLATE/validation.md
@@ -1,0 +1,30 @@
+---
+name: Validation Error
+about: Something went wrong with validation
+labels: bug, validation
+---
+
+# Validation Error
+
+## Minimal Reproduction
+<!-- like `await yahooFinance.quote('AAPL')` or maybe a link to a repo -->
+
+## Symbol(s) that it happened for
+- 
+- 
+- 
+
+## Error Message
+<!-- Paste the error message here -->
+```
+
+```
+
+## Environment
+Browser or Node: <!-- Please state either `browser` or `node` here -->
+Node version (if applicable): 
+Npm version: 
+Browser verion (if applicable):
+Library version (e.g. `1.10.1`): 
+
+## Additional Context

--- a/.github/pull_reequest_template.md
+++ b/.github/pull_reequest_template.md
@@ -12,3 +12,6 @@ Closes # .
 - [ ] Other Bugfix
 - [ ] Docs
 - [ ] Chore/other
+
+## Comments/notes
+<!-- add comments and notes here -->

--- a/.github/pull_reequest_template.md
+++ b/.github/pull_reequest_template.md
@@ -1,0 +1,13 @@
+Closes # .
+
+## Changes
+- 
+- 
+- 
+
+## Type
+- [ ] New Module
+- [ ] Other New Feature
+- [ ] Validation Fix
+- [ ] Other Bugfix
+- [ ] Docs

--- a/.github/pull_reequest_template.md
+++ b/.github/pull_reequest_template.md
@@ -11,3 +11,4 @@ Closes # .
 - [ ] Validation Fix
 - [ ] Other Bugfix
 - [ ] Docs
+- [ ] Chore/other


### PR DESCRIPTION
Closes #116.

## Changes
- Add issue templates
- Add `config.yml`
- Add PR template

## Type
- [ ] New Module
- [ ] Other New Feature
- [ ] Validation Fix
- [ ] Other Bugfix
- [ ] Docs
- [x] Chore/other

## Comments/notes
@gadicc I didn't add multiple PR templates, they aren't quite easy to use, apparently.