### PR TITLE
Remove node-fetch in favour of native fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
   "dependencies": {
     "@sinclair/typebox": "^0.32.27",
     "@types/tough-cookie": "^4.0.2",
-    "node-fetch": "^2.6.1",
     "tough-cookie": "^4.1.2",
     "tough-cookie-file-store": "^2.0.3"
   },
@@ -72,7 +71,6 @@
     "@tsconfig/node12": "12.1.3",
     "@types/har-format": "^1.2.15",
     "@types/jest": "^29.5.13",
-    "@types/node-fetch": "2.6.11",
     "@typescript-eslint/eslint-plugin": "5.62.0",
     "@typescript-eslint/parser": "5.62.0",
     "eslint": "8.57.1",

--- a/src/env-node.ts
+++ b/src/env-node.ts
@@ -1,5 +1,4 @@
 import { URLSearchParams } from "url";
-import fetch from "node-fetch";
 
 export default {
   fetch,

--- a/src/env-test.ts
+++ b/src/env-test.ts
@@ -1,6 +1,4 @@
 import { URLSearchParams } from "url";
-import fetch from "node-fetch";
-import type { RequestInfo, RequestInit, Response } from "node-fetch";
 
 // This let's us still only require the file if we need it, at runtime.
 let fetchDevelFunc: (url: RequestInfo, init?: RequestInit) => Promise<Response>;

--- a/src/lib/fetchDevel.js
+++ b/src/lib/fetchDevel.js
@@ -1,5 +1,4 @@
 /* istanbul ignore file */
-import nodeFetch, { Headers } from "node-fetch";
 import fs from "fs";
 import crypto from "crypto";
 
@@ -11,8 +10,7 @@ class FakeResponse {
     Object.keys(props).forEach((key) => (this[key] = props[key]));
     const rawHeaders = this.headers;
     this.headers = new Headers(rawHeaders);
-    // node-fetch extension, needed to handle multiple set-cookie headers
-    this.headers.raw = () => rawHeaders;
+    this.headers.getSetCookie = () => rawHeaders["set-cookie"];
   }
 
   async json() {
@@ -34,7 +32,7 @@ const cache = {};
 
 async function fetchDevel(url, fetchOptions) {
   if (process.env.FETCH_DEVEL === "nocache")
-    return await nodeFetch(url, fetchOptions);
+    return await fetch(url, fetchOptions);
 
   // Use query2 for all our tests / fixtures / cache
   url = url.replace(
@@ -70,7 +68,7 @@ async function fetchDevel(url, fetchOptions) {
     contentObj = JSON.parse(contentJson);
   } catch (error) {
     if (error.code === "ENOENT") {
-      const res = await nodeFetch(origUrl, fetchOptions);
+      const res = await fetch(origUrl, fetchOptions);
 
       contentObj = {
         request: {

--- a/src/lib/getCrumb.ts
+++ b/src/lib/getCrumb.ts
@@ -1,4 +1,3 @@
-import type { RequestInfo, RequestInit, Response } from "node-fetch";
 import type { ExtendedCookieJar } from "./cookieJar";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: we have to ignore this for csm output.
@@ -70,7 +69,7 @@ export async function _getCrumb(
   };
 
   const response = await fetch(url, fetchOptions);
-  await processSetCookieHeader(response.headers.raw()["set-cookie"], url);
+  await processSetCookieHeader(response.headers.getSetCookie(), url);
 
   // logger.debug(response.headers.raw());
   // logger.debug(cookieJar);
@@ -151,7 +150,7 @@ export async function _getCrumb(
         // Set-Cookie: CFC=AQABCAFkWkdkjEMdLwQ9&s=AQAAAClxdtC-&g=ZFj24w; Expires=Wed, 8 May 2024 01:18:54 GMT; Domain=consent.yahoo.com; Path=/; Secure
         if (
           !(await processSetCookieHeader(
-            collectConsentSubmitResponse.headers.raw()["set-cookie"],
+            collectConsentSubmitResponse.headers.getSetCookie(),
             consentLocation,
           ))
         )
@@ -189,7 +188,7 @@ export async function _getCrumb(
 
         if (
           !(await processSetCookieHeader(
-            copyConsentResponse.headers.raw()["set-cookie"],
+            copyConsentResponse.headers.getSetCookie(),
             collectConsentSubmitResponseLocation,
           ))
         )

--- a/src/lib/yahooFinanceFetch.spec.ts
+++ b/src/lib/yahooFinanceFetch.spec.ts
@@ -1,6 +1,5 @@
 import * as util from "util";
 import { jest } from "@jest/globals";
-import { Headers } from "node-fetch";
 
 import Queue from "./queue.js";
 import _yahooFinanceFetch, {

--- a/src/lib/yahooFinanceFetch.ts
+++ b/src/lib/yahooFinanceFetch.ts
@@ -1,4 +1,3 @@
-import type { RequestInfo, RequestInit, Response } from "node-fetch";
 import Queue from "./queue.js";
 
 import type { YahooFinanceOptions } from "./options.js";
@@ -134,7 +133,7 @@ async function yahooFinanceFetch(
 
   const response = (await queue.add(() => fetchFunc(url, fetchOptions))) as any;
 
-  const setCookieHeaders = response.headers.raw()["set-cookie"];
+  const setCookieHeaders = response.headers.getSetCookie();
   if (setCookieHeaders) {
     if (!this._opts.cookieJar) throw new Error("No cookieJar set");
     this._opts.cookieJar.setFromSetCookieHeaders(setCookieHeaders, url);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1760,14 +1760,6 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
   integrity sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
 
-"@types/node-fetch@2.6.11":
-  version "2.6.11"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.11.tgz#9b39b78665dae0e82a08f02f4967d62c66f95d24"
-  integrity sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==
-  dependencies:
-    "@types/node" "*"
-    form-data "^4.0.0"
-
 "@types/node@*":
   version "22.7.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.7.9.tgz#2bf2797b5e84702d8262ea2cf843c3c3c880d0e9"
@@ -2131,11 +2123,6 @@ asap@^2.0.0:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
-
-asynckit@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
-  integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
 babel-jest@^29.7.0:
   version "29.7.0"
@@ -2537,13 +2524,6 @@ columnify@~1.5.4:
     strip-ansi "^3.0.0"
     wcwidth "^1.0.0"
 
-combined-stream@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
-  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
-  dependencies:
-    delayed-stream "~1.0.0"
-
 common-ancestor-path@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz#4f7d2d1394d91b7abdf51871c62f71eadb0182a7"
@@ -2769,11 +2749,6 @@ del@^6.0.0:
     p-map "^4.0.0"
     rimraf "^3.0.2"
     slash "^3.0.0"
-
-delayed-stream@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
-  integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -3226,15 +3201,6 @@ flatted@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
   integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
-
-form-data@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
-  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    mime-types "^2.1.12"
 
 from2@^2.3.0:
   version "2.3.0"
@@ -4755,18 +4721,6 @@ micromatch@^4.0.4:
   dependencies:
     braces "^3.0.3"
     picomatch "^2.3.1"
-
-mime-db@1.45.0:
-  version "1.45.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.45.0.tgz#cceeda21ccd7c3a745eba2decd55d4b73e7879ea"
-  integrity sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==
-
-mime-types@^2.1.12:
-  version "2.1.28"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.28.tgz#1160c4757eab2c5363888e005273ecf79d2a0ecd"
-  integrity sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==
-  dependencies:
-    mime-db "1.45.0"
 
 mime@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Closes # .

## Changes
-  Removes `node-fetch` in favour of native fetch

## Type
- [ ] New Module
- [ ] Other New Feature
- [ ] Validation Fix
- [ ] Other Bugfix
- [ ] Docs
- [x] Chore/other

## Comments/notes
Annoyingly my last [PR](https://github.com/gadicc/node-yahoo-finance2/pull/793) was clobbered when I synced with the upstream, so I'm going to replay my changes here. This change is pretty uncontroversial so I'll start with it. 

Some things that have changed since my previous PR was opened:
1. Gadi did a bunch of work to bump to node 18 and did some awesome work on making the tests faster 🙇 (this really helped me in writing this PR)
2. Gadi fixed the interface change I accidentally pushed in my giant Typebox PR 🙇 🙇 🙇 
3. CloudFlare [released](https://developers.cloudflare.com/workers/configuration/compatibility-dates/#nodejs-compatibility-flag) and then made their `nodejs_compat_v2` flag GA. This obviates the need for a bunch of mundane changes in my previous PR to do with prefixing everything with `node:`

### Where does this leave us?
There are only two remaining blockers to supporting Cloudflare:
1. `node-fetch` which this PR addresses
2. The import assertions. Even though we are now using the standard syntax as per the latest LTS version of Node,  CloudFlare still doesn't love it. My understanding is that the next release of `node-yahoo-finance2` is looking to drop browser support, so I was thinking we could switch out the current import for a call to `node:fs` and then validate the structure with typebox (if we were so inclined). Though I appreciate that is a bit of a cludge fix and significantly less elegant than just using the features of the primary platform this library supports. 

Otherwise though I managed to get a local CloudFlare Worker running with this config using `wrangler@3.82.0`:
```
#:schema node_modules/wrangler/config-schema.json
name = "cloudflare"
main = "src/index.ts"
compatibility_date = "2024-09-23"
compatibility_flags = ["nodejs_compat"]
```

There is also the separate discussion of environment variables we started on my last PR. That is no longer a blocker for CloudFlare after the latest compatibility changes. HOWEVER, I think it still merits exploration at least for allowing callers to merge environment vars à la suggestion made by @gadicc in the last discussion:
```
export default {
  fetch(req, env) {
    yahooFinance.setGlobalConfig({ mergeEnv: env });
  }
};
```
I will have a look at doing this in a follow up. 