### PR TITLE
fix(historical): add the historical module back

### DIFF
--- a/src/index-common.ts
+++ b/src/index-common.ts
@@ -11,6 +11,7 @@ import search from "./modules/search.js";
 import recommendationsBySymbol from "./modules/recommendationsBySymbol.js";
 import trendingSymbols from "./modules/trendingSymbols.js";
 import optionsModule from "./modules/options.js";
+import historical from "./modules/historical.js";
 
 // other
 import quoteCombine from "./other/quoteCombine.js";
@@ -32,6 +33,7 @@ export default {
   trendingSymbols,
   options: optionsModule,
   insights,
+  historical,
 
   // other
   quoteCombine,


### PR DESCRIPTION
Closes #200.

## Changes
- Add historical module back to `index-common.ts` 

## Type
- [ ] New Module
- [ ] Other New Feature
- [ ] Validation Fix
- [x] Other Bugfix
- [ ] Docs
- [ ] Chore/other