### PR TITLE
feat(validation): allow additionalProperties (closes #401)

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -8,6 +8,7 @@ side-step this if you understand the risks.
 1. [Using Unvalidated Data](#using-unvalidated-data)
 1. [Skip Validation Completely](#using-unvalidated-data)
 1. [Don't Log Validation Failures](#dont-log-validation-fails)
+1. [A Note on Additional Properties](#note-additional-props)
 
 <a name="why-validate"></a>
 ## Why Validate
@@ -130,3 +131,26 @@ simply set:
 ```js
 yahooFinance.setGlobalConfig({ validation: { logErrors: false} });
 ```
+
+<a name="note-additional-props"></a>
+## A Note on "Additional Properties"
+
+*Since v2.2 (March 2022)*
+
+We now allow "additional properties" on results received from Yahoo.
+
+This means that while we can still guarantee the type of all known fields we
+receive back, we'll no longer throw a new error on new unknown keys.
+
+This is important because Yahoo constantly add new fields, and this would
+break all existing deployments.
+
+You can revert to the old behaviour with:
+
+```js
+yahooFinance._disallowAdditionalProps();
+```
+
+which is the default when `NODE_ENV==="test"`.  This means that during our
+development of the library itself, we make sure that we're testing against
+all types.

--- a/schema.json
+++ b/schema.json
@@ -64,8 +64,7 @@
       "required": [
         "meta",
         "indicators"
-      ],
-      "additionalProperties": false
+      ]
     },
     "ChartMeta": {
       "type": "object",
@@ -165,8 +164,7 @@
         "dataGranularity",
         "range",
         "validRanges"
-      ],
-      "additionalProperties": false
+      ]
     },
     "ChartMetaTradingPeriod": {
       "type": "object",
@@ -189,8 +187,7 @@
         "start",
         "end",
         "gmtoffset"
-      ],
-      "additionalProperties": false
+      ]
     },
     "ChartMetaTradingPeriods": {
       "type": "object",
@@ -222,8 +219,7 @@
             }
           }
         }
-      },
-      "additionalProperties": false
+      }
     },
     "ChartEventsObject": {
       "type": "object",
@@ -234,8 +230,7 @@
         "splits": {
           "$ref": "#/definitions/ChartEventSplits"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "ChartEventDividends": {
       "type": "object",
@@ -256,8 +251,7 @@
       "required": [
         "amount",
         "date"
-      ],
-      "additionalProperties": false
+      ]
     },
     "ChartEventSplits": {
       "type": "object",
@@ -286,8 +280,7 @@
         "numerator",
         "denominator",
         "splitRatio"
-      ],
-      "additionalProperties": false
+      ]
     },
     "ChartIndicatorsObject": {
       "type": "object",
@@ -307,8 +300,7 @@
       },
       "required": [
         "quote"
-      ],
-      "additionalProperties": false
+      ]
     },
     "ChartIndicatorQuote": {
       "type": "object",
@@ -350,8 +342,7 @@
         "open",
         "close",
         "volume"
-      ],
-      "additionalProperties": false
+      ]
     },
     "ChartIndicatorAdjclose": {
       "type": "object",
@@ -365,8 +356,7 @@
       },
       "required": [
         "adjclose"
-      ],
-      "additionalProperties": false
+      ]
     },
     "ChartResultArray": {
       "type": "object",
@@ -405,8 +395,7 @@
             "$ref": "#/definitions/ChartEventSplit"
           }
         }
