### PR TITLE
chore: fix issue with sed on osx

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "schema": "node --loader ts-node/esm scripts/schema.js > schema.json",
     "build": "yarn run build:esm && yarn run build:cjs && yarn run build:post",
     "build:esm": "tsc --module es2020 --target es2019 --outDir dist/esm",
-    "build:cjs": "tsc --module commonjs --target es2015 --outDir dist/cjs && sed -i '' 's/\"type\": \"module\",/\"type:\": \"commonjs\",/' dist/cjs/package.json",
+    "build:cjs": "tsc --module commonjs --target es2015 --outDir dist/cjs && sed 's/\"type\": \"module\",/\"type:\": \"commonjs\",/' dist/cjs/package.json > dist/cjs/package-changed.json && mv dist/cjs/package-changed.json dist/cjs/package.json",
     "build:post": "scripts/json-transform.sh",
     "generateSchema": "yarn schema",
     "prepublishOnly": "yarn build && yarn generateSchema && yarn build:post",


### PR DESCRIPTION
This PR changes the way we are using `sed` to work for both Mac OS X and Linux by removing the usage of `-i`. Instead we are now writing to a temporary file which then replaces the original file. Closes https://github.com/gadicc/node-yahoo-finance2/issues/318.

## Changes

- Change usage of `sed` for the script `build:cjs` to work on both Mac OS X and Linux

## Details

Since the contents of `build:cjs` is quite long this is a summary of what's happening:

1. Build the project for `commonjs`
2. Create a copy of `dist/cjs/package.json` where we replace `"type:": "module",` with `"type:": "commonjs",`
3. Overwrite the original file with the copy

## Type

- [x] Chore/other

## Comments/notes

- Please see the details reported in the issue; https://github.com/gadicc/node-yahoo-finance2/issues/318
- Let's make sure that this doesn't mess up anything for people using other operating systems (and GNU sed)