### PR TITLE
feat(quote): support { "return": "array"* | "map" | "object" } param

### DIFF
--- a/docs/modules/quote.md
+++ b/docs/modules/quote.md
@@ -89,9 +89,14 @@ const result = await yahooFinance.quote('AAPL');
   symbol: 'AAPL'
 }
 
-// Multiple symbols
-const results = await yahooFinance.quote(['AAPL','GOOGL']);
-const result = { AAPL: result[0], GOOGL: result[1] };
+// Multiple symbols, with default { return: "array" }.  Missing symbols skipped.
+const results = await yahooFinance.quote(['AAPL', 'NO_SUCH_SYMBOL', 'GOOGL']);
+const result = { AAPL: result[0], GOOGL: result[1] /* not result[2]! */ };
+
+// Other return types, where it's easier to deal with missing symbols, e.g.
+// here map.get("NO_SUCH_SYMBOL") === object.NO_SUCH_SYMBOL === undefined.
+const map = await yahooFinance.quote([...], { return: "map" });
+const object = await yahooFinance.quote([...], { return: "object" });
 ```
 
 ## API
@@ -111,6 +116,7 @@ an array of symbols, and you'll receive an array of results back.
 | Name          | Type      | Default    | Description                       |
 | ------------- | ----------| ---------- | --------------------------------- |
 | `fields`      | string[]  | (all)      | Which fields to return in query
+| `return`      | string    | "array"    | Return as "array" | "map" | "object"
 
 ```js
 // Don't return all fields, only return these two + other essentials.

--- a/schema.json
+++ b/schema.json
@@ -4719,6 +4719,9 @@
             "$ref": "#/definitions/QuoteField"
           },
           "type": "array"
+        },
+        "returnAs": {
+          "$ref": "#/definitions/ResultType"
         }
       },
       "type": "object"
@@ -5097,6 +5100,14 @@
         "Independent Non-Executive Director",
         "Officer",
         "President"
+      ],
+      "type": "string"
+    },
+    "ResultType": {
+      "enum": [
+        "array",
+        "object",
+        "map"
       ],
       "type": "string"
     },

--- a/schema.json
+++ b/schema.json
@@ -4726,7 +4726,7 @@
       },
       "type": "object"
     },
