### PR TITLE
Support `MONEY_MARKET` in Search

### DIFF
--- a/src/modules/search.schema.json
+++ b/src/modules/search.schema.json
@@ -606,6 +606,73 @@
       ],
       "additionalProperties": {}
     },
+    "SearchQuoteYahooMoneyMarket": {
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "type": "string"
+        },
+        "isYahooFinance": {
+          "type": "boolean",
+          "const": true
+        },
+        "exchange": {
+          "type": "string"
+        },
+        "exchDisp": {
+          "type": "string"
+        },
+        "shortname": {
+          "type": "string"
+        },
+        "longname": {
+          "type": "string"
+        },
+        "index": {
+          "type": "string",
+          "const": "quotes"
+        },
+        "score": {
+          "yahooFinanceType": "number"
+        },
+        "newListingDate": {
+          "yahooFinanceType": "date"
+        },
+        "prevName": {
+          "type": "string"
+        },
+        "nameChangeDate": {
+          "yahooFinanceType": "date"
+        },
+        "sector": {
+          "type": "string"
+        },
+        "industry": {
+          "type": "string"
+        },
+        "dispSecIndFlag": {
+          "type": "boolean"
+        },
+        "quoteType": {
+          "type": "string",
+          "const": "MONEY_MARKET"
+        },
+        "typeDisp": {
+          "type": "string",
+          "const": "MoneyMarket"
+        }
+      },
+      "required": [
+        "exchange",
+        "index",
+        "isYahooFinance",
+        "quoteType",
+        "score",
+        "symbol",
+        "typeDisp"
+      ],
+      "additionalProperties": {}
+    },
     "SearchQuoteNonYahoo": {
       "type": "object",
       "properties": {

--- a/src/modules/search.test.ts
+++ b/src/modules/search.test.ts
@@ -23,6 +23,7 @@ describe("search", () => {
       "NO0010123060", // has no shortname! (#31)
       "EUR", // a currency
       "BJ0CDD2", // additionalProperty: { exchDisp: "London" }
+      'RAMXX', // a money market
     ],
   });
 

--- a/src/modules/search.ts
+++ b/src/modules/search.ts
@@ -64,6 +64,11 @@ export interface SearchQuoteYahooFuture extends SearchQuoteYahoo {
   typeDisp: "Future" | "Futures";
 }
 
+export interface SearchQuoteYahooMoneyMarket extends SearchQuoteYahoo {
+  quoteType: 'MONEY_MARKET';
+  typeDisp: 'MoneyMarket';
+}
+
 export interface SearchQuoteNonYahoo {
   [key: string]: unknown;
   index: string; // '78ddc07626ff4bbcae663e88514c23a0'
@@ -105,6 +110,7 @@ export interface SearchResult {
     | SearchQuoteYahooCryptocurrency
     | SearchQuoteNonYahoo
     | SearchQuoteYahooFuture
+    | SearchQuoteYahooMoneyMarket
   >;
   news: Array<SearchNews>;
   nav: Array<unknown>;

--- a/tests/fixtures/http/search-RAMXX.json
+++ b/tests/fixtures/http/search-RAMXX.json
@@ -1,0 +1,66 @@
+{
+  "request": {
+    "url": "https://query2.finance.yahoo.com/v1/finance/search?lang=en-US&region=US&quotesCount=6&newsCount=4&enableFuzzyQuery=false&quotesQueryId=tss_match_phrase_query&multiQuoteQueryId=multi_quote_single_token_query&newsQueryId=news_cie_vespa&enableCb=true&enableNavLinks=true&enableEnhancedTrivialQuery=true&q=RAMXX",
+    "method": "GET",
+    "headers": {
+      "cookie": "",
+      "user-agent": "@gadicc/yahoo-finance2/0.0.1 (+https://github.com/gadicc/node-yahoo-finance2)"
+    }
+  },
+  "response": {
+    "ok": true,
+    "status": 200,
+    "statusText": "OK",
+    "headers": {
+      "age": "0",
+      "cache-control": "public, max-age=600, stale-while-revalidate=180",
+      "content-length": "713",
+      "content-type": "application/json;charset=utf-8",
+      "date": "Sun, 04 May 2025 04:06:02 GMT",
+      "referrer-policy": "no-referrer-when-downgrade",
+      "server": "ATS",
+      "strict-transport-security": "max-age=31536000",
+      "vary": "Origin,Origin,Accept-Encoding",
+      "x-content-type-options": "nosniff",
+      "x-envoy-decorator-operation": "finance-search--mtls-production-sg3.finance-k8s:4080/*",
+      "x-envoy-upstream-service-time": "28",
+      "x-frame-options": "SAMEORIGIN",
+      "x-xss-protection": "1; mode=block",
+      "y-rid": "5leo3vhk1dpta"
+    },
+    "bodyJson": {
+      "explains": [],
+      "count": 1,
+      "quotes": [
+        {
+          "exchange": "NAS",
+          "shortname": "Ramirez Government Money Market",
+          "quoteType": "MONEY_MARKET",
+          "symbol": "RAMXX",
+          "index": "quotes",
+          "score": 10004500,
+          "typeDisp": "MoneyMarket",
+          "longname": "Advisor Managed Portfolios - Ramirez Asset Management Money Market Fund",
+          "exchDisp": "NASDAQ",
+          "isYahooFinance": true
+        }
+      ],
+      "news": [],
+      "nav": [],
+      "lists": [],
+      "researchReports": [],
+      "screenerFieldResults": [],
+      "totalTime": 25,
+      "timeTakenForQuotes": 417,
+      "timeTakenForNews": 900,
+      "timeTakenForAlgowatchlist": 400,
+      "timeTakenForPredefinedScreener": 400,
+      "timeTakenForCrunchbase": 400,
+      "timeTakenForNav": 400,
+      "timeTakenForResearchReports": 0,
+      "timeTakenForScreenerField": 0,
+      "timeTakenForCulturalAssets": 0,
+      "timeTakenForSearchLists": 0
+    }
+  }
+}


### PR DESCRIPTION
As of the time of writing, there are no issues associated with this pull request.

## Changes

- Supports searching for `MONEY_MARKET` quotes.
- Generate a new `Search` schema that supports `MONEY_MARKET` type.
- Write a test of an example Money Market search (the quote that I use is `RAMXX`).

## Type

- [x] Validation Fix

## Comments

Thank you so much for developing and maintaining this module!

I noticed that when I search for something and the results contain a quote with a `quoteType` of `MONEY_MARKET`, the library will throw an error. I fixed it and ensured that it works.

Please let me know if there's something that I can do to enhance this pull request! Would be happy to get this merged so we can use it 😄 