### PR TITLE
feat(setGlobalConfig): add setGlobalConfig function

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ symbol, topHoldings, upgradeDowngradeHistory),
 [coming soon](https://github.com/gadicc/node-yahoo-finance2/issues/8).
 
 Extras: [`quoteCombine`](./docs/other/quoteCombine.md).
+Utils: [`setGlobalConfig`](./docs/utils/setGlobalConfig.md).
 
 See the [Full Documentation](./docs/README.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 1. [Common Options](#common-options)
 1. [Modules](#modules)
 1. [Other Methods](#other)
+1. [Util Methods](#utils)
 1. [Error Handling](#error-handling)
 1. [Validation](./validation.md)
 1. [Concurrency](./concurrency.md)
@@ -43,6 +44,9 @@ const result = await yahooFinance.module(query, queryOpts, moduleOpts);
 ## Other Methods
 
 1. [quoteCombine](./other/quoteCombine.md) - debounce and combine multiple quote calls.
+
+<a name="utils"></a>
+1. [setGlobalConfig](./utils/setGlobalConfig.md) - set global config options.
 
 <a name="error-handling"></a>
 ## Error Handling

--- a/docs/other/setGlobalConfig.md
+++ b/docs/other/setGlobalConfig.md
@@ -1,6 +1,6 @@
 # setGlobalConfig
 
-This util function sets global config options, merging (1 level deep only) with the defaults. These options are then the defaults used for every request. It is the **recommended** way of setting global config. Setting global config directly is not recommended.
+This util function sets global config options, merging with the defaults. These options are then the defaults used for every request. It is the **recommended** way of setting global config. Setting global config directly is not recommended.
 
 ## Usage:
 
@@ -16,14 +16,16 @@ yahooFinance.setGlobalConfig({
 
 Notes:
 
-- Options are merged only one level deep:
+- Config provided to this function is validated.
+
+- Options are merged infinite levels deep:
 ```js
 import yahooFinance from 'yahoo-finance2';
 
 yahooFinance.setGlobalConfig({
     queue: {
         concurrency: 2,
-        // timeout not set anymore, may/will cause errors
+        // timeout is still set
     }
 });
 ```

--- a/docs/other/setGlobalConfig.md
+++ b/docs/other/setGlobalConfig.md
@@ -1,0 +1,29 @@
+# setGlobalConfig
+
+This util function sets global config options, merging (1 level deep only) with the defaults. These options are then the defaults used for every request. It is the **recommended** way of setting global config. Setting global config directly is not recommended.
+
+## Usage:
+
+```js
+import yahooFinance from 'yahoo-finance2';
+
+yahooFinance.setGlobalConfig({
+    queue: {
+        // some options here
+    }
+});
+```
+
+Notes:
+
+- Options are merged only one level deep:
+```js
+import yahooFinance from 'yahoo-finance2';
+
+yahooFinance.setGlobalConfig({
+    queue: {
+        concurrency: 2,
+        // timeout not set anymore, may/will cause errors
+    }
+});
+```

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "scripts": {
     "coverage": "jest --coverage",
     "lint": "eslint . --ext .js,.ts",
-    "schema": "ts-json-schema-generator -f tsconfig.json -p 'src/modules/**/*.ts' -t '*' | node bin/schema-tweak.js > schema.json",
+    "schema": "ts-json-schema-generator -f tsconfig.json -p 'src/{modules,typings}/**/*.ts' -t '*' | node bin/schema-tweak.js > schema.json",
     "generateSchema": "yarn schema",
     "prepublishOnly": "tsc && yarn generateSchema",
     "test": "jest",

--- a/schema.json
+++ b/schema.json
@@ -2074,6 +2074,18 @@
       ],
       "type": "object"
     },
+    "Options": {
+      "additionalProperties": false,
+      "properties": {
+        "queue": {
+          "$ref": "#/definitions/QueueOptions"
+        },
+        "validation": {
+          "$ref": "#/definitions/ValidationOptions"
+        }
+      },
+      "type": "object"
+    },
     "OptionsOptions": {
       "additionalProperties": false,
       "properties": {
@@ -2186,6 +2198,18 @@
         "position",
         "value"
       ],
+      "type": "object"
+    },
+    "PartialOptions": {
+      "additionalProperties": false,
+      "properties": {
+        "queue": {
+          "$ref": "#/definitions/QueueOptions"
+        },
+        "validation": {
+          "$ref": "#/definitions/ValidationOptions"
+        }
+      },
       "type": "object"
     },
     "PeriodRange": {
@@ -2378,6 +2402,112 @@
         "marketState",
         "fromCurrency"
       ],
+      "type": "object"
+    },
+    "Queue": {
+      "additionalProperties": false,
+      "properties": {
+        "_queue": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "func": {
+                "additionalProperties": false,
+                "properties": {
+                  "arguments": {},
+                  "caller": {
+                    "$ref": "#/definitions/interface-2073358172-9814-11278-2073358172-0-212312"
+                  },
+                  "length": {
+                    "yahooFinanceType": "number"
+                  },
+                  "prototype": {}
+                },
+                "required": [
+                  "prototype",
+                  "length",
+                  "arguments",
+                  "caller"
+                ],
+                "type": "object"
+              },
+              "reject": {
+                "additionalProperties": false,
+                "properties": {
+                  "arguments": {},
+                  "caller": {
+                    "$ref": "#/definitions/interface-2073358172-9814-11278-2073358172-0-212312"
+                  },
+                  "length": {
+                    "yahooFinanceType": "number"
+                  },
+                  "prototype": {}
+                },
+                "required": [
+                  "prototype",
+                  "length",
+                  "arguments",
+                  "caller"
+                ],
+                "type": "object"
+              },
+              "resolve": {
+                "additionalProperties": false,
+                "properties": {
+                  "arguments": {},
+                  "caller": {
+                    "$ref": "#/definitions/interface-2073358172-9814-11278-2073358172-0-212312"
+                  },
+                  "length": {
+                    "yahooFinanceType": "number"
+                  },
+                  "prototype": {}
+                },
+                "required": [
+                  "prototype",
+                  "length",
+                  "arguments",
+                  "caller"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "func",
+              "resolve",
+              "reject"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "_running": {
+          "yahooFinanceType": "number"
+        },
+        "concurrency": {
+          "yahooFinanceType": "number"
+        }
+      },
+      "required": [
+        "concurrency",
+        "_running",
+        "_queue"
+      ],
+      "type": "object"
+    },
+    "QueueOptions": {
+      "additionalProperties": false,
+      "properties": {
+        "_queue": {
+          "$ref": "#/definitions/Queue"
+        },
+        "concurrency": {
+          "yahooFinanceType": "number"
+        },
+        "timeout": {
+          "yahooFinanceType": "number"
+        }
+      },
       "type": "object"
     },
     "Quote": {
@@ -6058,6 +6188,22 @@
       ],
       "type": "object"
     },
+    "ValidationOptions": {
+      "additionalProperties": false,
+      "properties": {
+        "logErrors": {
+          "type": "boolean"
+        },
+        "logOptionsErrors": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "logErrors",
+        "logOptionsErrors"
+      ],
+      "type": "object"
+    },
     "Yearly": {
       "additionalProperties": false,
       "properties": {
@@ -6075,6 +6221,26 @@
         "date",
         "revenue",
         "earnings"
+      ],
+      "type": "object"
+    },
+    "interface-2073358172-9814-11278-2073358172-0-212312": {
+      "additionalProperties": false,
+      "properties": {
+        "arguments": {},
+        "caller": {
+          "$ref": "#/definitions/interface-2073358172-9814-11278-2073358172-0-212312"
+        },
+        "length": {
+          "yahooFinanceType": "number"
+        },
+        "prototype": {}
+      },
+      "required": [
+        "prototype",
+        "length",
+        "arguments",
+        "caller"
       ],
       "type": "object"
     }

--- a/src/lib/options.ts
+++ b/src/lib/options.ts
@@ -1,11 +1,8 @@
 // TODO, keep defaults there too?
-import type { ValidationOptions } from "./validateAndCoerceTypes";
-import type { QueueOptions } from "./queue";
+// import type { ValidationOptions } from "./validateAndCoerceTypes";
+// import type { QueueOptions } from "./queue";
 
-export interface Options {
-  queue: QueueOptions;
-  validation: ValidationOptions;
-}
+import { Options } from "../typings/interfaces";
 
 const options: Options = {
   queue: {

--- a/src/lib/setGlobalConfig.spec.ts
+++ b/src/lib/setGlobalConfig.spec.ts
@@ -1,11 +1,30 @@
 import testYf from "../../tests/testYf";
+import options from "./options";
 import setGlobalConfig from "./setGlobalConfig";
 const yf = testYf({ setGlobalConfig });
 
 describe("setGlobalConfig", () => {
-  it("sets config options", () => {
+  const optionsBackup = JSON.parse(JSON.stringify(options));
+  beforeEach(() => {
+    yf._opts = JSON.parse(JSON.stringify(optionsBackup));
+  });
+
+  it("sets config options and passes validation", () => {
     const configOverrides = { queue: { concurrency: 10, timeout: 90 } };
     yf.setGlobalConfig(configOverrides);
-    expect(yf._opts.queue).toEqual(configOverrides.queue);
+    expect(yf._opts).toEqual({ ...optionsBackup, ...configOverrides });
+  });
+  it("sets config options multiple levels deep", () => {
+    const configOverrides = { queue: { concurrency: 10 } };
+    yf.setGlobalConfig(configOverrides);
+    expect(yf._opts.queue).toEqual({
+      concurrency: 10,
+      timeout: optionsBackup.queue.timeout,
+    });
+  });
+  it("should throw on invalid config", () => {
+    expect(() => yf.setGlobalConfig({ queue: { abc: "" } })).toThrow(
+      /yahooFinance.setGlobalConfig called with invalid options\./
+    );
   });
 });

--- a/src/lib/setGlobalConfig.spec.ts
+++ b/src/lib/setGlobalConfig.spec.ts
@@ -1,0 +1,11 @@
+import testYf from "../../tests/testYf";
+import setGlobalConfig from "./setGlobalConfig";
+const yf = testYf({ setGlobalConfig });
+
+describe("setGlobalConfig", () => {
+  it("sets config options", () => {
+    const configOverrides = { queue: { concurrency: 10, timeout: 90 } };
+    yf.setGlobalConfig(configOverrides);
+    expect(yf._opts.queue).toEqual(configOverrides.queue);
+  });
+});

--- a/src/lib/setGlobalConfig.ts
+++ b/src/lib/setGlobalConfig.ts
@@ -1,0 +1,22 @@
+import { Options } from "../typings/interfaces";
+import { ModuleThis } from "./moduleCommon";
+import validateAndCoerceTypes from "./validateAndCoerceTypes";
+
+export default function setGlobalConfig(
+  this: ModuleThis,
+  config: Partial<Options>
+): void {
+  // TODO: Add validation, but currently not possible, since `Options` interface
+  // not in modules directory (therefore, not in schema), so cannot validate
+  // using `validateAndCoerceTypes`
+  validateAndCoerceTypes({
+    object: config,
+    source: "setGlobalConfig",
+    type: "options",
+    options: this._opts.validation,
+    schemaKey: "#/definitions/PartialOptions",
+  });
+  for (const key of Reflect.ownKeys(config)) {
+    this._opts[key] = config[key as keyof Options];
+  }
+}

--- a/src/lib/setGlobalConfig.ts
+++ b/src/lib/setGlobalConfig.ts
@@ -13,7 +13,24 @@ export default function setGlobalConfig(
     options: this._opts.validation,
     schemaKey: "#/definitions/PartialOptions",
   });
-  for (const key of Reflect.ownKeys(config)) {
-    this._opts[key] = config[key as keyof Options];
+  mergeObjects(this._opts, config as Obj);
+}
+
+type Obj = Record<string, string | ObjRecurse>;
+
+// This is fine, since this is just a hack for recursive types
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface ObjRecurse extends Obj {}
+
+function mergeObjects(original: Obj, objToMerge: Obj) {
+  const ownKeys: (keyof typeof objToMerge)[] = Reflect.ownKeys(
+    objToMerge
+  ) as string[];
+  for (const key of ownKeys) {
+    if (typeof objToMerge[key] === "object") {
+      mergeObjects(original[key] as Obj, objToMerge[key] as Obj);
+    } else {
+      original[key] = objToMerge[key];
+    }
   }
 }

--- a/src/lib/setGlobalConfig.ts
+++ b/src/lib/setGlobalConfig.ts
@@ -6,9 +6,6 @@ export default function setGlobalConfig(
   this: ModuleThis,
   config: Partial<Options>
 ): void {
-  // TODO: Add validation, but currently not possible, since `Options` interface
-  // not in modules directory (therefore, not in schema), so cannot validate
-  // using `validateAndCoerceTypes`
   validateAndCoerceTypes({
     object: config,
     source: "setGlobalConfig",

--- a/src/lib/yahooFinanceFetch.ts
+++ b/src/lib/yahooFinanceFetch.ts
@@ -1,6 +1,6 @@
 import Queue from "./queue";
 
-import type { Options } from "./options";
+import type { Options } from "../typings/interfaces";
 import type { QueueOptions } from "./queue";
 
 import errors from "./errors";

--- a/src/typings/interfaces.ts
+++ b/src/typings/interfaces.ts
@@ -1,0 +1,9 @@
+import { QueueOptions } from "../lib/queue";
+import { ValidationOptions } from "../lib/validateAndCoerceTypes";
+
+export interface PartialOptions {
+  queue?: QueueOptions;
+  validation?: ValidationOptions;
+}
+
+export type Options = Required<PartialOptions>;


### PR DESCRIPTION
Relating to #129.

## Changes
- Add `setGlobalConfig` function
- Add tests for `setGlobalConfig`
- Add docs
- Refactor `Options` interface into a new `interfaces.ts` file
- Change schema script to generate schema defs for refactored out interface

## Type
- [ ] New Module
- [x] Other New Feature
- [ ] Validation Fix
- [ ] Other Bugfix
- [x] Docs
- [x] Chore/other

## Comments/notes
@gadicc Is the name good? Also, all tests seem to pass, yet some unnecessary things have been added to the schema. I am not sure whether it is worth it.
Also, should this function merge config several levels deep, or not?