### PR TITLE
feat(historical2): add historical2 module

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+	"typescript.tsdk": "node_modules\\typescript\\lib"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-	"typescript.tsdk": "node_modules\\typescript\\lib"
-}

--- a/schema.json
+++ b/schema.json
@@ -1654,6 +1654,275 @@
       ],
       "type": "string"
     },
+    "Historical2Options": {
+      "additionalProperties": false,
+      "properties": {
+        "events": {
+          "enum": [
+            "div",
+            "split",
+            "div|split"
+          ],
+          "type": "string"
+        },
+        "includeAdjustedClose": {
+          "type": "boolean"
+        },
+        "interval": {
+          "enum": [
+            "1d",
+            "1wk",
+            "1mo"
+          ],
+          "type": "string"
+        },
+        "period1": {
+          "anyOf": [
+            {
+              "yahooFinanceType": "date"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "yahooFinanceType": "number"
+            }
+          ]
+        },
+        "period2": {
+          "anyOf": [
+            {
+              "yahooFinanceType": "date"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "yahooFinanceType": "number"
+            }
+          ]
+        }
+      },
+      "required": [
+        "period1",
+        "period2"
+      ],
+      "type": "object"
+    },
+    "Historical2Result": {
+      "additionalProperties": false,
+      "properties": {
+        "dividends": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "amount": {
+                "yahooFinanceType": "number"
+              },
+              "date": {
+                "yahooFinanceType": "date"
+              }
+            },
+            "required": [
+              "date",
+              "amount"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "meta": {
+          "additionalProperties": false,
+          "properties": {
+            "chartPreviousClose": {
+              "yahooFinanceType": "number"
+            },
+            "currency": {
+              "type": "string"
+            },
+            "currentTradingPeriod": {
+              "additionalProperties": false,
+              "properties": {
+                "post": {
+                  "$ref": "#/definitions/Historical2TradingPeriod"
+                },
+                "pre": {
+                  "$ref": "#/definitions/Historical2TradingPeriod"
+                },
+                "regular": {
+                  "$ref": "#/definitions/Historical2TradingPeriod"
+                }
+              },
+              "required": [
+                "pre",
+                "regular",
+                "post"
+              ],
+              "type": "object"
+            },
+            "dataGranularity": {
+              "enum": [
+                "1d",
+                "1wk",
+                "1mo"
+              ],
+              "type": "string"
+            },
+            "exchangeName": {
+              "type": "string"
+            },
+            "exchangeTimezoneName": {
+              "type": "string"
+            },
+            "firstTradeDate": {
+              "yahooFinanceType": "date"
+            },
+            "gmtoffset": {
+              "yahooFinanceType": "number"
+            },
+            "instrumentType": {
+              "type": "string"
+            },
+            "priceHint": {
+              "yahooFinanceType": "number"
+            },
+            "range": {
+              "type": "string"
+            },
+            "regularMarketPrice": {
+              "yahooFinanceType": "number"
+            },
+            "regularMarketTime": {
+              "yahooFinanceType": "date"
+            },
+            "symbol": {
+              "type": "string"
+            },
+            "timezone": {
+              "type": "string"
+            },
+            "validRanges": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "symbol",
+            "exchangeName",
+            "instrumentType",
+            "firstTradeDate",
+            "regularMarketTime",
+            "gmtoffset",
+            "timezone",
+            "exchangeTimezoneName",
+            "regularMarketPrice",
+            "chartPreviousClose",
+            "priceHint",
+            "currentTradingPeriod",
+            "dataGranularity",
+            "range",
+            "validRanges"
+          ],
+          "type": "object"
+        },
+        "quote": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "adjClose": {
+                "yahooFinanceType": "number"
+              },
+              "close": {
+                "yahooFinanceType": "number"
+              },
+              "date": {
+                "yahooFinanceType": "date"
+              },
+              "high": {
+                "yahooFinanceType": "number"
+              },
+              "low": {
+                "yahooFinanceType": "number"
+              },
+              "open": {
+                "yahooFinanceType": "number"
+              },
+              "volume": {
+                "yahooFinanceType": "number"
+              }
+            },
+            "required": [
+              "date",
+              "open",
+              "high",
+              "low",
+              "close",
+              "volume"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "splits": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "date": {
+                "yahooFinanceType": "date"
+              },
+              "denominator": {
+                "yahooFinanceType": "number"
+              },
+              "numerator": {
+                "yahooFinanceType": "number"
+              },
+              "splitRatio": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "date",
+              "numerator",
+              "denominator",
+              "splitRatio"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "quote",
+        "meta"
+      ],
+      "type": "object"
+    },
+    "Historical2TradingPeriod": {
+      "additionalProperties": false,
+      "properties": {
+        "end": {
+          "yahooFinanceType": "date"
+        },
+        "gmtoffset": {
+          "yahooFinanceType": "number"
+        },
+        "start": {
+          "yahooFinanceType": "date"
+        },
+        "timezone": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "timezone",
+        "start",
+        "end",
+        "gmtoffset"
+      ],
+      "type": "object"
+    },
     "HistoricalOptions": {
       "additionalProperties": false,
       "properties": {

--- a/src/index-common.ts
+++ b/src/index-common.ts
@@ -7,6 +7,7 @@ import errors from "./lib/errors.js";
 // modules
 import autoc from "./modules/autoc.js";
 import historical from "./modules/historical.js";
+import historical2 from "./modules/historical2.js";
 import insights from "./modules/insights.js";
 import optionsModule from "./modules/options.js";
 import quote from "./modules/quote.js";
@@ -38,6 +39,7 @@ export default {
   recommendationsBySymbol,
   search,
   trendingSymbols,
+  historical2,
 
   // other
   quoteCombine,

--- a/src/modules/historical.ts
+++ b/src/modules/historical.ts
@@ -85,7 +85,7 @@ export default function historical(
         const fieldCount = Object.keys(result[0]).length;
 
         // Count number of null values in object (1-level deep)
-        function nullFieldCount(object: Object) {
+        function nullFieldCount(object: Record<string, unknown>) {
           let nullCount = 0;
           for (const val of Object.values(object))
             if (val === null) nullCount++;

--- a/src/modules/historical2.ts
+++ b/src/modules/historical2.ts
@@ -1,0 +1,173 @@
+import type {
+  ModuleOptions,
+  ModuleOptionsWithValidateTrue,
+  ModuleOptionsWithValidateFalse,
+  ModuleThis,
+} from "../lib/moduleCommon.js";
+
+export interface Historical2Result {
+  quote: {
+    date: Date;
+    open: number;
+    high: number;
+    low: number;
+    close: number;
+    adjClose?: number;
+    volume: number;
+  }[];
+  dividends?: { date: Date; amount: number }[];
+  splits?: {
+    date: Date;
+    numerator: number;
+    denominator: number;
+    splitRatio: string;
+  }[];
+  meta: {
+    currency?: string;
+    symbol: string;
+    exchangeName: string;
+    instrumentType: string;
+    firstTradeDate: Date;
+    regularMarketTime: Date;
+    gmtoffset: number;
+    timezone: string;
+    exchangeTimezoneName: string;
+    regularMarketPrice: number;
+    chartPreviousClose: number;
+    priceHint: number;
+    currentTradingPeriod: {
+      pre: Historical2TradingPeriod;
+      regular: Historical2TradingPeriod;
+      post: Historical2TradingPeriod;
+    };
+    dataGranularity: "1d" | "1wk" | "1mo";
+    range: string;
+    validRanges: string[];
+  };
+}
+
+export interface Historical2TradingPeriod {
+  timezone: string;
+  start: Date;
+  end: Date;
+  gmtoffset: number;
+}
+
+export interface Historical2Options {
+  period1: Date | string | number;
+  period2: Date | string | number;
+  interval?: "1d" | "1wk" | "1mo";
+  events?: "div" | "split" | "div|split";
+  includeAdjustedClose?: boolean;
+}
+
+const queryOptionsDefaults: Omit<
+  Omit<Historical2Options, "period1">,
+  "period2"
+> & {
+  formatted: true;
+} = {
+  interval: "1d",
+  includeAdjustedClose: true,
+  formatted: true,
+};
+
+export default function historical2(
+  this: ModuleThis,
+  symbol: string,
+  queryOptionsOverrides: Historical2Options,
+  moduleOptions?: ModuleOptionsWithValidateTrue
+): Promise<Historical2Result>;
+
+export default function historical2(
+  this: ModuleThis,
+  symbol: string,
+  queryOptionsOverrides: Historical2Options,
+  moduleOptions?: ModuleOptionsWithValidateFalse
+): Promise<any>;
+
+export default function historical2(
+  this: ModuleThis,
+  symbol: string,
+  queryOptionsOverrides: Historical2Options,
+  moduleOptions?: ModuleOptions
+): Promise<any> {
+  return this._moduleExec({
+    moduleName: "historical2",
+
+    query: {
+      url: "https://query1.finance.yahoo.com/v8/finance/chart/" + symbol,
+      schemaKey: "#/definitions/Historical2Options",
+      defaults: queryOptionsDefaults,
+      overrides: queryOptionsOverrides,
+      transformWith(queryOptions: Historical2Options) {
+        if (!queryOptions.period2) queryOptions.period2 = new Date();
+
+        const dates = ["period1", "period2"] as const;
+        for (const fieldName of dates) {
+          const value = queryOptions[fieldName];
+          if (value instanceof Date)
+            queryOptions[fieldName] = Math.floor(value.getTime() / 1000);
+          else typeof value === "string";
+          queryOptions[fieldName] = Math.floor(
+            new Date(value as string).getTime() / 1000
+          );
+        }
+
+        return queryOptions;
+      },
+    },
+
+    result: {
+      schemaKey: "#/definitions/Historical2Result",
+      transformWith(result: any) {
+        if (!result?.chart?.result[0]) {
+          throw new Error("Unexpected result: " + JSON.stringify(result));
+        }
+        const _result = result.chart.result[0];
+        const newResult: Record<string, any> = {};
+        newResult.meta = _result.meta;
+        const timestamps = _result.timestamp;
+        const quoteObj = _result.indicators.quote[0];
+        newResult.quote = [];
+        if (_result.indicators.adjclose) {
+          const adjClose = _result.indicators.adjclose[0].adjclose;
+          for (let i = 0; i < timestamps.length; i++) {
+            newResult.quote.push({
+              date: timestamps[i],
+              open: quoteObj.open[i],
+              close: quoteObj.close[i],
+              high: quoteObj.high[i],
+              low: quoteObj.low[i],
+              volume: quoteObj.volume[i],
+              adjClose: adjClose[i],
+            });
+          }
+        } else {
+          for (let i = 0; i < timestamps.length; i++) {
+            newResult.quote.push({
+              date: timestamps[i],
+              open: quoteObj.open[i],
+              close: quoteObj.close[i],
+              high: quoteObj.high[i],
+              low: quoteObj.low[i],
+              volume: quoteObj.volume[i],
+            });
+          }
+        }
+        const splits = _result.events?.splits;
+        const dividends = _result.events?.dividends;
+        if (splits) {
+          newResult.splits = Object.values(splits);
+        }
+        if (dividends) {
+          newResult.dividends = Object.values(dividends);
+        }
+
+        return newResult;
+      },
+    },
+
+    moduleOptions,
+  });
+}


### PR DESCRIPTION
Closes #238.

## Changes
- Add a new historical module that does not require CSV, and can also fetch stock splits and dividends data, all in one network request.
- Fixed a small nitpick while copying over the historical module: `Object` -> `Record<string, unknown>`

## Type
- [x] New Module
- [ ] Other New Feature
- [ ] Validation Fix
- [ ] Other Bugfix
- [ ] Docs
- [x] Chore/other

## Comments/notes
Tests and docs to come. @gadicc I think it might be appropriate to deprecate the other historical module, and then rename this one to be `historical` and delete the old one when we hit v2. What is your opinion on this?