-    "QuoteOptionsReturnArray": {
+    "QuoteOptionsWithReturnArray": {
       "additionalProperties": false,
       "properties": {
         "fields": {
@@ -4742,7 +4742,7 @@
       },
       "type": "object"
     },
-    "QuoteOptionsReturnMap": {
+    "QuoteOptionsWithReturnMap": {
       "additionalProperties": false,
       "properties": {
         "fields": {
@@ -4761,7 +4761,7 @@
       ],
       "type": "object"
     },
-    "QuoteOptionsReturnObject": {
+    "QuoteOptionsWithReturnObject": {
       "additionalProperties": false,
       "properties": {
         "fields": {

--- a/schema.json
+++ b/schema.json
@@ -4720,17 +4720,89 @@
           },
           "type": "array"
         },
-        "returnAs": {
+        "return": {
           "$ref": "#/definitions/ResultType"
         }
       },
       "type": "object"
     },
-    "QuoteResponse": {
+    "QuoteOptionsReturnArray": {
+      "additionalProperties": false,
+      "properties": {
+        "fields": {
+          "items": {
+            "$ref": "#/definitions/QuoteField"
+          },
+          "type": "array"
+        },
+        "return": {
+          "const": "array",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "QuoteOptionsReturnMap": {
+      "additionalProperties": false,
+      "properties": {
+        "fields": {
+          "items": {
+            "$ref": "#/definitions/QuoteField"
+          },
+          "type": "array"
+        },
+        "return": {
+          "const": "map",
+          "type": "string"
+        }
+      },
+      "required": [
+        "return"
+      ],
+      "type": "object"
+    },
+    "QuoteOptionsReturnObject": {
+      "additionalProperties": false,
+      "properties": {
+        "fields": {
+          "items": {
+            "$ref": "#/definitions/QuoteField"
+          },
+          "type": "array"
+        },
+        "return": {
+          "const": "object",
+          "type": "string"
+        }
+      },
+      "required": [
+        "return"
+      ],
+      "type": "object"
+    },
+    "QuoteResponseArray": {
       "items": {
         "$ref": "#/definitions/Quote"
       },
       "type": "array"
+    },
+    "QuoteResponseMap": {
+      "additionalProperties": false,
+      "properties": {
+        "size": {
+          "yahooFinanceType": "number"
+        }
+      },
+      "required": [
+        "size"
+      ],
+      "type": "object"
+    },
+    "QuoteResponseObject": {
+      "additionalProperties": {
+        "$ref": "#/definitions/Quote"
+      },
+      "type": "object"
     },
     "QuoteSummaryEarnings": {
       "additionalProperties": false,

--- a/src/modules/quote.spec.ts
+++ b/src/modules/quote.spec.ts
@@ -80,4 +80,42 @@ describe("quote", () => {
     expect(result.symbol).toBe("TSLA");
     expect(result.displayName).toBeDefined();
   });
+
+  describe("returnAs", () => {
+    it("array", async () => {
+      const devel = "quote-AAPL-BABA.json";
+      const results = await yf.quote(
+        ["AAPL", "BABA"],
+        { returnAs: "array" },
+        { devel }
+      );
+      expect(results.length).toBe(2);
+      expect(results[0].symbol).toBe("AAPL");
+      expect(results[1].symbol).toBe("BABA");
+    });
+
+    it("object", async () => {
+      const devel = "quote-AAPL-BABA.json";
+      const results = await yf.quote(
+        ["AAPL", "BABA"],
+        { returnAs: "object" },
+        { devel }
+      );
+      expect(Object.keys(results).length).toBe(2);
+      expect(results.AAPL.symbol).toBe("AAPL");
+      expect(results.BABA.symbol).toBe("BABA");
+    });
+
+    it("map", async () => {
+      const devel = "quote-AAPL-BABA.json";
+      const results = await yf.quote(
+        ["AAPL", "BABA"],
+        { returnAs: "map" },
+        { devel }
+      );
+      expect(results.size).toBe(2);
+      expect(results.get("AAPL").symbol).toBe("AAPL");
+      expect(results.get("BABA").symbol).toBe("BABA");
+    });
+  });
 });

--- a/src/modules/quote.spec.ts
+++ b/src/modules/quote.spec.ts
@@ -81,12 +81,12 @@ describe("quote", () => {
     expect(result.displayName).toBeDefined();
   });
 
-  describe("returnAs", () => {
+  describe("return type", () => {
     it("array", async () => {
       const devel = "quote-AAPL-BABA.json";
       const results = await yf.quote(
         ["AAPL", "BABA"],
-        { returnAs: "array" },
+        { return: "array" },
         { devel }
       );
       expect(results.length).toBe(2);
@@ -98,7 +98,7 @@ describe("quote", () => {
       const devel = "quote-AAPL-BABA.json";
       const results = await yf.quote(
         ["AAPL", "BABA"],
-        { returnAs: "object" },
+        { return: "object" },
         { devel }
       );
       expect(Object.keys(results).length).toBe(2);
@@ -110,7 +110,7 @@ describe("quote", () => {
       const devel = "quote-AAPL-BABA.json";
       const results = await yf.quote(
         ["AAPL", "BABA"],
-        { returnAs: "map" },
+        { return: "map" },
         { devel }
       );
       expect(results.size).toBe(2);

--- a/src/modules/quote.ts
+++ b/src/modules/quote.ts
@@ -215,7 +215,7 @@ export default function quote(
   moduleOptions?: ModuleOptionsWithValidateFalse
 ): Promise<any>;
 
-export default function quote(
+export default async function quote(
   this: ModuleThis,
   query: string | string[],
   queryOptionsOverrides?: QuoteOptions,
@@ -224,7 +224,7 @@ export default function quote(
   const symbols = typeof query === "string" ? query : query.join(",");
   const returnAs = queryOptionsOverrides && queryOptionsOverrides.return;
 
-  return this._moduleExec({
+  const results: Quote[] = await this._moduleExec({
     moduleName: "quote",
 
     query: {
@@ -254,25 +254,25 @@ export default function quote(
     },
 
     moduleOptions,
-  }).then((results: Quote[]) => {
-    if (returnAs) {
-      switch (returnAs) {
-        case "array":
-          return results as Quote[];
-        case "object":
-          const object = {} as any;
-          for (let result of results) object[result.symbol] = result;
-          return object; // TODO: type
-        case "map":
-          const map = new Map();
-          for (let result of results) map.set(result.symbol, result);
-          return map; // TODO: type
-      }
-    } else {
-      // By default, match the query input shape (string or string[]).
-      return typeof query === "string"
-        ? (results[0] as Quote)
-        : (results as Quote[]);
-    }
   });
+
+  if (returnAs) {
+    switch (returnAs) {
+      case "array":
+        return results as Quote[];
+      case "object":
+        const object = {} as any;
+        for (let result of results) object[result.symbol] = result;
+        return object; // TODO: type
+      case "map":
+        const map = new Map();
+        for (let result of results) map.set(result.symbol, result);
+        return map; // TODO: type
+    }
+  } else {
+    // By default, match the query input shape (string or string[]).
+    return typeof query === "string"
+      ? (results[0] as Quote)
+      : (results as Quote[]);
+  }
 }

--- a/src/modules/quote.ts
+++ b/src/modules/quote.ts
@@ -164,13 +164,13 @@ export interface QuoteOptions {
   return?: ResultType;
 }
 
-export interface QuoteOptionsReturnArray extends QuoteOptions {
+export interface QuoteOptionsWithReturnArray extends QuoteOptions {
   return?: "array";
 }
-export interface QuoteOptionsReturnMap extends QuoteOptions {
+export interface QuoteOptionsWithReturnMap extends QuoteOptions {
   return: "map";
 }
-export interface QuoteOptionsReturnObject extends QuoteOptions {
+export interface QuoteOptionsWithReturnObject extends QuoteOptions {
   return: "object";
 }
 
@@ -181,21 +181,21 @@ const queryOptionsDefaults = {};
 export default function quote(
   this: ModuleThis,
   query: string[],
-  queryOptionsOverrides?: QuoteOptionsReturnArray,
+  queryOptionsOverrides?: QuoteOptionsWithReturnArray,
   moduleOptions?: ModuleOptionsWithValidateTrue
 ): Promise<QuoteResponseArray>;
 
 export default function quote(
   this: ModuleThis,
   query: string[],
-  queryOptionsOverrides?: QuoteOptionsReturnMap,
+  queryOptionsOverrides?: QuoteOptionsWithReturnMap,
   moduleOptions?: ModuleOptionsWithValidateTrue
 ): Promise<QuoteResponseMap>;
 
 export default function quote(
   this: ModuleThis,
   query: string[],
-  queryOptionsOverrides?: QuoteOptionsReturnObject,
+  queryOptionsOverrides?: QuoteOptionsWithReturnObject,
   moduleOptions?: ModuleOptionsWithValidateTrue
 ): Promise<QuoteResponseObject>;
 


### PR DESCRIPTION
Relates to #150.

## Changes (in `quote()`)
- Allows a `{ return: "type" }` query option to force return type of `array`, `object` or `map`

## Type

**Other New Feature**

## Comments/notes

- [X] Initial support and tests
- [X] Proper typings for correct return type based on option
- [X] Docs
- [X] Original behaviour is `return: array` (the default)