### PR TITLE
feat(screener): add request-side start pagination option

### DIFF
--- a/src/modules/screener.schema.json
+++ b/src/modules/screener.schema.json
@@ -3031,27 +3031,30 @@
         "undervalued_large_caps"
       ]
     },
-    "ScreenerOptions": {
-      "type": "object",
-      "properties": {
-        "lang": {
-          "type": "string"
+        "ScreenerOptions": {
+          "type": "object",
+          "properties": {
+            "lang": {
+              "type": "string"
+            },
+            "region": {
+              "type": "string"
+            },
+            "scrIds": {
+              "$ref": "#/definitions/PredefinedScreenerModules"
+            },
+            "count": {
+              "type": "number"
+            },
+            "start": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "scrIds"
+          ],
+          "additionalProperties": false
         },
-        "region": {
-          "type": "string"
-        },
-        "scrIds": {
-          "$ref": "#/definitions/PredefinedScreenerModules"
-        },
-        "count": {
-          "type": "number"
-        }
-      },
-      "required": [
-        "scrIds"
-      ],
-      "additionalProperties": false
-    },
     "screener": {}
   }
 }

--- a/src/modules/screener.test.ts
+++ b/src/modules/screener.test.ts
@@ -42,6 +42,16 @@ describe("screener", () => {
     },
   );
 
+  it("supports pagination with start option", async (t, onFinish) => {
+    await yf.screener(
+      { scrIds: "most_actives", count: 5, start: 5 },
+      undefined,
+      {
+        devel: { id: "screener-most_actives", t, onFinish },
+      },
+    );
+  });
+
   // Test for using just the screener name as an argument w/o options obj
   it.each(["aggressive_small_caps"])(
     "passes validation for predefined screener '%s'",

--- a/src/modules/screener.ts
+++ b/src/modules/screener.ts
@@ -660,6 +660,13 @@ export interface ScreenerOptions {
   region?: string;
   scrIds: PredefinedScreenerModules;
   count?: number;
+  /**
+   * Pagination start index. Matches Yahoo's `start` query param.
+   * Use together with `count` to page through screener results.
+   *
+   * Example: `{ count: 25, start: 25 }` to fetch the second page of 25 results.
+   */
+  start?: number;
 }
 
 /**


### PR DESCRIPTION
Expose Yahoo’s start query parameter via ScreenerOptions to support request-side pagination in screener. This aligns the typed API with the endpoint, which paginates with start and count. Backward compatible; existing code continues to work unchanged.

## Changes
- src/modules/screener.ts: add start?: number to ScreenerOptions with JSDoc.
- src/modules/screener.schema.json: regenerated to include start in ScreenerOptions.
- src/modules/screener.test.ts: add a test invoking screener({ scrIds: "most_actives", count: 5, start: 5 }).

## Type
- [ ] New Module
- [x] Other New Feature
- [ ] Validation Fix
- [ ] Other Bugfix
- [ ] Docs
- [ ] Chore/other

## Comments/notes
- Rationale: The endpoint /v1/finance/screener/predefined/saved supports start and count. Previously, consumers had to disable options validation or bypass the library for pagination. This formalizes start in the public API.
- Usage example:
  ```js
  const res = await yahooFinance.screener("most_actives", { count: 25, start: 25 });
  console.log(res.start, res.count, res.total, res.quotes.length);
  ```
- Request param is start (Yahoo’s API). offset appears only in the response under criteriaMeta and is not used as a request param.