### PR TITLE
Add guidance to use CLI with submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,10 @@ considered acknowledgement and acceptance of these terms and of it's license.
 **CLI** (Command line interface)
 
 ```bash
+$ npx yahoo-finance2 --help
 $ npx yahoo-finance2 search AAPL
+$ npx yahoo-finance2 quoteSummary AAPL
+$ npx yahoo-finance2 quoteSummary AAPL '{"modules":["assetProfile", "secFilings"]}'
 
 # or install it
 $ npm install -g yahoo-finance2

--- a/bin/yahoo-finance.js
+++ b/bin/yahoo-finance.js
@@ -9,6 +9,23 @@ const script = process.argv[1];
 const moduleName = process.argv[2];
 const argsAsStrings = process.argv.slice(3);
 
+if (moduleName === "--help" || moduleName === "-h") {
+  console.log();
+  console.log("Usage: yahoo-finance.js <module> <args>");
+  console.log();
+  console.log("Get a quote for AAPL:");
+  console.log("> yahoo-finance.js quoteSummary AAPL");
+  console.log();
+  console.log("Run the quoteSummary module with two submodules:");
+  console.log(
+    '> yahoo-finance.js quoteSummary AAPL \'{"modules":["assetProfile", "secFilings"]}\''
+  );
+  console.log();
+  console.log("Available modules:");
+  console.log(moduleNames.join(", "));
+  process.exit();
+}
+
 if (!moduleNames.includes(moduleName)) {
   console.log("No such module: " + moduleName);
   console.log("Available modules: " + moduleNames.join(", "));

--- a/bin/yahoo-finance.js
+++ b/bin/yahoo-finance.js
@@ -14,11 +14,11 @@ if (moduleName === "--help" || moduleName === "-h") {
   console.log("Usage: yahoo-finance.js <module> <args>");
   console.log();
   console.log("Get a quote for AAPL:");
-  console.log("> yahoo-finance.js quoteSummary AAPL");
+  console.log("$ yahoo-finance.js quoteSummary AAPL");
   console.log();
   console.log("Run the quoteSummary module with two submodules:");
   console.log(
-    '> yahoo-finance.js quoteSummary AAPL \'{"modules":["assetProfile", "secFilings"]}\''
+    '$ yahoo-finance.js quoteSummary AAPL \'{"modules":["assetProfile", "secFilings"]}\''
   );
   console.log();
   console.log("Available modules:");


### PR DESCRIPTION
Minor changes to make it easier to use the CLI.

## Changes
- Add a help command to CLI (`--help` or `-h`
- Add a few more examples to the README file

## Type
- [ ] New Module
- [ ] Other New Feature
- [ ] Validation Fix
- [ ] Other Bugfix
- [x] Docs
- [ ] Chore/other

## Comments/notes
Might not be the best long term solution to log out the help commands manually, but it would've helped as first time experience to see if the data fits your needs.