### PR TITLE
docs: fix broken doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ symbol, topHoldings, upgradeDowngradeHistory),
 [coming soon](https://github.com/gadicc/node-yahoo-finance2/issues/8).
 
 Extras: [`quoteCombine`](./docs/other/quoteCombine.md).
-Utils: [`setGlobalConfig`](./docs/utils/setGlobalConfig.md).
+Utils: [`setGlobalConfig`](./docs/other/setGlobalConfig.md).
 
 See the [Full Documentation](./docs/README.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,7 +46,7 @@ const result = await yahooFinance.module(query, queryOpts, moduleOpts);
 1. [quoteCombine](./other/quoteCombine.md) - debounce and combine multiple quote calls.
 
 <a name="utils"></a>
-1. [setGlobalConfig](./utils/setGlobalConfig.md) - set global config options.
+1. [setGlobalConfig](./other/setGlobalConfig.md) - set global config options.
 
 <a name="error-handling"></a>
 ## Error Handling


### PR DESCRIPTION
## Changes
- fix broken documentation links for the `setGlobalConfig` documentation

## Type
- [ ] New Module
- [ ] Other New Feature
- [ ] Validation Fix
- [ ] Other Bugfix
- [X] Docs
- [ ] Chore/other

## Comments/notes
This PR fixes two links which reffered to the wrong url