### PR TITLE
docs: update to use setGlobalConfig

### DIFF
--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -78,7 +78,7 @@ databaseResults.forEach(async (row) => {
 You can change it with:
 
 ```js
-yahooFinance._opts.queue.concurrency = 1; // or 8, Infinity, etc.
+yahooFinance.setGlobalConfig({ queue: { concurrency: 1 } }); // or 8, Infinity, etc.
 ```
 
 Changing the value applies retroactively to previously queued requests.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -128,5 +128,5 @@ To turn off the helpful but verbose error logging on validation fails,
 simply set:
 
 ```js
-yahooFinance._opts.validation.logErrors = false;
+yahooFinance.setGlobalConfig({ validation: { logErrors: false} });
 ```


### PR DESCRIPTION
Ref #129.

## Changes
- Update docs to use `setGlobalConfig` instead of `_opts` directly

## Type
- [ ] New Module
- [ ] Other New Feature
- [ ] Validation Fix
- [ ] Other Bugfix
- [x] Docs
- [ ] Chore/other