-      },
-      "additionalProperties": false
+      }
     },
     "ChartResultArrayQuote": {
       "type": "object",
@@ -440,8 +429,7 @@
         "open",
         "close",
         "volume"
-      ],
-      "additionalProperties": false
+      ]
     },
     "ChartOptions": {
       "type": "object",
@@ -742,8 +730,7 @@
         "low",
         "close",
         "volume"
-      ],
-      "additionalProperties": false
+      ]
     },
     "HistoricalOptions": {
       "type": "object",
@@ -879,8 +866,7 @@
       "required": [
         "symbol",
         "sigDevs"
-      ],
-      "additionalProperties": false
+      ]
     },
     "InsightsInstrumentInfo": {
       "type": "object",
@@ -904,8 +890,7 @@
           "required": [
             "provider",
             "stopLoss"
-          ],
-          "additionalProperties": false
+          ]
         },
         "technicalEvents": {
           "type": "object",
@@ -931,8 +916,7 @@
             "shortTermOutlook",
             "intermediateTermOutlook",
             "longTermOutlook"
-          ],
-          "additionalProperties": false
+          ]
         },
         "valuation": {
           "type": "object",
@@ -955,16 +939,14 @@
           },
           "required": [
             "provider"
-          ],
-          "additionalProperties": false
+          ]
         }
       },
       "required": [
         "keyTechnicals",
         "technicalEvents",
         "valuation"
-      ],
-      "additionalProperties": false
+      ]
     },
     "InsightsOutlook": {
       "type": "object",
@@ -1008,8 +990,7 @@
         "indexDirection",
         "indexScore",
         "indexScoreDescription"
-      ],
-      "additionalProperties": false
+      ]
     },
     "InsightsDirection": {
       "type": "string",
@@ -1046,8 +1027,7 @@
             "dividends": {
               "yahooFinanceType": "number"
             }
-          },
-          "additionalProperties": false
+          }
         },
         "sector": {
           "type": "object",
@@ -1076,16 +1056,14 @@
             "hiring",
             "insiderSentiments",
             "dividends"
-          ],
-          "additionalProperties": false
+          ]
         }
       },
       "required": [
         "sectorInfo",
         "company",
         "sector"
-      ],
-      "additionalProperties": false
+      ]
     },
     "InsightsEvent": {
       "type": "object",
@@ -1120,8 +1098,7 @@
         "imageUrl",
         "startDate",
         "endDate"
-      ],
-      "additionalProperties": false
+      ]
     },
     "InsightsReport": {
       "type": "object",
@@ -1152,8 +1129,7 @@
         "reportDate",
         "reportTitle",
         "reportType"
-      ],
-      "additionalProperties": false
+      ]
     },
     "InsightsSigDev": {
       "type": "object",
@@ -1168,8 +1144,7 @@
       "required": [
         "headline",
         "date"
-      ],
-      "additionalProperties": false
+      ]
     },
     "InsightsUpsell": {
       "type": "object",
@@ -1184,8 +1159,7 @@
       "required": [
         "companyName",
         "upsellReportType"
-      ],
-      "additionalProperties": false
+      ]
     },
     "InsightsOptions": {
       "type": "object",
@@ -1537,8 +1511,7 @@
         "priceHint",
         "fullExchangeName",
         "symbol"
-      ],
-      "additionalProperties": false
+      ]
     },
     "TwoNumberRange": {
       "type": "object",
@@ -1886,8 +1859,7 @@
         "toCurrency",
         "tradeable",
         "triggerable"
-      ],
-      "additionalProperties": false
+      ]
     },
     "QuoteCurrency": {
       "type": "object",
@@ -2188,8 +2160,7 @@
         "symbol",
         "tradeable",
         "triggerable"
-      ],
-      "additionalProperties": false
+      ]
     },
     "QuoteEtf": {
       "type": "object",
@@ -2490,8 +2461,7 @@
         "symbol",
         "tradeable",
         "triggerable"
-      ],
-      "additionalProperties": false
+      ]
     },
     "QuoteEquity": {
       "type": "object",
@@ -2792,8 +2762,7 @@
         "symbol",
         "tradeable",
         "triggerable"
-      ],
-      "additionalProperties": false
+      ]
     },
     "QuoteIndex": {
       "type": "object",
@@ -3094,8 +3063,7 @@
         "symbol",
         "tradeable",
         "triggerable"
-      ],
-      "additionalProperties": false
+      ]
     },
     "QuoteOption": {
       "type": "object",
@@ -3413,8 +3381,7 @@
         "tradeable",
         "triggerable",
         "underlyingSymbol"
-      ],
-      "additionalProperties": false
+      ]
     },
     "QuoteMutualfund": {
       "type": "object",
@@ -3715,8 +3682,7 @@
         "symbol",
         "tradeable",
         "triggerable"
-      ],
-      "additionalProperties": false
+      ]
     },
     "Quote": {
       "anyOf": [
@@ -4020,8 +3986,7 @@
         "hasMiniOptions",
         "quote",
         "options"
-      ],
-      "additionalProperties": false
+      ]
     },
     "Option": {
       "type": "object",
@@ -4050,8 +4015,7 @@
         "hasMiniOptions",
         "calls",
         "puts"
-      ],
-      "additionalProperties": false
+      ]
     },
     "CallOrPut": {
       "type": "object",
@@ -4116,8 +4080,7 @@
         "lastTradeDate",
         "impliedVolatility",
         "inTheMoney"
-      ],
-      "additionalProperties": false
+      ]
     },
     "OptionsOptions": {
       "type": "object",
@@ -4272,8 +4235,7 @@
         "upgradeDowngradeHistory": {
           "$ref": "#/definitions/UpgradeDowngradeHistory"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "AssetProfile": {
       "type": "object",
@@ -4369,8 +4331,7 @@
       "required": [
         "maxAge",
         "companyOfficers"
-      ],
-      "additionalProperties": false
+      ]
     },
     "CompanyOfficer": {
       "type": "object",
@@ -4407,8 +4368,7 @@
         "maxAge",
         "name",
         "title"
-      ],
-      "additionalProperties": false
+      ]
     },
     "BalanceSheetHistory": {
       "type": "object",
@@ -4426,8 +4386,7 @@
       "required": [
         "balanceSheetStatements",
         "maxAge"
-      ],
-      "additionalProperties": false
+      ]
     },
     "BalanceSheetStatement": {
       "type": "object",
@@ -4529,8 +4488,7 @@
       "required": [
         "maxAge",
         "endDate"
-      ],
-      "additionalProperties": false
+      ]
     },
     "CalendarEvents": {
       "type": "object",
@@ -4551,8 +4509,7 @@
       "required": [
         "maxAge",
         "earnings"
-      ],
-      "additionalProperties": false
+      ]
     },
     "CalendarEventsEarnings": {
       "type": "object",
@@ -4584,8 +4541,7 @@
       },
       "required": [
         "earningsDate"
-      ],
-      "additionalProperties": false
+      ]
     },
     "CashflowStatementHistory": {
       "type": "object",
@@ -4603,8 +4559,7 @@
       "required": [
         "cashflowStatements",
         "maxAge"
-      ],
-      "additionalProperties": false
+      ]
     },
     "CashflowStatement": {
       "type": "object",
@@ -4680,8 +4635,7 @@
         "maxAge",
         "endDate",
         "netIncome"
-      ],
-      "additionalProperties": false
+      ]
     },
     "DefaultKeyStatistics": {
       "type": "object",
@@ -4859,8 +4813,7 @@
         "fundFamily",
         "legalType",
         "lastSplitFactor"
-      ],
-      "additionalProperties": false
+      ]
     },
     "QuoteSummaryEarnings": {
       "type": "object",
@@ -4882,8 +4835,7 @@
         "maxAge",
         "earningsChart",
         "financialsChart"
-      ],
-      "additionalProperties": false
+      ]
     },
     "EarningsChart": {
       "type": "object",
@@ -4913,8 +4865,7 @@
       "required": [
         "quarterly",
         "earningsDate"
-      ],
-      "additionalProperties": false
+      ]
     },
     "EarningsChartQuarterly": {
       "type": "object",
@@ -4933,8 +4884,7 @@
         "date",
         "actual",
         "estimate"
-      ],
-      "additionalProperties": false
+      ]
     },
     "FinancialsChart": {
       "type": "object",
@@ -4955,8 +4905,7 @@
       "required": [
         "yearly",
         "quarterly"
-      ],
-      "additionalProperties": false
+      ]
     },
     "Yearly": {
       "type": "object",
@@ -4975,8 +4924,7 @@
         "date",
         "revenue",
         "earnings"
-      ],
-      "additionalProperties": false
+      ]
     },
     "FinancialsChartQuarterly": {
       "type": "object",
@@ -4995,8 +4943,7 @@
         "date",
         "revenue",
         "earnings"
-      ],
-      "additionalProperties": false
+      ]
     },
     "EarningsHistory": {
       "type": "object",
@@ -5014,8 +4961,7 @@
       "required": [
         "history",
         "maxAge"
-      ],
-      "additionalProperties": false
+      ]
     },
     "EarningsHistoryHistory": {
       "type": "object",
@@ -5050,8 +4996,7 @@
         "surprisePercent",
         "quarter",
         "period"
-      ],
-      "additionalProperties": false
+      ]
     },
     "EarningsTrend": {
       "type": "object",
@@ -5069,8 +5014,7 @@
       "required": [
         "trend",
         "maxAge"
-      ],
-      "additionalProperties": false
+      ]
     },
     "EarningsTrendTrend": {
       "type": "object",
@@ -5109,8 +5053,7 @@
         "revenueEstimate",
         "epsTrend",
         "epsRevisions"
-      ],
-      "additionalProperties": false
+      ]
     },
     "EarningsEstimate": {
       "type": "object",
@@ -5141,8 +5084,7 @@
         "yearAgoEps",
         "numberOfAnalysts",
         "growth"
-      ],
-      "additionalProperties": false
+      ]
     },
     "RevenueEstimate": {
       "type": "object",
@@ -5173,8 +5115,7 @@
         "numberOfAnalysts",
         "yearAgoRevenue",
         "growth"
-      ],
-      "additionalProperties": false
+      ]
     },
     "EpsTrend": {
       "type": "object",
@@ -5201,8 +5142,7 @@
         "30daysAgo",
         "60daysAgo",
         "90daysAgo"
-      ],
-      "additionalProperties": false
+      ]
     },
     "EpsRevisions": {
       "type": "object",
@@ -5225,8 +5165,7 @@
         "upLast30days",
         "downLast30days",
         "downLast90days"
-      ],
-      "additionalProperties": false
+      ]
     },
     "FinancialData": {
       "type": "object",
@@ -5330,8 +5269,7 @@
         "currentPrice",
         "recommendationKey",
         "financialCurrency"
-      ],
-      "additionalProperties": false
+      ]
     },
     "Ownership": {
       "type": "object",
@@ -5349,8 +5287,7 @@
       "required": [
         "maxAge",
         "ownershipList"
-      ],
-      "additionalProperties": false
+      ]
     },
     "OwnershipList": {
       "type": "object",
@@ -5381,8 +5318,7 @@
         "pctHeld",
         "position",
         "value"
-      ],
-      "additionalProperties": false
+      ]
     },
     "FundPerformance": {
       "type": "object",
@@ -5435,8 +5371,7 @@
         "pastQuarterlyReturns",
         "riskOverviewStatistics",
         "riskOverviewStatisticsCat"
-      ],
-      "additionalProperties": false
+      ]
     },
     "PeriodRange": {
       "type": "object",
@@ -5465,8 +5400,7 @@
         "tenYear": {
           "yahooFinanceType": "number"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "FundPerformancePerformanceOverview": {
       "type": "object",
@@ -5504,8 +5438,7 @@
         "worstThreeYrTotalReturn": {
           "yahooFinanceType": "number"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "FundPerformancePerformanceOverviewCat": {
       "type": "object",
@@ -5516,8 +5449,7 @@
         "fiveYrAvgReturnPct": {
           "yahooFinanceType": "number"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "FundPerformanceTrailingReturns": {
       "type": "object",
@@ -5552,8 +5484,7 @@
         "lastBearMkt": {
           "yahooFinanceType": "number"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "FundPerformanceReturns": {
       "type": "object",
@@ -5573,8 +5504,7 @@
       },
       "required": [
         "returns"
-      ],
-      "additionalProperties": false
+      ]
     },
     "FundPerformanceReturnsRow": {
       "type": "object",
@@ -5600,8 +5530,7 @@
       },
       "required": [
         "year"
-      ],
-      "additionalProperties": false
+      ]
     },
     "FundPerformanceRiskOverviewStats": {
       "type": "object",
@@ -5618,8 +5547,7 @@
       },
       "required": [
         "riskStatistics"
-      ],
-      "additionalProperties": false
+      ]
     },
     "FundPerformanceRiskOverviewStatsRow": {
       "type": "object",
@@ -5658,8 +5586,7 @@
         "stdDev",
         "sharpeRatio",
         "treynorRatio"
-      ],
-      "additionalProperties": false
+      ]
     },
     "FundPerformanceRiskOverviewStatsCat": {
       "type": "object",
@@ -5673,8 +5600,7 @@
       },
       "required": [
         "riskStatisticsCat"
-      ],
-      "additionalProperties": false
+      ]
     },
     "FundProfile": {
       "type": "object",
@@ -5745,8 +5671,7 @@
         "family",
         "categoryName",
         "legalType"
-      ],
-      "additionalProperties": false
+      ]
     },
     "FundProfileManagementInfo": {
       "type": "object",
@@ -5770,8 +5695,7 @@
       "required": [
         "managerName",
         "managerBio"
-      ],
-      "additionalProperties": false
+      ]
     },
     "FundProfileFeesExpensesInvestment": {
       "type": "object",
@@ -5797,8 +5721,7 @@
       },
       "required": [
         "projectionValues"
-      ],
-      "additionalProperties": false
+      ]
     },
     "FundProfileFeesExpensesInvestmentCat": {
       "type": "object",
@@ -5824,8 +5747,7 @@
       },
       "required": [
         "projectionValuesCat"
-      ],
-      "additionalProperties": false
+      ]
     },
     "FundProfileBrokerage": {
       "type": "object",
@@ -5847,8 +5769,7 @@
       "required": [
         "incomeStatementHistory",
         "maxAge"
-      ],
-      "additionalProperties": false
+      ]
     },
     "IncomeStatementHistoryElement": {
       "type": "object",
@@ -5951,8 +5872,7 @@
         "otherItems",
         "netIncome",
         "netIncomeApplicableToCommonShares"
-      ],
-      "additionalProperties": false
+      ]
     },
     "IndexTrend": {
       "type": "object",
@@ -5982,8 +5902,7 @@
         "peRatio",
         "pegRatio",
         "estimates"
-      ],
-      "additionalProperties": false
+      ]
     },
     "Estimate": {
       "type": "object",
@@ -5997,8 +5916,7 @@
       },
       "required": [
         "period"
-      ],
-      "additionalProperties": false
+      ]
     },
     "Trend": {
       "type": "object",
@@ -6018,8 +5936,7 @@
         "maxAge",
         "symbol",
         "estimates"
-      ],
-      "additionalProperties": false
+      ]
     },
     "Holders": {
       "type": "object",
@@ -6037,8 +5954,7 @@
       "required": [
         "holders",
         "maxAge"
-      ],
-      "additionalProperties": false
+      ]
     },
     "Holder": {
       "type": "object",
@@ -6091,8 +6007,7 @@
         "url",
         "transactionDescription",
         "latestTransDate"
-      ],
-      "additionalProperties": false
+      ]
     },
     "Relation": {
       "type": "string",
@@ -6127,8 +6042,7 @@
       "required": [
         "transactions",
         "maxAge"
-      ],
-      "additionalProperties": false
+      ]
     },
     "Transaction": {
       "type": "object",
@@ -6188,8 +6102,7 @@
         "moneyText",
         "startDate",
         "ownership"
-      ],
-      "additionalProperties": false
+      ]
     },
     "OwnershipEnum": {
       "type": "string",
@@ -6219,8 +6132,7 @@
       },
       "required": [
         "maxAge"
-      ],
-      "additionalProperties": false
+      ]
     },
     "NetSharePurchaseActivity": {
       "type": "object",
@@ -6271,8 +6183,7 @@
         "netInfoCount",
         "netInfoShares",
         "totalInsiderShares"
-      ],
-      "additionalProperties": false
+      ]
     },
     "Price": {
       "type": "object",
@@ -6436,8 +6347,7 @@
         "lastMarket",
         "marketState",
         "fromCurrency"
-      ],
-      "additionalProperties": false
+      ]
     },
     "QuoteType": {
       "type": "object",
@@ -6504,8 +6414,7 @@
         "uuid",
         "gmtOffSetMilliseconds",
         "maxAge"
-      ],
-      "additionalProperties": false
+      ]
     },
     "RecommendationTrend": {
       "type": "object",
@@ -6523,8 +6432,7 @@
       "required": [
         "trend",
         "maxAge"
-      ],
-      "additionalProperties": false
+      ]
     },
     "RecommendationTrendTrend": {
       "type": "object",
@@ -6555,8 +6463,7 @@
         "hold",
         "sell",
         "strongSell"
-      ],
-      "additionalProperties": false
+      ]
     },
     "SECFilings": {
       "type": "object",
@@ -6574,8 +6481,7 @@
       "required": [
         "filings",
         "maxAge"
-      ],
-      "additionalProperties": false
+      ]
     },
     "Filing": {
       "type": "object",
@@ -6609,8 +6515,7 @@
         "title",
         "edgarUrl",
         "maxAge"
-      ],
-      "additionalProperties": false
+      ]
     },
     "Type": {
       "type": "string",
@@ -6792,8 +6697,7 @@
         "tradeable",
         "fromCurrency",
         "lastMarket"
-      ],
-      "additionalProperties": false
+      ]
     },
     "SummaryProfile": {
       "type": "object",
@@ -6863,8 +6767,7 @@
       "required": [
         "companyOfficers",
         "maxAge"
-      ],
-      "additionalProperties": false
+      ]
     },
     "TopHoldings": {
       "type": "object",
@@ -6924,8 +6827,7 @@
         "bondHoldings",
         "bondRatings",
         "sectorWeightings"
-      ],
-      "additionalProperties": false
+      ]
     },
     "TopHoldingsHolding": {
       "type": "object",
@@ -6944,8 +6846,7 @@
         "symbol",
         "holdingName",
         "holdingPercent"
-      ],
-      "additionalProperties": false
+      ]
     },
     "TopHoldingsEquityHoldings": {
       "type": "object",
@@ -6992,8 +6893,7 @@
         "priceToCashflow",
         "priceToEarnings",
         "priceToSales"
-      ],
-      "additionalProperties": false
+      ]
     },
     "TopHoldingsBondRating": {
       "type": "object",
@@ -7025,8 +6925,7 @@
         "us_government": {
           "yahooFinanceType": "number"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "TopHoldingsSectorWeighting": {
       "type": "object",
@@ -7064,8 +6963,7 @@
         "healthcare": {
           "yahooFinanceType": "number"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "UpgradeDowngradeHistory": {
       "type": "object",
@@ -7083,8 +6981,7 @@
       "required": [
         "history",
         "maxAge"
-      ],
-      "additionalProperties": false
+      ]
     },
     "UpgradeDowngradeHistoryHistory": {
       "type": "object",
@@ -7110,8 +7007,7 @@
         "firm",
         "toGrade",
         "action"
-      ],
-      "additionalProperties": false
+      ]
     },
     "Grade": {
       "type": "string",
@@ -7262,8 +7158,7 @@
             "required": [
               "score",
               "symbol"
-            ],
-            "additionalProperties": false
+            ]
           }
         },
         "symbol": {
@@ -7273,8 +7168,7 @@
       "required": [
         "recommendedSymbols",
         "symbol"
-      ],
-      "additionalProperties": false
+      ]
     },
     "RecommendationsBySymbolResponseArray": {
       "type": "array",
@@ -7363,8 +7257,7 @@
         "exchange",
         "index",
         "score"
-      ],
-      "additionalProperties": false
+      ]
     },
     "SearchQuoteYahooEquity": {
       "type": "object",
@@ -7421,8 +7314,7 @@
         "score",
         "symbol",
         "typeDisp"
-      ],
-      "additionalProperties": false
+      ]
     },
     "SearchQuoteYahooOption": {
       "type": "object",
@@ -7479,8 +7371,7 @@
         "score",
         "symbol",
         "typeDisp"
-      ],
-      "additionalProperties": false
+      ]
     },
     "SearchQuoteYahooETF": {
       "type": "object",
@@ -7537,8 +7428,7 @@
         "score",
         "symbol",
         "typeDisp"
-      ],
-      "additionalProperties": false
+      ]
     },
     "SearchQuoteYahooFund": {
       "type": "object",
@@ -7595,8 +7485,7 @@
         "score",
         "symbol",
         "typeDisp"
-      ],
-      "additionalProperties": false
+      ]
     },
     "SearchQuoteYahooIndex": {
       "type": "object",
@@ -7653,8 +7542,7 @@
         "score",
         "symbol",
         "typeDisp"
-      ],
-      "additionalProperties": false
+      ]
     },
     "SearchQuoteYahooCurrency": {
       "type": "object",
@@ -7711,8 +7599,7 @@
         "score",
         "symbol",
         "typeDisp"
-      ],
-      "additionalProperties": false
+      ]
     },
     "SearchQuoteYahooCryptocurrency": {
       "type": "object",
@@ -7769,8 +7656,7 @@
         "score",
         "symbol",
         "typeDisp"
-      ],
-      "additionalProperties": false
+      ]
     },
     "SearchQuoteYahooFuture": {
       "type": "object",
@@ -7827,8 +7713,7 @@
         "score",
         "symbol",
         "typeDisp"
-      ],
-      "additionalProperties": false
+      ]
     },
     "SearchQuoteNonYahoo": {
       "type": "object",
@@ -7852,8 +7737,7 @@
         "name",
         "permalink",
         "isYahooFinance"
-      ],
-      "additionalProperties": false
+      ]
     },
     "SearchNews": {
       "type": "object",
@@ -7884,8 +7768,7 @@
         "link",
         "providerPublishTime",
         "type"
-      ],
-      "additionalProperties": false
+      ]
     },
     "SearchResult": {
       "type": "object",
@@ -8004,8 +7887,7 @@
         "timeTakenForCrunchbase",
         "timeTakenForNav",
         "timeTakenForResearchReports"
-      ],
-      "additionalProperties": false
+      ]
     },
     "SearchOptions": {
       "type": "object",
@@ -8077,8 +7959,7 @@
       },
       "required": [
         "symbol"
-      ],
-      "additionalProperties": false
+      ]
     },
     "TrendingSymbolsResult": {
       "type": "object",
@@ -8104,8 +7985,7 @@
         "quotes",
         "jobTimestamp",
         "startInterval"
-      ],
-      "additionalProperties": false
+      ]
     }
   }
 }

