### PR TITLE
(docs) Link from every module doc to the type defs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@ const result = await yahooFinance.module(query, queryOpts, moduleOpts);
 ## Error Handling
 
 The modules rely on external services and *things can go wrong*.  Therefore,
-it's important to wrap your use of this library in try..catch statements,
+it's important to wrap your use of this library in try...catch statements,
 e.g.:
 
 ```js

--- a/docs/modules/autoc.md
+++ b/docs/modules/autoc.md
@@ -44,6 +44,8 @@ const result = await yahooFinance.autoc(query, /* queryOptions */);
 }
 ```
 
+**Note:** The example output above does not cover all possible return results, which can vary by asset type and even time of day (trading period). For an exhausting list of everything we cover and that you might get back, please see the TypeScript interface in https://github.com/gadicc/node-yahoo-finance2/blob/devel/src/modules/autoc.ts
+
 See also: [search](./search.md).
 
 ## API

--- a/docs/modules/chart.md
+++ b/docs/modules/chart.md
@@ -147,6 +147,8 @@ const result = await yahooFinance._chart(query, queryOptions);
 }
 ```
 
+**Note:** The example outputs above does not cover all possible return results, which can vary by asset type and even time of day (trading period). For an exhausting list of everything we cover and that you might get back, please see the TypeScript interface in https://github.com/gadicc/node-yahoo-finance2/blob/devel/src/modules/chart.ts
+
 ## API
 
 ```js

--- a/docs/modules/historical.md
+++ b/docs/modules/historical.md
@@ -41,6 +41,8 @@ const result = await yahooFinance.historical(query, queryOptions);
 ]
 ```
 
+**Note:** The example output above does not cover all possible return results, which can vary by asset type and even time of day (trading period). For an exhausting list of everything we cover and that you might get back, please see the TypeScript interface in https://github.com/gadicc/node-yahoo-finance2/blob/devel/src/modules/historical.ts
+
 Make sure to also look out for [historical() errors](#errors)
 and [general errors](../README.md#error-handling).
 

--- a/docs/modules/insights.md
+++ b/docs/modules/insights.md
@@ -124,6 +124,8 @@ in companies that are making progress on sustainability. He doubled down in his 
 }
 ```
 
+**Note:** The example output above does not cover all possible return results, which can vary by asset type and even time of day (trading period). For an exhausting list of everything we cover and that you might get back, please see the TypeScript interface in https://github.com/gadicc/node-yahoo-finance2/blob/devel/src/modules/insights.ts
+
 ## API
 
 ```js

--- a/docs/modules/options.md
+++ b/docs/modules/options.md
@@ -146,6 +146,8 @@ Example Result (Arrays are shortened so the docs aren't long):
 }
 ```
 
+**Note:** The example output above does not cover all possible return results, which can vary by asset type and even time of day (trading period). For an exhausting list of everything we cover and that you might get back, please see the TypeScript interface in https://github.com/gadicc/node-yahoo-finance2/blob/devel/src/modules/options.ts
+
 ## API
 
 ```js

--- a/docs/modules/quote.md
+++ b/docs/modules/quote.md
@@ -150,6 +150,8 @@ const map = await yahooFinance.quote([...], { return: "map" });
 const object = await yahooFinance.quote([...], { return: "object" });
 ```
 
+**Note:** The example output above does not cover all possible return results, which can vary by asset type and even time of day (trading period). For an exhausting list of everything we cover and that you might get back, please see the TypeScript interface in https://github.com/gadicc/node-yahoo-finance2/blob/devel/src/modules/quote.ts
+
 ## API
 
 ```js

--- a/docs/modules/quoteSummary.md
+++ b/docs/modules/quoteSummary.md
@@ -84,6 +84,8 @@ const result = await yahooFinance.quoteSummary(symbol, queryOptions);
 }
 ```
 
+**Note:** The example output above does not cover all possible return results, which can vary by asset type and even time of day (trading period). For an exhausting list of everything we cover and that you might get back, please see the TypeScript interface in https://github.com/gadicc/node-yahoo-finance2/blob/devel/src/modules/quoteSummary-iface.ts
+
 ## API
 
 ```js

--- a/docs/modules/recommendationsBySymbol.md
+++ b/docs/modules/recommendationsBySymbol.md
@@ -37,6 +37,8 @@ const searchMultiple = await yahooFinance2.recommendationsBySymbol([
 ]
 ```
 
+**Note:** The example output above does not cover all possible return results, which can vary by asset type and even time of day (trading period). For an exhausting list of everything we cover and that you might get back, please see the TypeScript interface in https://github.com/gadicc/node-yahoo-finance2/blob/devel/src/modules/recommendationsBySymbol.ts
+
 ## API
 
 ```js

--- a/docs/modules/search.md
+++ b/docs/modules/search.md
@@ -51,6 +51,8 @@ const result = await yahooFinance.search(query, /* queryOptions */);
 }
 ```
 
+**Note:** The example output above does not cover all possible return results, which can vary by asset type and even time of day (trading period). For an exhausting list of everything we cover and that you might get back, please see the TypeScript interface in https://github.com/gadicc/node-yahoo-finance2/blob/devel/src/modules/search.ts
+
 See also: [autoc](./autoc.md) (auto complete).
 
 ## API

--- a/docs/modules/trendingSymbols.md
+++ b/docs/modules/trendingSymbols.md
@@ -23,6 +23,8 @@ Result:
 }
 ```
 
+**Note:** The example output above does not cover all possible return results, which can vary by asset type and even time of day (trading period). For an exhausting list of everything we cover and that you might get back, please see the TypeScript interface in https://github.com/gadicc/node-yahoo-finance2/blob/devel/src/modules/trendingSymbols.ts
+
 ## API
 
 ```js

--- a/docs/other/quoteCombine.md
+++ b/docs/other/quoteCombine.md
@@ -26,7 +26,7 @@ Notes:
 * Each `quoteCombine()` call receives the result for only the symbol it
  asked for.
 
-* Query options (i.e. `fields`, above) and the shape of the return result is
+* Query options (i.e. `fields`, above) and the shape of the return result are
 identical to that of [quote()](../modules/quote.md).
 
 * If you call `quoteCombine()` multiple times with different `queryOptions`,


### PR DESCRIPTION
Closes #425.

## Changes
- Added link from every module type definition to its documentation page.
- Small typos on docs

## Type
- [ ] New Module
- [ ] Other New Feature
- [ ] Validation Fix
- [ ] Other Bugfix
- [X] Docs
- [ ] Chore/other