### PR TITLE
feat: Customisable logging

### DIFF
--- a/src/lib/getCrumb.spec.ts
+++ b/src/lib/getCrumb.spec.ts
@@ -3,8 +3,11 @@ import getCrumb, { _getCrumb, getCrumbClear } from "./getCrumb";
 import { MyCookieJar } from "./cookieJar.js";
 import { jest } from "@jest/globals";
 import { consoleSilent, consoleRestore } from "../../tests/console.js";
+import options from "./options.js";
 
 describe("getCrumb", () => {
+  const { logger } = options;
+
   beforeAll(consoleSilent);
   afterAll(consoleRestore);
 
@@ -14,8 +17,8 @@ describe("getCrumb", () => {
 
       const crumb = await _getCrumb(
         fetch,
-        // @ts-expect-error: fetchDevel still has no types (yet)
         { devel: true },
+        logger,
         "https://finance.yahoo.com/quote/AAPL",
         "getCrumb-quote-AAPL.json",
         true,
@@ -27,11 +30,7 @@ describe("getCrumb", () => {
     it("ditto with shared cookie jar (don't use it for other tests)", async () => {
       const fetch = await env.fetchDevel();
 
-      const crumb = await _getCrumb(
-        fetch,
-        // @ts-expect-error: fetchDevel still has no types (yet)
-        { devel: true }
-      );
+      const crumb = await _getCrumb(fetch, { devel: true }, logger);
       expect(crumb).toBe("mloUP8q7ZPH");
     });
 
@@ -40,8 +39,8 @@ describe("getCrumb", () => {
 
       let crumb = await _getCrumb(
         fetch,
-        // @ts-expect-error: fetchDevel still has no types (yet)
         { devel: true },
+        logger,
         "https://finance.yahoo.com/quote/AAPL"
       );
       expect(crumb).toBe("mloUP8q7ZPH");
@@ -50,8 +49,8 @@ describe("getCrumb", () => {
 
       crumb = await _getCrumb(
         fetch,
-        // @ts-expect-error: fetchDevel still has no types (yet)
         { devel: true },
+        logger,
         "https://finance.yahoo.com/quote/AAPL"
       );
       expect(crumb).toBe("mloUP8q7ZPH");
@@ -63,8 +62,8 @@ describe("getCrumb", () => {
       await expect(() =>
         _getCrumb(
           fetch,
-          // @ts-expect-error: fetchDevel still has no types (yet)
           { devel: true },
+          logger,
           "https://finance.yahoo.com/quote/AAPL",
           "getCrumb-quote-AAPL-no-cookies.fake.json",
           true,
@@ -79,8 +78,8 @@ describe("getCrumb", () => {
       await expect(() =>
         _getCrumb(
           fetch,
-          // @ts-expect-error: fetchDevel still has no types (yet)
           { devel: true },
+          logger,
           "https://finance.yahoo.com/quote/AAPL",
           "getCrumb-quote-AAPL-no-context.fake.json",
           true,
@@ -95,8 +94,8 @@ describe("getCrumb", () => {
       await expect(() =>
         _getCrumb(
           fetch,
-          // @ts-expect-error: fetchDevel still has no types (yet)
           { devel: true },
+          logger,
           "https://finance.yahoo.com/quote/AAPL",
           "getCrumb-quote-AAPL-invalid-json.fake.json",
           true,
@@ -111,8 +110,8 @@ describe("getCrumb", () => {
       await expect(() =>
         _getCrumb(
           fetch,
-          // @ts-expect-error: fetchDevel still has no types (yet)
           { devel: true },
+          logger,
           "https://finance.yahoo.com/quote/AAPL",
           "getCrumb-quote-AAPL-no-crumb.fake.json",
           true,
@@ -127,8 +126,8 @@ describe("getCrumb", () => {
 
       const crumb = await _getCrumb(
         fetch,
-        // @ts-expect-error: fetchDevel still has no types (yet)
         { devel: true },
+        logger,
         "https://finance.yahoo.com/quote/AAPL",
         "getCrumb-quote-AAPL-pre-consent-VPN-UK.json",
         true,
@@ -143,11 +142,7 @@ describe("getCrumb", () => {
     it("works", async () => {
       getCrumbClear();
       const fetch = await env.fetchDevel();
-      const crumb = await getCrumb(
-        fetch,
-        // @ts-expect-error: fetchDevel still has no types (yet)
-        { devel: true }
-      );
+      const crumb = await getCrumb(fetch, { devel: true }, logger);
       expect(crumb).toBe("mloUP8q7ZPH");
     });
 
@@ -158,18 +153,18 @@ describe("getCrumb", () => {
 
       getCrumb(
         fetch,
-        // @ts-expect-error: fetchDevel still has no types (yet)
         { devel: true },
+        logger,
         "https://finance.yahoo.com/quote/TSLA",
-        _getCrumb
+        _getCrumb as any
       );
 
       getCrumb(
         fetch,
-        // @ts-expect-error: fetchDevel still has no types (yet)
         { devel: true },
+        logger,
         "https://finance.yahoo.com/quote/TSLA",
-        _getCrumb
+        _getCrumb as any
       );
 
       expect(_getCrumb).toHaveBeenCalledTimes(1);

--- a/src/lib/options.ts
+++ b/src/lib/options.ts
@@ -2,10 +2,18 @@
 import type { ValidationOptions } from "./validateAndCoerceTypes.js";
 import type { QueueOptions } from "./queue.js";
 
+export interface Logger {
+  info: (...args: any[]) => void;
+  warn: (...args: any[]) => void;
+  error: (...args: any[]) => void;
+  debug: (...args: any[]) => void;
+}
+
 export interface YahooFinanceOptions {
   YF_QUERY_HOST?: string;
   queue?: QueueOptions;
   validation?: ValidationOptions;
+  logger: Logger;
 }
 
 const options: YahooFinanceOptions = {
@@ -17,6 +25,12 @@ const options: YahooFinanceOptions = {
   validation: {
     logErrors: true,
     logOptionsErrors: true,
+  },
+  logger: {
+    info: (...args: any[]) => console.log(...args),
+    warn: (...args: any[]) => console.error(...args),
+    error: (...args: any[]) => console.error(...args),
+    debug: (...args: any[]) => console.log(...args),
   },
 };
 

--- a/src/lib/setGlobalConfig.ts
+++ b/src/lib/setGlobalConfig.ts
@@ -13,15 +13,10 @@ export default function setGlobalConfig(
     options: this._opts.validation,
     schemaKey: "#/definitions/YahooFinanceOptions",
   });
-  mergeObjects(this._opts, config as Obj);
+  mergeObjects(this._opts, config);
 }
 
-type Obj = Record<string, string | ObjRecurse>;
-
-// This is fine, since this is just a hack for recursive types
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface ObjRecurse extends Obj {}
-
+type Obj = Record<string, any>;
 function mergeObjects(original: Obj, objToMerge: Obj) {
   const ownKeys: (keyof typeof objToMerge)[] = Reflect.ownKeys(
     objToMerge

--- a/src/lib/yahooFinanceFetch.ts
+++ b/src/lib/yahooFinanceFetch.ts
@@ -94,7 +94,11 @@ async function yahooFinanceFetch(
 
   if (needsCrumb) {
     // @ts-expect-error: TODO, crumb string type for partial params
-    params.crumb = await getCrumb(fetchFunc, fetchOptionsBase);
+    params.crumb = await getCrumb(
+      fetchFunc,
+      fetchOptionsBase,
+      this._opts.logger
+    );
   }
 
   // @ts-expect-error: TODO copy interface? @types lib?


### PR DESCRIPTION
## Changes
Makes logging customisable. Currently there's fair bit of noise like

>  Fetching crumb and cookies from https://finance.yahoo.com/quote/AAPL...
> Success. Cookie expires on Tue May 07 2024 00:13:50 GMT+1000 

etc. This PR makes it possible to either silence it, or pipe to standard logging destination.

The original behaviour with `console.log`'s is kept, meaning there's no breaking changes.


## Type
- [ ] New Module
- [ ] Other New Feature
- [ ] Validation Fix
- [ ] Other Bugfix
- [ ] Docs
- [x] Chore/other