--- a/schema.json
+++ b/schema.json
@@ -128,8 +128,7 @@
             "pre",
             "regular",
             "post"
-          ],
-          "additionalProperties": false
+          ]
         },
         "tradingPeriods": {
           "$ref": "#/definitions/ChartMetaTradingPeriods"

--- a/src/index-common.ts
+++ b/src/index-common.ts
@@ -4,6 +4,7 @@ import moduleExec from "./lib/moduleExec.js";
 import options from "./lib/options.js";
 import errors from "./lib/errors.js";
 import setGlobalConfig from "./lib/setGlobalConfig.js";
+import { disallowAdditionalProps } from "./lib/validateAndCoerceTypes.js";
 
 // modules
 import autoc from "./modules/autoc.js";
@@ -26,6 +27,7 @@ export default {
   _fetch: yahooFinanceFetch,
   _moduleExec: moduleExec,
   _opts: options,
+  _disallowAdditionalProps: disallowAdditionalProps,
 
   // common
   errors,

--- a/src/lib/validateAndCoerceTypes.ts
+++ b/src/lib/validateAndCoerceTypes.ts
@@ -203,6 +203,27 @@ export interface ValidateParams {
   options: ValidationOptions;
 }
 
+function disallowAdditionalProps(show = false) {
+  const disallowed = new Set();
+  for (let key of Object.keys(schema.definitions)) {
+    if (key.match(/Options$/)) {
+      continue;
+    }
+    // @ts-ignore
+    const def = schema.definitions[key];
+    if (def.type === "object" && def.additionalProperties === undefined) {
+      def.additionalProperties = false;
+      disallowed.add(key);
+    }
+  }
+  if (show)
+    console.log(
+      "Disallowed additional props in " + Array.from(disallowed).join(", ")
+    );
+}
+
+if (process.env.NODE_ENV === "test") disallowAdditionalProps();
+
 function validate({
   source,
   type,
@@ -270,4 +291,5 @@ see https://github.com/gadicc/node-yahoo-finance2/tree/devel/docs/validation.md.
   }
 }
 
+export { disallowAdditionalProps };
 export default validate;

--- a/src/lib/validateAndCoerceTypes.ts
+++ b/src/lib/validateAndCoerceTypes.ts
@@ -205,6 +205,7 @@ export interface ValidateParams {
 
 function disallowAdditionalProps(show = false) {
   const disallowed = new Set();
+  // @ts-ignore: this can cause a breaking catch-22 on schema generation
   for (let key of Object.keys(schema.definitions)) {
     if (key.match(/Options$/)) {
       continue;

--- a/src/lib/validateAndCoerceTypes.ts
+++ b/src/lib/validateAndCoerceTypes.ts
@@ -217,6 +217,7 @@ function disallowAdditionalProps(show = false) {
       disallowed.add(key);
     }
   }
+  /* istanbul ignore next */
   if (show)
     console.log(
       "Disallowed additional props in " + Array.from(disallowed).join(", ")

--- a/src/modules/chart.ts
+++ b/src/modules/chart.ts
@@ -8,6 +8,7 @@ import type {
 } from "../lib/moduleCommon.js";
 
 export interface ChartResultObject {
+  [key: string]: any;
   meta: ChartMeta;
   timestamp?: Array<number>;
   events?: ChartEventsObject;
@@ -21,6 +22,7 @@ export interface ChartResultArray {
 }
 
 export interface ChartResultArrayQuote {
+  [key: string]: any;
   date: Date;
   high: number;
   low: number;
@@ -31,6 +33,7 @@ export interface ChartResultArrayQuote {
 }
 
 export interface ChartMeta {
+  [key: string]: any;
   currency: string; // "USD"
   symbol: string; // "AAPL",
   exchangeName: string; // "NMS",
@@ -57,6 +60,7 @@ export interface ChartMeta {
 }
 
 export interface ChartMetaTradingPeriod {
+  [key: string]: any;
   timezone: string; // "EST",
   start: Date; // new Date(1637355600 * 1000),
   end: Date; // new Date(1637370000 * 10000),
@@ -64,17 +68,20 @@ export interface ChartMetaTradingPeriod {
 }
 
 export interface ChartMetaTradingPeriods {
+  [key: string]: any;
   pre?: Array<Array<ChartMetaTradingPeriod>>;
   post?: Array<Array<ChartMetaTradingPeriod>>;
   regular?: Array<Array<ChartMetaTradingPeriod>>;
 }
 
 export interface ChartEventsObject {
+  [key: string]: any;
   dividends?: ChartEventDividends;
   splits?: ChartEventSplits;
 }
 
 export interface ChartEventsArray {
+  [key: string]: any;
   dividends?: Array<ChartEventDividend>;
   splits?: Array<ChartEventSplit>;
 }
@@ -84,6 +91,7 @@ export interface ChartEventDividends {
 }
 
 export interface ChartEventDividend {
+  [key: string]: any;
   amount: number;
   date: Date;
 }
@@ -93,6 +101,7 @@ export interface ChartEventSplits {
 }
 
 export interface ChartEventSplit {
+  [key: string]: any;
   date: Date; // new Date(1598880600 * 1000)
   numerator: number; // 4
   denominator: number; // 1
@@ -100,11 +109,13 @@ export interface ChartEventSplit {
 }
 
 export interface ChartIndicatorsObject {
+  [key: string]: any;
   quote: Array<ChartIndicatorQuote>;
   adjclose?: Array<ChartIndicatorAdjclose>;
 }
 
 export interface ChartIndicatorQuote {
+  [key: string]: any;
   high: Array<number>;
   low: Array<number>;
   open: Array<number>;
@@ -113,6 +124,7 @@ export interface ChartIndicatorQuote {
 }
 
 export interface ChartIndicatorAdjclose {
+  [key: string]: any;
   adjclose: Array<number>;
 }
 

--- a/src/modules/chart.ts
+++ b/src/modules/chart.ts
@@ -49,6 +49,7 @@ export interface ChartMeta {
   scale?: number; // 3,
   priceHint: number; // 2,
   currentTradingPeriod: {
+    [key: string]: any;
     pre: ChartMetaTradingPeriod;
     regular: ChartMetaTradingPeriod;
     post: ChartMetaTradingPeriod;

--- a/src/modules/historical.ts
+++ b/src/modules/historical.ts
@@ -8,6 +8,7 @@ import type {
 export type HistoricalResult = Array<HistoricalRow>;
 
 export interface HistoricalRow {
+  [key: string]: any;
   date: Date;
   open: number;
   high: number;

--- a/src/modules/insights.ts
+++ b/src/modules/insights.ts
@@ -6,6 +6,7 @@ import type {
 } from "../lib/moduleCommon.js";
 
 export interface InsightsResult {
+  [key: string]: any;
   symbol: string;
   instrumentInfo?: InsightsInstrumentInfo;
   companySnapshot?: InsightsCompanySnapshot;
@@ -21,11 +22,13 @@ export interface InsightsResult {
 }
 
 export interface InsightsSigDev {
+  [key: string]: any;
   headline: string;
   date: Date;
 }
 
 export interface InsightsReport {
+  [key: string]: any;
   id: string;
   headHtml: string;
   provider: string;
@@ -35,6 +38,7 @@ export interface InsightsReport {
 }
 
 export interface InsightsEvent {
+  [key: string]: any;
   eventType: string;
   pricePeriod: string;
   tradingHorizon: string;
@@ -45,13 +49,16 @@ export interface InsightsEvent {
 }
 
 export interface InsightsInstrumentInfo {
+  [key: string]: any;
   keyTechnicals: {
+    [key: string]: any;
     provider: string;
     support?: number;
     resistance?: number;
     stopLoss: number;
   };
   technicalEvents: {
+    [key: string]: any;
     provider: string;
     sector?: string;
     shortTermOutlook: InsightsOutlook;
@@ -59,6 +66,7 @@ export interface InsightsInstrumentInfo {
     longTermOutlook: InsightsOutlook;
   };
   valuation: {
+    [key: string]: any;
     color?: number;
     description?: string;
     discount?: string;
@@ -68,8 +76,10 @@ export interface InsightsInstrumentInfo {
 }
 
 export interface InsightsCompanySnapshot {
+  [key: string]: any;
   sectorInfo: string;
   company: {
+    [key: string]: any;
     innovativeness?: number;
     hiring?: number;
     sustainability?: number;
@@ -78,6 +88,7 @@ export interface InsightsCompanySnapshot {
     dividends?: number;
   };
   sector: {
+    [key: string]: any;
     innovativeness: number;
     hiring: number;
     sustainability?: number;
@@ -90,6 +101,7 @@ export interface InsightsCompanySnapshot {
 export type InsightsDirection = "Bearish" | "Bullish" | "Neutral";
 
 export interface InsightsOutlook {
+  [key: string]: any;
   stateDescription: string;
   direction: InsightsDirection;
   score: number;
@@ -102,15 +114,16 @@ export interface InsightsOutlook {
   indexScoreDescription: string;
 }
 
+export interface InsightsUpsell {
+  [key: string]: any;
+  companyName: string;
+  upsellReportType: string;
+}
+
 export interface InsightsOptions {
   lang?: string;
   region?: string;
   reportsCount?: number;
-}
-
-export interface InsightsUpsell {
-  companyName: string;
-  upsellReportType: string;
 }
 
 const queryOptionsDefaults = {

--- a/src/modules/options.ts
+++ b/src/modules/options.ts
@@ -8,6 +8,7 @@ import type {
 import { Quote } from "./quote.js";
 
 export interface OptionsResult {
+  [key: string]: any;
   underlyingSymbol: string;
   expirationDates: Date[];
   strikes: number[];
@@ -17,6 +18,7 @@ export interface OptionsResult {
 }
 
 export interface Option {
+  [key: string]: any;
   expirationDate: Date;
   hasMiniOptions: boolean;
   calls: CallOrPut[];
@@ -24,6 +26,7 @@ export interface Option {
 }
 
 export interface CallOrPut {
+  [key: string]: any;
   contractSymbol: string;
   strike: number;
   currency: string;

--- a/src/modules/quote.ts
+++ b/src/modules/quote.ts
@@ -8,6 +8,7 @@ import type {
 import type { DateInMs, TwoNumberRange } from "../lib/commonTypes.js";
 
 export interface QuoteBase {
+  [key: string]: any;
   language: string; // "en-US",
   region: string; // "US",
   quoteType: string; // "EQUITY" | "ETF" | "MUTUALFUND";

--- a/src/modules/quoteSummary-iface.ts
+++ b/src/modules/quoteSummary-iface.ts
@@ -12,6 +12,7 @@
  */
 
 export interface QuoteSummaryResult {
+  [key: string]: any;
   assetProfile?: AssetProfile;
   balanceSheetHistory?: BalanceSheetHistory;
   balanceSheetHistoryQuarterly?: BalanceSheetHistory;
@@ -48,6 +49,7 @@ export interface QuoteSummaryResult {
 }
 
 export interface AssetProfile {
+  [key: string]: any;
   maxAge: number;
   address1?: string;
   address2?: string;
@@ -79,6 +81,7 @@ export interface AssetProfile {
 }
 
 export interface CompanyOfficer {
+  [key: string]: any;
   maxAge: number;
   name: string;
   age?: number;
@@ -91,11 +94,13 @@ export interface CompanyOfficer {
 }
 
 export interface BalanceSheetHistory {
+  [key: string]: any;
   balanceSheetStatements: BalanceSheetStatement[];
   maxAge: number;
 }
 
 export interface BalanceSheetStatement {
+  [key: string]: any;
   maxAge: number;
   endDate: Date;
   cash?: number;
@@ -130,6 +135,7 @@ export interface BalanceSheetStatement {
 }
 
 export interface CalendarEvents {
+  [key: string]: any;
   maxAge: number;
   earnings: CalendarEventsEarnings;
   exDividendDate?: Date;
@@ -137,6 +143,7 @@ export interface CalendarEvents {
 }
 
 export interface CalendarEventsEarnings {
+  [key: string]: any;
   earningsDate: Date[];
   earningsAverage?: number;
   earningsLow?: number;
@@ -147,11 +154,13 @@ export interface CalendarEventsEarnings {
 }
 
 export interface CashflowStatementHistory {
+  [key: string]: any;
   cashflowStatements: CashflowStatement[];
   maxAge: number;
 }
 
 export interface CashflowStatement {
+  [key: string]: any;
   maxAge: number;
   endDate: Date;
   netIncome: number;
@@ -177,6 +186,7 @@ export interface CashflowStatement {
 }
 
 export interface DefaultKeyStatistics {
+  [key: string]: any;
   maxAge: number;
   priceHint: number;
   enterpriseValue?: number;
@@ -231,6 +241,7 @@ export interface DefaultKeyStatistics {
 }
 
 export interface QuoteSummaryEarnings {
+  [key: string]: any;
   maxAge: number;
   earningsChart: EarningsChart;
   financialsChart: FinancialsChart;
@@ -238,6 +249,7 @@ export interface QuoteSummaryEarnings {
 }
 
 export interface EarningsChart {
+  [key: string]: any;
   quarterly: EarningsChartQuarterly[];
   currentQuarterEstimate?: number;
   currentQuarterEstimateDate?: string;
@@ -246,34 +258,40 @@ export interface EarningsChart {
 }
 
 export interface EarningsChartQuarterly {
+  [key: string]: any;
   date: string;
   actual: number;
   estimate: number;
 }
 
 export interface FinancialsChart {
+  [key: string]: any;
   yearly: Yearly[];
   quarterly: FinancialsChartQuarterly[];
 }
 
 export interface FinancialsChartQuarterly {
+  [key: string]: any;
   date: string;
   revenue: number;
   earnings: number;
 }
 
 export interface Yearly {
+  [key: string]: any;
   date: number;
   revenue: number;
   earnings: number;
 }
 
 export interface EarningsHistory {
+  [key: string]: any;
   history: EarningsHistoryHistory[];
   maxAge: number;
 }
 
 export interface EarningsHistoryHistory {
+  [key: string]: any;
   maxAge: number;
   epsActual: number | null;
   epsEstimate: number | null;
@@ -284,11 +302,13 @@ export interface EarningsHistoryHistory {
 }
 
 export interface EarningsTrend {
+  [key: string]: any;
   trend: EarningsTrendTrend[];
   maxAge: number;
 }
 
 export interface EarningsTrendTrend {
+  [key: string]: any;
   maxAge: number;
   period: string;
   endDate: Date | null;
@@ -300,6 +320,7 @@ export interface EarningsTrendTrend {
 }
 
 export interface EarningsEstimate {
+  [key: string]: any;
   avg: number | null;
   low: number | null;
   high: number | null;
@@ -309,6 +330,7 @@ export interface EarningsEstimate {
 }
 
 export interface EpsRevisions {
+  [key: string]: any;
   upLast7days: number | null;
   upLast30days: number | null;
   downLast30days: number | null;
@@ -316,6 +338,7 @@ export interface EpsRevisions {
 }
 
 export interface EpsTrend {
+  [key: string]: any;
   current: number | null;
   "7daysAgo": number | null;
   "30daysAgo": number | null;
@@ -324,6 +347,7 @@ export interface EpsTrend {
 }
 
 export interface RevenueEstimate {
+  [key: string]: any;
   avg: number | null;
   low: number | null;
   high: number | null;
@@ -333,6 +357,7 @@ export interface RevenueEstimate {
 }
 
 export interface FinancialData {
+  [key: string]: any;
   maxAge: number;
   currentPrice: number;
   targetHighPrice?: number;
@@ -366,11 +391,13 @@ export interface FinancialData {
 }
 
 export interface Ownership {
+  [key: string]: any;
   maxAge: number;
   ownershipList: OwnershipList[];
 }
 
 export interface OwnershipList {
+  [key: string]: any;
   maxAge: number;
   reportDate: Date;
   organization: string;
@@ -380,6 +407,7 @@ export interface OwnershipList {
 }
 
 export interface FundPerformance {
+  [key: string]: any;
   maxAge: number;
   loadAdjustedReturns?: PeriodRange;
   rankInCategory?: PeriodRange;
@@ -395,6 +423,7 @@ export interface FundPerformance {
 }
 
 export interface PeriodRange {
+  [key: string]: any;
   asOfDate?: Date;
   ytd?: number;
   oneMonth?: number;
@@ -406,11 +435,13 @@ export interface PeriodRange {
 }
 
 export interface FundPerformanceTrailingReturns extends PeriodRange {
+  [key: string]: any;
   lastBullMkt?: number;
   lastBearMkt?: number;
 }
 
 export interface FundPerformancePerformanceOverview {
+  [key: string]: any;
   asOfDate?: Date;
   ytdReturnPct?: number;
   oneYearTotalReturn?: number;
@@ -425,16 +456,19 @@ export interface FundPerformancePerformanceOverview {
 }
 
 export interface FundPerformancePerformanceOverviewCat {
+  [key: string]: any;
   ytdReturnPct?: number;
   fiveYrAvgReturnPct?: number;
 }
 
 export interface FundPerformanceReturns {
+  [key: string]: any;
   returns: FundPerformanceReturnsRow[];
   returnsCat?: FundPerformanceReturnsRow[];
 }
 
 export interface FundPerformanceReturnsRow {
+  [key: string]: any;
   year: number; // coerce to number from string "2020"
   annualValue?: number;
   q1?: number;
@@ -444,15 +478,18 @@ export interface FundPerformanceReturnsRow {
 }
 
 export interface FundPerformanceRiskOverviewStats {
+  [key: string]: any;
   riskStatistics: FundPerformanceRiskOverviewStatsRow[];
   riskRating?: number;
 }
 
 export interface FundPerformanceRiskOverviewStatsCat {
+  [key: string]: any;
   riskStatisticsCat: FundPerformanceRiskOverviewStatsRow[];
 }
 
 export interface FundPerformanceRiskOverviewStatsRow {
+  [key: string]: any;
   year: string; // "5y" | "3y" | "10y" | anything else?
   alpha: number; // 7.76
   beta: number; // 1.04
@@ -464,6 +501,7 @@ export interface FundPerformanceRiskOverviewStatsRow {
 }
 
 export interface FundProfile {
+  [key: string]: any;
   maxAge: number;
   styleBoxUrl?: null | string;
   family: null | string;
@@ -482,12 +520,14 @@ export interface FundProfile {
 }
 
 export interface FundProfileManagementInfo {
+  [key: string]: any;
   managerName: null | string;
   managerBio: null | string;
   startdate?: Date;
 }
 
 export interface FundProfileFeesExpensesInvestment {
+  [key: string]: any;
   annualHoldingsTurnover?: number;
   annualReportExpenseRatio?: number;
   grossExpRatio?: number;
@@ -498,17 +538,20 @@ export interface FundProfileFeesExpensesInvestment {
 
 export interface FundProfileFeesExpensesInvestmentCat
   extends Omit<FundProfileFeesExpensesInvestment, "projectionValues"> {
+  [key: string]: any;
   projectionValuesCat: object;
 }
 
 export interface FundProfileBrokerage {}
 
 export interface IncomeStatementHistory {
+  [key: string]: any;
   incomeStatementHistory: IncomeStatementHistoryElement[];
   maxAge: number;
 }
 
 export interface IncomeStatementHistoryElement {
+  [key: string]: any;
   maxAge: number;
   endDate: Date;
   totalRevenue: number;
@@ -536,6 +579,7 @@ export interface IncomeStatementHistoryElement {
 }
 
 export interface IndexTrend {
+  [key: string]: any;
   maxAge: number;
   symbol: string;
   peRatio: number;
@@ -544,22 +588,26 @@ export interface IndexTrend {
 }
 
 export interface Estimate {
+  [key: string]: any;
   period: string;
   growth?: number;
 }
 
 export interface Trend {
+  [key: string]: any;
   maxAge: number;
   symbol: null;
   estimates: any[];
 }
 
 export interface Holders {
+  [key: string]: any;
   holders: Holder[];
   maxAge: number;
 }
 
 export interface Holder {
+  [key: string]: any;
   maxAge: number;
   name: string;
   relation: Relation | string;
@@ -589,11 +637,13 @@ export enum Relation {
 }
 
 export interface InsiderTransactions {
+  [key: string]: any;
   transactions: Transaction[];
   maxAge: number;
 }
 
 export interface Transaction {
+  [key: string]: any;
   maxAge: number;
   shares: number;
   filerUrl: string;
@@ -612,6 +662,7 @@ export enum OwnershipEnum {
 }
 
 export interface MajorHoldersBreakdown {
+  [key: string]: any;
   maxAge: number;
   insidersPercentHeld?: number;
   institutionsPercentHeld?: number;
@@ -619,6 +670,7 @@ export interface MajorHoldersBreakdown {
   institutionsCount?: number;
 }
 export interface NetSharePurchaseActivity {
+  [key: string]: any;
   maxAge: number;
   period: string;
   buyInfoCount: number;
@@ -638,6 +690,7 @@ export interface NetSharePurchaseActivity {
  * result to include an ISODate.
  */
 export interface Price {
+  [key: string]: any;
   averageDailyVolume10Day?: number;
   averageDailyVolume3Month?: number;
   exchange: string;
@@ -689,6 +742,7 @@ export interface Price {
 }
 
 export interface QuoteType {
+  [key: string]: any;
   exchange: string;
   quoteType: string;
   symbol: string;
@@ -705,11 +759,13 @@ export interface QuoteType {
 }
 
 export interface RecommendationTrend {
+  [key: string]: any;
   trend: RecommendationTrendTrend[];
   maxAge: number;
 }
 
 export interface RecommendationTrendTrend {
+  [key: string]: any;
   period: string;
   strongBuy: number;
   buy: number;
@@ -719,11 +775,13 @@ export interface RecommendationTrendTrend {
 }
 
 export interface SECFilings {
+  [key: string]: any;
   filings: Filing[];
   maxAge: number;
 }
 
 export interface Filing {
+  [key: string]: any;
   date: string; // TODO: check the format
   epochDate: Date;
   type: Type;
@@ -742,6 +800,7 @@ export enum Type {
 }
 
 export interface SummaryDetail {
+  [key: string]: any;
   maxAge: number;
   priceHint: number;
   previousClose: number;
@@ -797,6 +856,7 @@ export interface SummaryDetail {
 }
 
 export interface SummaryProfile {
+  [key: string]: any;
   address1?: string;
   address2?: string;
   address3?: string;
@@ -823,6 +883,7 @@ export interface SummaryProfile {
 }
 
 export interface TopHoldings {
+  [key: string]: any;
   maxAge: number;
   stockPosition: number;
   bondPosition: number;
@@ -838,12 +899,14 @@ export interface TopHoldings {
 }
 
 export interface TopHoldingsHolding {
+  [key: string]: any;
   symbol: string;
   holdingName: string;
   holdingPercent: number;
 }
 
 export interface TopHoldingsEquityHoldings {
+  [key: string]: any;
   medianMarketCap?: number;
   medianMarketCapCat?: number;
   priceToBook: number;
@@ -859,6 +922,7 @@ export interface TopHoldingsEquityHoldings {
 }
 
 export interface TopHoldingsBondRating {
+  [key: string]: any;
   a?: number;
   aa?: number;
   aaa?: number;
@@ -871,6 +935,7 @@ export interface TopHoldingsBondRating {
 }
 
 export interface TopHoldingsSectorWeighting {
+  [key: string]: any;
   realestate?: number;
   consumer_cyclical?: number;
   basic_materials?: number;
@@ -885,11 +950,13 @@ export interface TopHoldingsSectorWeighting {
 }
 
 export interface UpgradeDowngradeHistory {
+  [key: string]: any;
   history: UpgradeDowngradeHistoryHistory[];
   maxAge: number;
 }
 
 export interface UpgradeDowngradeHistoryHistory {
+  [key: string]: any;
   epochGradeDate: Date;
   firm: string;
   toGrade: Grade;

--- a/src/modules/recommendationsBySymbol.ts
+++ b/src/modules/recommendationsBySymbol.ts
@@ -6,7 +6,9 @@ import type {
 } from "../lib/moduleCommon.js";
 
 export interface RecommendationsBySymbolResponse {
+  [key: string]: any;
   recommendedSymbols: Array<{
+    [key: string]: any;
     score: number; // 0.1927
     symbol: string; // "BMW.DE"
   }>;

--- a/src/modules/search.ts
+++ b/src/modules/search.ts
@@ -6,6 +6,7 @@ import type {
 } from "../lib/moduleCommon.js";
 
 export interface SearchQuoteYahoo {
+  [key: string]: any;
   symbol: string; // "BABA"
   isYahooFinance: true; // true
   exchange: string; // "NYQ"
@@ -53,6 +54,7 @@ export interface SearchQuoteYahooFuture extends SearchQuoteYahoo {
 }
 
 export interface SearchQuoteNonYahoo {
+  [key: string]: any;
   index: string; // '78ddc07626ff4bbcae663e88514c23a0'
   name: string; // 'AAPlasma'
   permalink: string; // 'aaplasma',
@@ -60,6 +62,7 @@ export interface SearchQuoteNonYahoo {
 }
 
 export interface SearchNews {
+  [key: string]: any;
   uuid: string; // "9aff624a-e84c-35f3-9c23-db39852006dc"
   title: string; // "Analyst Report: Alibaba Group Holding Limited"
   publisher: string; // "Morningstar Research"
@@ -69,6 +72,7 @@ export interface SearchNews {
 }
 
 export interface SearchResult {
+  [key: string]: any;
   explains: Array<any>;
   count: number;
   quotes: Array<

--- a/src/modules/trendingSymbols.ts
+++ b/src/modules/trendingSymbols.ts
@@ -6,10 +6,12 @@ import type {
 } from "../lib/moduleCommon.js";
 
 export interface TrendingSymbol {
+  [key: string]: any;
   symbol: string;
 }
 
 export interface TrendingSymbolsResult {
+  [key: string]: any;
   count: number;
   quotes: TrendingSymbol[];
   jobTimestamp: number;


### PR DESCRIPTION
Closes #401.

Not done yet but in process.

We need to make a distinction between Options and Results, since we do actually rely on `{ additionalProperties: false }` to validate the options the user is passing to various modules (and ensure e.g. they didn't mispell anything).

Should be fine to simply traverse the tree and apply `additionalProperties` on interfaces with names ending `Options` (while remembering there's a module called `Options` too, and see if there are any other naming conflicts).