### PR TITLE
fix: update SearchResult to include new properties

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -7825,6 +7825,10 @@
           "type": "array",
           "items": {}
         },
+        "culturalAssets": {
+          "type": "array",
+          "items": {}
+        },
         "timeTakenForQuotes": {
           "yahooFinanceType": "number"
         },
@@ -7847,6 +7851,9 @@
           "yahooFinanceType": "number"
         },
         "timeTakenForScreenerField": {
+          "yahooFinanceType": "number"
+        },
+        "timeTakenForCulturalAssets": {
           "yahooFinanceType": "number"
         }
       },

--- a/src/modules/search.ts
+++ b/src/modules/search.ts
@@ -92,6 +92,11 @@ export interface SearchResult {
   // Array<any> until we can find some examples of what it actually looks
   // like (#255).
   screenerFieldResults?: Array<any>;
+  // ALWAYS present, but TEMPORARILY marked optional ("?") since its
+  // sudden appearance, let's make sure it doesn't get suddenly removed.
+  // Array<any> until we can find some examples of what it actually looks
+  // like (#399).
+  culturalAssets?: Array<any>;
   timeTakenForQuotes: number; // 26
   timeTakenForNews: number; // 419
   timeTakenForAlgowatchlist: number; // 700
@@ -102,6 +107,9 @@ export interface SearchResult {
   // ALWAYS present, but TEMPORARILY marked optional ("?") since its
   // sudden appearance, let's make sure it doesn't get suddenly removed.
   timeTakenForScreenerField?: number;
+  // ALWAYS present, but TEMPORARILY marked optional ("?") since its
+  // sudden appearance, let's make sure it doesn't get suddenly removed.
+  timeTakenForCulturalAssets?: number;
 }
 
 export interface SearchOptions {


### PR DESCRIPTION
This PR fixes an issue for the `search` method where validation was failing due to two new properties being added two the response from Yahoo Finance. Closes https://github.com/gadicc/node-yahoo-finance2/issues/398.

## Changes

- Add two new properties `culturalAssets` and `timeTakenForCulturalAssets`

## Type

- [x] Validation Fix

## Comments/notes

Since I don't know the data that can be returned for `culturalAssets` it's currently set to `Array<any>`, just in order for the validation to pass. Created a new issue where we can track and improve this; https://github.com/gadicc/node-yahoo-finance2/issues/399