### PR TITLE
feat: accept `date` option in `options` module

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -2523,6 +2523,9 @@
     "OptionsOptions": {
       "additionalProperties": false,
       "properties": {
+        "date": {
+          "yahooFinanceType": "number"
+        },
         "formatted": {
           "type": "boolean"
         },

--- a/src/modules/options.ts
+++ b/src/modules/options.ts
@@ -45,6 +45,7 @@ export interface OptionsOptions {
   formatted?: boolean;
   lang?: string;
   region?: string;
+  date?: number;
 }
 
 const queryOptionsDefaults: OptionsOptions = {


### PR DESCRIPTION
Closes #175.

## Changes
- Accept `date` option in `options` module

## Type
- [ ] New Module
- [x] Other New Feature
- [ ] Validation Fix
- [ ] Other Bugfix
- [ ] Docs
- [ ] Chore/other