### PR TITLE
Fixes Insights and SEC Filings Validation Errors

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1112,8 +1112,7 @@
             }
           },
           "required": [
-            "provider",
-            "stopLoss"
+            "provider"
           ]
         },
         "technicalEvents": {
@@ -1284,7 +1283,6 @@
         }
       },
       "required": [
-        "sectorInfo",
         "company",
         "sector"
       ]
@@ -7285,7 +7283,17 @@
             "SC 13G/A",
             "DEFA14A",
             "25-NSE",
-            "S-8 POS"
+            "S-8 POS",
+            "6-K",
+            "F-3ASR",
+            "SC 13D/A",
+            "20-F",
+            "425",
+            "SC14D9C",
+            "SC 13G",
+            "S-8",
+            "DEF 14A",
+            "F-10"
           ]
         },
         "title": {

--- a/src/modules/insights.ts
+++ b/src/modules/insights.ts
@@ -83,7 +83,7 @@ export interface InsightsInstrumentInfo {
     provider: string;
     support?: number;
     resistance?: number;
-    stopLoss: number;
+    stopLoss?: number;
   };
   technicalEvents: {
     [key: string]: any;
@@ -105,7 +105,7 @@ export interface InsightsInstrumentInfo {
 
 export interface InsightsCompanySnapshot {
   [key: string]: any;
-  sectorInfo: string;
+  sectorInfo?: string;
   company: {
     [key: string]: any;
     innovativeness?: number;

--- a/src/modules/quoteSummary-iface.ts
+++ b/src/modules/quoteSummary-iface.ts
@@ -823,11 +823,7 @@ type FilingType =
   | "SC 13G"
   | "S-8"
   | "DEF 14A"
-  | "F-10"
-  
-  
-  
-  ;
+  | "F-10";
 
 export interface SummaryDetail {
   [key: string]: any;

--- a/src/modules/quoteSummary-iface.ts
+++ b/src/modules/quoteSummary-iface.ts
@@ -813,7 +813,21 @@ type FilingType =
   | "SC 13G/A"
   | "DEFA14A"
   | "25-NSE"
-  | "S-8 POS";
+  | "S-8 POS"
+  | "6-K"
+  | "F-3ASR"
+  | "SC 13D/A"
+  | "20-F"
+  | "425"
+  | "SC14D9C"
+  | "SC 13G"
+  | "S-8"
+  | "DEF 14A"
+  | "F-10"
+  
+  
+  
+  ;
 
 export interface SummaryDetail {
   [key: string]: any;


### PR DESCRIPTION
Partially Closes #663 , and closes #664.

## Changes
- stopLoss under insights is not always present in response, changed to optional
- sectorInfo under insights is not always present in response, changed to optional
- Added missing Filing forms for some non-US companies

## Type
- [ ] New Module
- [ ] Other New Feature
- [X] Validation Fix
- [ ] Other Bugfix
- [ ] Docs
- [ ] Chore/other

## Comments/notes
<!-- add comments and notes here -->